### PR TITLE
Ensure Tentacle binary is linked on new container

### DIFF
--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -15,14 +15,14 @@ alreadyConfiguredSemaphore="$configurationDirectory/.configuredSemaphore"
 mkdir -p $configurationDirectory
 mkdir -p $applicationsDirectory
 
+if [ ! -f /usr/bin/tentacle ]; then
+	ln -s /opt/octopus/tentacle/Tentacle /usr/bin/tentacle
+fi
+
 if [ -f "$alreadyConfiguredSemaphore" ]; then
     echo "Octopus Tentacle is already configured. Skipping reconfiguration."
     echo "If you want to force reconfiguration, please delete the file $alreadyConfiguredSemaphore and re-launch the container."
     exit 0
-fi
-
-if [ ! -f /usr/bin/tentacle ]; then
-	ln -s /opt/octopus/tentacle/Tentacle /usr/bin/tentacle
 fi
 
 function getPublicHostName() {


### PR DESCRIPTION
Even if the "i am configured" semaphore exists

# Background

If the `.configuredSemaphore` file exists, the Tentacle container wont attempt to reconfigure.

In https://github.com/OctopusDeploy/OctopusTentacle/pull/290, we changed it from completely aborting to "ignore reconfiguration and continue". 

However, in the wild (ie, on my nas), the new container, I found that sometimes it still would be unable to launch, as the binary had not been linked into the expected location.

This PR changes the order, so that if the symbolic link does not exist, it creates that before checking if the semaphore exists.

# Testing

Here are the steps I used to test this pull request:

```
docker run `
  --interactive `
  --detach `
  --name OctopusTentacle10996 `
  --publish 10996:10996 `
  --env "ListeningPort=10996" `
  --env "ServerApiKey=API-XXXX" `
  --env "TargetEnvironment=Home" `
  --env "TargetRole=container-server" `
  --env "ServerUrl=https://myoctopus.octopus.app" `
  --env "ACCEPT_EULA=Y" `
  --env "DISABLE_DIND=Y" `
  --restart always `
  -v C:\temp\testing-link-tentacle-binary-order:/etc/octopus `
  docker.packages.octopushq.com/octopusdeploy/tentacle:6.1.940-mattr-link-tentacle-binary-order
```
Then I connected to the container, installed `ps` (via `apt-get install procps`) and killed the tentacle process. Docker restarted the container, _interestingly with the same id_.

I then stopped the container, deleted it, and re-ran the command above - it successfully re-launched.

I believe that this second step was what was missed in #290.

# Review

Firstly, thanks for reviewing this pull request! :tada:

A sanity check on the ideas and a quick :eyes: over the code will be sufficient.

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
