### PR TITLE
Include Windows .zip files in the cross-platform bundle.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -352,6 +352,7 @@ Task("Pack-CrossPlatformBundle")
     .Description("Packs the cross-platform Tentacle.nupkg used by Octopus Server to dynamically upgrade Tentacles.")
     .IsDependentOn("Build-Windows") // for the Octopus.Tentacle.Upgrader binary
     .IsDependentOn("Pack-WindowsInstallers")    // for the .msi files (Windows)
+    .IsDependentOn("Pack-WindowsZips")  // for the .zip files (Windows)
     .IsDependentOn("Pack-LinuxTarballs")    // for the .tar.gz bundles (Linux)
     .IsDependentOn("Pack-OSXTarballs")  // for the .tar.gz bundle (OS X)
     .Does(() => {
@@ -370,7 +371,6 @@ Task("Pack-CrossPlatformBundle")
             foreach (var runtimeId in runtimeIds)
             {
                 if (framework == "net452" && runtimeId != "win-x64") continue;  // General exclusion of net452+(not Windows)
-                if (runtimeId.StartsWith("win-")) continue; // We don't include Windows zips in the bundle as we use MSIs instead.
 
                 var fileExtension = runtimeId.StartsWith("win-") ? "zip" : "tar.gz";
                 CopyFile($"{artifactsDir}/zip/tentacle-{versionInfo.FullSemVer}-{framework}-{runtimeId}.{fileExtension}", $"{workingDir}/tentacle-{framework}-{runtimeId}.{fileExtension}");


### PR DESCRIPTION
# Background

This helps with completeness and with testing.

Our Octopus Server tests have specific dependencies on Tentacle binaries and, at least in the short term, this is the most effective way to support them. Specifically, it will help to fix [builds like this](https://build.octopushq.com/buildConfiguration/OctopusDeploy_OctopusServer_TestOrchestration_WipTestCypressUiE2eTestsTom/1686585?buildTab=log&focusLine=3&linesState=116).

We already ship all of the other OS/runtime combinations in this file so it feels a little more complete to do things this way, too, even though we might not use the .zipped contents in anger on customers' servers (yet).

## Before

![image](https://user-images.githubusercontent.com/375332/96825762-38b44700-1475-11eb-88b1-69772debe383.png)

## After

![image](https://user-images.githubusercontent.com/375332/96830702-33f49080-147f-11eb-8b06-58b787672ca0.png)

# Testing

- :eyes:
- 💚  build

# Review

Firstly, thanks for reviewing this pull request! :tada:

<!-- Describe the outcomes you want from a review. In-principle? Exploratory testing? Add inline comments calling out important changes. -->

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
