### PR TITLE
Create _artifacts.upload.filespec.json

### DIFF
--- a/_artifacts.upload.filespec.json
+++ b/_artifacts.upload.filespec.json
@@ -1,16 +1,10 @@
 {
   "files": [
-    {
-      "pattern": "_artifacts/chocolatey/*.nupkg",
-      "target": "chocolatey"
-    },
-    {
-      "pattern": "_artifacts/msi/*.msi",
-      "target": "msi"
-    },
-    {
-      "pattern": "_artifacts/zip/*",
-      "target": "zip"
-    }
+    { "pattern": "_artifacts/chocolatey/*", "target": "chocolatey" },
+    { "pattern": "_artifacts/deb/*", "target": "deb" },
+    { "pattern": "_artifacts/msi/*", "target": "msi" },
+    { "pattern": "_artifacts/nuget/*", "target": "nuget" },
+    { "pattern": "_artifacts/rpm/*", "target": "rpm" },
+    { "pattern": "_artifacts/zip/*", "target": "zip" }
   ]
 }


### PR DESCRIPTION
This is the filespec used by the Artifactory plugin for TeamCity to upload artifacts to their respective repositories.

We have the option to inline the filespec into the build configuration in TeamCity, or refer to a file in the repository. This is a test of the file in the repository pattern.

I decided to make the file name match the `_artifacts` folder naming convention to help people connect the two pieces of the puzzle together.

The filespec is a fairly simple JSON structure which isn't necessarily tied to Artifactory - we could use the same approach for a custom meta-runner.

See https://www.jfrog.com/confluence/display/JFROG/TeamCity+Artifactory+Plug-in
See https://www.jfrog.com/confluence/display/JFROG/Using+File+Specs

# Results

![image](https://user-images.githubusercontent.com/1627582/95828902-e5593f00-0d78-11eb-9223-2a66fc07a335.png)

We get a reasonably helpful error when the file is missing:

![image](https://user-images.githubusercontent.com/1627582/95830917-b55f6b00-0d7b-11eb-9ac7-3d77dad83738.png)

And the packages are all being pushed:

![image](https://user-images.githubusercontent.com/1627582/95835400-84823480-0d81-11eb-83f6-79b2fb94abf2.png)


# Review

Firstly, thanks for reviewing this pull request! :tada:

At the moment, this is experimental.

1. Look at the [build configuration](https://build.octopushq.com/admin/editRunType.html?id=buildType:OctopusDeploy_OctopusTentacle_BuildTentacleWindows&runnerId=RUNNER_241&cameFromUrl=%2Fadmin%2FeditBuildRunners.html%3Fid%3DbuildType%253AOctopusDeploy_OctopusTentacle_BuildTentacleWindows%26init%3D1&cameFromTitle=)
1. Look at the filespec.
1. Think about the available patterns. :)

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Existing automation scripts will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
