### PR TITLE
Pass TextBoxLogger to command execution

### DIFF
--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/Views/InstallTab.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/Views/InstallTab.cs
@@ -76,7 +76,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard.Views
                 try
                 {
                     var script = model.GenerateScript();
-                    success = commandLineRunner.Execute(script);
+                    success = commandLineRunner.Execute(script, logger.Verbose, logger.Info, logger.Error, logger.Error);
                 }
                 catch (Exception ex)
                 {

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -31,7 +31,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="8.9.2" />
-		<PackageReference Include="Octopus.Shared" Version="10.0.1" />
+		<PackageReference Include="Octopus.Shared" Version="10.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
# Background

Tentacle configuration logs were not being displayed in the Tentacle Manager log output window.

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/265

## Before

![image](https://user-images.githubusercontent.com/171197/109581894-e1239780-7b48-11eb-8391-cb5f78bf5047.png)

## After

![image](https://user-images.githubusercontent.com/171197/109581976-02848380-7b49-11eb-805e-0743fcbfface.png)

# Testing

Manually testing

