### PR TITLE
Fix UseDefaultProxy setting for tentacle registration

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
@@ -55,7 +55,7 @@ namespace Octopus.Tentacle.Tests.Commands
             var certificateConfigurationResource = new CertificateConfigurationResource { Thumbprint = serverThumbprint };
             certificateConfigurationRepository.GetOctopusCertificate().Returns(Task.FromResult(certificateConfigurationResource));
             repository.CertificateConfiguration.Returns(certificateConfigurationRepository);
-            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>())
+            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>(), Arg.Is(false))
                 .Returns(Task.FromResult(octopusAsyncClient));
             var selector = Substitute.For<IApplicationInstanceSelector>();
             selector.Current.Returns(info => new ApplicationInstanceConfiguration(null, null!, null!, null!));

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
@@ -55,7 +55,7 @@ namespace Octopus.Tentacle.Tests.Commands
             var certificateConfigurationResource = new CertificateConfigurationResource { Thumbprint = serverThumbprint };
             certificateConfigurationRepository.GetOctopusCertificate().Returns(Task.FromResult(certificateConfigurationResource));
             repository.CertificateConfiguration.Returns(certificateConfigurationRepository);
-            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>())
+            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), false)
                 .Returns(Task.FromResult(octopusAsyncClient));
             var selector = Substitute.For<IApplicationInstanceSelector>();
             selector.Current.Returns(info => new ApplicationInstanceConfiguration(null, null!, null!, null!));

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
@@ -55,7 +55,7 @@ namespace Octopus.Tentacle.Tests.Commands
             var certificateConfigurationResource = new CertificateConfigurationResource { Thumbprint = serverThumbprint };
             certificateConfigurationRepository.GetOctopusCertificate().Returns(Task.FromResult(certificateConfigurationResource));
             repository.CertificateConfiguration.Returns(certificateConfigurationRepository);
-            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>(), Arg.Is(false))
+            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>())
                 .Returns(Task.FromResult(octopusAsyncClient));
             var selector = Substitute.For<IApplicationInstanceSelector>();
             selector.Current.Returns(info => new ApplicationInstanceConfiguration(null, null!, null!, null!));

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
@@ -55,7 +55,7 @@ namespace Octopus.Tentacle.Tests.Commands
             var certificateConfigurationResource = new CertificateConfigurationResource { Thumbprint = serverThumbprint };
             certificateConfigurationRepository.GetOctopusCertificate().Returns(Task.FromResult(certificateConfigurationResource));
             repository.CertificateConfiguration.Returns(certificateConfigurationRepository);
-            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>(), Arg.Is(false))
+            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>())
                 .Returns(Task.FromResult(octopusAsyncClient));
 
             var applicationInstanceSelector = Substitute.For<IApplicationInstanceSelector>();

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
@@ -55,7 +55,7 @@ namespace Octopus.Tentacle.Tests.Commands
             var certificateConfigurationResource = new CertificateConfigurationResource { Thumbprint = serverThumbprint };
             certificateConfigurationRepository.GetOctopusCertificate().Returns(Task.FromResult(certificateConfigurationResource));
             repository.CertificateConfiguration.Returns(certificateConfigurationRepository);
-            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>())
+            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), false)
                 .Returns(Task.FromResult(octopusAsyncClient));
 
             var applicationInstanceSelector = Substitute.For<IApplicationInstanceSelector>();

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
@@ -55,7 +55,7 @@ namespace Octopus.Tentacle.Tests.Commands
             var certificateConfigurationResource = new CertificateConfigurationResource { Thumbprint = serverThumbprint };
             certificateConfigurationRepository.GetOctopusCertificate().Returns(Task.FromResult(certificateConfigurationResource));
             repository.CertificateConfiguration.Returns(certificateConfigurationRepository);
-            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>())
+            octopusClientInitializer.CreateClient(Arg.Any<ApiEndpointOptions>(), Arg.Any<IWebProxy>(), Arg.Is(false))
                 .Returns(Task.FromResult(octopusAsyncClient));
 
             var applicationInstanceSelector = Substitute.For<IApplicationInstanceSelector>();

