### PR TITLE
Now signing unsigned DLL's and assemblies

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -176,6 +176,8 @@ Task("__SignBuiltFiles")
         .Union(GetFiles($"{coreWinPublishDir}/*.exe"))
         .Union(GetFiles($"./source/Octopus.Tentacle/bin/**/*.dll"))
         .Union(GetFiles($"./source/Octopus.Tentacle/bin/**/*.exe"))
+        .Union(GetFiles($"./source/Octopus.Manager.Tentacle/bin/*.dll"))
+        .Union(GetFiles($"./source/Octopus.Manager.Tentacle/bin/*.exe"))
             .Where(f => !HasAuthenticodeSignature(f))
             .Select(f => f.FullPath)
             .ToArray();


### PR DESCRIPTION
As a result of some recent customer requests I thought I'd look into authenticode signing our dependencies so that security scanning tools don't have a bad day. Thanks @matt-richardson for the assist.

[internal discussion forum link](https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1551655877004400)