### PR TITLE
Include worker details in show-configuration output

### DIFF
--- a/source/Octopus.Tentacle/Commands/ShowConfigurationCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ShowConfigurationCommand.cs
@@ -117,28 +117,35 @@ namespace Octopus.Tentacle.Commands
 
         async Task CollectServerSideConfiguration(IWritableKeyValueStore outputStore)
         {
+            if (tentacleConfiguration.Value.TentacleCertificate == null)
+                throw new ControlledFailureException("No certificate has been generated for this Tentacle. Unable to display configuration.");
+
             var proxyOverride = proxyConfig.ParseToWebProxy(tentacleConfiguration.Value.PollingProxyConfiguration);
             try
             {
                 using (var client = await octopusClientInitializer.CreateClient(apiEndpointOptions, proxyOverride))
                 {
                     var repository = await spaceRepositoryFactory.CreateSpaceRepository(client, spaceName);
-                    var matchingMachines = await repository.Machines.FindByThumbprint(tentacleConfiguration.Value.TentacleCertificate.Thumbprint);
+                    var matchingMachines = (await repository.Machines.FindByThumbprint(tentacleConfiguration.Value.TentacleCertificate.Thumbprint)).Cast<MachineBasedResource>().ToArray();
+                    var matchingWorkers = (await repository.Workers.FindByThumbprint(tentacleConfiguration.Value.TentacleCertificate.Thumbprint)).Cast<MachineBasedResource>().ToArray();
 
-                    switch (matchingMachines.Count)
+                    var matches = matchingMachines.Concat(matchingWorkers).ToList();
+                    switch (matches.Count)
                     {
                         case 0:
-                            log.Error($"No machines were found on the specified server with the thumbprint '{tentacleConfiguration.Value.TentacleCertificate.Thumbprint}'. Unable to retrieve server side configuration.");
+                            log.Error($"No machines or workers were found on the specified server with the thumbprint '{tentacleConfiguration.Value.TentacleCertificate.Thumbprint}'. Unable to retrieve server side configuration.");
                             break;
 
-                        case 1:
-                            await CollectionServerSideConfigurationFromMachine(outputStore, repository, matchingMachines.First());
+                        case 1 when matches.First() is MachineResource:
+                            await CollectionServerSideConfigurationFromMachine(outputStore, repository, matches.First() as MachineResource);
+                            break;
+
+                        case 1 when matches.First() is WorkerResource:
+                            await CollectionServerSideConfigurationFromWorker(outputStore, repository, matches.First() as WorkerResource);
                             break;
 
                         default:
-                            if (matchingMachines.Count > 1)
-                                throw new ControlledFailureException("This Tentacle is registered multiple times with the server - unable to display configuration");
-                            break;
+                            throw new ControlledFailureException("This Tentacle is registered multiple times with the server. Unable to display configuration.");
                     }
                 }
             }
@@ -167,6 +174,22 @@ namespace Octopus.Tentacle.Commands
             }
 
             outputStore.Set("Tentacle.Roles", machine.Roles);
+            if (machine.MachinePolicyId != null)
+            {
+                var machinePolicy = await repository.MachinePolicies.Get(machine.MachinePolicyId);
+                outputStore.Set("Tentacle.MachinePolicy", new { machinePolicy.Id, machinePolicy.Name });
+            }
+
+            outputStore.Set<string>("Tentacle.DisplayName", machine.Name);
+            if (machine.Endpoint is ListeningTentacleEndpointResource)
+                outputStore.Set<string>("Tentacle.Communication.PublicHostName", ((ListeningTentacleEndpointResource)machine.Endpoint).Uri);
+        }
+
+        async Task CollectionServerSideConfigurationFromWorker(IWritableKeyValueStore outputStore, IOctopusSpaceAsyncRepository repository, WorkerResource machine)
+        {
+            var workerPools = await repository.WorkerPools.FindAll();
+            outputStore.Set("Tentacle.WorkerPools", workerPools.Where(x => machine.WorkerPoolIds.Contains(x.Id)).Select(x => new { x.Id, x.Name }));
+
             if (machine.MachinePolicyId != null)
             {
                 var machinePolicy = await repository.MachinePolicies.Get(machine.MachinePolicyId);


### PR DESCRIPTION
# Background

While testing out some changes around no longer requiring elevation when executing Tentacle, I found that `show-configuration` didn't include any details about worker configuration - only for Tentacles.

Results

This PR adds output for:
* `Tentacle.WorkerPools`
* `Tentacle.MachinePolicy` (if one is set)
* `Tentacle.DisplayName`
* `Tentacle.Communication.PublicHostName` (if configured in listening mode)

This brings this into line with the information returned by a normal Tentacle

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/...

<!-- Consider adding a before/after log excerpt or screen capture. -->

## Before

```
PS [main ≡]> .\tentacle show-configuration --server http://localhost:8065 --apikey API-XXXXXXXXXXXXXXXX --instance testing-show-configuration
No machines were found on the specified server with the thumbprint '521DD92C50EA49C4FD31595827B074B3BB821E62'. Unable to retrieve server side configuration.
{
  "Octopus": {
    "Home": "c:\\octopusdev\\testing-show-configuration",
    "Watchdog": {
      "Enabled": false,
      "Instances": "*",
      "Interval": 0
    }
  },
  "Tentacle": {
    "CertificateThumbprint": "521DD92C50EA49C4FD31595827B074B3BB821E62",
    "Communication": {
      "TrustedOctopusServers": [
        {
          "Thumbprint": "FB6BCD0CC211963A2160F2BC3FB136D6705821C3",
          "CommunicationStyle": 1,
          "Address": null,
          "Squid": null,
          "SubscriptionId": null
        }
      ]
    },
    "Deployment": {
      "ApplicationDirectory": "C:\\Octopus\\Applications"
    },
    "Services": {
      "ListenIP": null,
      "NoListen": false,
      "PortNumber": 10933
    }
  }
}
```

## After

note:
* lack of warning message
* extra fields

```
PS [mattr/workers-in-show-configuration ≡]> .\tentacle show-configuration --server http://localhost:8065 --apikey API-XXXXXXXXXXXXXXXX --instance testing-show-configuration
{
  "Octopus": {
    "Home": "c:\\octopusdev\\testing-show-configuration",
    "Watchdog": {
      "Enabled": false,
      "Instances": "*",
      "Interval": 0
    }
  },
  "Tentacle": {
    "CertificateThumbprint": "521DD92C50EA49C4FD31595827B074B3BB821E62",
    "Communication": {
      "PublicHostName": "https://vladimir:10933/",
      "TrustedOctopusServers": [
        {
          "Thumbprint": "FB6BCD0CC211963A2160F2BC3FB136D6705821C3",
          "CommunicationStyle": 1,
          "Address": null,
          "Squid": null,
          "SubscriptionId": null
        }
      ]
    },
    "Deployment": {
      "ApplicationDirectory": "C:\\Octopus\\Applications"
    },
    "DisplayName": "testing-show-configuration",
    "MachinePolicy": {
      "Id": "MachinePolicies-1",
      "Name": "Default Machine Policy"
    },
    "Services": {
      "ListenIP": null,
      "NoListen": false,
      "PortNumber": 10933
    },
    "WorkerPools": [
      {
        "Id": "WorkerPools-1",
        "Name": "Default Worker Pool"
      }
    ]
  }
}
```

# Testing

Here are the steps I used to test this pull request:

- manual testing

# Review

Firstly, thanks for reviewing this pull request! :tada:

tbc

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
