### PR TITLE
Upgrade Tentacle to target .NET Core 3.1 instead of 2.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Currently we can only debug netcore apps running in WSL from VSCode, Visual Stud
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/source/Octopus.Tentacle/bin/netcoreapp2.2/Tentacle.dll",
+            "program": "${workspaceFolder}/source/Octopus.Tentacle/bin/netcoreapp3.1/Tentacle.dll",
             "args": ["run"],
             "cwd": "${workspaceFolder}/source/Octopus.Tentacle",
             "console": "internalConsole",
@@ -44,7 +44,7 @@ Currently we can only debug netcore apps running in WSL from VSCode, Visual Stud
     ]
 }
 ```
-- Make sure the build task (in `.vscode/tasks.json`) specifies the target framework, by inclusing `--framework=netcoreapp2.2` as a build arg, otherwise VSCode will attempt to build for all frameworks in the csproj and fail on full .Net framework. the build task should look similar to:
+- Make sure the build task (in `.vscode/tasks.json`) specifies the target framework, by inclusing `--framework=netcoreapp3.1` as a build arg, otherwise VSCode will attempt to build for all frameworks in the csproj and fail on full .Net framework. the build task should look similar to:
 ```
 {
     "label": "build",
@@ -52,7 +52,7 @@ Currently we can only debug netcore apps running in WSL from VSCode, Visual Stud
     "type": "process",
     "args": [
         "build",
-        "--framework=netcoreapp2.2",
+        "--framework=netcoreapp3.1",
         "${workspaceFolder}/source/Octopus.Tentacle/Octopus.Tentacle.csproj",
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"

--- a/build.cake
+++ b/build.cake
@@ -133,14 +133,14 @@ Task("__CreateLinuxPackages")
     DockerRunWithoutResult(new DockerContainerRunSettings {
         Rm = true,
         Tty = true,
-        Env = new string[] { 
+        Env = new string[] {
             $"VERSION={gitVersion.NuGetVersion}",
             "BINARIES_PATH=/app/",
             "PACKAGES_PATH=/artifacts",
             "SIGN_PRIVATE_KEY",
             "SIGN_PASSPHRASE"
         },
-        Volume = new string[] { 
+        Volume = new string[] {
             $"{Path.Combine(Environment.CurrentDirectory, "scripts")}:/scripts",
             $"{Path.Combine(Environment.CurrentDirectory, linuxPackageFeedsDir)}:/opt/linux-package-feeds",
             $"{Path.Combine(Environment.CurrentDirectory, corePublishDir, "linux-x64")}:/app",
@@ -148,8 +148,8 @@ Task("__CreateLinuxPackages")
         }
     }, "octopusdeploy/package-linux-docker:latest", "bash /scripts/package.sh");
 
-    CopyFiles("./source/Octopus.Tentacle/bin/netcoreapp2.2/linux-x64/*.deb", artifactsDir);
-    CopyFiles("./source/Octopus.Tentacle/bin/netcoreapp2.2/linux-x64/*.rpm", artifactsDir);
+    CopyFiles("./source/Octopus.Tentacle/bin/netcoreapp3.1/linux-x64/*.deb", artifactsDir);
+    CopyFiles("./source/Octopus.Tentacle/bin/netcoreapp3.1/linux-x64/*.rpm", artifactsDir);
 });
 
 Task("__CheckForbiddenWords")
@@ -257,7 +257,7 @@ Task("__DotnetPublish")
                 "./source/Octopus.Tentacle/Octopus.Tentacle.csproj",
                 new DotNetCorePublishSettings
                 {
-                    Framework = "netcoreapp2.2",
+                    Framework = "netcoreapp3.1",
                     Configuration = configuration,
                     OutputDirectory = $"{corePublishDir}/{rid}",
                     Runtime = rid,
@@ -282,7 +282,7 @@ Task("__SignBuiltFiles")
     // check that any unsigned libraries, that Octopus Deploy authors, get signed to play nice with security scanning tools
     // refer: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1551655877004400
     // decision re: no signing everything: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1557938890227100
-    var filesToSign = 
+    var filesToSign =
         GetFiles($"{coreWinPublishDir}/**/Octo*.exe",
             $"{coreWinPublishDir}/**/Octo*.dll",
             $"{coreWinPublishDir}/**/Tentacle.exe",
@@ -438,12 +438,12 @@ Task("__CreateBinariesNuGet")
     foreach(var rid in GetProjectRuntimeIds(@"./source/Octopus.Tentacle/Octopus.Tentacle.csproj"))
     {
         CleanDirectory(binariesPackageDir);
-        CreateDirectory($"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.{rid}");
-        CopyFiles($"{corePublishDir}/{rid}/*", $"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.{rid}");
-        DeleteFile($"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.{rid}/Tentacle.exe.manifest");
-        CleanBinariesDirectory($"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.{rid}");
+        CreateDirectory($"{binariesPackageDir}/build/netcoreapp3.1/Tentacle.{rid}");
+        CopyFiles($"{corePublishDir}/{rid}/*", $"{binariesPackageDir}/build/netcoreapp3.1/Tentacle.{rid}");
+        DeleteFile($"{binariesPackageDir}/build/netcoreapp3.1/Tentacle.{rid}/Tentacle.exe.manifest");
+        CleanBinariesDirectory($"{binariesPackageDir}/build/netcoreapp3.1/Tentacle.{rid}");
         CopyFileToDirectory("./source/Octopus.Tentacle/Tentacle.Binaries.nuspec", binariesPackageDir);
-        CopyFile("./source/Octopus.Tentacle/Tentacle.Binaries.targets", $"{binariesPackageDir}/build/netcoreapp2.2/Tentacle.Binaries.{rid}.targets");
+        CopyFile("./source/Octopus.Tentacle/Tentacle.Binaries.targets", $"{binariesPackageDir}/build/netcoreapp3.1/Tentacle.Binaries.{rid}.targets");
 
         NuGetPack(Path.Combine(binariesPackageDir, $"Tentacle.Binaries.nuspec"), new NuGetPackSettings {
             Version = gitVersion.NuGetVersion,

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -9,13 +9,13 @@
     <NoWin32Manifest>true</NoWin32Manifest>
     <OutputPath>bin\</OutputPath>
     <ApplicationManifest>Tentacle.exe.manifest</ApplicationManifest>
-    <AppConfig Condition="'$(TargetFramework)' == 'netcoreapp2.2'">app.netcore.config</AppConfig>
+    <AppConfig Condition="'$(TargetFramework)' == 'netcoreapp3.1'">app.netcore.config</AppConfig>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net452;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
The .NET Framework target remains unchanged at .NET 4.5.2.