### PR TITLE
Add JQ to the base tentacle image.

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_NUMBER
 ARG BUILD_DATE
 
 RUN apt-get update && \
-    apt-get install -y curl sudo dos2unix && \
+    apt-get install -y curl sudo dos2unix jq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Background

There are lot of opportunities to script tentacles as they are added and removed from a Kubernetes cluster, but most API calls need to parse JSON to do anything useful. This PR adds jq to the base image to allow postStart and preStop hooks to make curl API requests and process the results.

# Testing

Here are the steps I used to test this pull request:

- `docker container run -it <image name> /bin/bash`
- run `jq` to ensure it exists

# Review

Firstly, thanks for reviewing this pull request! :tada:

<!-- Describe the outcomes you want from a review. In-principle? Exploratory testing? Add inline comments calling out important changes. -->

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
