### PR TITLE
Fix package path on linux

### DIFF
--- a/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
+++ b/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
@@ -88,7 +88,7 @@ namespace Octopus.Tentacle.Services.FileTransfer
         {
             if (!PlatformDetection.IsRunningOnWindows)
             {
-                path = path.Replace("\\", "/");
+                path = path.Replace('\\', Path.DirectorySeparatorChar);
             }
             
             if (Path.IsPathRooted(path))


### PR DESCRIPTION
This fixes the issue where packages are extracted to the wrong path on Linux Tentacles
## The Issue
On Linux Tentacles, packages were copied and extracted to the wrong locations because we partially construct the file path on Server, which is a Windows path.
On the Linux Tentacle instead of putting the package in the Files directory it would create a file in the root of the Tentacle home directory with the name e.g.
`'.\Files\TestPackage@S1.0.1@CF883A216E4E2B49AD16146CD5953A4A.zip'`

## Solution
Ideally we would remove constructing the path from Server and do it all on the Tentacles, as the Tentacles know where everything should go. However to keep backwards compatibility this PR simply does string manipulation on the file path.