### PR TITLE
Removed line containing syntax error.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ source/packages
 *.ncrunchproject
 *.ncrunchsolution
 source/Octopus.v2.ncrunchsolution
-source/_ReSharper**
 source/_ReSharper*
 
 *.sublime-project


### PR DESCRIPTION
# Background

The syntax error is causing ripgrep to [complain](https://build.octopushq.com/buildConfiguration/OctopusDeploy_OctopusTentacle_TestProfanity/1710938?buildTab=log&focusLine=676&linesState=591) about an invalid `.gitignore` file when it scans for forbidden keywords.

The removed line is covered by the next line. 

## Before

![image](https://user-images.githubusercontent.com/375332/97633702-3dce5300-1a80-11eb-9fa4-4c61f888a3b8.png)

## After

![image](https://user-images.githubusercontent.com/375332/97633660-2db67380-1a80-11eb-8f8e-f57f282b4294.png)

# Review

Firstly, thanks for reviewing this pull request! :tada:

- :eyes:
- 💚 build

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
