### PR TITLE
Add PackageRetentionJournal environment variable

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
@@ -31,7 +31,7 @@ namespace Octopus.Tentacle.Tests.Commands
         public string PackagesDirectory { get; private set; }
         public string LogsDirectory { get; private set; }
         public string JournalFilePath { get; private set; }
-        public string PackageRetentionFilePath { get; private set; }
+        public string PackageRetentionJournalFilePath { get; private set; }
         public X509Certificate2 TentacleCertificate { get; set; }
         public string ListenIpAddress { get; set; }
         public bool NoListen { get; set; }

--- a/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
@@ -31,7 +31,7 @@ namespace Octopus.Tentacle.Tests.Commands
         public string PackagesDirectory { get; private set; }
         public string LogsDirectory { get; private set; }
         public string JournalFilePath { get; private set; }
-        public string PackageRetentionJournalFilePath { get; private set; }
+        public string PackageRetentionJournalPath { get; private set; }
         public X509Certificate2 TentacleCertificate { get; set; }
         public string ListenIpAddress { get; set; }
         public bool NoListen { get; set; }

--- a/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
@@ -31,6 +31,7 @@ namespace Octopus.Tentacle.Tests.Commands
         public string PackagesDirectory { get; private set; }
         public string LogsDirectory { get; private set; }
         public string JournalFilePath { get; private set; }
+        public string PackageRetentionFilePath { get; private set; }
         public X509Certificate2 TentacleCertificate { get; set; }
         public string ListenIpAddress { get; set; }
         public bool NoListen { get; set; }

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -92,6 +92,8 @@ namespace Octopus.Tentacle.Commands
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleHome, home.Value.HomeDirectory);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleApplications, configuration.Value.ApplicationDirectory);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleJournal, configuration.Value.JournalFilePath);
+            // Package retention - TODO: Move hard-coded name to Shared
+            Environment.SetEnvironmentVariable("PackageRetentionJournal", configuration.Value.PackageRetentionFilePath);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleInstanceName, selector.Current.InstanceName);
             var currentPath = typeof(RunAgentCommand).Assembly.FullLocalPath();
             var exePath = PlatformDetection.IsRunningOnWindows
@@ -107,6 +109,7 @@ namespace Octopus.Tentacle.Commands
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, proxyConfiguration.Value.CustomProxyPassword);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, proxyConfiguration.Value.CustomProxyHost);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, proxyConfiguration.Value.CustomProxyPort.ToString());
+
 
             LogWarningIfNotRunningAsAdministrator();
 

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -92,8 +92,7 @@ namespace Octopus.Tentacle.Commands
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleHome, home.Value.HomeDirectory);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleApplications, configuration.Value.ApplicationDirectory);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleJournal, configuration.Value.JournalFilePath);
-            // Package retention - TODO: Move hard-coded name to Shared
-            Environment.SetEnvironmentVariable("PackageRetentionJournal", configuration.Value.PackageRetentionFilePath);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.CalamariPackageRetentionJournalPath, configuration.Value.PackageRetentionJournalFilePath);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleInstanceName, selector.Current.InstanceName);
             var currentPath = typeof(RunAgentCommand).Assembly.FullLocalPath();
             var exePath = PlatformDetection.IsRunningOnWindows

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -92,7 +92,7 @@ namespace Octopus.Tentacle.Commands
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleHome, home.Value.HomeDirectory);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleApplications, configuration.Value.ApplicationDirectory);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleJournal, configuration.Value.JournalFilePath);
-            Environment.SetEnvironmentVariable(EnvironmentVariables.CalamariPackageRetentionJournalPath, configuration.Value.PackageRetentionJournalFilePath);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.CalamariPackageRetentionJournalPath, configuration.Value.PackageRetentionJournalPath);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleInstanceName, selector.Current.InstanceName);
             var currentPath = typeof(RunAgentCommand).Assembly.FullLocalPath();
             var exePath = PlatformDetection.IsRunningOnWindows
@@ -108,7 +108,6 @@ namespace Octopus.Tentacle.Commands
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, proxyConfiguration.Value.CustomProxyPassword);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, proxyConfiguration.Value.CustomProxyHost);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, proxyConfiguration.Value.CustomProxyPort.ToString());
-
 
             LogWarningIfNotRunningAsAdministrator();
 

--- a/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
@@ -51,7 +51,7 @@ namespace Octopus.Tentacle.Configuration
         /// <summary>
         /// Gets the file where package usages should be stored.
         /// </summary>
-        string PackageRetentionFilePath { get; }
+        string PackageRetentionJournalFilePath { get; }
 
         /// <summary>
         /// Gets or sets the X509 certificate used by the Tentacle.

--- a/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
@@ -49,6 +49,11 @@ namespace Octopus.Tentacle.Configuration
         string JournalFilePath { get; }
 
         /// <summary>
+        /// Gets the file where package usages should be stored.
+        /// </summary>
+        string PackageRetentionFilePath { get; }
+
+        /// <summary>
         /// Gets or sets the X509 certificate used by the Tentacle.
         /// </summary>
         X509Certificate2? TentacleCertificate { get; }

--- a/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
@@ -51,7 +51,7 @@ namespace Octopus.Tentacle.Configuration
         /// <summary>
         /// Gets the file where package usages should be stored.
         /// </summary>
-        string PackageRetentionJournalFilePath { get; }
+        string PackageRetentionJournalPath { get; }
 
         /// <summary>
         /// Gets or sets the X509 certificate used by the Tentacle.

--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -97,10 +97,8 @@ namespace Octopus.Tentacle.Configuration
             get { return Path.Combine(ApplicationDirectory, "Packages"); }
         }
 
-        public string JournalFilePath
-        {
-            get { return Path.Combine(home.HomeDirectory ?? ".", "DeploymentJournal.xml"); }
-        }
+        public string JournalFilePath => Path.Combine(home.HomeDirectory ?? ".", "DeploymentJournal.xml");
+        public string PackageRetentionFilePath => Path.Combine(home.HomeDirectory ?? ".", "PackageRetentionJournal.json");
 
         public X509Certificate2? TentacleCertificate
         {

--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -98,7 +98,7 @@ namespace Octopus.Tentacle.Configuration
         }
 
         public string JournalFilePath => Path.Combine(home.HomeDirectory ?? ".", "DeploymentJournal.xml");
-        public string PackageRetentionFilePath => Path.Combine(home.HomeDirectory ?? ".", "PackageRetentionJournal.json");
+        public string PackageRetentionJournalFilePath => Path.Combine(home.HomeDirectory ?? ".", "PackageRetentionJournal.json");
 
         public X509Certificate2? TentacleCertificate
         {

--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -98,7 +98,7 @@ namespace Octopus.Tentacle.Configuration
         }
 
         public string JournalFilePath => Path.Combine(home.HomeDirectory ?? ".", "DeploymentJournal.xml");
-        public string PackageRetentionJournalFilePath => Path.Combine(home.HomeDirectory ?? ".", "PackageRetentionJournal.json");
+        public string PackageRetentionJournalPath => Path.Combine(home.HomeDirectory ?? ".", "PackageRetentionJournal.json");
 
         public X509Certificate2? TentacleCertificate
         {

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
-		<PackageReference Include="Octopus.Shared" Version="10.4.1" />
+		<PackageReference Include="Octopus.Shared" Version="10.4.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
# Background

Package retention requires a new journal file to be stored on the Tentacle to keep track of package usages. This PR adds a new environment variable similar to the existing `JournalPath` used for deployments which we can use in Calamari to retrieve the correct file.