### PR TITLE
Mask sensitive values in the Tentacle Manager log window

### DIFF
--- a/source/Octopus.Manager.Tentacle/DeleteWizard/DeleteWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/DeleteWizard/DeleteWizardModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using FluentValidation;
+using Octopus.Diagnostics;
 using Octopus.Manager.Tentacle.Infrastructure;
 using Octopus.Manager.Tentacle.Util;
 using Octopus.Shared.Configuration;
@@ -38,6 +39,11 @@ namespace Octopus.Manager.Tentacle.DeleteWizard
             var validator = new InlineValidator<DeleteWizardModel>();
 
             return validator;
+        }
+
+        public void ContributeSensitiveValues(ILog log)
+        {
+            // no sensitive values to contribute
         }
     }
 }

--- a/source/Octopus.Manager.Tentacle/Dialogs/ServerConnectionDialog.xaml.cs
+++ b/source/Octopus.Manager.Tentacle/Dialogs/ServerConnectionDialog.xaml.cs
@@ -34,6 +34,7 @@ namespace Octopus.Manager.Tentacle.Dialogs
             logger = new TextBoxLogger(outputLog);
             Loaded += async (a, e) =>
             {
+                model.ContributeSensitiveValues(logger);
                 await model.VerifyCredentials(logger);
                 if (model.HaveCredentialsBeenVerified)
                 {

--- a/source/Octopus.Manager.Tentacle/Infrastructure/ICanHaveSensitiveValues.cs
+++ b/source/Octopus.Manager.Tentacle/Infrastructure/ICanHaveSensitiveValues.cs
@@ -1,0 +1,9 @@
+using Octopus.Diagnostics;
+
+namespace Octopus.Manager.Tentacle.Infrastructure
+{
+    public interface ICanHaveSensitiveValues
+    {
+        void ContributeSensitiveValues(ILog log);
+    }
+}

--- a/source/Octopus.Manager.Tentacle/Infrastructure/IScriptableViewModel.cs
+++ b/source/Octopus.Manager.Tentacle/Infrastructure/IScriptableViewModel.cs
@@ -3,7 +3,7 @@ using Octopus.Shared.Util;
 
 namespace Octopus.Manager.Tentacle.Infrastructure
 {
-    public interface IScriptableViewModel
+    public interface IScriptableViewModel : ICanHaveSensitiveValues
     {
         string InstanceName { get; }
         IEnumerable<CommandLineInvocation> GenerateScript();

--- a/source/Octopus.Manager.Tentacle/Infrastructure/TextBoxLogger.cs
+++ b/source/Octopus.Manager.Tentacle/Infrastructure/TextBoxLogger.cs
@@ -55,7 +55,7 @@ namespace Octopus.Manager.Tentacle.Infrastructure
         {
             if (textBox.Dispatcher.CheckAccess())
             {
-                textBox.AppendText(line);
+                SensitiveValueMasker.SafeSanitize(line, sanitized => textBox.AppendText(sanitized));
                 textBox.AppendText(Environment.NewLine);
                 textBox.ScrollToEnd();
             }

--- a/source/Octopus.Manager.Tentacle/Proxy/ProxyWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/Proxy/ProxyWizardModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using FluentValidation;
+using Octopus.Diagnostics;
 using Octopus.Manager.Tentacle.Controls;
 using Octopus.Manager.Tentacle.Infrastructure;
 using Octopus.Manager.Tentacle.Util;
@@ -234,6 +235,12 @@ namespace Octopus.Manager.Tentacle.Proxy
         bool NotContainHttp(string host)
         {
             return true;
+        }
+
+        public void ContributeSensitiveValues(ILog log)
+        {
+            if (proxyPassword != null)
+                log.WithSensitiveValue(proxyPassword);
         }
     }
 }

--- a/source/Octopus.Manager.Tentacle/Proxy/TentacleProxyWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/Proxy/TentacleProxyWizardModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Octopus.Diagnostics;
 using Octopus.Manager.Tentacle.Infrastructure;
 using Octopus.Shared.Util;
 
@@ -47,6 +48,11 @@ namespace Octopus.Manager.Tentacle.Proxy
         {
             pollingProxyWizardModel = pollingWizardModel;
             pollingProxyWizardModel.ToggleService = false;
+        }
+
+        public void ContributeSensitiveValues(ILog log)
+        {
+            proxyWizardModel.ContributeSensitiveValues(log);
         }
     }
 }

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/TentacleSetupWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/TentacleSetupWizardModel.cs
@@ -946,6 +946,14 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
         {
             return CliBuilder.ForTool(TentacleExe, action, InstanceName);
         }
+
+        public void ContributeSensitiveValues(ILog log)
+        {
+            if (password != null)
+                log.WithSensitiveValue(password);
+            if (apiKey != null)
+                log.WithSensitiveValue(apiKey);
+        }
     }
 
     public class SpaceSpecificData

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/Views/InstallTab.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/Views/InstallTab.cs
@@ -76,6 +76,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard.Views
                 try
                 {
                     var script = model.GenerateScript();
+                    model.ContributeSensitiveValues(logger);
                     success = commandLineRunner.Execute(script, logger);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
 Background

This PR will mask sensitive values in the Tentacle Manager logs.

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/271


## Before

```
The command that failed was: "C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe" register-with ... --password "Password"
```

## After

```
The command that failed was: "C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe" register-with ... --password "*****"
```
