### PR TITLE
During linux installation, the API key is not hidden

### DIFF
--- a/scripts/configure-tentacle.sh
+++ b/scripts/configure-tentacle.sh
@@ -131,7 +131,7 @@ function setupPollingTentacle {
         *)
             while [ -z "$apikey" ] 
             do
-                read -p 'API-Key: ' apikey
+                read -s -p 'API-Key: ' apikey
             done 
             auth="--apiKey \"$apikey\""
             displayauth="--apiKey \"API-XXXXXXXXXXXXXXXXXXXXXXXXXX\""


### PR DESCRIPTION
This PR makes the API text entry work like the password entry, i.e. hides any secrets on the console.

