### PR TITLE
Cleanup tentacle manager compilation warnings

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -9,6 +9,7 @@
     <TargetFramework>net452</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Properties\Icon.ico</ApplicationIcon>

--- a/source/Octopus.Manager.Tentacle/Shell/TabView.cs
+++ b/source/Octopus.Manager.Tentacle/Shell/TabView.cs
@@ -90,6 +90,7 @@ namespace Octopus.Manager.Tentacle.Shell
         public virtual async Task OnSkip(CancelEventArgs e)
         {
             Model.PopRuleSet(RuleSet);
+            await Task.FromResult(0);
         }
 
         public virtual async Task OnNext(CancelEventArgs e)
@@ -100,6 +101,7 @@ namespace Octopus.Manager.Tentacle.Shell
             {
                 e.Cancel = true;
             }
+            await Task.FromResult(0);
         }
 
         public virtual void OnBack(CancelEventArgs e)

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/TentacleSetupWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/TentacleSetupWizardModel.cs
@@ -50,7 +50,6 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
         string spaceDataLoadError;
         string selectedMachinePolicy;
         string selectedSpace;
-        string[] selectedWorkerPools;
         string[] potentialEnvironments;
         string[] potentialRoles;
         string[] potentialMachinePolicies;
@@ -114,7 +113,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
             Validator = CreateValidator();
             ServerCommsPort = "10943";
             CommunicationStyle = CommunicationStyle.TentaclePassive;
-            
+
 
             // It would be nice to do this by sniffing for the advfirewall command, but doing
             // so would slow down showing the wizard. This check identifies and excludes Windows Server 2003.
@@ -522,7 +521,9 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
                 selectedSpace = value;
                 OnPropertyChanged();
                 if (!string.IsNullOrEmpty(selectedSpace))
-                    LoadSpaceData(client => LoadSpaceSpecificData(client));
+#pragma warning disable 4014 // we want this to be async
+                    LoadSpaceData(async client => await LoadSpaceSpecificData(client));
+#pragma warning restore 4014
             }
         }
 
@@ -767,8 +768,8 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
                 PotentialMachinePolicies = spaceSpecificData.MachinePolicies.Select(e => e.Name).ToArray();
                 if (spaceSpecificData.MachinePoliciesAreSupported)
                 {
-                    SelectedMachinePolicy = PotentialMachinePolicies.Contains(SelectedMachinePolicy) 
-                        ? SelectedMachinePolicy 
+                    SelectedMachinePolicy = PotentialMachinePolicies.Contains(SelectedMachinePolicy)
+                        ? SelectedMachinePolicy
                         : spaceSpecificData.MachinePolicies.First(x => x.IsDefault).Name;
                     ShowMachinePolicySelection = PotentialMachinePolicies.Length > 1;
                 }


### PR DESCRIPTION
# Background

Tentacle Manager has had compilation warnings for a while. I've taken the time to fix these up.

## Before

Warnings. Sadness.
![image](https://user-images.githubusercontent.com/373389/124041139-a32c7680-da49-11eb-9a0e-de9e625a43d6.png)

## After

No warnings (ignoring the test ones now). Happiness. Unicorns. Rainbows.
![image](https://user-images.githubusercontent.com/373389/124041805-efc48180-da4a-11eb-969d-5c89aab80359.png)

# Testing

Here are the steps I used to test this pull request:

- I've run it up and clicked around to make sure changing spaces still loads data correctly

# Review

Firstly, thanks for reviewing this pull request! :tada:

* :eyes: will be sufficient.

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
