### PR TITLE
bump Octopus.Shared version

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -43,7 +43,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
-		<PackageReference Include="Octopus.Shared" Version="10.5.4" />
+		<PackageReference Include="Octopus.Shared" Version="10.6.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
# Background

Bumps the `Octopus.Shared` version to pull in the fix in https://github.com/OctopusDeploy/OctopusShared/pull/173