### PR TITLE
Limiting signed assemblies to the ones we author

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -171,6 +171,7 @@ Task("__SignBuiltFiles")
 {
     // check that any unsigned libraries, that Octopus Deploy authors, get signed to play nice with security scanning tools
     // refer: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1551655877004400
+    // decision re: no signing everything: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1557938890227100
     var filesToSign = 
         GetFiles($"{coreWinPublishDir}/**/Octo*.exe",
             $"{coreWinPublishDir}/**/Octo*.dll",


### PR DESCRIPTION
**Background**
[Internal discussion](https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1556587012067600)
We initially decided to sign all assemblies to help customers that needed to pass A/V checks. However, we've since refined this position to only sign assemblies that we author.

This PR, rather than fully reverting previous commits, keeps the benefit of the timestamping approach, while ensuring we are signing various Octopus assemblies.

**Before this change**
All assemblies that were otherwise unsigned, would have been signed & timestamped by Octopus Deploy. Any assemblies already signed by us or someone else would retain that signature.

**After this change**
Only unsigned assemblies that we author should be signed as part of the build process.

**How to review this PR**
To check this all out, just run the `build.cake` script, and have a look at my changes here.

Hoping that a reviewer can:
- validate that this approach is :+1:
- check that I haven't missed any assemblies that we author