### PR TITLE
Sign Harden-InstallationDirectory.ps1 during build.

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -132,7 +132,6 @@ partial class Build
                     .ForEach(x => FileSystemTasks.CopyFileToDirectory(x, installerDirectory, FileExistsPolicy.Overwrite));
                 (BuildDirectory / "Octopus.Manager.Tentacle" / NetFramework / "win").GlobFiles("*")
                     .ForEach(x => FileSystemTasks.CopyFileToDirectory(x, installerDirectory, FileExistsPolicy.Overwrite));
-                FileSystemTasks.CopyFileToDirectory(RootDirectory / "scripts" / "Harden-InstallationDirectory.ps1", installerDirectory, FileExistsPolicy.Overwrite);
 
                 var harvestFilePath = RootDirectory / "installer" / "Octopus.Tentacle.Installer" / "Tentacle.Generated.wxs";
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,7 +1,6 @@
 // ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -25,7 +24,6 @@ using Nuke.Common.Tools.SignTool;
 using Nuke.Common.Utilities.Collections;
 using Nuke.OctoVersion;
 using OctoVersion.Core;
-using Serilog;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 


### PR DESCRIPTION
# Background

This PR is a step on the road to signing all our PowerShell scripts, as discussed here: https://github.com/OctopusDeploy/OctopusTentacle/pull/285 and here: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1627507335269700 (internal link).

Note that this doesn't actually allow the script to run on machine with an Execution Policy set to 'Only signed scripts' yet, because that still requires the Octopus certificate to be installed under Trusted Publishers.  This particular script is only used in the MSI installer for Windows.

The way this is implemented may change in the future as we further develop our script signing process.

## Before
Script wasn't signed.

## After
Script _is_ signed!

# Testing
Ran the build process, installed Tentacle from the produced MSI, noted that the Harden-InstallationDirectory.ps1 file had a signature.
Also ran `Get-AuthenticodeSignature Harden-InstallationDirectory.ps1`, which showed that the file had a valid signature.

# Review

Firstly, thanks for reviewing this pull request! :tada:

# Checks

- [X] :green_heart: All automated builds and tests are passing
- [X] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [X] Existing installations will continue working after updating to this version of Tentacle
- [X] I have considered the changes to public documentation needed to reflect this change
- [X] I have considered the changes to the project wiki needed to reflect this change
