### PR TITLE
Version-bump Halibut and Octopus.Shared libraries to remove the immediate-retry bug

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -392,8 +392,8 @@
       <HintPath>..\packages\FluentValidation.7.2.1\lib\net45\FluentValidation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Halibut, Version=4.3.27.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Halibut.4.3.27\lib\net45\Halibut.dll</HintPath>
+    <Reference Include="Halibut, Version=4.3.31.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Halibut.4.3.31\lib\net45\Halibut.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MaterialDesignColors, Version=1.2.0.325, Culture=neutral, PublicKeyToken=null">
@@ -469,8 +469,8 @@
       <HintPath>..\packages\Octopus.Diagnostics.1.3.0\lib\netstandard1.0\Octopus.Diagnostics.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Shared, Version=5.0.6.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Octopus.Shared.5.0.6\lib\net45\Octopus.Shared.dll</HintPath>
+    <Reference Include="Octopus.Shared, Version=5.0.12.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Octopus.Shared.5.0.12\lib\net45\Octopus.Shared.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Octopus.Time, Version=1.1.6.0, Culture=neutral, PublicKeyToken=null">

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="4.6.2" targetFramework="net452" />
   <package id="FluentValidation" version="7.2.1" targetFramework="net452" />
-  <package id="Halibut" version="4.3.27" targetFramework="net452" />
+  <package id="Halibut" version="4.3.31" targetFramework="net452" />
   <package id="MaterialDesignColors" version="1.2.0" targetFramework="net452" />
   <package id="MaterialDesignThemes" version="2.5.0.1205" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
@@ -20,7 +20,7 @@
   <package id="Octopus.Client" version="7.1.1" targetFramework="net452" />
   <package id="Octopus.Configuration" version="2.0.1" targetFramework="net452" />
   <package id="Octopus.Diagnostics" version="1.3.0" targetFramework="net452" />
-  <package id="Octopus.Shared" version="5.0.6" targetFramework="net452" />
+  <package id="Octopus.Shared" version="5.0.12" targetFramework="net452" />
   <package id="Octopus.Time" version="1.1.6" targetFramework="net452" />
   <package id="Polly" version="5.3.1" targetFramework="net452" />
   <package id="Portable.BouncyCastle" version="1.8.4" targetFramework="net452" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -29,7 +29,7 @@
     </PackageReference>
     <PackageReference Include="Octopus.Configuration" Version="2.0.1" />
     <PackageReference Include="Octopus.Client" Version="7.1.1" />
-    <PackageReference Include="Octopus.Shared" Version="5.0.6" />
+    <PackageReference Include="Octopus.Shared" Version="5.0.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We have a DDoS scenario in Halibut where for particular flavours of `SocketException` Halibut will immediately retry to establish a TCP connection. Unfortunately, that flavour of `SocketException` is most likely to occur when Octopus Server is experiencing thread starvation. This doesn't end well :)

[HelpScout ticket](https://secure.helpscout.net/conversation/1203338483/66583?folderId=954335)

[Slack thread](https://app.slack.com/client/T02G7QA31/CLQNM80U9/thread/CNHBHV2BX-1594681419.107000)

This PR version-bumps Halibut and Octopus.Shared (which references Halibut), which should mitigate part of the issue by introducing a retry delay for retries for any purpose. We still have some way to go to understand why we appear to be experiencing thread starvation within Octopus Server. Our suspicions currently fall on the .NET Core migration, but either way this mitigation should help in the meantime.