### PR TITLE
Update Shared to get verbose halibut identity logging

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -392,8 +392,8 @@
       <HintPath>..\packages\FluentValidation.7.2.1\lib\net45\FluentValidation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Halibut, Version=4.3.23.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Halibut.4.3.23\lib\net45\Halibut.dll</HintPath>
+    <Reference Include="Halibut, Version=4.3.24.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Halibut.4.3.24\lib\net45\Halibut.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MaterialDesignColors, Version=1.2.0.325, Culture=neutral, PublicKeyToken=null">
@@ -469,8 +469,8 @@
       <HintPath>..\packages\Octopus.Diagnostics.1.3.0\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Shared, Version=4.13.6.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Octopus.Shared.4.13.6\lib\net45\Octopus.Shared.dll</HintPath>
+    <Reference Include="Octopus.Shared, Version=4.13.7.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Octopus.Shared.4.13.7\lib\net45\Octopus.Shared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.1.6.0, Culture=neutral, PublicKeyToken=null">

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="4.6.2" targetFramework="net452" />
   <package id="FluentValidation" version="7.2.1" targetFramework="net452" />
-  <package id="Halibut" version="4.3.23" targetFramework="net452" />
+  <package id="Halibut" version="4.3.24" targetFramework="net452" />
   <package id="MaterialDesignColors" version="1.2.0" targetFramework="net452" />
   <package id="MaterialDesignThemes" version="2.5.0.1205" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
@@ -20,7 +20,7 @@
   <package id="Octopus.Client" version="7.1.1" targetFramework="net452" />
   <package id="Octopus.Configuration" version="2.0.1" targetFramework="net452" />
   <package id="Octopus.Diagnostics" version="1.3.0" targetFramework="net452" />
-  <package id="Octopus.Shared" version="4.13.6" targetFramework="net452" />
+  <package id="Octopus.Shared" version="4.13.7" targetFramework="net452" />
   <package id="Octopus.Time" version="1.1.6" targetFramework="net452" />
   <package id="Portable.BouncyCastle" version="1.8.4" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
     <PackageReference Include="Octopus.Client" Version="7.1.1" />
-    <PackageReference Include="Octopus.Shared" Version="4.13.6" />
+    <PackageReference Include="Octopus.Shared" Version="4.13.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The response is now logged when remote identity is unknown:

```
2019-09-26 12:13:33 [Error] "https://google.com/"             4  "Response:"
2019-09-26 12:13:33 [Error] "https://google.com/"             4  "HTTP/1.0 400 Bad Request"
2019-09-26 12:13:33 [Error] "https://google.com/"             4  "Content-Type: text/html; charset=UTF-8
Referrer-Policy: no-referrer
Content-Length: 1555
Date: Thu, 26 Sep 2019 02:13:35 GMT

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content=\"initial-scale=1, minimum-scale=1, width=device-width\">
  <title>Error 400 (Bad Request)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px)
{body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/bran
ding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>400.</b> <ins>That's an error.</ins>
  <p>Your client has issued a malformed or illegal request.  <ins>That's all we know.</ins>
"
```

Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/168

See https://github.com/OctopusDeploy/Halibut/commit/d70d8076023c7890f4ea72bf9e206fc4a7e93bb3