### PR TITLE
Dont show stacktrace on missing params

### DIFF
--- a/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
@@ -28,7 +28,8 @@ namespace Octopus.Tentacle.Commands.OptionSets
 
         public void Validate()
         {
-            Guard.ArgumentNotNullOrEmpty(Server, "Please specify an Octopus server, e.g., --server=http://your-octopus-server");
+            if (string.IsNullOrWhiteSpace(Server))
+                throw new ControlledFailureException("Please specify an Octopus server, e.g., --server=http://your-octopus-server");
 
             if (string.IsNullOrEmpty(Username) && string.IsNullOrEmpty(ApiKey))
                 throw new ControlledFailureException("Please specify a username and password, or an Octopus API key. You can get an API key from the Octopus web portal. E.g., --apiKey=ABC1234");

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommand.cs
@@ -83,6 +83,9 @@ namespace Octopus.Tentacle.Commands
             if (environmentNames.Count == 0 || string.IsNullOrWhiteSpace(environmentNames.First()))
                 throw new ControlledFailureException("Please specify an environment name, e.g., --environment=Development");
 
+            if (roles.Count == 0 || string.IsNullOrWhiteSpace(roles.First()))
+                throw new ControlledFailureException("Please specify an role name, e.g., --role=web-server");
+
             CommunicationStyle communicationStyle;
             if (!Enum.TryParse(comms, true, out communicationStyle))
                 throw new ControlledFailureException("Please specify a valid communications style, e.g. --comms-style=TentaclePassive");


### PR DESCRIPTION
Now validates the `--server` and `--role` parameters are supplied and
prints a error message rather than a stack trace.

Fixes #15

See [issue](https://github.com/OctopusDeploy/OctopusTentacle/issues/15) for before state.

After fix:

Missing `--server`:
```
PS \>Tentacle.exe register-with
Please specify an Octopus server, e.g., --server=http://your-octopus-server
-------------------------------------------------------------------------------
Terminating process with exit code 1
Full error details are available in the log files at:
C:\Octopus\Logs
C:\Users\<username>\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------
```

Missing `--role`
```
PS \>Tentacle.exe register-with --server https://octopus.example.com --apikey=API-XXXXXXXXXXXXXXXXX--environment=Test --force --comms-style=TentacleActive
Octopus Deploy: Tentacle version 0.0.0-local (0.0.0-local) instance Default
Environment Information:
  OperatingSystem: Microsoft Windows NT 6.2.9200.0
  OsBitVersion: x64
  Is64BitProcess: True
  CurrentUser: <computername>\<username>
  MachineName: <computername>
  ProcessorCount: 8
  CurrentDirectory: C:\Program Files\Octopus Deploy\Tentacle
  TempDirectory: C:\Users\<username>\AppData\Local\Temp\
  HostProcessName: Tentacle
==== RegisterMachineCommand ====
Please specify an role name, e.g., --role=web-server
-------------------------------------------------------------------------------
Terminating process with exit code 1
Full error details are available in the log files at:
C:\Octopus\Logs
C:\Users\<username>\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------
```