--- a/source/Octopus.Tentacle/Commands/OptionSets/IOctopusClientInitializer.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/IOctopusClientInitializer.cs
@@ -7,6 +7,6 @@ namespace Octopus.Tentacle.Commands.OptionSets
 {
     public interface IOctopusClientInitializer
     {
-        Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions api, IWebProxy proxyOverride);
+        Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions api, IWebProxy proxyOverride, bool allowDefaultProxy = true);
     }
 }

--- a/source/Octopus.Tentacle/Commands/OptionSets/IOctopusClientInitializer.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/IOctopusClientInitializer.cs
@@ -7,6 +7,7 @@ namespace Octopus.Tentacle.Commands.OptionSets
 {
     public interface IOctopusClientInitializer
     {
-        Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions api, IWebProxy proxyOverride, bool allowDefaultProxy = true);
+        Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions apiEndpointOptions, IWebProxy overrideProxy);
+        Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions apiEndpointOptions, bool useDefaultProxy);
     }
 }

--- a/source/Octopus.Tentacle/Commands/OptionSets/OctopusClientInitializer.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/OctopusClientInitializer.cs
@@ -8,13 +8,15 @@ namespace Octopus.Tentacle.Commands.OptionSets
 {
     public class OctopusClientInitializer : IOctopusClientInitializer
     {
-        public async Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions apiEndpointOptions, IWebProxy overrideProxy)
+        public async Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions apiEndpointOptions, IWebProxy overrideProxy, bool allowDefaultProxy = true)
         {
             IOctopusAsyncClient client = null;
             try
             {
                 var endpoint = GetEndpoint(apiEndpointOptions, overrideProxy);
-                client = await OctopusAsyncClient.Create(endpoint).ConfigureAwait(false);
+                var clientOptions = new OctopusClientOptions() { AllowDefaultProxy = allowDefaultProxy };
+                client = await OctopusAsyncClient.Create(endpoint, clientOptions).ConfigureAwait(false);
+
                 if (string.IsNullOrWhiteSpace(apiEndpointOptions.ApiKey))
                 {
                     await client.Repository.Users

--- a/source/Octopus.Tentacle/Commands/OptionSets/OctopusClientInitializer.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/OctopusClientInitializer.cs
@@ -8,13 +8,23 @@ namespace Octopus.Tentacle.Commands.OptionSets
 {
     public class OctopusClientInitializer : IOctopusClientInitializer
     {
-        public async Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions apiEndpointOptions, IWebProxy overrideProxy, bool allowDefaultProxy = true)
+        public async Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions apiEndpointOptions, IWebProxy overrideProxy)
+        {
+            return await CreateClient(apiEndpointOptions, overrideProxy, false);
+        }
+
+        public async Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions apiEndpointOptions, bool useDefaultProxy)
+        {
+            return await CreateClient(apiEndpointOptions, null, useDefaultProxy);
+        }
+
+        async Task<IOctopusAsyncClient> CreateClient(ApiEndpointOptions apiEndpointOptions, IWebProxy overrideProxy, bool useDefaultProxy)
         {
             IOctopusAsyncClient client = null;
             try
             {
                 var endpoint = GetEndpoint(apiEndpointOptions, overrideProxy);
-                var clientOptions = new OctopusClientOptions() { AllowDefaultProxy = allowDefaultProxy };
+                var clientOptions = new OctopusClientOptions() { AllowDefaultProxy = useDefaultProxy };
                 client = await OctopusAsyncClient.Create(endpoint, clientOptions).ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(apiEndpointOptions.ApiKey))

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -96,6 +96,7 @@ namespace Octopus.Tentacle.Commands
 
             Uri serverAddress = null;
 
+            var useDefaultProxy = configuration.Value.PollingProxyConfiguration.UseDefaultProxy;
             //if we are on a polling tentacle with a polling proxy set up, use the api through that proxy
             IWebProxy proxyOverride = null;
             string sslThumbprint = null;
@@ -108,7 +109,7 @@ namespace Octopus.Tentacle.Commands
 
             log.Info($"Registering the tentacle with the server at {api.ServerUri}");
 
-            using (var client = await octopusClientInitializer.CreateClient(api, proxyOverride))
+            using (var client = await octopusClientInitializer.CreateClient(api, proxyOverride, useDefaultProxy))
             {
                 var spaceRepository = await spaceRepositoryFactory.CreateSpaceRepository(client, spaceName);
                 await RegisterMachine(client.ForSystem(), spaceRepository, serverAddress, sslThumbprint, communicationStyle);

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -96,7 +96,10 @@ namespace Octopus.Tentacle.Commands
 
             Uri serverAddress = null;
 
-            var useDefaultProxy = configuration.Value.PollingProxyConfiguration.UseDefaultProxy;
+            var useDefaultProxy = communicationStyle == CommunicationStyle.TentacleActive
+                ? configuration.Value.PollingProxyConfiguration.UseDefaultProxy
+                : configuration.Value.ProxyConfiguration.UseDefaultProxy;
+
             //if we are on a polling tentacle with a polling proxy set up, use the api through that proxy
             IWebProxy proxyOverride = null;
             string sslThumbprint = null;

--- a/source/Octopus.Tentacle/Communications/OctopusServerChecker.cs
+++ b/source/Octopus.Tentacle/Communications/OctopusServerChecker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
@@ -38,11 +39,12 @@ namespace Octopus.Tentacle.Communications
 
             Retry("Checking that server communications are open", () =>
             {
+#pragma warning disable DE0003
                 var req = WebRequest.Create(handshake);
                 req.Proxy = proxyOverride;
                 req.Method = "POST";
                 req.ContentLength = 0;
-
+#pragma warning restore DE0003
                 try
                 {
                     using (var resp = req.GetResponse())

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -42,7 +42,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Octopus.Client" Version="11.3.28-MissedTheMark-bug-ProxyIssue" />
+		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
 		<PackageReference Include="Octopus.Shared" Version="10.3.3" />
 	</ItemGroup>
 

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -42,7 +42,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Octopus.Client" Version="11.3.3425" />
+		<PackageReference Include="Octopus.Client" Version="11.3.28-MissedTheMark-bug-ProxyIssue" />
 		<PackageReference Include="Octopus.Shared" Version="10.3.3" />
 	</ItemGroup>
 


### PR DESCRIPTION
# Background

Polling tentacles currently ignore the `UseDefaultProxy` setting when registering, and will attempt to use the default proxy on Windows if no specific proxy is configured. 

Fixes https://github.com/OctopusDeploy/Issues/issues/7065

<!-- Consider adding a before/after log excerpt or screen capture. -->

Added `allowDefaultProxy` parameter to `OctopusClientInitializer`, and passed it to the client creater. This allows the configuration value of `UseDefaultProxy` to be used for polling tentacles on registration.

## Before
![image](https://user-images.githubusercontent.com/46470837/137843713-595c2115-c472-4215-abe6-5ef3bb9a1453.png)

## After
![image](https://user-images.githubusercontent.com/46470837/137843774-1e77e3b5-60a7-4aad-852d-2ab261475c4b.png)

# Testing

Here are the steps I used to test this pull request:
- Setup a broken default proxy
- Attempted to register a pre-fix tentacle with a remote server
	- Failed 😢 
- Attempted to register a post-fix tentacle with a remote server
	- Success 🥳🍾:tada:   

# Review

Firstly, thanks for reviewing this pull request! :tada:
A double check that this won't effect existing scripting etc would be tops 🙏 

# Checks

- [X] :green_heart: All automated builds and tests are passing
- [X] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [X] Existing installations will continue working after updating to this version of Tentacle
- [X] I have considered the changes to public documentation needed to reflect this change
- [X] I have considered the changes to the project wiki needed to reflect this change
