### PR TITLE
Replace the OutboundLinks with Octopurl

### DIFF
--- a/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
+++ b/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
@@ -12,7 +12,7 @@ namespace Octopus.Manager.Tentacle.PreReq
         {
             return CheckPowerShellIsInstalled()
                 ? PrerequisiteCheckResult.Successful()
-                : PrerequisiteCheckResult.Failed("Windows PowerShell 2.0 or above does not appear to be installed and on the System Path on this machine. Please install Windows PowerShell or add it to the System Path then re-run this setup tool.", helpLink: OutboundLinks.HowDoIInstallPowerShell, helpLinkText: "Download and install Windows PowerShell");
+                : PrerequisiteCheckResult.Failed("Windows PowerShell 2.0 or above does not appear to be installed and on the System Path on this machine. Please install Windows PowerShell or add it to the System Path then re-run this setup tool.", helpLink: "http://g.octopushq.com/HowDoIInstallPowerShell", helpLinkText: "Download and install Windows PowerShell");
         }
 
         static bool CheckPowerShellIsInstalled()


### PR DESCRIPTION
Does what it says on the tin - I am removing `OutboundLinks` from `OctopusShared`, so when this pulls the next version of Shared it will need to not rely on getting links there anymore.