### PR TITLE
Drop the windows 20h2 docker image

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -44,13 +44,4 @@ services:
             args:
                 BUILD_DATE: ${BUILD_DATE:?err}
                 BUILD_NUMBER: ${BUILD_NUMBER:?err}
-        image: docker.packages.octopushq.com/octopusdeploy/tentacle:${BUILD_NUMBER?err}-windows-2019
-
-    octopusdeploy-tentacle-windows-20H2:
-        build:
-            context: .
-            dockerfile: ./docker/windows/Dockerfile
-            args:
-                BUILD_DATE: ${BUILD_DATE:?err}
-                BUILD_NUMBER: ${BUILD_NUMBER:?err}
-        image: docker.packages.octopushq.com/octopusdeploy/tentacle:${BUILD_NUMBER?err}-windows-20H2        
+        image: docker.packages.octopushq.com/octopusdeploy/tentacle:${BUILD_NUMBER?err}-windows-2019  


### PR DESCRIPTION
As we're not using it, and having trouble with docker on - it's not stable

# Background

We started adding support for docker images for windows 20H2, but 20H2 is causing more pain than it's worth. It never made it out the door.
Dropping it to reduce complexity.

# Review

Firstly, thanks for reviewing this pull request! :tada:

A simple sanity check of the idea will suffice.

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
