### PR TITLE
Add OCTOPUS_RUNNING_IN_CONTAINER flag to docker containers

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /
 # We know this won't reduce the image size at all. It's just to make the filesystem a little tidier.
 RUN rm -rf /tmp/*
 
+ENV OCTOPUS_RUNNING_IN_CONTAINER=Y
 ENV ACCEPT_EULA=N
 ENV CustomPublicHostName=""
 ENV DISABLE_DIND=N

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -4,6 +4,7 @@ ARG BUILD_NUMBER
 ARG BUILD_DATE
 
 ENV TentacleVersion ${BUILD_NUMBER}
+ENV OCTOPUS_RUNNING_IN_CONTAINER Y
 
 LABEL \
     org.label-schema.schema-version="1.0" \


### PR DESCRIPTION
New property `OCTOPUS_RUNNING_IN_CONTAINER` added to Tentacle containers to allow for detection and reporting of container usage during tentacle health checks.
Rather than relying on `DOTNET_RUNNING_IN_CONTAINER` which is only exposed in specific Linux containers this makes it very explicit that it is _our_ container. We also dont care so much if it is a container created by the end user, hence our explicit environment variable should get us more accurate data about our published container usage