### PR TITLE
Use ordinal instead of invariant/current culture for string comparisons

### DIFF
--- a/source/Octopus.Manager.Tentacle/Controls/AutoCompleteTagControl.xaml.cs
+++ b/source/Octopus.Manager.Tentacle/Controls/AutoCompleteTagControl.xaml.cs
@@ -213,17 +213,17 @@ namespace Octopus.Manager.Tentacle.Controls
 
             if (item.IsCreateEntry)
             {
-                filterEventArgs.Accepted = !string.IsNullOrWhiteSpace(Text) && !SuggestedTags.Contains(Text, StringComparison.InvariantCultureIgnoreCase) && !SelectedTags.Contains(Text, StringComparison.InvariantCultureIgnoreCase);
+                filterEventArgs.Accepted = !string.IsNullOrWhiteSpace(Text) && !SuggestedTags.Contains(Text, StringComparison.OrdinalIgnoreCase) && !SelectedTags.Contains(Text, StringComparison.OrdinalIgnoreCase);
                 return;
             }
 
-            if (SelectedTags.Contains(item.Value, StringComparison.CurrentCultureIgnoreCase))
+            if (SelectedTags.Contains(item.Value, StringComparison.OrdinalIgnoreCase))
             {
                 filterEventArgs.Accepted = false;
                 return;
             }
 
-            if (item.Value.Contains(Text, StringComparison.CurrentCultureIgnoreCase))
+            if (item.Value.Contains(Text, StringComparison.OrdinalIgnoreCase))
             {
                 filterEventArgs.Accepted = true;
                 return;
@@ -251,9 +251,9 @@ namespace Octopus.Manager.Tentacle.Controls
 
         private bool AddTag(string value)
         {
-            if (SelectedTags.Contains(value, StringComparison.CurrentCultureIgnoreCase)) return false;
+            if (SelectedTags.Contains(value, StringComparison.OrdinalIgnoreCase)) return false;
 
-            var matchingSuggested = SuggestedTags.Find(value, StringComparison.CurrentCultureIgnoreCase);
+            var matchingSuggested = SuggestedTags.Find(value, StringComparison.OrdinalIgnoreCase);
 
             SelectedTags.Add(matchingSuggested ?? value);
             return true;

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/TentacleSetupWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/TentacleSetupWizardModel.cs
@@ -780,7 +780,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
 
             void UpdateSelection(ObservableCollection<string> selectedCollection, IEnumerable<string> potentialValues)
             {
-                var potentialValuesSet = new HashSet<string>(potentialValues, StringComparer.InvariantCulture);
+                var potentialValuesSet = new HashSet<string>(potentialValues, StringComparer.Ordinal);
                 selectedCollection.RemoveWhere(v => !potentialValuesSet.Contains(v));
             }
         }

--- a/source/Octopus.Manager.Tentacle/Validators/InstanceName.cs
+++ b/source/Octopus.Manager.Tentacle/Validators/InstanceName.cs
@@ -41,6 +41,6 @@ namespace Octopus.Manager.Tentacle.Validators
         }
 
         public static readonly DependencyProperty ExistingInstanceNamesProperty = DependencyProperty.Register(
-            "ExistingInstanceNames", typeof(HashSet<string>), typeof(InstanceNameWrapper), new PropertyMetadata(new HashSet<string>(StringComparer.CurrentCultureIgnoreCase)));
+            "ExistingInstanceNames", typeof(HashSet<string>), typeof(InstanceNameWrapper), new PropertyMetadata(new HashSet<string>(StringComparer.OrdinalIgnoreCase)));
     }
 }

--- a/source/Octopus.Tentacle.Tests/Support/InMemoryLog.cs
+++ b/source/Octopus.Tentacle.Tests/Support/InMemoryLog.cs
@@ -53,24 +53,5 @@ namespace Octopus.Tentacle.Tests.Support
         {
             return logText.ToString();
         }
-
-        public void AssertContains(LogCategory category, string partialString)
-        {
-            var match = GetLog()
-                .Split(new[] {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries)
-                .FirstOrDefault(line => line.StartsWith(category.ToString()) &&
-                    CultureInfo.CurrentCulture.CompareInfo.IndexOf(line, partialString, CompareOptions.IgnoreCase) >= 0);
-
-            if (match == null) throw new Exception($"The log does not contain any {category} entry containing the substring {partialString}.");
-        }
-
-        public void AssertContains(string partialString)
-        {
-            var match = GetLog()
-                .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
-                .FirstOrDefault(line => CultureInfo.CurrentCulture.CompareInfo.IndexOf(line, partialString, CompareOptions.IgnoreCase) >= 0);
-
-            if (match == null) throw new Exception($"The log does not contain any entry containing the substring {partialString}.");
-        }
     }
 }


### PR DESCRIPTION
We should default to using ordinal unless we actually want to deal with culture

 https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1309?view=vs-2019

Our Ubuntu18 agent exposed this because its InvariantCulture + CurrentCulture behaved differently.