### PR TITLE
Remove Centos:latest package test

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -27,7 +27,6 @@ partial class Build
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:rolling", "deb"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:trusty", "deb"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:xenial", "deb"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "centos:latest", "rpm"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "centos:7", "rpm"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel7", "rpm"),


### PR DESCRIPTION
Centos 8 is EOL. See https://www.centos.org/centos-linux-eol/
I don't think we need an alternative - Centos Stream is the replacement but does not have an image on Docker and does not appear in .NET supported operating systems.

Fixes https://github.com/OctopusDeploy/ResearchAndDevelopment/issues/279