### PR TITLE
No support for dotnet core in 22.04 

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -23,10 +23,11 @@ partial class Build
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldstable-slim", "deb"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:stable-slim", "deb"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "linuxmintd/mint19.3-amd64", "deb"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:latest", "deb"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:rolling", "deb"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:trusty", "deb"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:xenial", "deb"),
+        // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:latest", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
+        // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:rolling", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
+        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:focal", "deb"), // 20.04
+        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:trusty", "deb"), // 14.04
+        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:xenial", "deb"), // 16.04
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "centos:7", "rpm"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel7", "rpm"),


### PR DESCRIPTION
# Background

Ubuntu image for latest and rolling is now 22.04 

dotnet core isn't supported yet. https://github.com/dotnet/core/issues/7038

## Before

Unable to install libssl1.1 as it's not in 22.04

## After

just going to not test against it for now. We don't officially support latest 

# Testing

Here are the steps I used to test this pull request:

- teamcity build should pass

# Review

Firstly, thanks for reviewing this pull request! :tada:

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
