### PR TITLE
Make use of ephemeral keys

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
-		<PackageReference Include="Octopus.Shared" Version="10.5.2" />
+		<PackageReference Include="Octopus.Shared" Version="10.5.4-luke-dont-write-0006" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
-		<PackageReference Include="Octopus.Shared" Version="10.5.4-luke-dont-write-0006" />
+		<PackageReference Include="Octopus.Shared" Version="10.5.4-luke-dont-write-0013" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
-		<PackageReference Include="Octopus.Shared" Version="10.5.4-luke-dont-write-0013" />
+		<PackageReference Include="Octopus.Shared" Version="10.5.4-luke-dont-write-0015" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
-		<PackageReference Include="Octopus.Shared" Version="10.5.4-luke-dont-write-0015" />
+		<PackageReference Include="Octopus.Shared" Version="10.5.4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
# Background

Improves security related to certificates by making use of the changes made in https://github.com/OctopusDeploy/OctopusShared/pull/169 .

Fixes: https://github.com/OctopusDeploy/ResearchAndDevelopment/issues/228