### PR TITLE
Include runtime in folder name in test binaries packages

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -407,7 +407,7 @@ Task("__CreateBinariesNuGet")
         CleanDirectory(binariesPackageDir);
         CreateDirectory($"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.{rid}");
         CopyFiles($"{corePublishDir}/{rid}/*", $"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.{rid}");
-        DeleteFile($"{binariesPackageDir}/build/netcoreapp2.2/Tentacle/Tentacle.exe.manifest");
+        DeleteFile($"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.{rid}/Tentacle.exe.manifest");
         CleanBinariesDirectory($"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.{rid}");
         CopyFileToDirectory("./source/Octopus.Tentacle/Tentacle.Binaries.nuspec", binariesPackageDir);
         CopyFile("./source/Octopus.Tentacle/Tentacle.Binaries.targets", $"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.Binaries.{rid}.targets");


### PR DESCRIPTION
So we can put them into different folders when we use them in server e2e tests

That will help us use the linux tentacle when we're running on linux, and the windows tentacle when we're on windows