### PR TITLE
Pass isolation mutex name to workspace

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
-		<PackageReference Include="Octopus.Shared" Version="10.5.1-tothegills-named0005" />
+		<PackageReference Include="Octopus.Shared" Version="10.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
-		<PackageReference Include="Octopus.Shared" Version="10.5.0" />
+		<PackageReference Include="Octopus.Shared" Version="10.5.1-tothegills-named0005" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
@@ -48,6 +48,7 @@ namespace Octopus.Tentacle.Services.Scripts
             workspace.IsolationLevel = command.Isolation;
             workspace.ScriptMutexAcquireTimeout = command.ScriptIsolationMutexTimeout;
             workspace.ScriptArguments = command.Arguments;
+            workspace.ScriptMutexName = command.IsolationMutexName;
 
             if (PlatformDetection.IsRunningOnNix || PlatformDetection.IsRunningOnMac)
             {


### PR DESCRIPTION
# Background

This works in conjunctions with the changes to Octopus Shared that allows passing a script isolation mutex name with a command: https://github.com/OctopusDeploy/OctopusShared/pull/165
This PR sets the isolation mutex name on the workspace to match the name sent with the command.
