### PR TITLE
Sign the Tentacle files with our production certificate when building in TeamCity

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -24,7 +24,7 @@ var signingCertificatPassword = Argument("signing_certificate_password", "Passwo
 var signingTimestampUrls = new string[] {
     "http://timestamp.globalsign.com/scripts/timestamp.dll",
     "http://www.startssl.com/timestamp",
-    "http://timestamp.comodoca.com/rfc3161", 
+    "http://timestamp.comodoca.com/rfc3161",
     "http://timestamp.verisign.com/scripts/timstamp.dll",
     "http://tsa.starfieldtech.com"};
 
@@ -186,7 +186,7 @@ Task("__CreateChocolateyPackage")
 
         var checksum64 = CalculateFileHash(File($"{artifactsDir}/Octopus.Tentacle.{gitVersion.NuGetVersion}-x64.msi"));
         var checksum64Value = BitConverter.ToString(checksum64.ComputedHash).Replace("-", "");
-        Information($"Checksum: Octopus.Tentacle-x64.msi = {checksum64Value}");               
+        Information($"Checksum: Octopus.Tentacle-x64.msi = {checksum64Value}");
 
         var chocolateyInstallScriptPath = "./source/Chocolatey/chocolateyInstall.ps1";
         RestoreFileOnCleanup(chocolateyInstallScriptPath);


### PR DESCRIPTION
Main change involved was updating the TeamCity build step to pass `"-signing_certificate_path='%system.signing_certificate_path%' -signing_certificate_password='%system.signing_certificate_password%'"` to `build.cmd`

Fixes OctopusDeploy/Issues#3672