### PR TITLE
Masking tentacle proxy password in deployment logs (#137)

### DIFF
--- a/source/Octopus.Tentacle.Tests/Configuration/Proxy/ProxyPasswordMaskValuesProviderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Configuration/Proxy/ProxyPasswordMaskValuesProviderFixture.cs
@@ -1,0 +1,59 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.Configuration.Proxy;
+
+namespace Octopus.Tentacle.Tests.Configuration.Proxy
+{
+    public class ProxyPasswordMaskValuesProviderFixture
+    {
+        ProxyPasswordMaskValuesProvider sut;
+
+        [SetUp]
+        public void SetUp()
+        {
+            sut = new ProxyPasswordMaskValuesProvider();
+        }
+
+        [TestCase("")]
+        [TestCase(null)]
+        public void GetProxyPasswordMaskValues_NullOrEmpty_EmptyList(string password)
+        {
+            sut.GetProxyPasswordMaskValues(password).Should().BeEmpty();
+        }
+        
+        [Test]
+        public void GetProxyPasswordMaskValues_NoSpecialCharacters_JustPassword()
+        {
+            string password = "Some-sTAr";
+            sut.GetProxyPasswordMaskValues(password).Should().BeEquivalentTo(new []
+            {
+                "Some-sTAr"
+            });
+        }
+        
+        [Test]
+        public void GetProxyPasswordMaskValues_HasSpecialCharacters_EncodedWithBothCases()
+        {
+            string password = "Some@sT:r/";
+            sut.GetProxyPasswordMaskValues(password).Should().BeEquivalentTo(new []
+            {
+                "Some@sT:r/",
+                "Some%40sT%3Ar%2F", //WebUtility.UrlEncode generates uppercase hex characters
+                "Some%40sT%3ar%2f"  //HttpUtility.UrlEncode generates lowercase hex characters
+            });
+        }
+        
+        [Test]
+        public void GetProxyPasswordMaskValues_HasSpecialCharactersWithHexCharactersFollowing_HexCharacterCasingPreserved()
+        {
+            string password = "Some@sT:Ar/";
+            sut.GetProxyPasswordMaskValues(password).Should().BeEquivalentTo(new []
+            {
+                "Some@sT:Ar/",
+                "Some%40sT%3AAr%2F", //WebUtility.UrlEncode generates uppercase hex characters
+                "Some%40sT%3aAr%2f"  //HttpUtility.UrlEncode generates lowercase hex characters
+            });
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
@@ -1,7 +1,11 @@
 ﻿using System.IO;
+using System.Linq;
+using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Shared.Contracts;
+using Octopus.Shared.Diagnostics;
 using Octopus.Shared.Util;
+using Octopus.Tentacle.Configuration.Proxy;
 using Octopus.Tentacle.Services.Scripts;
 
 namespace Octopus.Tentacle.Tests.Integration
@@ -9,25 +13,38 @@ namespace Octopus.Tentacle.Tests.Integration
     [TestFixture]
     public class ScriptLogFixture
     {
+        string logFile;
+        ScriptLog sut;
+        ISensitiveValueMasker sensitiveValueMasker;
+        LogContext logContext;
+
         [SetUp]
         public void SetUp()
         {
+            logFile = Path.GetTempFileName();
+            logContext = new LogContext();
+            sensitiveValueMasker = new SensitiveValueMasker(logContext);
+            sut = new ScriptLog(logFile, new OctopusPhysicalFileSystem(), sensitiveValueMasker);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (logFile != null)
+                File.Delete(logFile);
         }
 
         [Test]
         public void ShouldAppend()
         {
-            var logFile = Path.GetTempFileName();
-            try
-            {
-                var log = new ScriptLog(logFile, new OctopusPhysicalFileSystem());
 
-                var appender = log.CreateWriter();
+            using (var appender = sut.CreateWriter())
+            {
                 appender.WriteOutput(ProcessOutputSource.StdOut, "Hello");
                 appender.WriteOutput(ProcessOutputSource.StdOut, "World");
 
                 long next;
-                var logs = log.GetOutput(long.MinValue, out next);
+                var logs = sut.GetOutput(long.MinValue, out next);
                 Assert.That(logs.Count, Is.EqualTo(2));
                 Assert.That(logs[0].Text, Is.EqualTo("Hello"));
                 Assert.That(logs[0].Source, Is.EqualTo(ProcessOutputSource.StdOut));
@@ -36,23 +53,58 @@ namespace Octopus.Tentacle.Tests.Integration
                 appender.WriteOutput(ProcessOutputSource.StdOut, "More");
                 appender.WriteOutput(ProcessOutputSource.StdOut, "Output");
 
-                logs = log.GetOutput(next, out next);
+                logs = sut.GetOutput(next, out next);
                 Assert.That(logs.Count, Is.EqualTo(2));
                 Assert.That(logs[0].Text, Is.EqualTo("More"));
                 Assert.That(logs[1].Text, Is.EqualTo("Output"));
 
                 appender.WriteOutput(ProcessOutputSource.StdErr, "ErrorHappened");
 
-                logs = log.GetOutput(next, out next);
+                logs = sut.GetOutput(next, out next);
                 Assert.That(logs.Count, Is.EqualTo(1));
                 Assert.That(logs[0].Text, Is.EqualTo("ErrorHappened"));
                 Assert.That(logs[0].Source, Is.EqualTo(ProcessOutputSource.StdErr));
-
-                appender.Dispose();
             }
-            finally
+        }
+
+        [Test]
+        public void MaskSensitiveValues_SingleMessage_Masked()
+        {
+            logContext.WithSensitiveValues(new[] {"abcde"});
+            using (var writer = sut.CreateWriter())
             {
-                File.Delete(logFile);
+                writer.WriteOutput(ProcessOutputSource.Debug, "hello abcde123");
+
+                var logs = sut.GetOutput(0, out long next);
+
+                logs.Should().ContainSingle().Subject.Text.Should().Be("hello ********123");
+            }
+        }
+        
+        //We currently don't mask the first message if a secret spans 2 messages. 
+        //This shouldn't happen in practice since even when Calamari logs a really long line (10K chars), it won't get split
+        //
+        //Sample PowerShell script step:
+        //        Write-Host "hello start"
+        //
+        //        for ($i=1; $i -le 10000; $i++) {
+        //            $prefix = " " * ($i*2)
+        //            Write-Host $prefix $env:HTTP_PROXY
+        //        }
+        //
+        //        Write-Host "hello end"
+        [Test]
+        public void MaskSensitiveValues_MultiMessage_2ndMessageMasked()
+        {
+            logContext.WithSensitiveValues(new[] {"abcde12345"});
+            using (var writer = sut.CreateWriter())
+            {
+                writer.WriteOutput(ProcessOutputSource.Debug, "hello abcde");
+                writer.WriteOutput(ProcessOutputSource.Debug, "12345 bye");
+
+                var logs = sut.GetOutput(0, out long next);
+
+                logs.Select(l => l.Text).Should().ContainInOrder("hello abcde", "******** bye");
             }
         }
     }

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceFixture.cs
@@ -6,8 +6,10 @@ using NSubstitute;
 using NUnit.Framework;
 using Octopus.Shared.Configuration;
 using Octopus.Shared.Contracts;
+using Octopus.Shared.Diagnostics;
 using Octopus.Shared.Scripts;
 using Octopus.Shared.Util;
+using Octopus.Tentacle.Configuration.Proxy;
 using Octopus.Tentacle.Services.Scripts;
 
 namespace Octopus.Tentacle.Tests.Integration
@@ -26,7 +28,7 @@ namespace Octopus.Tentacle.Tests.Integration
             service = new ScriptService(PlatformDetection.IsRunningOnWindows 
                 ? (IShell) new PowerShell() 
                 : new Bash()
-                , new ScriptWorkspaceFactory(new OctopusPhysicalFileSystem(), homeConfiguration), new OctopusPhysicalFileSystem());
+                , new ScriptWorkspaceFactory(new OctopusPhysicalFileSystem(), homeConfiguration), new OctopusPhysicalFileSystem(), new SensitiveValueMasker(new LogContext()));
         }
 
         [Test]

--- a/source/Octopus.Tentacle/Configuration/LogMaskingModule.cs
+++ b/source/Octopus.Tentacle/Configuration/LogMaskingModule.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Linq;
+using System.Net;
+using Autofac;
+using Octopus.Diagnostics;
+using Octopus.Shared.Diagnostics;
+using Octopus.Tentacle.Configuration.Proxy;
+
+namespace Octopus.Tentacle.Configuration
+{
+    public class LogMaskingModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterType<ProxyPasswordMaskValuesProvider>().As<IProxyPasswordMaskValuesProvider>();
+            builder.Register(b =>
+            {
+                var proxyPassword = b.Resolve<ITentacleConfiguration>().ProxyConfiguration.CustomProxyPassword;
+                var sensitiveValues = b.Resolve<IProxyPasswordMaskValuesProvider>().GetProxyPasswordMaskValues(proxyPassword).ToArray();
+                
+                //Wrap the log context in another class so we don't register it on the container (ILogContext isn't usually global)
+                return new SensitiveValueMasker(new LogContext(null, sensitiveValues));
+            }).As<ISensitiveValueMasker>();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Configuration/Proxy/ProxyPasswordMaskValuesProvider.cs
+++ b/source/Octopus.Tentacle/Configuration/Proxy/ProxyPasswordMaskValuesProvider.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace Octopus.Tentacle.Configuration.Proxy
+{
+    
+    public interface IProxyPasswordMaskValuesProvider
+    {
+        IEnumerable<string> GetProxyPasswordMaskValues(string proxyPassword);
+    }
+    
+    public class ProxyPasswordMaskValuesProvider : IProxyPasswordMaskValuesProvider
+    {
+        static readonly Regex UrlEncodedCharactersRegex = new Regex(@"%[A-F0-9]{2}", RegexOptions.Compiled);
+        public IEnumerable<string> GetProxyPasswordMaskValues(string proxyPassword)
+        {
+            if (string.IsNullOrEmpty(proxyPassword)) 
+                return Enumerable.Empty<string>();
+
+            //$Env:HTTP_PROXY will contain the URL encoded version of the password
+            //We also need to handle cases where the encoded hex is in upper or lower case
+            //Calamari calls both WebUtility.UrlEncode (uppercase hex) and HttpUtility.UrlEncode (lowercase hex)
+            string upperCaseUrlEncodedProxyPassword = WebUtility.UrlEncode(proxyPassword);
+            string lowerCaseUrlEncodedProxyPassword = UrlEncodedCharactersRegex.Replace(upperCaseUrlEncodedProxyPassword, m => m.Value.ToLowerInvariant());
+            
+            return new[]
+            {
+                proxyPassword,
+                upperCaseUrlEncodedProxyPassword,
+                lowerCaseUrlEncodedProxyPassword
+            }.Distinct();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Configuration/Proxy/SensitiveValueMasker.cs
+++ b/source/Octopus.Tentacle/Configuration/Proxy/SensitiveValueMasker.cs
@@ -1,0 +1,30 @@
+using System;
+using Octopus.Diagnostics;
+
+namespace Octopus.Tentacle.Configuration.Proxy
+{
+    public interface ISensitiveValueMasker
+    {
+        string MaskSensitiveValues(string rawMessage);
+    }
+
+    //Wrap the log context in this until we extract the the masking from it
+    public class SensitiveValueMasker : ISensitiveValueMasker
+    {
+        readonly ILogContext logContext;
+
+        public SensitiveValueMasker(ILogContext logContext)
+        {
+            this.logContext = logContext;
+        }
+
+        public string MaskSensitiveValues(string rawMessage)
+        {
+            string maskedMessage = null;
+            logContext.SafeSanitize(rawMessage, s => maskedMessage = s);
+            logContext.Flush();
+
+            return maskedMessage;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -52,6 +52,7 @@ namespace Octopus.Tentacle
             builder.RegisterModule(new ShellModule());
             builder.RegisterModule(new ConfigurationModule(applicationName, instanceName));
             builder.RegisterModule(new TentacleConfigurationModule());
+            builder.RegisterModule(new LogMaskingModule());
             builder.RegisterModule(new OctopusClientInitializerModule());
             builder.RegisterModule(new LoggingModule());
             builder.RegisterModule(new OctopusFileSystemModule());


### PR DESCRIPTION
Cherry pick https://github.com/OctopusDeploy/OctopusTentacle/pull/137 into v4 so Server 2019.3 and 2019.6 don't have to reference v5. 

Jumping from v4 to v5 is too risky for LTS due to all the changes that have happened

Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/142