### PR TITLE
Version-bump Halibut to released version to pull in the new retry policy

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -392,8 +392,8 @@
       <HintPath>..\packages\FluentValidation.7.2.1\lib\net45\FluentValidation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Halibut, Version=4.3.31.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Halibut.4.3.31\lib\net45\Halibut.dll</HintPath>
+    <Reference Include="Halibut, Version=4.3.32.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Halibut.4.3.32\lib\net45\Halibut.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MaterialDesignColors, Version=1.2.0.325, Culture=neutral, PublicKeyToken=null">

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="4.6.2" targetFramework="net452" />
   <package id="FluentValidation" version="7.2.1" targetFramework="net452" />
-  <package id="Halibut" version="4.3.31" targetFramework="net452" />
+  <package id="Halibut" version="4.3.32" targetFramework="net452" />
   <package id="MaterialDesignColors" version="1.2.0" targetFramework="net452" />
   <package id="MaterialDesignThemes" version="2.5.0.1205" targetFramework="net452" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Halibut" Version="4.3.32" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
This PR attempts to partially address the thread starvation issues we're observing in Octopus Server in some circumstances.

Specifically, this version-bump pulls in the new retry policy introduced into Halibut in [this pull request](https://github.com/OctopusDeploy/Halibut/pull/122).

Addresses [this issue](https://github.com/OctopusDeploy/Issues/issues/6482).