### PR TITLE
Ignore errors when attempting to run harden script

### DIFF
--- a/installer/Octopus.Tentacle.Installer/Product.wxs
+++ b/installer/Octopus.Tentacle.Installer/Product.wxs
@@ -141,7 +141,7 @@
     Harden installation directory
     -->
     <CustomAction Id="SetExecProp" Property="WixQuietExecCmdLine" Value='"[POWERSHELLEXE]" -NoProfile -NonInteractive -InputFormat None -ExecutionPolicy Bypass -File "[INSTALLLOCATION]Harden-InstallationDirectory.ps1"'></CustomAction>
-    <CustomAction Id="HardenInstallationDirectory" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check"/>
+    <CustomAction Id="HardenInstallationDirectory" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="ignore"/>
     <InstallExecuteSequence>
       <Custom Action="SetExecProp" After="InstallExecute"/>
       <Custom Action="HardenInstallationDirectory" After="SetExecProp"/>


### PR DESCRIPTION
# Background

When Tentacle is installed we run a hardening script to set permissions on folders. Currently that script will swallow exceptions, but PowerShell can fail to run, resulting in an installation failure. This PR ignores errors when attempting to run PowerShell.

Fixes OctopusDeploy/OctopusTentacle#291

<!-- Consider adding a before/after log excerpt or screen capture. -->

## Before

![image](https://user-images.githubusercontent.com/171197/117401611-3f556800-af48-11eb-9fc1-a27487b50d59.png)

## After

Tentacle is installed.

# Testing

Here are the steps I used to test this pull request:

- Use group policy to set execution policy to AllSigned
- Attempt to install the current version of Tentacle - observe it fails
- Install Tentacle from the branch - observe it succeeds

# Review

Firstly, thanks for reviewing this pull request! :tada:

<!-- Describe the outcomes you want from a review. In-principle? Exploratory testing? Add inline comments calling out important changes. -->
