### PR TITLE
Improved development experience on non-windows environments

### DIFF
--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceFixture.cs
@@ -74,14 +74,15 @@ namespace Octopus.Tentacle.Tests.Integration
                 Thread.Sleep(100);
             }
 
-            var bashExpectedResult = $"ping: {guid}: Name or service not known";
+            // The specific bash results might vary depending on the specific platform you are on, which each may have different editions of `ping`
+            var bashExpectedResults = new [] {$"ping: {guid}: Name or service not known", $"ping: {guid}: No address associated with hostname"};
             var cmdExpectedResult = $"Ping request could not find host {guid}. Please check the name and try again.";
             
             var finalStatus = service.CompleteScript(new CompleteScriptCommand(ticket, 0));
             DumpLog(finalStatus);
             Assert.That(finalStatus.State, Is.EqualTo(ProcessState.Complete));
             Assert.That(finalStatus.ExitCode, Is.Not.EqualTo(0));
-            finalStatus.Logs.Select(l => l.Text).Should().Contain(PlatformDetection.IsRunningOnWindows ? cmdExpectedResult : bashExpectedResult);
+            finalStatus.Logs.Select(l => l.Text).Should().IntersectWith(PlatformDetection.IsRunningOnWindows ? new [] {cmdExpectedResult} : bashExpectedResults);
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -2,10 +2,16 @@
   <PropertyGroup>
     <RootNamespace>Octopus.Tentacle.Tests</RootNamespace>
     <AssemblyName>Octopus.Tentacle.Tests</AssemblyName>
-    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -3,13 +3,19 @@
     <RootNamespace>Octopus.Tentacle</RootNamespace>
     <AssemblyName>Tentacle</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputType>Exe</OutputType>
     <NoWin32Manifest>true</NoWin32Manifest>
     <OutputPath>bin\</OutputPath>
     <ApplicationManifest>Tentacle.exe.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
+    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
- You can now open the projects within the `TentacleNetcore.sln` solution on non-windows machines
- The tests should all pass on non-windows machines