### PR TITLE
Ensure that file permissions are preserved when packaging tentacle for linux and OSX

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -9,7 +9,6 @@
 
 #tool "nuget:?package=TeamCity.Dotnet.Integration&version=1.0.10"
 #tool "nuget:?package=WiX&version=3.11.2"
-#addin "nuget:?package=Cake.Compression&version=0.2.4"
 #addin "nuget:?package=Cake.Docker&version=0.10.0"
 #addin "nuget:?package=Cake.FileHelpers&version=3.2.1"
 #addin "nuget:?package=Cake.Incubator&version=5.0.1"


### PR DESCRIPTION
# Background

There has been a lot of renovation around the way we package tentacle recently. One of the things that was changed was the way we package up our linux and OSX packages into tar.gz files in our cake scripts.

As a result of these changes, the tar.gz did not contain any information about the file permissions. In particular, this meant that the Tentacle executable did not contain the executable bit (+x) by default.

This would be a potential issue for customers trying to use this package (a breaking change!) but it also prevents us (or at least introduces further roadblocks) when we try to use these packages in our build and test pipeline, particularly around running E2E tests.

Context: https://octopusdeploy.slack.com/archives/C01DCQQQQBX/p1603855905017300

## Before

After extracting the linux .tar.gz package, you would end up with something like this

![image](https://user-images.githubusercontent.com/1892715/97399684-60098900-1939-11eb-8a16-39cada49e2af.png)


## After

After extracting the linux .tar.gz package, you now end up with something like this

![image](https://user-images.githubusercontent.com/1892715/97399709-6d267800-1939-11eb-8c81-6635f5e187e6.png)

# Review

Firstly, thanks for reviewing this pull request! :tada:
Sanity check these changes. Is this the right approach?
We might not be able to package our linux packages on non-linux machines now (this is untested) - is this ok? We may not have been able to anyway :man_shrugging: 

<!-- Describe the outcomes you want from a review. In-principle? Exploratory testing? Add inline comments calling out important changes. -->