### PR TITLE
Update Octopus.Shared to 4.13.12.

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -392,8 +392,8 @@
       <HintPath>..\packages\FluentValidation.7.2.1\lib\net45\FluentValidation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Halibut, Version=4.3.25.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Halibut.4.3.25\lib\net45\Halibut.dll</HintPath>
+    <Reference Include="Halibut, Version=4.3.26.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Halibut.4.3.26\lib\net45\Halibut.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MaterialDesignColors, Version=1.2.0.325, Culture=neutral, PublicKeyToken=null">
@@ -469,12 +469,16 @@
       <HintPath>..\packages\Octopus.Diagnostics.1.3.0\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Shared, Version=4.13.9.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Octopus.Shared.4.13.9\lib\net45\Octopus.Shared.dll</HintPath>
+    <Reference Include="Octopus.Shared, Version=4.13.12.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Octopus.Shared.4.13.12\lib\net45\Octopus.Shared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.1.6.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\Octopus.Time.1.1.6\lib\netstandard1.0\Octopus.Time.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Polly, Version=5.3.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Polly.5.3.1\lib\net45\Polly.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="4.6.2" targetFramework="net452" />
   <package id="FluentValidation" version="7.2.1" targetFramework="net452" />
-  <package id="Halibut" version="4.3.25" targetFramework="net452" />
+  <package id="Halibut" version="4.3.26" targetFramework="net452" />
   <package id="MaterialDesignColors" version="1.2.0" targetFramework="net452" />
   <package id="MaterialDesignThemes" version="2.5.0.1205" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
@@ -20,8 +20,9 @@
   <package id="Octopus.Client" version="7.1.1" targetFramework="net452" />
   <package id="Octopus.Configuration" version="2.0.1" targetFramework="net452" />
   <package id="Octopus.Diagnostics" version="1.3.0" targetFramework="net452" />
-  <package id="Octopus.Shared" version="4.13.9" targetFramework="net452" />
+  <package id="Octopus.Shared" version="4.13.12" targetFramework="net452" />
   <package id="Octopus.Time" version="1.1.6" targetFramework="net452" />
+  <package id="Polly" version="5.3.1" targetFramework="net452" />
   <package id="Portable.BouncyCastle" version="1.8.4" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
     <PackageReference Include="Octopus.Client" Version="7.1.1" />
-    <PackageReference Include="Octopus.Shared" Version="4.13.9" />
+    <PackageReference Include="Octopus.Shared" Version="4.13.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Octopus.Shared 4.13.12 includes Halibut 4.3.26, which contains a fix for high IO usage on Windows machines when tentacles are in listening mode.

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/177
Relates to https://github.com/OctopusDeploy/OctopusShared/pull/85
Relates to https://github.com/OctopusDeploy/Issues/issues/6035