### PR TITLE
Security cleanup

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -868,7 +868,7 @@ private void SignWithSignTool(IEnumerable<FilePath> files, string display = "", 
 
     foreach (var url in signingTimestampUrls)
     {
-        InBlock($"Trying to time stamp [{string.Join(Environment.NewLine, files.Select(a => a.ToString()))}] using {url}", () => {
+        InBlock($"Trying to time stamp using {url}", () => {
             signSettings.TimeStampUri = new Uri(url);
             try
             {


### PR DESCRIPTION
# Background

This PR aims to clean up a couple of security concerns in the Tentacle build file. The first is some stale GPG settings, including an insecure password, that weren't being used by the build. The second is to add support for signing binaries using a certificate stored in Azure Key Vault, rather than requiring it to be available locally.

A local certificate file will be used if the arguments for Azure Key Vault are not supplied.

# Testing

Here are the steps I used to test this pull request:

- Run the build using a development Azure Key Vault to sign the assemblies with a self-signed certificate.

# Review

Firstly, thanks for reviewing this pull request! :tada:

How's my Cake?

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
