### PR TITLE
Install docker 19 when building Tentacle linux image

### DIFF
--- a/docker/linux/install-scripts/install-docker.sh
+++ b/docker/linux/install-scripts/install-docker.sh
@@ -33,6 +33,7 @@ dos2unix /usr/local/bin/dind
 chmod +x /usr/local/bin/dockerd-entrypoint.sh
 dos2unix /usr/local/bin/dockerd-entrypoint.sh
 
+export VERSION=19
 curl -sSL https://get.docker.com/ | sh
 
 # https://forums.docker.com/t/failing-to-start-dockerd-failed-to-create-nat-chain-docker/78269


### PR DESCRIPTION
# Background

NOTE to future us: undo this change once fix is in docker 20 (see containerd issue below)

downgrading docker to version 19 due to this https://github.com/containerd/containerd/issues/4837

Unable to run docker in docker using latest tentacle

Context: 
https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1614649456196900 (internal link)
https://octopususergroup.slack.com/archives/C6UGLUWMQ/p1615484103107800 (community slack)

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/270

## Before

```
docker: Error response from daemon: io.containerd.runc.v2: failed to adjust OOM score for shim: set shim OOM score: write /proc/211/oom_score_adj: invalid argument
```

## After

works!

# Testing

Manually tested 

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
