### PR TITLE
Get updated .wxs file reference in build

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -178,8 +178,7 @@ partial class Build : NukeBuild
     ModifiableFileWithRestoreContentsOnDispose ModifyTemplatedVersionAndProductFilesWithValues()
     {
         var versionInfoFilePath = SourceDirectory / "Solution Items" / "VersionInfo.cs";
-        
-        
+
         var versionInfoFile = new ModifiableFileWithRestoreContentsOnDispose(versionInfoFilePath);
 
         versionInfoFile.ReplaceRegexInFiles("AssemblyVersion\\(\".*?\"\\)", $"AssemblyVersion(\"{OctoVersionInfo.MajorMinorPatch}\")");
@@ -194,7 +193,6 @@ partial class Build : NukeBuild
     ModifiableFileWithRestoreContentsOnDispose UpdateMsiProductVersion()
     {
         var productWxsFilePath = RootDirectory / "installer" / "Octopus.Tentacle.Installer" / "Product.wxs";
-        var productWxsFile = new ModifiableFileWithRestoreContentsOnDispose(productWxsFilePath);
         
         var xmlDoc = new XmlDocument();
         xmlDoc.Load(productWxsFilePath);
@@ -205,14 +203,14 @@ partial class Build : NukeBuild
         var product = xmlDoc.SelectSingleNode("//wi:Product", namespaceManager);
 
         if (product == null) throw new Exception("Couldn't find Product Node in wxs file");
-        if (product.Attributes == null) throw new Exception("Couldn't find Version attribute in Product Node");
+        if (product.Attributes == null) throw new Exception("Couldn't find Attributes in Product Node");
+        if (product.Attributes["Version"] == null) throw new Exception("Couldn't find Version attribute in Product Node");
 
-        // ReSharper disable once PossibleNullReferenceException
         product.Attributes["Version"]!.Value = OctoVersionInfo.MajorMinorPatch;
 
         xmlDoc.Save(productWxsFilePath);
 
-        return productWxsFile;
+        return new ModifiableFileWithRestoreContentsOnDispose(productWxsFilePath);
     }
     
     void RunBuildFor(string framework, string runtimeId)


### PR DESCRIPTION
# Background

When installing Octopus Tentacle version 6.1.1056 or newer, the Octopus Server UI correctly displays the Tentacle Version, however Windows shows Version 1.0.0.0 is installed.

Fixes https://github.com/OctopusDeploy/Issues/issues/7298

It looks like a minor detail was missed in the [Cake -> Nuke](https://github.com/OctopusDeploy/OctopusTentacle/pull/308) conversion. The original wxs file reference was being returned, so the version was being set to the default even though we actually save the file correctly.

## Before

![image](https://user-images.githubusercontent.com/11970672/154596346-d284b131-9d6f-4141-8a33-b426735bb34a.png)

## After

![image](https://user-images.githubusercontent.com/11970672/154596362-fa80282f-6d06-45fb-86f0-d3e9d6860c8c.png)

# Review

Firstly, thanks for reviewing this pull request! :tada:

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
