### PR TITLE
Mask sensitive values in Windows Tentacle container creation logs

### DIFF
--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -215,12 +215,16 @@ function Register-Tentacle(){
     Write-Verbose "Registering Tentacle with api key"
     $arg += "--apiKey";
     $arg += $ServerApiKey
+
+    $mask = $ServerApiKey
   } else {
     Write-Verbose "Registering Tentacle with username/password"
     $arg += "--username";
     $arg += $ServerUsername
     $arg += "--password";
     $arg += $ServerPassword
+    
+    $mask = $ServerPassword
   }
 
   if($TargetName -ne $null) {
@@ -254,7 +258,7 @@ function Register-Tentacle(){
     $arg += "`"$Space`"";
   }
 
-  Execute-Command $TentacleExe $arg;
+  Execute-Command $TentacleExe $arg $mask;
 }
 
 try


### PR DESCRIPTION
# Background

Fixes https://github.com/OctopusDeploy/ResearchAndDevelopment/issues/208

## Before

```
[2021-12-09T01:49:52] Registering with server ...
[2021-12-09T01:49:52] Executing command 'C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe register-worker --console --instance Tentacle --server http://dr-octopus.corp.adslot.com --force --comms-style TentacleActive --server-comms-port 10943 --apiKey **apiKeyWouldAppearHere** --name octopus-worker-win-dr --workerpool Default Worker Pool --space "Default"'
```

With API key:
![image](https://user-images.githubusercontent.com/11970672/148165866-0a6085a7-b2ed-4f96-86e5-f7ab6feb6566.png)

With username/password:
![image](https://user-images.githubusercontent.com/11970672/148166019-53994019-429d-43d3-a70c-cddbc8ddd3c2.png)

## After

With API key:
![image](https://user-images.githubusercontent.com/11970672/148165158-163fceb8-b8aa-40b9-ba28-96c6d5e7e561.png)

With username/password:
![image](https://user-images.githubusercontent.com/11970672/148165941-794fb2f1-415c-4c54-9889-af51fc853cf1.png)

# Review

Firstly, thanks for reviewing this pull request! :tada:

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
