### PR TITLE
Ensure if working on mac that we enter this block

### DIFF
--- a/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
@@ -49,7 +49,7 @@ namespace Octopus.Tentacle.Services.Scripts
             workspace.ScriptMutexAcquireTimeout = command.ScriptIsolationMutexTimeout;
             workspace.ScriptArguments = command.Arguments;
 
-            if (PlatformDetection.IsRunningOnNix || PlatformDetection.IsRunningOnNix)
+            if (PlatformDetection.IsRunningOnNix || PlatformDetection.IsRunningOnMac)
             {
                 //TODO: This could be better
                 workspace.BootstrapScript(command.Scripts.ContainsKey(ScriptType.Bash)


### PR DESCRIPTION
# Background

When running the test Octopus.E2ETests.API PackageTransferTestScript on a mac. the test would fail with the bellow error

```
Step 1: TransferPackage - Failed
        --------------------------------
        Fatal: The step failed: Activity TransferPackage on listening-tentacle failed with error 'The remote script failed with exit code 2'.

                listening-tentacle - Failed
                ---------------------------
                Info: Transferring staged package '/var/folders/tn/qz5ypy4x7sz8zt30plvm78m40000gn/T/OctopusTest/Api Test/1/listening-tentacle/Files/Acme.Service@S1.9.3@9432B1C68BA16F45ABC0806968D01880.nupkg'
                Error: /var/folders/tn/qz5ypy4x7sz8zt30plvm78m40000gn/T/OctopusTest/Api Test/1/listening-tentacle/Work/20210929065851-8-2/Bootstrap.sh: line 1: =: command not found
                Error: /var/folders/tn/qz5ypy4x7sz8zt30plvm78m40000gn/T/OctopusTest/Api Test/1/listening-tentacle/Work/20210929065851-8-2/Bootstrap.sh: command substitution: line 3: syntax error near unexpected token `"/var/folders/tn/qz5ypy4x7sz8zt30plvm78m40000gn/T/OctopusTest/Api Test/1/PackageTransfer",'
                Error: /var/folders/tn/qz5ypy4x7sz8zt30plvm78m40000gn/T/OctopusTest/Api Test/1/listening-tentacle/Work/20210929065851-8-2/Bootstrap.sh: command substitution: line 3: `[IO.Path]::Combine("/var/folders/tn/qz5ypy4x7sz8zt30plvm78m40000gn/T/OctopusTest/Api Test/1/PackageTransfer", "Acme.Service.1.9.3.nupkg")'
                Error: /var/folders/tn/qz5ypy4x7sz8zt30plvm78m40000gn/T/OctopusTest/Api Test/1/listening-tentacle/Work/20210929065851-8-2/Bootstrap.sh: line 3: =: command not found
                Error: /var/folders/tn/qz5ypy4x7sz8zt30plvm78m40000gn/T/OctopusTest/Api Test/1/listening-tentacle/Work/20210929065851-8-2/Bootstrap.sh: line 5: syntax error near unexpected token `{'
                Error: /var/folders/tn/qz5ypy4x7sz8zt30plvm78m40000gn/T/OctopusTest/Api Test/1/listening-tentacle/Work/20210929065851-8-2/Bootstrap.sh: line 5: `if (Test-Path $FullTransferPath) {'
                Fatal: The remote script failed with exit code 2
                Fatal: The action TransferPackage on listening-tentacle failed
```

## After

After some splunking, it was noticed that it was trying to run powershell commands as a bash file where this specific line of code looked suspect
```   
if (PlatformDetection.IsRunningOnNix || PlatformDetection.IsRunningOnNix)
```
https://github.com/OctopusDeploy/OctopusTentacle/blob/56ab573fc4b8217b6ea959e3f10e[…]1ad62/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs

Changing to 

```   
if (PlatformDetection.IsRunningOnNix || PlatformDetection.IsRunningOnMac)
```

Will hopefully force the script into this code block and can pass the error. 
- 

# Review

Firstly, thanks for reviewing this pull request! :tada:

Can reviewer run this change locaaly and ensure that the cause is fixed!

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
