### PR TITLE
Use outputs from dotnet publish rather than dotnet build

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -1,23 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
-    <OutputType>WinExe</OutputType>
-    <OutputPath>bin</OutputPath>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IsPublishable>false</IsPublishable>
+    <OutputPath>bin</OutputPath>
+    <OutputType>WinExe</OutputType>
+    <PublishDir>../../_build/$(AssemblyName)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <TargetFrameworks>net452</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
-    <OutputPath>../../_build/$(AssemblyName)</OutputPath>
-    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Properties\Icon.ico</ApplicationIcon>
-  </PropertyGroup>
-  <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Framework)'=='net-452'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
     <IsPublishable>true</IsPublishable>
   </PropertyGroup>
 

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RootNamespace>Octopus.Tentacle.Tests</RootNamespace>
     <AssemblyName>Octopus.Tentacle.Tests</AssemblyName>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IsPublishable>true</IsPublishable>
+    <OutputPath>bin</OutputPath>
+    <PublishDir>../../_build/$(AssemblyName)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
+    <RootNamespace>Octopus.Tentacle.Tests</RootNamespace>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm64;linux-musl-x64</RuntimeIdentifiers>
-    <OutputPath>../../_build/$(AssemblyName)</OutputPath>
-    <IsPublishable>false</IsPublishable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -1,16 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<RootNamespace>Octopus.Tentacle</RootNamespace>
-		<AssemblyName>Tentacle</AssemblyName>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
-		<RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm64;linux-musl-x64</RuntimeIdentifiers>
-		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-		<OutputType>Exe</OutputType>
-		<NoWin32Manifest>true</NoWin32Manifest>
-		<OutputPath>../../_build/$(AssemblyName)</OutputPath>
-		<ApplicationManifest>Tentacle.exe.manifest</ApplicationManifest>
 		<AppConfig Condition="'$(TargetFramework)' == 'netcoreapp3.1'">app.netcore.config</AppConfig>
+		<ApplicationManifest>Tentacle.exe.manifest</ApplicationManifest>
+		<AssemblyName>Tentacle</AssemblyName>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<IsPublishable>true</IsPublishable>
+		<NoWin32Manifest>true</NoWin32Manifest>
+		<OutputPath>bin</OutputPath>
+		<OutputType>Exe</OutputType>
+		<PublishDir>../../_build/$(AssemblyName)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
+		<RootNamespace>Octopus.Tentacle</RootNamespace>
+		<RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm64;linux-musl-x64</RuntimeIdentifiers>
+		<TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/source/Octopus.Upgrader/Octopus.Upgrader.csproj
+++ b/source/Octopus.Upgrader/Octopus.Upgrader.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RootNamespace>Octopus.Upgrader</RootNamespace>
     <AssemblyName>Octopus.Upgrader</AssemblyName>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <OutputPath>../../_build/$(AssemblyName)</OutputPath>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPublishable>false</IsPublishable>
+    <OutputPath>bin</OutputPath>
+    <OutputType>Exe</OutputType>
+    <PublishDir>../../_build/$(AssemblyName)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
     <PublishReadyToRun>true</PublishReadyToRun>
-    <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
+    <RootNamespace>Octopus.Upgrader</RootNamespace>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
# Background

This pull request brings Tentacle more into line with the intentions behind `dotnet build` and `dotnet publish`. It was prompted by the omission of the `Octopus.Upgrader.exe` binary from the cross-platform bundle.

This PR:
- Modifies the `.csproj` files to place build outputs in the normal location (`bin/...`) and only publish outputs in shared locations.
- Sets the `dotnet publish` directories for each project to match (almost) where the `dotnet build` outputs were before.
- Re-includes the `Octopus.Upgrader.exe` binary in the cross-platform bundle, and adds assertions to Cakefile to ensure that appropriate binaries are included in future.
- Sorts `.csproj` elements alphabetically to help avoid duplication/overwriting of properties in the future.

# Testing

Here are the steps I used to test this pull request:
- Ran the `UpgradeTestScript` fixture in Octopus Server using  version 6.0.176 of Tentacle: FAILED (as expected - it was missing  `Octopus.Upgrader.exe`.
- Ran the `UpgradeTestScript` fixture in Octopus Server using  version 6.0.209-use-published-outputs of Tentacle: SUCCESS.

# Review

Firstly, thanks for reviewing this pull request! :tada:

- 👀 
- Green build
- Inspecting the contents of the `Octopus.Tentacle.CrossPlatformBundle.nupkg` build artifact to confirm that all is as expected.

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Existing automation scripts will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
