### PR TITLE
Removed Debug Code to Check Major Verison of Powershell

### DIFF
--- a/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
+++ b/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
@@ -44,7 +44,7 @@ namespace Octopus.Manager.Tentacle.PreReq
 
                 commandLineOutput = $"{commandLineOutput}{Environment.NewLine}{stdOut}{Environment.NewLine}{stdErr}";
 
-                return false;// outputText.Contains("Major");
+                return outputText.Contains("Major");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes bug where it always says "Windows Powershell 2.0 or above is unavailable" 