### PR TITLE
Validate provided instance name in all commands

### DIFF
--- a/source/Octopus.Tentacle/Commands/ConfigureCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ConfigureCommand.cs
@@ -88,6 +88,7 @@ namespace Octopus.Tentacle.Commands
 
         protected override void Start()
         {
+            base.Start();
             if (resetTrust)
             {
                 log.Info("Removing all trusted Octopus Servers...");

--- a/source/Octopus.Tentacle/Commands/DeregisterMachineCommand.cs
+++ b/source/Octopus.Tentacle/Commands/DeregisterMachineCommand.cs
@@ -46,6 +46,7 @@ namespace Octopus.Tentacle.Commands
 
         protected override void Start()
         {
+            base.Start();
             StartAsync().GetAwaiter().GetResult();
         }
 

--- a/source/Octopus.Tentacle/Commands/DeregisterWorkerCommand.cs
+++ b/source/Octopus.Tentacle/Commands/DeregisterWorkerCommand.cs
@@ -46,6 +46,7 @@ namespace Octopus.Tentacle.Commands
 
         protected override void Start()
         {
+            base.Start();
             StartAsync().GetAwaiter().GetResult();
         }
 

--- a/source/Octopus.Tentacle/Commands/ImportCertificateCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ImportCertificateCommand.cs
@@ -34,6 +34,7 @@ namespace Octopus.Tentacle.Commands
 
         protected override void Start()
         {
+            base.Start();
             if (!fromRegistry && string.IsNullOrWhiteSpace(importFile))
                 throw new ControlledFailureException("Please specify the certificate to import.");
 

--- a/source/Octopus.Tentacle/Commands/NewCertificateCommand.cs
+++ b/source/Octopus.Tentacle/Commands/NewCertificateCommand.cs
@@ -40,7 +40,7 @@ namespace Octopus.Tentacle.Commands
 
         protected override void Start()
         {
-
+            base.Start();
             if (preserve && !string.IsNullOrWhiteSpace(exportFile))
                 throw new ControlledFailureException("Invalid command: --if-blank and --export-file cannot be specified together");
             if (preserve && !string.IsNullOrWhiteSpace(exportPfx))

--- a/source/Octopus.Tentacle/Commands/PollCommand.cs
+++ b/source/Octopus.Tentacle/Commands/PollCommand.cs
@@ -50,6 +50,7 @@ namespace Octopus.Tentacle.Commands
 
         protected override void Start()
         {
+            base.Start();
             StartAsync().GetAwaiter().GetResult();
         }
 

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -75,6 +75,7 @@ namespace Octopus.Tentacle.Commands
 
         protected override void Start()
         {
+            base.Start();
             StartAsync().GetAwaiter().GetResult();
         }
 

--- a/source/Octopus.Tentacle/Commands/ServerCommsCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ServerCommsCommand.cs
@@ -40,6 +40,7 @@ namespace Octopus.Tentacle.Commands
             if (!distinctTrustedThumbprints.Any())
                 throw new ControlledFailureException("Before server communications can be modified, trust must be established with the configure command");
 
+            base.Start();
             if (string.IsNullOrWhiteSpace(serverThumbprint))
             {
                 if (distinctTrustedThumbprints.Count() != 1)

--- a/source/Octopus.Tentacle/Commands/UpdateTrustCommand.cs
+++ b/source/Octopus.Tentacle/Commands/UpdateTrustCommand.cs
@@ -38,6 +38,7 @@ namespace Octopus.Tentacle.Commands
 
         protected override void Start()
         {
+            base.Start();
             CheckArgs();
 
             log.Info($"Updating Octopus servers thumbprint from {oldThumbprint} to {newThumbprint}");


### PR DESCRIPTION
To prevent ugly exceptions

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/172


# before

```
PS> .\Tentacle.exe agent --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe checkservices --instance foo
Unrecognized command line arguments: --instance foo

PS> .\Tentacle.exe configure --instance foo

PS> .\Tentacle.exe delete-instance --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe deregister-from --instance foo --server=http://localhost --apikey 1234
===============================================================================
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = TentacleConfiguration (ReflectionActivator), Services = [Octopus.Tentacle.Configuration.ITentacleConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.) (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Features.LazyDependencies.LazyRegistrationSource.<>c__DisplayClass5_0`1.<CreateLazyRegistration>b__1()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at Octopus.Tentacle.Commands.DeregisterMachineCommand.StartAsync
   at Octopus.Tentacle.Commands.DeregisterMachineCommand.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()

--Inner Exception--
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)

--Inner Exception--
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------


PS> .\Tentacle.exe deregister-worker --instance foo --server=http://localhost --apikey 1234
===============================================================================
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = TentacleConfiguration (ReflectionActivator), Services = [Octopus.Tentacle.Configuration.ITentacleConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.) (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Features.LazyDependencies.LazyRegistrationSource.<>c__DisplayClass5_0`1.<CreateLazyRegistration>b__1()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at Octopus.Tentacle.Commands.DeregisterWorkerCommand.StartAsync
   at Octopus.Tentacle.Commands.DeregisterWorkerCommand.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()

--Inner Exception--
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)

--Inner Exception--
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------


PS> .\Tentacle.exe extract --instance foo
Unrecognized command line arguments: --instance foo

PS> .\Tentacle.exe import-certificate --instance foo from-file=c:\temp\foo.pfx
Importing the certificate stored in PFX file in c:\temp\foo.pfx...
===============================================================================
The system cannot find the file specified.

System.Security.Cryptography.CryptographicException
   at System.Security.Cryptography.X509Certificates.X509Certificate2Collection.LoadStoreFromFile(String fileName, String password, UInt32 dwFlags, Boolean persistKeyContainers)
   at System.Security.Cryptography.X509Certificates.X509Certificate2Collection.Import(String fileName, String password, X509KeyStorageFlags keyStorageFlags)
   at Octopus.Shared.Security.Certificates.CertificateEncoder.FromPfxFile(String pfxFilePath, String password)
   at Octopus.Tentacle.Commands.ImportCertificateCommand.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------


PS> .\Tentacle.exe list-instances --instance foo
Unrecognized command line arguments: --instance foo

PS> .\Tentacle.exe new-certificate --instance foo
===============================================================================
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = TentacleConfiguration (ReflectionActivator), Services = [Octopus.Tentacle.Configuration.ITentacleConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.) (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Features.LazyDependencies.LazyRegistrationSource.<>c__DisplayClass5_0`1.<CreateLazyRegistration>b__1()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at Octopus.Tentacle.Commands.NewCertificateCommand.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()

--Inner Exception--
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)

--Inner Exception--
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------


PS> .\Tentacle.exe polling-proxy --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe poll-server --instance foo --server=http://localhost --apikey 1234
===============================================================================
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = TentacleConfiguration (ReflectionActivator), Services = [Octopus.Tentacle.Configuration.ITentacleConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.) (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Features.LazyDependencies.LazyRegistrationSource.<>c__DisplayClass5_0`1.<CreateLazyRegistration>b__1()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at Octopus.Tentacle.Commands.PollCommand.StartAsync
   at Octopus.Tentacle.Commands.PollCommand.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()

--Inner Exception--
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)

--Inner Exception--
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------


PS> .\Tentacle.exe proxy --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe register-with --instance foo --server=http://localhost --apikey 1234 --environment dev
===============================================================================
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = TentacleConfiguration (ReflectionActivator), Services = [Octopus.Tentacle.Configuration.ITentacleConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.) (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Features.LazyDependencies.LazyRegistrationSource.<>c__DisplayClass5_0`1.<CreateLazyRegistration>b__1()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at Octopus.Tentacle.Commands.RegisterMachineCommandBase`1.StartAsync
   at Octopus.Tentacle.Commands.RegisterMachineCommandBase`1.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()

--Inner Exception--
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)

--Inner Exception--
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------


PS> .\Tentacle.exe register-worker --instance foo --server=http://localhost --apikey 1234 --workerpool MyPool
===============================================================================
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = TentacleConfiguration (ReflectionActivator), Services = [Octopus.Tentacle.Configuration.ITentacleConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.) (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Features.LazyDependencies.LazyRegistrationSource.<>c__DisplayClass5_0`1.<CreateLazyRegistration>b__1()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at Octopus.Tentacle.Commands.RegisterMachineCommandBase`1.StartAsync
   at Octopus.Tentacle.Commands.RegisterMachineCommandBase`1.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()

--Inner Exception--
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)

--Inner Exception--
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------


PS> .\Tentacle.exe server-comms --instance foo
===============================================================================
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = TentacleConfiguration (ReflectionActivator), Services = [Octopus.Tentacle.Configuration.ITentacleConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.) (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Features.LazyDependencies.LazyRegistrationSource.<>c__DisplayClass5_0`1.<CreateLazyRegistration>b__1()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at Octopus.Tentacle.Commands.ServerCommsCommand.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()

--Inner Exception--
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)

--Inner Exception--
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------


PS> .\Tentacle.exe service --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe show-configuration --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe show-thumbprint --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe update-trust --instance foo --oldThumbprint 1234
Updating Octopus servers thumbprint from 1234 to 5678
===============================================================================
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = TentacleConfiguration (ReflectionActivator), Services = [Octopus.Tentacle.Configuration.ITentacleConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.) (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Features.LazyDependencies.LazyRegistrationSource.<>c__DisplayClass5_0`1.<CreateLazyRegistration>b__1()
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at Octopus.Tentacle.Commands.UpdateTrustCommand.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()

--Inner Exception--
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces. (See inner exception for details.)
Autofac.Core.DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)

--Inner Exception--
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------


PS> .\Tentacle.exe version --instance foo
Unrecognized command line arguments: --instance foo

PS> .\Tentacle.exe watchdog --instance foo
Unrecognized command line arguments: --instance foo
```

# after

```
PS> .\Tentacle.exe agent --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe checkservices --instance foo
Unrecognized command line arguments: --instance foo

PS> .\Tentacle.exe configure --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe delete-instance --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe deregister-from --instance foo --server=http://localhost --apikey 1234
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe deregister-worker --instance foo --server=http://localhost --apikey 1234
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe extract --instance foo
Unrecognized command line arguments: --instance foo

PS> .\Tentacle.exe import-certificate --instance foo from-file=c:\temp\foo.pfx
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe list-instances --instance foo
Unrecognized command line arguments: --instance foo

PS> .\Tentacle.exe new-certificate --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe polling-proxy --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe poll-server --instance foo --server=http://localhost --apikey 1234
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe proxy --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe register-with --instance foo --server=http://localhost --apikey 1234 --environment dev
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe register-worker --instance foo --server=http://localhost --apikey 1234 --workerpool MyPool
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe server-comms --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe service --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe show-configuration --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe show-thumbprint --instance foo
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe update-trust --instance foo --oldThumbprint 1234
Instance foo of Tentacle has not been configured on this machine. Available instances: anotherinstance, AppDeploy-Worker, enh-metrics-Tentacle1, hapolling, HealthCheck3, locallistening, localtentacle, newpollingworker, polling, polling3, polling-tentacle, Tentacle, test-with-spaces.

PS> .\Tentacle.exe version --instance foo
Unrecognized command line arguments: --instance foo

PS> .\Tentacle.exe watchdog --instance foo
Unrecognized command line arguments: --instance foo
```