### PR TITLE
Update Halibut and move AutofacServiceFactory to Tentacle

### DIFF
--- a/linux-packages/packaging-scripts/create-linux-packages.sh
+++ b/linux-packages/packaging-scripts/create-linux-packages.sh
@@ -129,12 +129,16 @@ fpm --version "$VERSION" \
   --vendor 'Octopus Deploy' \
   --url 'https://octopus.com/' \
   --description "$PACKAGE_DESC" \
-  --rpm-sign \
   --verbose \
   "${FPM_RPM_OPTS[@]}" \
   "${FPM_OPTS[@]}" \
   "$INPUT_PATH/=$INSTALL_PATH/" \
   tmp_usr_bin/=/usr/bin/
+set +ex
+
+echo "Signing .rpm package."
+set -ex
+rpmsign --addsign "$PACKAGE_NAME.rpm"
 set +ex
 
   # "$INPUT_PATH/=$INSTALL_PATH/" \

--- a/linux-packages/packaging-scripts/create-linux-packages.sh
+++ b/linux-packages/packaging-scripts/create-linux-packages.sh
@@ -138,7 +138,7 @@ set +ex
 
 echo "Signing .rpm package."
 set -ex
-rpmsign --addsign "$PACKAGE_NAME.rpm"
+rpmsign --addsign *.rpm
 set +ex
 
   # "$INPUT_PATH/=$INSTALL_PATH/" \

--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -116,7 +116,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="FluentValidation" Version="7.2.1" />
-    <PackageReference Include="Halibut" Version="4.3.34" />
+    <PackageReference Include="Halibut" Version="4.4.4" />
     <PackageReference Include="MaterialDesignColors" Version="1.2.0" />
     <PackageReference Include="MaterialDesignThemes" Version="2.5.0.1205" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/source/Octopus.Tentacle.Tests/Communications/AutofacServiceFactoryFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Communications/AutofacServiceFactoryFixture.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Linq;
