### PR TITLE
Run Tentacle in non-interactive mode when running in a container

### DIFF
--- a/docker/linux/scripts/run-tentacle.sh
+++ b/docker/linux/scripts/run-tentacle.sh
@@ -8,4 +8,4 @@ else
     nohup /usr/local/bin/dockerd-entrypoint.sh dockerd &
 fi
 
-tentacle agent --instance Tentacle
+tentacle agent --instance Tentacle --noninteractive


### PR DESCRIPTION
... to prevent an immediate exit when running without an interactive terminal attached.

# Background

`Tentacle.exe` uses the `WaitForUserToExit` capability out of `Octopus.Shared` to detect when to exit when running as a console application.

- When running in a container with an interactive terminal attached (i.e. `docker run -it octopusdeploy/tentacle`) we're all good.
- When running in a container _without_ an interactive terminal attached (i.e. `docker run octopusdeploy/tentacle`) the Tentacle host exits immediately after calling `WaitForUserToExit()`. This is suboptimal.

Without making invasive changes to `Octopus.Shared` to support cross-platform `SIGHUP`/`SIGTERM` monitoring, the next best option is to just allocate a pseudo-terminal when running Tentacle in a container.

# Results

## Before

Tentacle containers running in a Kubernetes cluster exit immediately after successfully launching.

## After

Tentacle containers keep running as expected after launching.
