### PR TITLE
Add validation for file existence in import-certificate command

### DIFF
--- a/source/Octopus.Tentacle/Commands/ImportCertificateCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ImportCertificateCommand.cs
@@ -54,6 +54,9 @@ namespace Octopus.Tentacle.Commands
             }
             else if (!string.IsNullOrWhiteSpace(importFile))
             {
+                if (!File.Exists(importFile))
+                    throw new ControlledFailureException($"Certificate '{importFile}' was not found.");
+                
                 var fileExtension = Path.GetExtension(importFile);
 
                 //We assume if the file does not end in .pfx that it is the legacy base64 encoded certificate, however if this fails we should still attempt to read as the PFX format.


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/174

# before
```
PS> .\Tentacle.exe import-certificate --instance foo from-file=c:\temp\foo.pfx
Importing the certificate stored in PFX file in c:\temp\foo.pfx...
===============================================================================
The system cannot find the file specified.

System.Security.Cryptography.CryptographicException
   at System.Security.Cryptography.X509Certificates.X509Certificate2Collection.LoadStoreFromFile(String fileName, String password, UInt32 dwFlags, Boolean persistKeyContainers)
   at System.Security.Cryptography.X509Certificates.X509Certificate2Collection.Import(String fileName, String password, X509KeyStorageFlags keyStorageFlags)
   at Octopus.Shared.Security.Certificates.CertificateEncoder.FromPfxFile(String pfxFilePath, String password)
   at Octopus.Tentacle.Commands.ImportCertificateCommand.Start()
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Users\matt\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------
```

# after

```
PS> .\Tentacle.exe import-certificate --instance foo --from-file=c:\temp\foo.pfx
Certificate 'c:\temp\foo.pfx' was not found.
```