### PR TITLE
Updated Halibut NuGet package version to 4.3.34

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -115,7 +115,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="FluentValidation" Version="7.2.1" />
-    <PackageReference Include="Halibut" Version="4.3.34-richev-async-dyn0004" />
+    <PackageReference Include="Halibut" Version="4.3.34" />
     <PackageReference Include="MaterialDesignColors" Version="1.2.0" />
     <PackageReference Include="MaterialDesignThemes" Version="2.5.0.1205" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -25,7 +25,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Halibut" Version="4.3.34-richev-async-dyn0004" />
+		<PackageReference Include="Halibut" Version="4.3.34" />
 		<PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
# Background

This PR updates the version of Halibut that is used. For details about the issue that  this fixes, see the corresponding [Halibut PR](https://github.com/OctopusDeploy/Halibut/pull/129).

It should be considered alongside the corresponding [Octopus Deploy PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/7832).

# Testing

Here are the steps I used to test this pull request:

* Manual testing of a Runbook, that uses an Ubuntu Dynamic Worker, verifying that the timeout issue (see Halibut PR) has been fixed.
* Regression testing in Tentacle Army, with 1500 polling tentacles, verifying that they can connect and run in a "reasonable" time.

# Review

Firstly, thanks for reviewing this pull request! :tada:

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
