### PR TITLE
OctopusValidationException is okay to show just the message to a user

### DIFF
--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Halibut;
 using Octopus.Client;
+using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
 using Octopus.Client.Operations;
 using Octopus.Diagnostics;
@@ -158,6 +159,10 @@ namespace Octopus.Tentacle.Commands
                 await registerMachineOperation.ExecuteAsync(repository);
             }
             catch (InvalidRegistrationArgumentsException ex)
+            {
+                throw new ControlledFailureException(ex.Message, ex);
+            }
+            catch (OctopusValidationException ex)
             {
                 throw new ControlledFailureException(ex.Message, ex);
             }


### PR DESCRIPTION
# Background

Attempting to register a worker against an Octopus Cloud dynamic worker pool shows an ugly stack trace.

It should show a nice validation error message instead.

## Results

This PR just catches the `OctopusValidationException` and treats it as a `ControlledFailureException` (which we special case when we show to the user.

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/331

## Before

Running
```
PS > ./tentacle.exe register-worker --instance $env:INSTANCE_NAME --server $env:OCTOPUS_SERVER --apikey $env:OCTOPUS_APIKEY --workerpool "Default Worker Pool"
```
shows:
```
Registering the tentacle with the server at https://example.octopus.app/
Detected automation environment: NoneOrUnknown
===============================================================================
There was a problem with your request.

 - Worker Pools 'Default Worker Pool' do not support adding workers directly

Octopus.Client.Exceptions.OctopusValidationException
   at Octopus.Client.OctopusAsyncClient.DispatchRequest[TResponseResource](OctopusRequest request, Boolean readResponse)
   at Octopus.Client.OctopusAsyncClient.Create[TResource](String path, TResource resource, Object pathParameters)
   at Octopus.Client.Repositories.Async.BasicRepository`1.Create(TResource resource, Object pathParameters)
   at Octopus.Client.Operations.RegisterWorkerOperation.ExecuteAsync(IOctopusSpaceAsyncRepository repository)
   at Octopus.Tentacle.Commands.RegisterMachineCommandBase`1.RegisterMachine(IOctopusSystemAsyncRepository systemRepository, IOctopusSpaceAsyncRepository repository, Uri serverAddress, String sslThumbprint, CommunicationStyle communicationStyle) in RegisterMachineCommandBase.cs:line 159
   at Octopus.Tentacle.Commands.RegisterMachineCommandBase`1.StartAsync() in RegisterMachineCommandBase.cs:line 115
   at Octopus.Tentacle.Commands.RegisterMachineCommandBase`1.Start() in RegisterMachineCommandBase.cs:line 81
   at Octopus.Shared.Startup.AbstractCommand.Start(String[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
   at Octopus.Shared.Startup.OctopusProgram.Start(ICommandRuntime commandRuntime)
   at Octopus.Shared.Startup.ConsoleHost.Run(Action`1 start, Action shutdown)
   at Octopus.Shared.Startup.OctopusProgram.RunHost(ICommandHost host)
   at Octopus.Shared.Startup.OctopusProgram.Run()
-------------------------------------------------------------------------------
Terminating process with exit code 100
Full error details are available in the log files at:
C:\Program Files\OctopusDeploy\Tentacle\Logs
C:\Users\<username>\AppData\Local\Octopus\Logs
If you need help, please send these log files to https://octopus.com/support
-------------------------------------------------------------------------------
```
## After

```
PS > ./tentacle.exe register-worker --instance $env:INSTANCE_NAME --server $env:OCTOPUS_SERVER --apikey $env:OCTOPUS_APIKEY --workerpool "Default Worker Pool"
```
now returns:
```
Registering the tentacle with the server at https://example.octopus.app/
Detected automation environment: NoneOrUnknown
There was a problem with your request.

 - Worker Pools 'Default Worker Pool' do not support adding workers directly
```

(note, while this message isn't awesome, that's what comes from the server, so out of scope of this fix)

# Testing

Here are the steps I used to test this pull request:

* tested locally manually 

# Review

Firstly, thanks for reviewing this pull request! :tada:

<!-- Describe the outcomes you want from a review. In-principle? Exploratory testing? Add inline comments calling out important changes. -->

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
