### PR TITLE
Fix the stream closed halibut bug.

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -116,7 +116,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="FluentValidation" Version="7.2.1" />
-    <PackageReference Include="Halibut" Version="4.4.9" />
+    <PackageReference Include="Halibut" Version="4.4.10" />
     <PackageReference Include="MaterialDesignColors" Version="1.2.0" />
     <PackageReference Include="MaterialDesignThemes" Version="2.5.0.1205" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -25,7 +25,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Octopus.Tentacle\Octopus.Tentacle.csproj" />
-    <PackageReference Include="Halibut" Version="4.4.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Octopus.Tentacle\Octopus.Tentacle.csproj" />
+    <PackageReference Include="Halibut" Version="4.4.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -37,7 +37,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Halibut" Version="4.4.9" />
+		<PackageReference Include="Halibut" Version="4.4.10" />
 		<PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
The is, if octopus server closes the stream, tentacle will consume 100% CPU trying to read the rest of the stream.

The fix is actually in: https://github.com/OctopusDeploy/Halibut/pull/142
Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/360

# Review

Does this make sense?

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
