### PR TITLE
Fix NullRefException when showing config when no certificate exists

### DIFF
--- a/source/Octopus.Tentacle/Commands/ShowConfigurationCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ShowConfigurationCommand.cs
@@ -100,7 +100,7 @@ namespace Octopus.Tentacle.Commands
             };
 
             //we dont want the actual certificate, as its encrypted, and we get a different output everytime
-            outputStore.Set<string>("Tentacle.CertificateThumbprint", tentacleConfiguration.Value.TentacleCertificate.Thumbprint);
+            outputStore.Set<string>("Tentacle.CertificateThumbprint", tentacleConfiguration.Value.TentacleCertificate?.Thumbprint);
 
             var watchdogConfiguration = watchdog.Value.GetConfiguration();
             watchdogConfiguration.WriteTo(outputStore);


### PR DESCRIPTION
Will add a test in the E2E tests for this.

Fixes https://github.com/OctopusDeploy/Issues/issues/4620