+using Autofac;
+using Autofac.Core;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using NUnit.Framework;
+using Octopus.Tentacle.Communications;
+
+namespace Octopus.Tentacle.Tests.Communications
+{
+    public class AutofacServiceFactoryFixture
+    {
+        readonly IAutofacServiceSource simpleSource = new KnownServiceSource(typeof(SimpleService));
+        readonly IAutofacServiceSource pieSource = new KnownServiceSource(typeof(PieService));
+        readonly IAutofacServiceSource emptySource = new KnownServiceSource(new Type[] {});
+        readonly IAutofacServiceSource nullSource = new KnownServiceSource();
+        readonly IAutofacServiceSource invalidInterfaceSource = new KnownServiceSource(typeof(ISimpleService));
+        readonly IAutofacServiceSource invalidClassSource = new KnownServiceSource(typeof(PlainClass));
+        
+        [Test]
+        public void Resolved_WithNoSources_WorksAsExpected()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
+            
+            var container = builder.Build();
+            
+            var factory = container.Resolve<IServiceFactory>();
+            factory.RegisteredServiceTypes.Count.Should().Be(0);
+        }
+        
+        [Test]
+        public void Resolved_WithSingleSource_CanCreateServices()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterInstance(simpleSource).AsImplementedInterfaces();
+            
+            var container = builder.Build();
+            
+            var factory = container.Resolve<IServiceFactory>();
+            factory.RegisteredServiceTypes.Count.Should().Be(1);
+            factory.RegisteredServiceTypes.Select(x => x.Name).Should().Contain(nameof(ISimpleService));
+
+            var service = factory.CreateService(nameof(ISimpleService));
+            var greeting = (service.Service as ISimpleService)?.Greet("Fred");
+            greeting.Should().Be("Hello Fred!");
+        }
+
+        [Test]
+        public void Resolved_WithMultipleSources_CanCreateServices()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterInstance(simpleSource).AsImplementedInterfaces();
+            builder.RegisterInstance(pieSource).AsImplementedInterfaces();
+            
+            var container = builder.Build();
+            
+            var factory = container.Resolve<IServiceFactory>();
+            factory.RegisteredServiceTypes.Count.Should().Be(2);
+            var types = factory.RegisteredServiceTypes.Select(x => x.Name).ToList();
+            types.Should().Contain(nameof(ISimpleService));
+            types.Should().Contain(nameof(IPieService));
+            
+            var service = factory.CreateService(nameof(ISimpleService));
+            var greeting = (service.Service as ISimpleService)?.Greet("Fred");
+            greeting.Should().Be("Hello Fred!");
+
+            var pieService = factory.CreateService(nameof(IPieService));
+            var pie = (pieService.Service as IPieService)?.GetPie();
+            pie.Should().Be(3.14159f);
+        }
+
+        [Test]
+        public void Resolved_WithNullSource_DoesNotThrow()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterInstance(nullSource).AsImplementedInterfaces();
+            var container = builder.Build();
+            
+            var factory = container.Resolve<IServiceFactory>();
+            factory.RegisteredServiceTypes.Count.Should().Be(0);
+        }
+        
+        [Test]
+        public void Resolved_WithEmptySource_DoesNotThrow()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterInstance(emptySource).AsImplementedInterfaces();
+            var container = builder.Build();
+            
+            var factory = container.Resolve<IServiceFactory>();
+            factory.RegisteredServiceTypes.Count.Should().Be(0);
+        }
+        
+        [Test]
+        public void Resolved_WithInvalidInterfaceSource_ThrowsExpectedException()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterInstance(invalidInterfaceSource).AsImplementedInterfaces();
+            var container = builder.Build();
+
+            try
+            {
+                container.Resolve<IServiceFactory>();
+            }
+            catch (Exception ex)
+            {
+                ex.Should().BeOfType<DependencyResolutionException>();
+                var baseEx = ex.GetBaseException();
+                baseEx.Should().BeOfType<InvalidServiceTypeException>();
+                (baseEx as InvalidServiceTypeException)?.InvalidType.Name.Should().Be(nameof(ISimpleService));
+            }
+        }
+        
+        [Test]
+        public void Resolved_WithInvalidClassSource_ThrowsExpectedException()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterInstance(invalidClassSource).AsImplementedInterfaces();
+            var container = builder.Build();
+
+            try
+            {
+                container.Resolve<IServiceFactory>();
+            }
+            catch (Exception ex)
+            {
+                ex.Should().BeOfType<DependencyResolutionException>();
+                var baseEx = ex.GetBaseException();
+                baseEx.Should().BeOfType<InvalidServiceTypeException>();
+                (baseEx as InvalidServiceTypeException)?.InvalidType.Name.Should().Be(nameof(PlainClass));
+            }
+        }
+                
+        [Test]
+        public void CreateService_WithMissingService_ThrowsExpectedException()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterInstance(simpleSource).AsImplementedInterfaces();
+            
+            var container = builder.Build();
+            
+            var factory = container.Resolve<IServiceFactory>();
+            factory.RegisteredServiceTypes.Count.Should().Be(1);
+
+            const string missingService = "IAmNotHere";
+            try
+            {
+                var _ = factory.CreateService(missingService);
+            }
+            catch (Exception ex)
+            {
+                ex.Should().BeOfType<UnknownServiceNameException>();
+                (ex as UnknownServiceNameException)?.ServiceName.Should().Be(missingService);
+            }
+        }
+        
+        interface IPieService
+        {
+            float GetPie();
+        }
+
+        class PieService : IPieService
+        {
+            public float GetPie()
+            {
+                return 3.14159f;
+            }
+        }
+        
+        interface ISimpleService
+        {
+            string Greet(string name);
+        }
+
+        class SimpleService : ISimpleService
+        {
+            public string Greet(string name)
+            {
+                return $"Hello {name}!";
+            }
+        }
+
+        // No interface, this will not be register-able
+        class PlainClass
+        {
+            // ReSharper disable once UnusedMember.Local
+            public string Greet(string name)
+            {
+                return $"Hello {name}!";
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Octopus.Tentacle\Octopus.Tentacle.csproj" />
+    <PackageReference Include="Halibut" Version="4.4.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/source/Octopus.Tentacle/Communications/AutofacServiceFactory.cs
+++ b/source/Octopus.Tentacle/Communications/AutofacServiceFactory.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using Halibut.ServiceModel;
+using Octopus.CoreUtilities.Extensions;
+using Octopus.Shared.Util;
+
+namespace Octopus.Tentacle.Communications
+{
+    /// <summary>
+    /// This IServiceFactory allows you to resolve service classes from Autofac.
+    /// However, before resolving, one or more IAutofacServiceSources must also be registered.
+    /// This is so that only explicitly specified services will be resolved, and the types of all messages are known when the service is instantiated.
+    /// </summary>
+    public class AutofacServiceFactory : IServiceFactory, IDisposable
+    {
+        readonly ILifetimeScope scope;
+        readonly Dictionary<string, Type> serviceTypes = new Dictionary<string, Type>();
+
+        public AutofacServiceFactory(ILifetimeScope scope, IEnumerable<IAutofacServiceSource> sources)
+        {
+            this.scope = scope.BeginLifetimeScope(b =>
+            {
+                foreach (var service in sources.SelectMany(x => x.ServiceTypes.EmptyIfNull()))
+                {
+                    BuildService(b, service);
+                }
+            });
+        }
+
+        void BuildService(ContainerBuilder builder, Type serviceType)
+        {
+            var registrationBuilder = builder.RegisterType(serviceType).SingleInstance();
+            var interfaces = serviceType.GetInterfaces();
+            if (serviceType.IsInterface || interfaces.IsNullOrEmpty())
+            {
+                throw new InvalidServiceTypeException(serviceType);
+            }
+            
+            foreach (var face in interfaces)
+            {
+                serviceTypes[face.Name] = face;
+                registrationBuilder.As(face);
+            }
+        }
+
+        public IServiceLease CreateService(string serviceName)
+        {
+            try
+            {
+                if (serviceTypes.TryGetValue(serviceName, out var serviceType))
+                {
+                    return new Lease(scope.Resolve(serviceType));
+                }
+                
+                throw new UnknownServiceNameException(serviceName);
+            }
+            catch (ObjectDisposedException)
+            {
+                throw new Exception("The Tentacle service is shutting down and cannot process this request.");
+            }
+        }
+
+        public IReadOnlyList<Type> RegisteredServiceTypes => serviceTypes.Values.ToList();
+
+        class Lease : IServiceLease
+        {
+            public Lease(object service)
+            {
+                Service = service;
+            }
+
+            public object Service { get; }
+
+            public void Dispose()
+            {
+                if (Service is IDisposable disposable)
+                    disposable.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            scope.Dispose();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -88,9 +88,9 @@ namespace Octopus.Tentacle.Communications
                     log.WarnFormat("Configured to connect to server {0}, but its configuration is incomplete; skipping.", pollingEndPoint);
                     continue;
                 }
-                if (pollingEndPoint.SubscriptionId == null)
+
 #pragma warning disable 618
-                    pollingEndPoint.SubscriptionId = "poll://" + configuration.TentacleSquid.ToLowerInvariant() + "/";
+                pollingEndPoint.SubscriptionId ??= "poll://" + configuration.TentacleSquid.ToLowerInvariant() + "/";
 #pragma warning restore 618
 
                 log.Info($"Agent will poll Octopus Server at {pollingEndPoint.Address} for subscription {pollingEndPoint.SubscriptionId} expecting thumbprint {pollingEndPoint.Thumbprint}");

--- a/source/Octopus.Tentacle/Communications/IAutofacServiceSource.cs
+++ b/source/Octopus.Tentacle/Communications/IAutofacServiceSource.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Octopus.Tentacle.Communications
+{
+    public interface IAutofacServiceSource
+    {
+        IEnumerable<Type> ServiceTypes { get; }
+    }
+}

--- a/source/Octopus.Tentacle/Communications/InvalidServiceTypeException.cs
+++ b/source/Octopus.Tentacle/Communications/InvalidServiceTypeException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Octopus.Tentacle.Communications
+{
+    public class InvalidServiceTypeException : Exception
+    {
+        public InvalidServiceTypeException(Type invalidType)
+            : base($"Error: {invalidType.Name} must be a class that implements an interface")
+        {
+            InvalidType = invalidType;
+        }
+        
+        public Type InvalidType { get; }
+    }
+}

--- a/source/Octopus.Tentacle/Communications/KnownServiceSource.cs
+++ b/source/Octopus.Tentacle/Communications/KnownServiceSource.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Octopus.Tentacle.Communications
+{
+    public class KnownServiceSource : IAutofacServiceSource
+    {
+        public KnownServiceSource(params Type[] serviceTypes)
+        {
+            ServiceTypes = serviceTypes;
+        }
+        
+        public IEnumerable<Type> ServiceTypes { get; }
+    }
+}

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Autofac;
 using Halibut;
 using Halibut.ServiceModel;
-using Octopus.Shared.Communications;
 using Octopus.Shared.Configuration;
 using Octopus.Tentacle.Configuration;
 

--- a/source/Octopus.Tentacle/Communications/UnknownServiceNameException.cs
+++ b/source/Octopus.Tentacle/Communications/UnknownServiceNameException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Octopus.Tentacle.Communications
+{
+    public class UnknownServiceNameException : Exception
+    {
+        public UnknownServiceNameException(string serviceName)
+            : base($"Error: {serviceName} has not been registered through an IAutofacServiceSource")
+        {
+            ServiceName = serviceName;
+        }
+        
+        public string ServiceName { get; }
+    }
+}

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -37,13 +37,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Halibut" Version="4.3.34" />
+		<PackageReference Include="Halibut" Version="4.4.4" />
 		<PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.2.3350" />
-		<PackageReference Include="Octopus.Shared" Version="10.3.1-ci0015" />
+		<PackageReference Include="Octopus.Shared" Version="10.3.1-andrew-w-update-0022" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.2.3350" />
-		<PackageReference Include="Octopus.Shared" Version="10.3.1-andrew-w-update-0022" />
+		<PackageReference Include="Octopus.Shared" Version="10.3.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/source/Octopus.Tentacle/Services/ServicesModule.cs
+++ b/source/Octopus.Tentacle/Services/ServicesModule.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Linq;
 using Autofac;
 using Octopus.Shared.Packages;
 using Octopus.Shared.Scripts;
+using Octopus.Tentacle.Communications;
 
 namespace Octopus.Tentacle.Services
 {
@@ -15,11 +17,10 @@ namespace Octopus.Tentacle.Services
 
             builder.RegisterType<NuGetPackageInstaller>().As<IPackageInstaller>();
 
-            // Find anything with the [Service] attribute
-            builder.RegisterAssemblyTypes(ThisAssembly)
-                .Where(t => t.GetCustomAttributes(typeof (ServiceAttribute), true).Length > 0)
-                .Named(t => "I" + t.Name, typeof (object))
-                .SingleInstance();
+            // Register our Halibut services
+            var serviceTypes = ThisAssembly.GetTypes().Where(t => t.GetCustomAttributes(typeof(ServiceAttribute), true).Length > 0).ToArray();
+            var assemblyServices = new KnownServiceSource(serviceTypes);
+            builder.RegisterInstance(assemblyServices).AsImplementedInterfaces();
         }
     }
 }


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? Describe it here or link to an issue. -->
Halibut has been updated to make the protocol more secure.
In the process, the AutofacServiceFactory has been moved from shared to here.

<!-- Consider adding a before/after log excerpt or screen capture. -->

# Review

Firstly, thanks for reviewing this pull request! :tada:

<!-- Describe the outcomes you want from a review. In-principle? Exploratory testing? Add inline comments calling out important changes. -->

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
