### PR TITLE
Ensures input read is treated as a line instead of separate words

### DIFF
--- a/scripts/configure-tentacle.sh
+++ b/scripts/configure-tentacle.sh
@@ -42,7 +42,7 @@ function showFinishedMessage {
 }
 
 function setupListeningTentacle {
-    instancename=$1
+    instancename=$@
     logpath="/etc/octopus"
     applicationpath="/home/Octopus/Applications"
     port="10933"
@@ -91,7 +91,7 @@ function setupListeningTentacle {
 }
 
 function setupPollingTentacle {
-    instancename=$1
+    instancename=$@
     displayname=$(hostname)
     logpath="/etc/octopus"
     applicationpath="/home/Octopus/Applications"


### PR DESCRIPTION
# Background

Fixes https://github.com/OctopusDeploy/Issues/issues/6574

## After

![image](https://user-images.githubusercontent.com/2706018/93551976-73c2e680-f9ae-11ea-93e2-90382f99e697.png)

# Testing

Here are the steps I used to test this pull request:

- Pulled the latest tentacle package from `build`
- Un-tarred the package on Ubuntu 20.04 running in WSL2
- Updated the base paths in `configure-tentacle.sh` to point to the extracted location
- Ran `configure-tentacle.sh` with appropriate input values to ensure spaces were tolerated correctly and the tentacle was registered in an Octopus instance as desired
- Tested with invalid characters to ensure they were appropriately sanitised still

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Existing automation scripts will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
