### PR TITLE
Now signing all unsigned exe's and dll's

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -166,8 +166,9 @@ Task("__SignBuiltFiles")
 {
     // check that any unsigned libraries get signed, to play nice with security scanning tools
     // refer: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1551655877004400
-    // note: "we are signing dll's we have written (& some we don't own),
-    // but we are asserting that they are distributed by us, and are not altered after this step
+    // note: we are signing both dll's we have written & some we haven't, not because we are
+    //       claiming we own them, but rather asserting that they are distributed by us, and
+    //       have not been subsequently altered
     var filesToSign = 
         GetFiles($"{coreWinPublishDir}/*.dll")
         .Union(GetFiles($"{coreWinPublishDir}/*.exe"))


### PR DESCRIPTION
As a result of some recent customer requests I thought I'd look into authenticode signing our dependencies so that security scanning tools don't have a bad day. Thanks @matt-richardson for the assist.

[internal discussion forum link](https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1551655877004400)