### PR TITLE
Update Octopus.Client to 4.33.1

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -109,8 +109,8 @@
     <Reference Include="NuGet.Versioning, Version=3.6.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NuGet.Versioning.3.6.0-octopus-58676\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Client, Version=4.32.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Client.4.32.0\lib\net45\Octopus.Client.dll</HintPath>
+    <Reference Include="Octopus.Client, Version=4.33.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Client.4.33.1\lib\net45\Octopus.Client.dll</HintPath>
     </Reference>
     <Reference Include="Octopus.Configuration, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Octopus.Configuration.1.0.11\lib\net45\Octopus.Configuration.dll</HintPath>

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -18,7 +18,7 @@
   <package id="NuGet.Packaging.Core" version="3.6.0-octopus-58676" targetFramework="net45" />
   <package id="NuGet.Packaging.Core.Types" version="3.6.0-octopus-58676" targetFramework="net45" />
   <package id="NuGet.Versioning" version="3.6.0-octopus-58676" targetFramework="net45" />
-  <package id="Octopus.Client" version="4.32.0" targetFramework="net45" />
+  <package id="Octopus.Client" version="4.33.1" targetFramework="net45" />
   <package id="Octopus.Configuration" version="1.0.11" targetFramework="net45" />
   <package id="Octopus.Diagnostics" version="1.2.0" targetFramework="net45" />
   <package id="Octopus.Shared" version="4.2.3" targetFramework="net45" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octopus.Client" Version="4.32.0" />
+    <PackageReference Include="Octopus.Client" Version="4.33.1" />
     <PackageReference Include="Octopus.Configuration" Version="1.0.11" />
     <PackageReference Include="Octopus.Shared" Version="4.2.3" />
   </ItemGroup>


### PR DESCRIPTION
Gets registration environments and tenant in one request per environment/tenant, rather than using `FindByNames` which iterates through every page of environments and tenants.  See related: https://github.com/OctopusDeploy/OctopusClients/pull/251

Fixes #75 
