### PR TITLE
adding HSTS to Octopus Tentacle

### DIFF
--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -68,7 +68,8 @@ namespace Octopus.Tentacle.Communications
             new KeyValuePair<string, string>("Referrer-Policy", "no-referrer"),
             new KeyValuePair<string, string>("X-Content-Type-Options", "nosniff"),
             new KeyValuePair<string, string>("X-Frame-Options", "DENY"),
-            new KeyValuePair<string, string>("X-XSS-Protection",  "1; mode=block")
+            new KeyValuePair<string, string>("X-XSS-Protection",  "1; mode=block"),
+            new KeyValuePair<string, string>("Strict-Transport-Security",  "max-age=31536000")
         };
     }
 }


### PR DESCRIPTION
Adds the `Strict-Transport-Security` header with a fixed duration of 1 year, to satisfy security scanners

Fixes: https://github.com/OctopusDeploy/Issues/issues/5143
Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/105