### PR TITLE
API Key printed to screen during linux installation

### DIFF
--- a/scripts/configure-tentacle.sh
+++ b/scripts/configure-tentacle.sh
@@ -131,7 +131,7 @@ function setupPollingTentacle {
         *)
             while [ -z "$apikey" ] 
             do
-                read -p 'API-Key: ' apikey
+                read -s -p 'API-Key: ' apikey
             done 
             auth="--apiKey \"$apikey\""
             displayauth="--apiKey \"API-XXXXXXXXXXXXXXXXXXXXXXXXXX\""


### PR DESCRIPTION
During polling tentacle installation, the API Key is printed to screen. This should be treated with the same or more sensitivity as a password.

> This PR is a deliberate duplicate of #194 because I think the branch name was causing CI failures. Given that that branch was approved, I'll merge this one without approval.

https://trello.com/c/MKNzU6Lq/3079-https-githubcom-octopusdeploy-octopustentacle-pull-194