### PR TITLE
Add ability to specify a machine policy when registering tentacle

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -39,6 +39,7 @@ ENV ServerPort=10943
 ENV ServerApiKey="API-SOURCE-THIS-FROM-YOUR-OCTOPUS-SERVER"
 ENV Space="Default"
 ENV WorkerPool="Default Worker Pool"
+ENV MachinePolicy="Default Machine Policy"
 ENV CommunicationsStype=TentacleActive
 ENV DISABLE_DIND=N
 ENV ACCEPT_EULA=N

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -29,4 +29,4 @@ mkdir -p $applicationsDirectory
 tentacle create-instance --instance "$instanceName" --config "$configurationDirectory/tentacle.config"
 tentacle new-certificate --instance "$instanceName" --if-blank
 tentacle configure --instance "$instanceName" --app "$applicationsDirectory" --noListen "True" --reset-trust
-tentacle register-worker --instance "$instanceName" --server "$ServerUrl" --name "$HOSTNAME" --comms-style "$CommunicationsStype" --server-comms-port $ServerPort --apiKey $ServerApiKey --space "$Space" --workerpool="$WorkerPool" --force
+tentacle register-worker --instance "$instanceName" --server "$ServerUrl" --name "$HOSTNAME" --comms-style "$CommunicationsStype" --server-comms-port $ServerPort --apiKey $ServerApiKey --space "$Space" --workerpool="$WorkerPool" --policy="$MachinePolicy" --force


### PR DESCRIPTION
We are in the process of using a Kubernetes deployment to provision self-registering workers within a kube cluster. Workers by default will be registered using the `Default Machine Policy`. When worker pods are terminated and recreated by the pod scheduler, the registrations will not be removed.

This PR is to enable a machine policy to be selected when registering a worker so that we can use a policy which automatically deletes unreachable/unhealthy workers.