### PR TITLE
Adding Space support to Windows docker.

### DIFF
--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -251,7 +251,7 @@ function Register-Tentacle(){
 
   if($null -ne $Space) {
     $arg += "--space";
-    $arg += $Space;
+    $arg += "`"$Space`"";
   }
 
   Execute-Command $TentacleExe $arg;


### PR DESCRIPTION
# Background

The script for configuring the Tentacle for the Windows docker image did not support the Space environment variable.

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/...

<!-- Consider adding a before/after log excerpt or screen capture. -->

## Before

![Before](https://www.fillmurray.com/g/300/150)

## After

![After](https://www.fillmurray.com/300/150)

# Testing

Yeah ... I want to, but want to make sure I do it correctly.  Can I get a hand?

- 

# Review

Firstly, thanks for reviewing this pull request! :tada:

<!-- Describe the outcomes you want from a review. In-principle? Exploratory testing? Add inline comments calling out important changes. -->

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
