### PR TITLE
Delete files leftover from old installations

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -119,8 +119,8 @@
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Shared, Version=3.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Shared.3.17.0\lib\net45\Octopus.Shared.dll</HintPath>
+    <Reference Include="Octopus.Shared, Version=3.17.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Shared.3.17.1\lib\net45\Octopus.Shared.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.9.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.9\lib\netstandard1.0\Octopus.Time.dll</HintPath>

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -18,7 +18,7 @@
   <package id="Octopus.Client" version="4.19.0" targetFramework="net45" />
   <package id="Octopus.Configuration" version="1.0.11" targetFramework="net45" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net45" />
-  <package id="Octopus.Shared" version="3.17.0" targetFramework="net45" />
+  <package id="Octopus.Shared" version="3.17.1" targetFramework="net45" />
   <package id="Octopus.Time" version="1.0.9" targetFramework="net45" />
   <package id="System.Collections" version="4.0.11" targetFramework="net45" />
   <package id="System.Net.Http" version="4.1.0" targetFramework="net45" />

--- a/source/Octopus.Tentacle.Tests/FileSystem/FileSystemCleanerFixtture.cs
+++ b/source/Octopus.Tentacle.Tests/FileSystem/FileSystemCleanerFixtture.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Octopus.Shared.Startup;
+using Octopus.Shared.Util;
+
+namespace Octopus.Tentacle.Tests.FileSystem
+{
+    [TestFixture]
+    public class FileSystemCleanerFixture
+    {
+        [Test]
+        public void ShouldNotDeleteFilesThatWeNeed()
+        {
+            var fileSystem = new OctopusPhysicalFileSystem();
+
+            var pathsThatWillBeDeleted = GetPathsThatWillBeDeleted();
+            Assert.That(pathsThatWillBeDeleted, Is.Not.Empty);
+
+            var filesThatShouldntBeDeleted = pathsThatWillBeDeleted.Where(p => fileSystem.FileExists(p));
+            var directoriesThatShouldntBeDeleted = pathsThatWillBeDeleted.Where(p => fileSystem.DirectoryExists(p));
+
+            OutputPathsThatShouldntBeDeleted(filesThatShouldntBeDeleted, "files");
+            OutputPathsThatShouldntBeDeleted(directoriesThatShouldntBeDeleted, "directories");
+
+            Assert.That(filesThatShouldntBeDeleted, Is.Empty);
+            Assert.That(directoriesThatShouldntBeDeleted, Is.Empty);
+        }
+
+        static IReadOnlyList<string> GetPathsThatWillBeDeleted()
+        {
+            var assembly = typeof(FileSystemCleaner).Assembly;
+
+            using (var stream = assembly.GetManifestResourceStream(FileSystemCleaner.PathsToDeleteOnStartupResource))
+            using (var reader = new StreamReader(stream))
+            {
+                string line;
+                var allLines = new List<string>();
+                while ((line = reader.ReadLine()) != null)
+                {
+                    allLines.Add(line);
+                }
+                return allLines;
+            }
+        }
+
+        static void OutputPathsThatShouldntBeDeleted(IEnumerable<string> paths, string pathType)
+        {
+            if (!paths.Any())
+                return;
+
+            Console.WriteLine($"The following {pathType} will be deleted on Octopus startup but we need them:");
+            foreach (var p in paths)
+                Console.WriteLine(p);
+            Console.WriteLine("Remove the path from the list of files to be deleted in Octopus.Shared.");
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -138,8 +138,8 @@
     <Reference Include="Octopus.Diagnostics, Version=1.0.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Diagnostics.1.0.12\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Shared, Version=3.17.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Shared.3.17.0\lib\net45\Octopus.Shared.dll</HintPath>
+    <Reference Include="Octopus.Shared, Version=3.17.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Shared.3.17.1\lib\net45\Octopus.Shared.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.0.9.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Time.1.0.9\lib\netstandard1.0\Octopus.Time.dll</HintPath>
@@ -209,6 +209,7 @@
     <Compile Include="Commands\RunAgentCommandFixture.cs" />
     <Compile Include="Commands\StubHomeConfiguration.cs" />
     <Compile Include="Commands\StubTentacleConfiguration.cs" />
+    <Compile Include="FileSystem\FileSystemCleanerFixtture.cs" />
     <Compile Include="Integration\ScriptLogFixture.cs" />
     <Compile Include="Integration\ScriptServiceFixture.cs" />
     <Compile Include="Orchestration\Agentless\Ssh\SshHealthReporterFixture.cs" />

--- a/source/Octopus.Tentacle.Tests/packages.config
+++ b/source/Octopus.Tentacle.Tests/packages.config
@@ -40,7 +40,7 @@
   <package id="Octopus.Configuration" version="1.0.11" targetFramework="net452" />
   <package id="Octopus.Data" version="1.0.24" targetFramework="net452" />
   <package id="Octopus.Diagnostics" version="1.0.12" targetFramework="net452" />
-  <package id="Octopus.Shared" version="3.17.0" targetFramework="net452" />
+  <package id="Octopus.Shared" version="3.17.1" targetFramework="net452" />
   <package id="Octopus.Time" version="1.0.9" targetFramework="net452" />
   <package id="Octostache" version="2.1.5" targetFramework="net452" />
   <package id="Polly" version="5.1.0" targetFramework="net452" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Autofac" Version="3.5.2" />
     <PackageReference Include="Octopus.Client" Version="4.19.0" />
     <PackageReference Include="Octopus.Configuration" Version="1.0.11" />
-    <PackageReference Include="Octopus.Shared" Version="3.17.0" />
+    <PackageReference Include="Octopus.Shared" Version="3.17.1" />
     <PackageReference Include="System.Net.Http" Version="4.1.0" />
     <PackageReference Include="TaskScheduler" Version="2.5.21" />
   </ItemGroup>


### PR DESCRIPTION
Updates Octopus.Shared to 3.17.1 and adds a test to ensure we don't accidently delete files we need.
Fixes #39

Replaces https://github.com/OctopusDeploy/OctopusTentacle/pull/40