### PR TITLE
Fix tentacle certificate handling on macOS

### DIFF
--- a/source/Octopus.Tentacle/Certificates/CertificateGenerator.cs
+++ b/source/Octopus.Tentacle/Certificates/CertificateGenerator.cs
@@ -96,7 +96,7 @@ namespace Octopus.Tentacle.Certificates
             using (var ms = new MemoryStream())
             {
                 store.Save(ms, exportpw.ToCharArray(), random);
-                var platformSpecificX509KeyStorageFlags = !PlatformDetection.IsRunningOnMac ? X509KeyStorageFlags.EphemeralKeySet : X509KeyStorageFlags.DefaultKeySet;
+                var platformSpecificX509KeyStorageFlags = PlatformDetection.IsRunningOnMac ? X509KeyStorageFlags.DefaultKeySet : X509KeyStorageFlags.EphemeralKeySet;
                 certificate = exportable
 #pragma warning disable PC001 // API not supported on all platforms
                     ? new X509Certificate2(ms.ToArray(), exportpw, X509KeyStorageFlags.Exportable | platformSpecificX509KeyStorageFlags)


### PR DESCRIPTION
# Background

To run E2E tests on macOS as an engineer, the E2E runner needs to set up a Tentacle instance, and this currently blows up on macOS because [EphemeralKeySet isn't supported at all on macOS](https://docs.microsoft.com/en-us/dotnet/standard/security/cross-platform-cryptography#write-a-pkcs12pfx).

This PR alters the certificate flags used when Tentacle is run under macOS so that the EphemeralKeySet flag is not set, instead using the default flag.

I'm not certain whether this represents additional risk to our customers (if we have any running Tentacle on macOS in production) and would appreciate review.

## Before

```
There was a problem running 'dotnet /var/folders/sd/rlhhjpxs52vbs7qs4y2js57m0000gn/T/OctopusTest/tar/extracted/tentacle/Tentacle.dll new-certificate  --instance "e2e-8D8FAB7609AFCBA"' in working directory ''.
stderr: ===============================================================================
stderr: This platform does not support loading with EphemeralKeySet. Remove the flag to allow keys to be temporarily created on disk.
stderr: System.PlatformNotSupportedException
stderr:    at Internal.Cryptography.Pal.AppleCertificatePal.FromBlob(Byte[] rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
stderr:    at System.Security.Cryptography.X509Certificates.X509Certificate..ctor(Byte[] rawData, String password, X509KeyStorageFlags keyStorageFlags)
stderr:    at System.Security.Cryptography.X509Certificates.X509Certificate2..ctor(Byte[] rawData, String password, X509KeyStorageFlags keyStorageFlags)
stderr:    at Octopus.Tentacle.Certificates.CertificateGenerator.Generate(String fullName, Boolean exportable) in CertificateGenerator.cs:line 92
stderr:    at Octopus.Tentacle.Certificates.CertificateGenerator.GenerateNew(String fullName) in CertificateGenerator.cs:line 34
stderr:    at Octopus.Tentacle.Configuration.WritableTentacleConfiguration.GenerateNewCertificate(Boolean writeToConfig) in TentacleConfiguration.cs:line 269
stderr:    at Octopus.Tentacle.Commands.NewCertificateCommand.Start() in NewCertificateCommand.cs:line 76
stderr:    at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
stderr:    at Octopus.Shared.Startup.OctopusProgram.Start(ICommandRuntime commandRuntime)
stderr:    at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
stderr:    at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
stderr:    at Octopus.Shared.Startup.OctopusProgram.Run()
```

## After

```
[INF]() Test script times from slowest to fastest:
[INF](1)  - [00:12] ActionTemplateTestScript was estimated to take 0 minutes and ran in partition 1
[INF]() -------------------------------------------------------------------------------
[INF]() -------------------------------------------------------------------------------
[INF]() Test run complete! Executed 7 tests across 1 test scripts
[INF]() 7/7 tests passed
```

# Testing

Here are the steps I used to test this pull request:

- Used the `.dll` in an E2E test to confirm it no longer blows up
- Ran all the unit tests under macOS
- Will be watching the CI chain

# Review

Firstly, thanks for reviewing this pull request! :tada:

Please consider whether there are experience or security risks to our customers - I don't believe that macOS will persist these certificates on disk the way that Windows does (which is the [reason for the flag](https://stackoverflow.com/a/52840537) in the first place, apparently).

Also I have no idea about Net452/Mono impacts on other platforms, I have tested this against Net Core 3.1 on macOS Big Sur only.

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
