### PR TITLE
Added a global.json file to force us to use a fixed .NET SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "3.1.402",
+        "rollForward": "latestFeature"
+    }
+}


### PR DESCRIPTION
This temporarily unblocks us while our build servers have 2 versions of the .NET SDK installed (3.1 and 5) and also allows local development to continue even when the .NET 5.0 SDK has been installed.
