### PR TITLE
Adjustments to more Nullable Reference Type things for Configuration

### DIFF
--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -54,7 +54,7 @@ namespace Octopus.Tentacle.Configuration
         [Obsolete("This configuration entry is obsolete as of 3.0. It is only used as a Subscription ID where one does not exist.")]
         public string? TentacleSquid => settings.Get("Octopus.Communications.Squid", (string?)null);
 
-        public IEnumerable<OctopusServerConfiguration> TrustedOctopusServers => settings.Get(TrustedServersSettingName, new OctopusServerConfiguration[0]);
+        public IEnumerable<OctopusServerConfiguration> TrustedOctopusServers => settings.Get<IEnumerable<OctopusServerConfiguration>>(TrustedServersSettingName) ?? new OctopusServerConfiguration[0];
 
         public IEnumerable<string> TrustedOctopusThumbprints
         {
@@ -72,7 +72,7 @@ namespace Octopus.Tentacle.Configuration
             get
             {
                 var path = settings.Get<string>(DeploymentApplicationDirectorySettingName);
-                if (string.IsNullOrWhiteSpace(path))
+                if (path is null || string.IsNullOrWhiteSpace(path))
                 {
                     if (PlatformDetection.IsRunningOnWindows)
                     {
@@ -112,9 +112,9 @@ namespace Octopus.Tentacle.Configuration
                 {
                     return null;
                 }
-                
+
                 var encoded = settings.Get<string>(CertificateSettingName, protectionLevel: ProtectionLevel.MachineKey);
-                return string.IsNullOrWhiteSpace(encoded) ? null : CertificateEncoder.FromBase64String(thumbprint!, encoded, log);
+                return encoded is null || string.IsNullOrWhiteSpace(encoded) ? null : CertificateEncoder.FromBase64String(thumbprint!, encoded, log);
             }
         }
 
@@ -130,7 +130,7 @@ namespace Octopus.Tentacle.Configuration
                     return OctopusServerConfiguration;
 
                 var setting = settings.Get<string>(LastReceivedHandshakeSettingName);
-                if (string.IsNullOrWhiteSpace(setting)) return null;
+                if (setting is null || string.IsNullOrWhiteSpace(setting)) return null;
                 return JsonConvert.DeserializeObject<OctopusServerConfiguration>(setting);
             }
         }

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -12,7 +12,7 @@
 		<RootNamespace>Octopus.Tentacle</RootNamespace>
 		<TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<LangVersion>8</LangVersion>
+		<LangVersion>9</LangVersion>
 	</PropertyGroup>
 
 	<Choose>
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
-		<PackageReference Include="Octopus.Shared" Version="10.4.2" />
+		<PackageReference Include="Octopus.Shared" Version="10.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
# Background

This is to deal with changes in the later .NET SDKs that cause Visual Studio and Rider, and sometimes the builds, to hit errors.

# Review

👀 the code, there are only a few lines.

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
