### PR TITLE
Bump Octopus Clients to remove deprecation message

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -42,7 +42,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Octopus.Client" Version="11.2.3319" />
+		<PackageReference Include="Octopus.Client" Version="11.2.3350" />
 		<PackageReference Include="Octopus.Shared" Version="10.3.1-ci0014" />
 	</ItemGroup>
 


### PR DESCRIPTION
# Background

A deprecation message is shown when Octopus Client is used from the server/tentacle install location; however, when running legitimate Tentacle.exe commands, you still get the message. The fix for this was done in https://github.com/OctopusDeploy/OctopusClients/pull/591.

# Results

This bumps the Octopus Clients to the version with the fix.

Fixes https://github.com/OctopusDeploy/Issues/issues/6924

<!-- Consider adding a before/after log excerpt or screen capture. -->

## Before

![image](https://user-images.githubusercontent.com/36631337/122868735-b5822280-d36e-11eb-86d1-9f21b7f8013f.png)

## After

![image](https://user-images.githubusercontent.com/36631337/122868636-8ec3ec00-d36e-11eb-8a70-a1de30eb4bf1.png)

# Testing

Here are the steps I used to test this pull request:

- Run the following command `.\Tentacle.exe register-with --instance "Tester2" --server "http://192.168.139.160" --name "Tester2" --comms-style "TentacleActive" --server-comms-port "10943" --force --apiKey "API-" --environment "Development" --role "TestRole" --policy "Default Machine Policy" --console`
- Confirm there is no deprecation message

# Review

Firstly, thanks for reviewing this pull request! :tada:

<!-- Describe the outcomes you want from a review. In-principle? Exploratory testing? Add inline comments calling out important changes. -->

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
