### PR TITLE
Set default internal listening port for Linux docker image

### DIFF
--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -11,6 +11,7 @@ instanceName=Tentacle
 configurationDirectory=/etc/octopus
 applicationsDirectory=/home/Octopus/Applications
 alreadyConfiguredSemaphore="$configurationDirectory/.configuredSemaphore"
+internalListeningPort=10933
 
 mkdir -p $configurationDirectory
 mkdir -p $applicationsDirectory
@@ -103,7 +104,7 @@ function configureTentacle() {
 	if [[ ! -z "$ServerPort" ]]; then
 		tentacle configure --instance "$instanceName" --noListen "True"
 	else
-		tentacle configure --instance "$instanceName" --port $ListeningPort --noListen "False"
+		tentacle configure --instance "$instanceName" --port $internalListeningPort --noListen "False"
 	fi
 
 	echo "Updating trust ..."
@@ -159,7 +160,7 @@ function registerTentacle() {
 			'--comms-style' 'TentaclePassive'
 			'--publicHostName' $(getPublicHostName))
 
-		if [[ ! -z "$ListeningPort" && "$ListeningPort" != "10933" ]]; then
+		if [[ ! -z "$ListeningPort" && "$ListeningPort" != "$internalListeningPort" ]]; then
 			ARGS+=('--tentacle-comms-port' $ListeningPort)
 		fi
 	fi


### PR DESCRIPTION
# Background

Our documentation states that the Tentacle running in a Docker container will be running on port 10933. This works for the Windows Tentacle image as the internal port is always configured with a default value. However, the Linux Tentacle image configures the internal port with the environment variable ListeningPort. This is the same environment variable that is used to register the Tentacle with Octopus Server (this is the same in both Linux and Windows). There are two problems with this:

1. The Tentacle in Linux Docker does not always run on the internal port 10933
2. Docker images allow the user to map an internal port to a different host port (eg. for a web server like nginx the internal port is 80, but this can be mapped to a known unused port like 12321 on the host with -p 12321:80). On the Windows image this works as expected, you can set up Tentacles on 10934, 10935 and they will both be running on 10933 within each Docker container. But since the Linux image uses the same environment variable for both the internal and listening port, it's currently not possible to use a different port. If you want to create a listening Tentacle on host port 10934, then the internal port will also be 10934, meaning the image must always be run with matching ports -p 10934:10934.

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/322

## Before

A Tentacle created using the following command on a local instance of Server:
```
docker run --name TentacleOld -d -p 10935:10933 --env ACCEPT_EULA="Y" --env ServerApiKey="API-XXXXXXXXXXXXX" --env TargetRole="web" --env TargetEnvironment="Dev" --env PublicHostNameConfiguration="Custom" --env CustomPublicHostName="localhost" --env ServerUrl="http://host.docker.internal:8065" --env ListeningPort="10935" octopusdeploy/tentacle
```
results in a Listening Tentacle that fails to connect
![image](https://user-images.githubusercontent.com/11970672/149255559-045cfc2c-386c-4727-9125-ec1ae18f8f9d.png)

## After

A Tentacle created using the following command on a local instance of Server:
```
docker run --name Tentacle -d -p 10934:10933 --env ACCEPT_EULA="Y" --env ServerApiKey="API-XXXXXXXXXXXX" --env TargetRole="web" --env TargetEnvironment="Dev" --env PublicHostNameConfiguration="Custom" --env CustomPublicHostName="localhost" --env ServerUrl="http://host.docker.internal:8065" --env ListeningPort="10934" docker.packages.octopushq.com/octopusdeploy/tentacle:6.1.1267-nelson-listening-port-linux
```
results in a successfully connected Listening Tentacle
![image](https://user-images.githubusercontent.com/11970672/149255296-967ef3dd-98c7-426b-ba41-e30200b378c6.png)

# Testing

Here are the steps I used to test this pull request:

- Try to run a Linux Tentacle container with a port that doesn't match the internal port using the current Docker image eg.
```
docker run --name TentacleOld -d -p 10934:10933 --env ACCEPT_EULA="Y" --env ServerApiKey="API-XXXXXXXXXXXX" --env TargetRole="web" --env TargetEnvironment="Dev" --env PublicHostNameConfiguration="Custom" --env CustomPublicHostName="localhost" --env ServerUrl="http://host.docker.internal:8065" --env ListeningPort="10934" octopusdeploy/tentacle
```
The Tentacle will fail the health check.
- Try to run with the new image:
```
docker run --name Tentacle -d -p 10934:10933 --env ACCEPT_EULA="Y" --env ServerApiKey="API-XXXXXXXXXXXX" --env TargetRole="web" --env TargetEnvironment="Dev" --env PublicHostNameConfiguration="Custom" --env CustomPublicHostName="localhost" --env ServerUrl="http://host.docker.internal:8065" --env ListeningPort="10934" docker.packages.octopushq.com/octopusdeploy/tentacle:6.1.1267-nelson-listening-port-linux
```

# Review

Firstly, thanks for reviewing this pull request! :tada:

<!-- Describe the outcomes you want from a review. In-principle? Exploratory testing? Add inline comments calling out important changes. -->

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
