### PR TITLE
Added handling of non-numeric entry for config options for Linux tentacle setup

### DIFF
--- a/linux-packages/content/configure-tentacle.sh
+++ b/linux-packages/content/configure-tentacle.sh
@@ -146,7 +146,7 @@ function setupPollingTentacle {
     space=$(assignNonEmptyValue "$spaceinput" $space)
 
     read -p "What name would you like to register this Tentacle with? ($displayname): " displaynameinput
-    displayname=$(assignNonEmptyValue "$displaynameinput" $displayname)	
+    displayname=$(assignNonEmptyValue "$displaynameinput" $displayname)
 
     case machinetype in
         2 | worker)


### PR DESCRIPTION
Added handling of non-numeric entry for config options for Linux tentacle setup

# Background

Fixes https://github.com/OctopusDeploy/Issues/issues/6808

If you enter the text displayed during the prompts when running the tentacle configure bash script, the default option is always selected, even if the text entered matches the name of the option.  

Also updated machine type and auth type entry similarly.

## Before

![image](https://user-images.githubusercontent.com/46470837/112437080-a8b75800-8d9a-11eb-868e-1258bd8a3ec5.png)

## After

![image](https://user-images.githubusercontent.com/46470837/112437584-37c47000-8d9b-11eb-8ba4-d9421e0b4700.png)

- Tentacle type accepts **2** or **polling** (case insensitive) to set up a polling tentacle, and all other values set up a listening one.
- Machine type accepts **2** or **worker** (case insensitive) to set up a worker type, all other values set up a deployment target.
- Auth type accepts **2** or **username**  or **username and password** (case insensitive) for the username/password auth, all other values set up api-key auth

# Testing

Here are the steps I used to test this pull request:
I just ran the script, and tested each option manually in bash on Windows, and checked that it created the output I was expecting.

# Review

I'm not 100% sure this is the correct approach, given that I've taken the easy route in continuing to assume that all non-specifically handled input should choose the default option.

Also, I haven't ever written/modified a bash script before, so please be thorough in reviewing this!

# Checks

- [X] :green_heart: All automated builds and tests are passing
- [X] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [X] Existing installations will continue working after updating to this version of Tentacle
- [X] I have considered the changes to public documentation needed to reflect this change
- [X] I have considered the changes to the project wiki needed to reflect this change
