### PR TITLE
Downgrade the Octopus.Tentacle.Upgrader's framework target to net452 to match Tentacle

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -363,9 +363,7 @@ Task("Pack-CrossPlatformBundle")
         CopyFiles($"./source/Octopus.Tentacle.CrossPlatformBundle/Octopus.Tentacle.CrossPlatformBundle.nuspec", workingDir);
         CopyFile($"{artifactsDir}/msi/Octopus.Tentacle.{versionInfo.FullSemVer}.msi", $"{workingDir}/Octopus.Tentacle.msi");
         CopyFile($"{artifactsDir}/msi/Octopus.Tentacle.{versionInfo.FullSemVer}-x64.msi", $"{workingDir}/Octopus.Tentacle-x64.msi");
-        CopyFiles($"{buildDir}/Octopus.Tentacle.Upgrader/netcoreapp3.1/win-x64/*", workingDir);     // NOTE: This is packaged as a self-contained binary. It doesn't require
-                                                                                                    // .NET anything installed on the target, so it can happily upgrade any
-                                                                                                    // version of Tentacle: net452, netcoreapp3.1 or other.
+        CopyFiles($"{buildDir}/Octopus.Tentacle.Upgrader/net452/win-x64/*", workingDir);
 
         foreach (var framework in frameworks)
         {

--- a/source/Octopus.Tentacle.Upgrader/Octopus.Tentacle.Upgrader.csproj
+++ b/source/Octopus.Tentacle.Upgrader/Octopus.Tentacle.Upgrader.csproj
@@ -7,12 +7,9 @@
     <OutputPath>bin</OutputPath>
     <OutputType>Exe</OutputType>
     <PublishDir>../../_build/$(AssemblyName)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishSingleFile>true</PublishSingleFile>
     <RootNamespace>Octopus.Tentacle.Upgrader</RootNamespace>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
-    <SelfContained>true</SelfContained>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -20,7 +17,7 @@
     <Optimize>True</Optimize>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1' AND '$(RuntimeIdentifier)'=='win-x64'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net452' AND '$(RuntimeIdentifier)'=='win-x64'">
     <IsPublishable>true</IsPublishable>
   </PropertyGroup>
 
@@ -37,9 +34,12 @@
 		</Compile>
 	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-  </ItemGroup>
+	<ItemGroup>
+	  <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Reference Include="System.ServiceProcess" />
+	</ItemGroup>
 
 </Project>

--- a/source/Octopus.Tentacle.Upgrader/Program.cs
+++ b/source/Octopus.Tentacle.Upgrader/Program.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -11,7 +9,7 @@ namespace Octopus.Tentacle.Upgrader
 {
     class Program
     {
-        static readonly string Version = typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+        static readonly string Version = typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
         static int Main(string[] args)
         {

--- a/source/Octopus.Tentacle.Upgrader/ServiceBouncer.cs
+++ b/source/Octopus.Tentacle.Upgrader/ServiceBouncer.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -114,7 +112,7 @@ namespace Octopus.Tentacle.Upgrader
             }
         }
 
-        string? GetRegistryValue(string registryPath, string value)
+        string GetRegistryValue(string registryPath, string value)
         {
             var hklm = Registry.LocalMachine;
             var key = hklm.OpenSubKey(registryPath);
@@ -122,7 +120,7 @@ namespace Octopus.Tentacle.Upgrader
             if (key == null || regValue == null)
                 return null;
 
-            var keyValue = Environment.ExpandEnvironmentVariables(regValue.ToString()!);
+            var keyValue = Environment.ExpandEnvironmentVariables(regValue.ToString());
             key.Close();
 
             return keyValue;

--- a/source/Tentacle.sln
+++ b/source/Tentacle.sln
@@ -85,12 +85,12 @@ Global
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net452-win-x64|Any CPU.ActiveCfg = Release|Any CPU
+		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net452-win-x64|Any CPU.Build.0 = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-netcoreapp3.1-linux-arm64|Any CPU.ActiveCfg = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-netcoreapp3.1-linux-musl-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-netcoreapp3.1-linux-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-netcoreapp3.1-osx-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-netcoreapp3.1-win-x64|Any CPU.ActiveCfg = Release|Any CPU
-		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-netcoreapp3.1-win-x64|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Background

[Slack thread](https://octopusdeploy.slack.com/archives/CG4JP65N2/p1603164277075400)

The `Octopus.Tentacle.Upgrader.exe` binary was previously built for `netcoreapp3.1`.

We build Tentacle (for Windows) to target `netcoreapp3.1` and `net452`, but the only version installed by the MSIs is the `net452` one. To upgrade Tentacle, we run `Octopus.Tentacle.Upgrader.exe`, which works even on hosts without .NET Core 3.1 installed, because it's a self-contained executable...

... which won't run on any version of Windows Server before 2012R2.

Before targeting `Octopus.Tentacle.Upgrader.exe` exclusively at .NET Core 3.1, we also targeted it at .NET Framework 4.7.2. This meant that hosts with an appropriate framework to run Tentacle (4.5.2) might not have had the appropriate framework (4.7.2) to run the upgrader.

This PR brings the upgrader's target framework back into line with Tentacle's.

TL;DR:  Supporting multiple OSes and .NET framework versions is complicated.

## Before

- `Octopus.Tentacle.Upgrader.exe` was built for `netcoreapp3.1`.

## After

- `Octopus.Tentacle.Upgrader.exe` is built for `net452`.
- Usage of later C# language features (nullability) has been removed so that we can target `net452` :(
- Publishing as a single file has been disabled (`net452` again). There is only one additional DLL, though, so it's not terrible.

# Testing

Here are the steps I used to test this pull request:

- Pulled this branch version of Tentacle into Octopus Server and run the upgrade tests (SUCCESS).

# Review

Firstly, thanks for reviewing this pull request! :tada:

- 👀 
- green build
- You can see the [build artifacts here](https://build.octopushq.com/buildConfiguration/OctopusDeploy_OctopusTentacle_BuildCreateCrossPlatformBundle/1677881?buildTab=artifacts). The one of interest is the `Octopus.Tentacle.CrossPlatformBundle` NuGet package.

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Existing automation scripts will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
