### PR TITLE
Set executable path on linux

### DIFF
--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -89,7 +89,7 @@ namespace Octopus.Tentacle.Commands
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleInstanceName, selector.GetCurrentInstance().InstanceName);
             var exePath = PlatformDetection.IsRunningOnWindows
                 ? Path.ChangeExtension(typeof(RunAgentCommand).Assembly.FullLocalPath(), "exe")
-                : Path.ChangeExtension(typeof(RunAgentCommand).Assembly.FullLocalPath(), "");
+                : Path.GetFileNameWithoutExtension(typeof(RunAgentCommand).Assembly.FullLocalPath());
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleExecutablePath, exePath);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProgramDirectoryPath, Path.GetDirectoryName(exePath));
             Environment.SetEnvironmentVariable(EnvironmentVariables.AgentProgramDirectoryPath, Path.GetDirectoryName(exePath));


### PR DESCRIPTION
This will set the executable path to `/opt/octopus/tentacle/Tentacle` instead of `/opt/octopus/tentacle/Tentacle.exe`