### PR TITLE
Update Shared to get system log interface

### DIFF
--- a/source/Octopus.Manager.Tentacle/Infrastructure/TextBoxLogger.cs
+++ b/source/Octopus.Manager.Tentacle/Infrastructure/TextBoxLogger.cs
@@ -50,11 +50,6 @@ namespace Octopus.Manager.Tentacle.Infrastructure
             foreach (var log in logEvents) WriteEvent(log);
         }
 
-        public override IDisposable WithinBlock(ILogContext logContext)
-        {
-            return null;
-        }
-
         public override void Flush()
         {
         }

--- a/source/Octopus.Manager.Tentacle/Infrastructure/UnhandledErrorTrapper.cs
+++ b/source/Octopus.Manager.Tentacle/Infrastructure/UnhandledErrorTrapper.cs
@@ -9,7 +9,7 @@ namespace Octopus.Manager.Tentacle.Infrastructure
 {
     public static class UnhandledErrorTrapper
     {
-        static readonly ILog Log = Shared.Diagnostics.Log.Octopus();
+        static readonly ILog Log = Shared.Diagnostics.SystemLog.Instance;
 
         public static void Initialize()
         {

--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -392,8 +392,8 @@
       <HintPath>..\packages\FluentValidation.7.2.1\lib\net45\FluentValidation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Halibut, Version=4.3.26.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Halibut.4.3.26\lib\net45\Halibut.dll</HintPath>
+    <Reference Include="Halibut, Version=4.3.27.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Halibut.4.3.27\lib\net45\Halibut.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MaterialDesignColors, Version=1.2.0.325, Culture=neutral, PublicKeyToken=null">
@@ -465,12 +465,12 @@
       <HintPath>..\packages\Octopus.Configuration.2.0.1\lib\net45\Octopus.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Diagnostics, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Octopus.Diagnostics.1.3.0\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
+    <Reference Include="Octopus.Diagnostics, Version=1.3.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Octopus.Diagnostics.1.3.1-frank-systemlog0001\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Shared, Version=4.13.12.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Octopus.Shared.4.13.12\lib\net45\Octopus.Shared.dll</HintPath>
+    <Reference Include="Octopus.Shared, Version=5.0.4.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Octopus.Shared.5.0.4-frank-systemlog1\lib\net45\Octopus.Shared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.1.6.0, Culture=neutral, PublicKeyToken=null">

--- a/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
+++ b/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
@@ -40,7 +40,7 @@ namespace Octopus.Manager.Tentacle.PreReq
                     s => stdErr.WriteLine($"ERR: {s}"));
 
                 var outputText = stdOut.ToString();
-                Log.Octopus().Verbose("PowerShell prerequisite check output: " + outputText);
+                SystemLog.Instance.Verbose("PowerShell prerequisite check output: " + outputText);
 
                 commandLineOutput = $"{commandLineOutput}{Environment.NewLine}{stdOut}{Environment.NewLine}{stdErr}";
 

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManager/TentacleManagerModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManager/TentacleManagerModel.cs
@@ -154,7 +154,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.TentacleManager
                 new CertificateGenerator(),
                 new ProxyConfiguration(keyStore),
                 new PollingProxyConfiguration(keyStore),
-                Shared.Diagnostics.Log.Octopus()
+                Shared.Diagnostics.SystemLog.Instance
             );
 
             pollsServers = false;

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManager/TentacleManagerView.xaml.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManager/TentacleManagerView.xaml.cs
@@ -60,7 +60,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.TentacleManager
                 var defaultInstall = instances.SingleOrDefault(s => s.InstanceName == instanceSelection.SelectedInstance);
                 if (defaultInstall != null && !File.Exists(defaultInstall.ConfigurationFilePath))
                 {
-                    Log.Octopus().WarnFormat("An instance of {0} named {1} was configured, but the associated configuration file {2} does not exist. Deleting the instance.", defaultInstall.ApplicationName, defaultInstall.InstanceName, defaultInstall.ConfigurationFilePath);
+                    SystemLog.Instance.WarnFormat("An instance of {0} named {1} was configured, but the associated configuration file {2} does not exist. Deleting the instance.", defaultInstall.ApplicationName, defaultInstall.InstanceName, defaultInstall.ConfigurationFilePath);
                     instanceStore.DeleteInstance(defaultInstall);
                     defaultInstall = null;
                 }

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="4.6.2" targetFramework="net452" />
   <package id="FluentValidation" version="7.2.1" targetFramework="net452" />
-  <package id="Halibut" version="4.3.26" targetFramework="net452" />
+  <package id="Halibut" version="4.3.27" targetFramework="net452" />
   <package id="MaterialDesignColors" version="1.2.0" targetFramework="net452" />
   <package id="MaterialDesignThemes" version="2.5.0.1205" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
@@ -19,8 +19,8 @@
   <package id="NuGet.Versioning" version="3.6.0-octopus-58692" targetFramework="net452" />
   <package id="Octopus.Client" version="7.1.1" targetFramework="net452" />
   <package id="Octopus.Configuration" version="2.0.1" targetFramework="net452" />
-  <package id="Octopus.Diagnostics" version="1.3.0" targetFramework="net452" />
-  <package id="Octopus.Shared" version="4.13.12" targetFramework="net452" />
+  <package id="Octopus.Diagnostics" version="1.3.1-frank-systemlog0001" targetFramework="net452" />
+  <package id="Octopus.Shared" version="5.0.4-frank-systemlog1" targetFramework="net452" />
   <package id="Octopus.Time" version="1.1.6" targetFramework="net452" />
   <package id="Polly" version="5.3.1" targetFramework="net452" />
   <package id="Portable.BouncyCastle" version="1.8.4" targetFramework="net452" />

--- a/source/Octopus.Tentacle.Tests/Support/InMemoryLog.cs
+++ b/source/Octopus.Tentacle.Tests/Support/InMemoryLog.cs
@@ -19,7 +19,7 @@ namespace Octopus.Tentacle.Tests.Support
 
         public InMemoryLog(ILog log)
         {
-            this.log = log ?? Log.Octopus();
+            this.log = log ?? SystemLog.Instance;
         }
 
         public override ILogContext CurrentContext => new LogContext();
@@ -33,11 +33,6 @@ namespace Octopus.Tentacle.Tests.Support
         protected override void WriteEvents(IList<LogEvent> logEvents)
         {
             throw new NotImplementedException();
-        }
-
-        public override IDisposable WithinBlock(ILogContext logContext)
-        {
-            return null;
         }
 
         public override void Flush()

--- a/source/Octopus.Tentacle/Commands/ExtractCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ExtractCommand.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Commands
     public class ExtractCommand : AbstractCommand
     {
         readonly Lazy<IPackageInstaller> packageInstaller;
-        readonly ILog log = Log.Octopus();
+        readonly ILog log = SystemLog.Instance;
         string packageFile;
         string destinationDirectory;
 

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Communications
         readonly ITentacleConfiguration configuration;
         readonly HalibutRuntime halibut;
         readonly IProxyConfigParser proxyConfigParser;
-        readonly ILog log = Log.Octopus();
+        readonly ILog log = SystemLog.Instance;
 
         public HalibutInitializer(ITentacleConfiguration configuration, HalibutRuntime halibut, IProxyConfigParser proxyConfigParser)
         {
@@ -37,7 +37,7 @@ namespace Octopus.Tentacle.Communications
 
             if (configuration.NoListen)
             {
-                Log.Octopus().Info("Agent will not listen on any TCP ports");
+                SystemLog.Instance.Info("Agent will not listen on any TCP ports");
                 return;
             }
 
@@ -86,7 +86,7 @@ namespace Octopus.Tentacle.Communications
             {
                 if (pollingEndPoint.Address == null)
                 {
-                    Log.Octopus().WarnFormat("Configured to connect to server {0}, but its configuration is incomplete; skipping.", pollingEndPoint);
+                    SystemLog.Instance.WarnFormat("Configured to connect to server {0}, but its configuration is incomplete; skipping.", pollingEndPoint);
                     continue;
                 }
                 if (pollingEndPoint.SubscriptionId == null)

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -23,7 +23,7 @@
     </PackageReference>
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
     <PackageReference Include="Octopus.Client" Version="7.1.1" />
-    <PackageReference Include="Octopus.Shared" Version="4.13.12" />
+    <PackageReference Include="Octopus.Shared" Version="5.0.4-frank-systemlog1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
+++ b/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
@@ -12,7 +12,7 @@ namespace Octopus.Tentacle.Services.FileTransfer
     [Service]
     public class FileTransferService : IFileTransferService
     {
-        readonly ILog log = Log.Octopus();
+        readonly ILog log = SystemLog.Instance;
         readonly IOctopusFileSystem fileSystem;
         readonly IHomeConfiguration home;
 


### PR DESCRIPTION
Server PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/5040

# Background
Tentacle only has a system log (no task log), so it should be calling `SystemLog.Instance`.