### PR TITLE
Add Tenant/TenantTag/TenantedDeploymentParticipation options to Tentacle docker image, add documentation for Space/MachinePolicy options

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -50,6 +50,8 @@ ENV Space="Default"
 ENV TargetEnvironment=""
 ENV TargetName=""
 ENV TargetRole=""
+ENV Tenant=""
+ENV TenantTag=""
 ENV TargetWorkerPool=""
 
 VOLUME /var/lib/docker

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -50,8 +50,9 @@ ENV Space="Default"
 ENV TargetEnvironment=""
 ENV TargetName=""
 ENV TargetRole=""
-ENV Tenant=""
-ENV TenantTag=""
+ENV TargetTenant=""
+ENV TargetTenantTag=""
+ENV TargetTenantedDeploymentParticipation=""
 ENV TargetWorkerPool=""
 
 VOLUME /var/lib/docker

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -72,6 +72,13 @@ function validateVariables() {
 		fi
     fi
 
+	if [[ ! -z "$TargetTenant" || -z "$TargetTenantTag" ]]; then
+		if [[ "$TargetTenantedDeploymentParticipation" != "Tenanted" || "$TargetTenantedDeploymentParticipation" != "TenantedOrUntenanted" ]]; then
+			echo "The 'TargetTenant' and 'TargetTenantTag' environment variables are not valid when the 'TargetTenantedDeploymentParticipation' variable is not set to 'Tenanted' or 'TenantedOrUntenanted'"
+			exit 1
+		fi
+	fi
+
     echo " - server endpoint '$ServerUrl'"
     echo " - api key '##########'"
   if [[ ! -z "$ServerPort" ]]; then
@@ -142,15 +149,15 @@ function registerTentacle() {
 			done
 		fi
 
-		if [[ ! -z "$Tenant" ]]; then
-			IFS=',' read -ra TENANT <<< "$Tenant"
+		if [[ ! -z "$TargetTenant" ]]; then
+			IFS=',' read -ra TENANT <<< "$TargetTenant"
 			for i in "${TENANTS[@]}"; do
 				ARGS+=('--tenant' "$i")
 			done
 		fi
 
-		if [[ ! -z "$TenantTag" ]]; then
-			IFS=',' read -ra TENANTTAGS <<< "$TenantTag"
+		if [[ ! -z "$TargetTenantTag" ]]; then
+			IFS=',' read -ra TENANTTAGS <<< "$TargetTenantTag"
 			for i in "${TENANTTAGS[@]}"; do
 				ARGS+=('--tenanttag' "$i")
 			done
@@ -190,6 +197,10 @@ function registerTentacle() {
 
 	if [[ ! -z "$TargetName" ]]; then
 		ARGS+=('--name' "$TargetName")
+	fi
+	
+	if [[ ! -z "$TargetTenantedDeploymentParticipation" ]]; then
+		ARGS+=('--tenanted-deployment-participation' "$TargetTenantedDeploymentParticipation")
 	fi
 
 	tentacle "${ARGS[@]}"

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -141,6 +141,20 @@ function registerTentacle() {
 				ARGS+=('--role' "$i")
 			done
 		fi
+
+		if [[ ! -z "$Tenant" ]]; then
+			IFS=',' read -ra TENANT <<< "$Tenant"
+			for i in "${TENANTS[@]}"; do
+				ARGS+=('--tenant' "$i")
+			done
+		fi
+
+		if [[ ! -z "$TenantTag" ]]; then
+			IFS=',' read -ra TENANTTAGS <<< "$TenantTag"
+			for i in "${TENANTTAGS[@]}"; do
+				ARGS+=('--tenanttag' "$i")
+			done
+		fi
 	fi
 
 	ARGS+=(

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -92,6 +92,15 @@ function validateVariables() {
   if [[ ! -z "$TargetName" ]]; then
     echo " - name '$TargetName'"
   fi
+  if [[ ! -z "$TargetTenant" ]]; then
+    echo " - tenant '$TargetTenant'"
+  fi
+  if [[ ! -z "$TargetTenantTag" ]]; then
+    echo " - tenant tag '$TargetTenantTag'"
+  fi
+  if [[ ! -z "$TargetTenantedDeploymentParticipation" ]]; then
+    echo " - tenanted deployment participation '$TargetTenantedDeploymentParticipation'"
+  fi
   if [[ ! -z "$Space" ]]; then
     echo " - space '$Space'"
   fi
@@ -147,7 +156,7 @@ function registerTentacle() {
 		fi
 
 		if [[ ! -z "$TargetTenant" ]]; then
-			IFS=',' read -ra TENANT <<< "$TargetTenant"
+			IFS=',' read -ra TENANTS <<< "$TargetTenant"
 			for i in "${TENANTS[@]}"; do
 				ARGS+=('--tenant' "$i")
 			done

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -38,47 +38,6 @@ function getPublicHostName() {
 }
 
 function validateVariables() {
-	if [[ -z "$ServerApiKey" ]]; then
-		if [[ -z "$ServerPassword" || -z "$ServerUsername" ]]; then
-			echo "No 'ServerApiKey' or username/pasword environment variables are available" >&2
-			exit 1
-		fi
-	fi
-
-	if [[ -z "$ServerUrl" ]]; then
-		echo "Missing 'ServerUrl' environment variable" >&2
-		exit 1
-	fi
-
-	if [[ ! -z "$TargetWorkerPool" ]]; then
-		if [[ ! -z "$TargetEnvironment" ]]; then
-			echo "The 'TargetEnvironment' environment variable is not valid in combination with the 'TargetWorkerPool' variable" >&2
-			exit 1
-		fi
-
-		if [[ ! -z "$TargetRole" ]]; then
-			echo "The 'TargetRole' environment variable is not valid in combination with the 'TargetWorkerPool' variable" >&2
-			exit 1
-		fi
-	else
-		if [[ -z "$TargetEnvironment" ]]; then
-			echo "Missing 'TargetEnvironment' environment variable" >&2
-			exit 1
-		fi
-
-		if [[ -z "$TargetRole" ]]; then
-			echo "Missing 'TargetRole' environment variable" >&2
-			exit 1
-		fi
-    fi
-
-	if [[ ! -z "$TargetTenant" || ! -z "$TargetTenantTag" ]]; then
-		if [[ "$TargetTenantedDeploymentParticipation" != "Tenanted" || "$TargetTenantedDeploymentParticipation" != "TenantedOrUntenanted" ]]; then
-			echo "The 'TargetTenant' and 'TargetTenantTag' environment variables are not valid when the 'TargetTenantedDeploymentParticipation' variable is not set to 'Tenanted' or 'TenantedOrUntenanted'"
-			exit 1
-		fi
-	fi
-
     echo " - server endpoint '$ServerUrl'"
     echo " - api key '##########'"
   if [[ ! -z "$ServerPort" ]]; then

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -72,7 +72,7 @@ function validateVariables() {
 		fi
     fi
 
-	if [[ ! -z "$TargetTenant" || -z "$TargetTenantTag" ]]; then
+	if [[ ! -z "$TargetTenant" || ! -z "$TargetTenantTag" ]]; then
 		if [[ "$TargetTenantedDeploymentParticipation" != "Tenanted" || "$TargetTenantedDeploymentParticipation" != "TenantedOrUntenanted" ]]; then
 			echo "The 'TargetTenant' and 'TargetTenantTag' environment variables are not valid when the 'TargetTenantedDeploymentParticipation' variable is not set to 'Tenanted' or 'TenantedOrUntenanted'"
 			exit 1

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -11,7 +11,6 @@ instanceName=Tentacle
 configurationDirectory=/etc/octopus
 applicationsDirectory=/home/Octopus/Applications
 alreadyConfiguredSemaphore="$configurationDirectory/.configuredSemaphore"
-defaultListeningPort=10933
 
 mkdir -p $configurationDirectory
 mkdir -p $applicationsDirectory
@@ -116,7 +115,7 @@ function configureTentacle() {
 	if [[ ! -z "$ServerPort" ]]; then
 		tentacle configure --instance "$instanceName" --noListen "True"
 	else
-		tentacle configure --instance "$instanceName" --port $defaultListeningPort --noListen "False"
+		tentacle configure --instance "$instanceName" --port $ListeningPort --noListen "False"
 	fi
 
 	echo "Updating trust ..."
@@ -186,7 +185,7 @@ function registerTentacle() {
 			'--comms-style' 'TentaclePassive'
 			'--publicHostName' $(getPublicHostName))
 
-		if [[ ! -z "$ListeningPort" && "$ListeningPort" != $defaultListeningPort ]]; then
+		if [[ ! -z "$ListeningPort" && "$ListeningPort" != "10933" ]]; then
 			ARGS+=('--tentacle-comms-port' $ListeningPort)
 		fi
 	fi

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -48,8 +48,10 @@ docker run --publish 10931:10933 --tty --interactive --env "ListeningPort=10931"
 - **ServerUrl**: The Url of the Octopus Server the Tentacle should register with.
 - **TargetEnvironment**: Comma delimited list of environments to add this target to.
 - **TargetRole**: Comma delimited list of roles to add to this target.
-- **TargetWorkerPool**: Comma delimited list of worker pools to add to this target to (not to be used with environments or role variable).
+- **TargetWorkerPool**: Comma delimited list of worker pools to add this target to (not to be used with environment, tenant, tenant tag or role variable).
 - **TargetName**: Optional Target name, defaults to host.
+- **Tenant**: Comma delimited list of tenants to add to this target.
+- **TenantTag**: Comma delimited list of tenant tags to add to this target.
 - **ServerPort**: The port on the Octopus Server that the Tentacle will poll for work. Implies a polling Tentacle.
 - **ListeningPort**: The port that the Octopus Server will connect back to the Tentacle with. Defaults to 10933. Implies a listening Tentacle.
 - **PublicHostNameConfiguration**: How the url that the Octopus server will use to communicate with the Tentacle is determined. Can be `PublicIp`, `FQDN`, `ComputerName` or `Custom`. Defaults to `PublicIp`.

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -46,6 +46,7 @@ docker run --publish 10931:10933 --tty --interactive --env "ListeningPort=10931"
 - **ServerUsername**: If not using an API key, the user to use when registering the Tentacle with the Octopus Servr.
 - **ServerPassword**: If not using an API key, the password to use when registering the Tentacle
 - **ServerUrl**: The Url of the Octopus Server the Tentacle should register with.
+- **Space**: The name of the space which the Tentacle will be added to. Defaults to the default space.
 - **TargetEnvironment**: Comma delimited list of environments to add this target to.
 - **TargetRole**: Comma delimited list of roles to add to this target.
 - **TargetWorkerPool**: Comma delimited list of worker pools to add this target to (not to be used with environment, tenant, tenant tag or role variable).
@@ -53,6 +54,7 @@ docker run --publish 10931:10933 --tty --interactive --env "ListeningPort=10931"
 - **TargetTenant**: Comma delimited list of tenants to add to this target.
 - **TargetTenantTag**: Comma delimited list of tenant tags to add to this target.
 - **TargetTenantedDeploymentParticipation**: The tenanted deployment mode of the target. Allowed values are Untenanted, TenantedOrUntenanted and Tenanted. Defaults to Untenanted.
+- **MachinePolicy**: The name of the machine policy that will apply to this Tentacle. Defaults to the default machine policy.
 - **ServerPort**: The port on the Octopus Server that the Tentacle will poll for work. Implies a polling Tentacle.
 - **ListeningPort**: The port that the Octopus Server will connect back to the Tentacle with. Defaults to 10933. Implies a listening Tentacle.
 - **PublicHostNameConfiguration**: How the url that the Octopus server will use to communicate with the Tentacle is determined. Can be `PublicIp`, `FQDN`, `ComputerName` or `Custom`. Defaults to `PublicIp`.

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -43,15 +43,16 @@ docker run --publish 10931:10933 --tty --interactive --env "ListeningPort=10931"
 ### Environment variables
 
 - **ServerApiKey**: The API Key of the Octopus Server the Tentacle should register with.
-- **ServerUsername**: If not using an api key, the user to use when registering the Tentacle with the Octopus Servr.
-- **ServerPassword**: If not using an api key, the password to use when registering the Tentacle
+- **ServerUsername**: If not using an API key, the user to use when registering the Tentacle with the Octopus Servr.
+- **ServerPassword**: If not using an API key, the password to use when registering the Tentacle
 - **ServerUrl**: The Url of the Octopus Server the Tentacle should register with.
 - **TargetEnvironment**: Comma delimited list of environments to add this target to.
 - **TargetRole**: Comma delimited list of roles to add to this target.
 - **TargetWorkerPool**: Comma delimited list of worker pools to add this target to (not to be used with environment, tenant, tenant tag or role variable).
 - **TargetName**: Optional Target name, defaults to host.
-- **Tenant**: Comma delimited list of tenants to add to this target.
-- **TenantTag**: Comma delimited list of tenant tags to add to this target.
+- **TargetTenant**: Comma delimited list of tenants to add to this target.
+- **TargetTenantTag**: Comma delimited list of tenant tags to add to this target.
+- **TargetTenantedDeploymentParticipation**: The tenanted deployment mode of the target. Allowed values are Untenanted, TenantedOrUntenanted and Tenanted. Defaults to Untenanted.
 - **ServerPort**: The port on the Octopus Server that the Tentacle will poll for work. Implies a polling Tentacle.
 - **ListeningPort**: The port that the Octopus Server will connect back to the Tentacle with. Defaults to 10933. Implies a listening Tentacle.
 - **PublicHostNameConfiguration**: How the url that the Octopus server will use to communicate with the Tentacle is determined. Can be `PublicIp`, `FQDN`, `ComputerName` or `Custom`. Defaults to `PublicIp`.

--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -117,53 +117,6 @@ function Get-PublicHostName
 }
 
 function Validate-Variables() {
-  if($ServerApiKey -eq $null) {
-    if($ServerPassword -eq $null -or $ServerUsername -eq $null){
-      Write-Error "No 'ServerApiKey' or username/pasword environment variables are available"
-      exit 1;
-    }
-  }
-
-  if($ServerUrl -eq $null) {
-    Write-Error "Missing 'ServerUrl' environment variable"
-    exit 1;
-  }
-
-  if($TargetWorkerPool -ne $null) {
-    if($TargetEnvironment -ne $null) {
-      Write-Error "The 'TargetEnvironment' environment variable is not valid in combination with the 'TargetWorkerPool' variable"
-      exit 1;
-    }
-    if($TargetRole -ne $null) {
-      Write-Error "The 'TargetRole' environment variable is not valid in combination with the 'TargetWorkerPool' variable"
-      exit 1;
-    }
-    if($TargetTenant -ne $null) {
-      Write-Error "The 'TargetTenant' environment variable is not valid in combination with the 'TargetWorkerPool' variable"
-      exit 1;
-    }
-    if($TargetTenantTag -ne $null) {
-      Write-Error "The 'TargetTenantTag' environment variable is not valid in combination with the 'TargetWorkerPool' variable"
-      exit 1;
-    }
-  } else {
-    if($TargetEnvironment -eq $null) {
-      Write-Error "Missing 'TargetEnvironment' environment variable"
-      exit 1;
-    }
-    if($TargetRole -eq $null) {
-      Write-Error "Missing 'TargetRole' environment variable"
-      exit 1;
-    }
-  }
-
-  if($TargetTenant -ne $null -or $TargetTenantTag -ne $null) {
-    if($TargetTenantedDeploymentParticipation -ne "Tenanted" -or $TargetTenantedDeploymentParticipation -ne "TenantedOrUntenanted"){
-      Write-Error "The 'TargetTenant' and 'TargetTenantTag' environment variables are not valid when the 'TargetTenantedDeploymentParticipation' variable is not set to 'Tenanted' or 'TenantedOrUntenanted'"
-      exit 1;
-    }
-  }
-
   if($PublicHostNameConfiguration -eq $null) {
     $script:PublicHostNameConfiguration = 'ComputerName'
   }

--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -18,7 +18,7 @@ $TargetName=$env:TargetName;
 $ListeningPort=$env:ListeningPort;
 $PublicHostNameConfiguration=$env:PublicHostNameConfiguration;
 $CustomPublicHostName=$env:CustomPublicHostName;
-$DefaultListeningPort=10933;
+$InternalListeningPort=10933;
 $ServerPort=$env:ServerPort;
 $Space=$env:Space;
 $MachinePolicy=$env:MachinePolicy;
@@ -168,7 +168,7 @@ function Configure-Tentacle
       'configure',
       '--console',
       '--instance', 'Tentacle',
-      '--port', $DefaultListeningPort,
+      '--port', $InternalListeningPort,
       '--noListen', '"False"')
   }
 
@@ -219,7 +219,7 @@ function Register-Tentacle(){
     $publicHostName = Get-PublicHostName $PublicHostNameConfiguration;
     $arg += "--publicHostName"
     $arg += $publicHostName
-    if (($null -ne $ListeningPort) -and ($ListeningPort -ne $DefaultListeningPort)) {
+    if (($null -ne $ListeningPort) -and ($ListeningPort -ne $InternalListeningPort)) {
       $arg += "--tentacle-comms-port"
       $arg += $ListeningPort
     }

--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -24,53 +24,6 @@ $Space=$env:Space;
 $MachinePolicy=$env:MachinePolicy;
 
 $TentacleExe=$Exe
-function Configure-Tentacle
-{
-  Write-Log "Configure Octopus Deploy Tentacle"
-
-  if(!(Test-Path $TentacleExe)) {
-    throw "File not found. Expected to find '$TentacleExe' to perform setup."
-  }
-
-  Write-Log "Setting directory paths ..."
-  Execute-Command $TentacleExe @(
-    'configure',
-    '--console',
-    '--instance', 'Tentacle',
-    '--home', 'C:\TentacleHome',
-    '--app', 'C:\Applications')
-
-  Write-Log "Configuring communication type ..."
-  if ($ServerPort -ne $null) {
-    Execute-Command $TentacleExe @(
-      'configure',
-      '--console',
-      '--instance', 'Tentacle',
-      '--noListen', '"True"')
-  } else {
-    Execute-Command $TentacleExe @(
-      'configure',
-      '--console',
-      '--instance', 'Tentacle',
-      '--port', $DefaultListeningPort,
-      '--noListen', '"False"')
-  }
-
-  Write-Log "Updating trust ..."
-  Execute-Command $TentacleExe @(
-    'configure',
-    '--console',
-    '--instance', 'Tentacle',
-    '--reset-trust')
-
-  Write-Log "Creating certificate ..."
-  Execute-Command $TentacleExe @(
-    'new-certificate',
-    '--console',
-    '--instance', 'Tentacle',
-    '--if-blank'
-  )
-}
 
 # After the Tentacle is registered with Octopus, Tentacle listens on a TCP port, and Octopus connects to it. The Octopus server
 # needs to know the public IP address to use to connect to this Tentacle instance. Is there a way in Windows Azure in which we can
@@ -173,9 +126,66 @@ function Validate-Variables() {
   if($TargetName -ne $null) {
     Write-Log " - name '$env:TargetName'"
   }
+  if($TargetTenant -ne $null) {
+    Write-Log " - tenant '$env:TargetTenant'"
+  }
+  if($TargetTenantTag -ne $null) {
+    Write-Log " - tenant tag '$env:TargetTenantTag'"
+  }
+  if($TargetTenantedDeploymentParticipation -ne $null) {
+    Write-Log " - tenanted deployment participation '$env:TargetTenantedDeploymentParticipation'"
+  }
   if($null -ne $Space) {
     Write-Log " - space '$Space'"
   }
+}
+
+function Configure-Tentacle
+{
+  Write-Log "Configure Octopus Deploy Tentacle"
+
+  if(!(Test-Path $TentacleExe)) {
+    throw "File not found. Expected to find '$TentacleExe' to perform setup."
+  }
+
+  Write-Log "Setting directory paths ..."
+  Execute-Command $TentacleExe @(
+    'configure',
+    '--console',
+    '--instance', 'Tentacle',
+    '--home', 'C:\TentacleHome',
+    '--app', 'C:\Applications')
+
+  Write-Log "Configuring communication type ..."
+  if ($ServerPort -ne $null) {
+    Execute-Command $TentacleExe @(
+      'configure',
+      '--console',
+      '--instance', 'Tentacle',
+      '--noListen', '"True"')
+  } else {
+    Execute-Command $TentacleExe @(
+      'configure',
+      '--console',
+      '--instance', 'Tentacle',
+      '--port', $DefaultListeningPort,
+      '--noListen', '"False"')
+  }
+
+  Write-Log "Updating trust ..."
+  Execute-Command $TentacleExe @(
+    'configure',
+    '--console',
+    '--instance', 'Tentacle',
+    '--reset-trust')
+
+  Write-Log "Creating certificate ..."
+  Execute-Command $TentacleExe @(
+    'new-certificate',
+    '--console',
+    '--instance', 'Tentacle',
+    '--if-blank'
+  )
 }
 
 function Register-Tentacle(){

--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -228,25 +228,39 @@ function Register-Tentacle(){
     $arg += $TargetName;
   }
 
-  if($TargetEnvironment -ne $null) {
-    $TargetEnvironment.Split(",") | ForEach {
-      $arg += '--environment';
-      $arg += $_.Trim();
-     };
-  }
-
-  if($TargetRole -ne $null) {
-     $TargetRole.Split(",") | ForEach {
-      $arg += '--role';
-      $arg += $_.Trim();
-     };
-  }
-
   if($TargetWorkerPool -ne $null) {
     $TargetWorkerPool.Split(",") | ForEach {
       $arg += '--workerpool';
       $arg += $_.Trim();
      };
+  } else {
+    if($TargetEnvironment -ne $null) {
+      $TargetEnvironment.Split(",") | ForEach {
+        $arg += '--environment';
+        $arg += $_.Trim();
+       };
+    }
+  
+    if($TargetRole -ne $null) {
+       $TargetRole.Split(",") | ForEach {
+        $arg += '--role';
+        $arg += $_.Trim();
+       };
+    }
+  
+    if($Tenant -ne $null) {
+       $Tenant.Split(",") | ForEach {
+        $arg += '--tenant';
+        $arg += $_.Trim();
+       };
+    }
+  
+    if($TenantTag -ne $null) {
+       $TenantTag.Split(",") | ForEach {
+        $arg += '--tenanttag';
+        $arg += $_.Trim();
+       };
+    }
   }
 
   if($null -ne $Space) {

--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -11,6 +11,9 @@ $ServerUrl = $env:ServerUrl;
 $TargetEnvironment = $env:TargetEnvironment;
 $TargetRole = $env:TargetRole;
 $TargetWorkerPool = $env:TargetWorkerPool;
+$TargetTenant = $env:TargetTenant;
+$TargetTenantTag = $env:TargetTenantTag;
+$TargetTenantedDeploymentParticipation = $env:TargetTenantedDeploymentParticipation;
 $TargetName=$env:TargetName;
 $ListeningPort=$env:ListeningPort;
 $PublicHostNameConfiguration=$env:PublicHostNameConfiguration;
@@ -135,6 +138,14 @@ function Validate-Variables() {
       Write-Error "The 'TargetRole' environment variable is not valid in combination with the 'TargetWorkerPool' variable"
       exit 1;
     }
+    if($TargetTenant -ne $null) {
+      Write-Error "The 'TargetTenant' environment variable is not valid in combination with the 'TargetWorkerPool' variable"
+      exit 1;
+    }
+    if($TargetTenantTag -ne $null) {
+      Write-Error "The 'TargetTenantTag' environment variable is not valid in combination with the 'TargetWorkerPool' variable"
+      exit 1;
+    }
   } else {
     if($TargetEnvironment -eq $null) {
       Write-Error "Missing 'TargetEnvironment' environment variable"
@@ -142,6 +153,13 @@ function Validate-Variables() {
     }
     if($TargetRole -eq $null) {
       Write-Error "Missing 'TargetRole' environment variable"
+      exit 1;
+    }
+  }
+
+  if($TargetTenant -ne $null -or $TargetTenantTag -ne $null) {
+    if($TargetTenantedDeploymentParticipation -ne "Tenanted" -or $TargetTenantedDeploymentParticipation -ne "TenantedOrUntenanted"){
+      Write-Error "The 'TargetTenant' and 'TargetTenantTag' environment variables are not valid when the 'TargetTenantedDeploymentParticipation' variable is not set to 'Tenanted' or 'TenantedOrUntenanted'"
       exit 1;
     }
   }
@@ -228,39 +246,44 @@ function Register-Tentacle(){
     $arg += $TargetName;
   }
 
+  if($TargetTenantedDeploymentParticipation -ne $null) {
+    $arg += "--tenanted-deployment-participation";
+    $arg += $TargetTenantedDeploymentParticipation;
+  }
+
+  if($TargetEnvironment -ne $null) {
+    $TargetEnvironment.Split(",") | ForEach {
+      $arg += '--environment';
+      $arg += $_.Trim();
+     };
+  }
+
+  if($TargetRole -ne $null) {
+     $TargetRole.Split(",") | ForEach {
+      $arg += '--role';
+      $arg += $_.Trim();
+     };
+  }
+
+  if($TargetTenant -ne $null) {
+     $TargetTenant.Split(",") | ForEach {
+      $arg += '--tenant';
+      $arg += $_.Trim();
+     };
+  }
+
+  if($TargetTenantTag -ne $null) {
+     $TargetTenantTag.Split(",") | ForEach {
+      $arg += '--tenanttag';
+      $arg += $_.Trim();
+     };
+  }
+
   if($TargetWorkerPool -ne $null) {
     $TargetWorkerPool.Split(",") | ForEach {
       $arg += '--workerpool';
       $arg += $_.Trim();
      };
-  } else {
-    if($TargetEnvironment -ne $null) {
-      $TargetEnvironment.Split(",") | ForEach {
-        $arg += '--environment';
-        $arg += $_.Trim();
-       };
-    }
-  
-    if($TargetRole -ne $null) {
-       $TargetRole.Split(",") | ForEach {
-        $arg += '--role';
-        $arg += $_.Trim();
-       };
-    }
-  
-    if($Tenant -ne $null) {
-       $Tenant.Split(",") | ForEach {
-        $arg += '--tenant';
-        $arg += $_.Trim();
-       };
-    }
-  
-    if($TenantTag -ne $null) {
-       $TenantTag.Split(",") | ForEach {
-        $arg += '--tenanttag';
-        $arg += $_.Trim();
-       };
-    }
   }
 
   if($null -ne $Space) {


### PR DESCRIPTION
# Background

Tentacle allows you to specify Tenants/TenantTags via the CLI. Currently these options don't exist when running a new Tentacle Docker container.

Fixes https://github.com/OctopusDeploy/Issues/issues/7251

This PR also adds some documentation for the `Space` and `MachinePolicy` environment variables - currently both of these can be configured for the Linux image, but only `Space` existed for the Windows image. Neither of these were included in the readme, so I've added some documentation for these as well.

## Before

Tentacles could not be created with Tenant options

## After

### Linux
Default Tentacle with no extra options:
![image](https://user-images.githubusercontent.com/11970672/149034392-34e70d9d-6574-4063-afec-e364cb6cb341.png)

Tentacle with Tenant (`--env TargetTenant="T1"`):
![image](https://user-images.githubusercontent.com/11970672/149034313-3fd39afe-3616-4897-b65c-4e91a6632319.png)

Tentacle with Tenant Tag (`--env TargetTenantTag="TS1/TT1"`):
![image](https://user-images.githubusercontent.com/11970672/149034270-778a1fdc-c8bf-471a-bd7e-f9726513e184.png)

Tentacle with Tenanted Deployment Mode (`--env TargetTenantedDeploymentParticipation="TenantedOrUntenanted"`):
![image](https://user-images.githubusercontent.com/11970672/149034549-4c74d85e-5da7-4ecd-b22d-4ce7b4768154.png)

Tentacle with Space (`--env Space="Space2"`):
![image](https://user-images.githubusercontent.com/11970672/149034627-6ae2a90b-de45-4da9-acb3-d84e802c7513.png)

Tentacle with Machine Policy (`--env MachinePolicy="TestMachinePolicy"`):
![image](https://user-images.githubusercontent.com/11970672/149034435-838fff5c-c44c-4789-b203-d19fc97ec786.png)

Tentacle with a bunch of options (`--env TargetRole="web" --env TargetEnvironment="Dev,Test" --env TargetTenant="T2,T3" --env TargetTenantTag="TS1/TT1" --env MachinePolicy="MP2" --env Space="Space2" --env TargetTenantedDeploymentParticipation="TenantedOrUntenanted"`):
![image](https://user-images.githubusercontent.com/11970672/149034867-21d822d0-621a-4437-9a50-be1dc7e890b8.png)
![image](https://user-images.githubusercontent.com/11970672/149034896-a8ea0213-7d8b-4234-8fa5-056016de0d92.png)


### Windows
Tentacle with a bunch of options (`--env TargetRole="web" --env TargetEnvironment="Development,Test" --env TargetTenant="T2,T3" --env TargetTenantTag="TTS1/TT1" --env MachinePolicy="MP2" --env Space="Space2" --env TargetTenantedDeploymentParticipation="TenantedOrUntenanted"`):
![image](https://user-images.githubusercontent.com/11970672/149045632-bea44a90-67a1-4caa-8b4e-63c7bb73ec44.png)
![image](https://user-images.githubusercontent.com/11970672/149045673-4b691622-5fa9-41ca-a888-69da7b0e37c0.png)


# Review

Firstly, thanks for reviewing this pull request! :tada:

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
