### PR TITLE
Use apt to install the latest Docker daemon and upgrade docker-ce

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -4,7 +4,12 @@ ARG BUILD_NUMBER
 ARG BUILD_DATE
 
 RUN apt-get update && \
-    apt-get install -y curl sudo dos2unix jq && \
+    apt-get install -y \
+        curl \
+        dos2unix \
+        jq \
+        sudo \
+        && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/linux/install-scripts/install-docker.sh
+++ b/docker/linux/install-scripts/install-docker.sh
@@ -3,19 +3,42 @@ set -eux
 
 # This script is adapted from https://github.com/docker-library/docker/blob/master/19.03/dind/Dockerfile
 
+
+# Add the apt sources for Docker (they're not part of the stock Debian distro).
 apt-get update
 
+apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+
+# Install Docker and its runtime dependencies.
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+
+apt-get update
 apt-get install -y \
     btrfs-progs \
+    containerd.io \
+    docker-ce \
+    docker-ce-cli \
+    dos2unix \
     e2fsprogs \
     iptables \
+    jq \
     openssl \
+    pigz \
+    sudo \
     uidmap \
     xfsprogs \
-    xz-utils \
-    pigz \
-    dos2unix
+    xz-utils
 
 # set up subuid/subgid so that "--userns-remap=default" works out-of-the-box
 addgroup --system dockremap
@@ -32,9 +55,6 @@ dos2unix /usr/local/bin/dind
 
 chmod +x /usr/local/bin/dockerd-entrypoint.sh
 dos2unix /usr/local/bin/dockerd-entrypoint.sh
-
-export VERSION=19
-curl -sSL https://get.docker.com/ | sh
 
 # https://forums.docker.com/t/failing-to-start-dockerd-failed-to-create-nat-chain-docker/78269
 update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy


### PR DESCRIPTION
# Background

Fixes #381 .

# Testing

1. Push the changes; wait until a prerelease build is ready.
2. `docker run -it --rm ...` that generated image.
3. Confirm that Tentacle can run Docker-in-Docker commands on relevant virtual machines.

To do the last:
```bash
docker run -it --rm --privileged docker.packages.octopushq.com/octopusdeploy/tentacle:<version_from_build> bash
```

In the resulting Docker container:
```
# Launch the Docker daemon. This is normally done by the Tentacle's startup script itself.
/scripts/dockerd-entrypoint.sh &

# Confirm that we can talk to the nested Docker daemon
docker ps

# Confirm that the nested Docker daemon can run a container.
docker run -it --rm alpine pwd
```

# Review

Firstly, thanks for reviewing this pull request! :tada:

* We previously used a `curl`ed script to install Docker; however, the installation procedure using apt is now much more usable.
* Ultimately, all this really does is version-bumps Docker using a nicer installation mechanism.
* It would be good to better understand whether _everything_ the previous installation script did can be removed. It appears to but I don't have a good feel for what the downstream dependencies might be, so I've kept them to be safe.

# Checks

- [x] :green_heart: All automated builds and tests are passing
- [x] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [x] Existing installations will continue working after updating to this version of Tentacle
- [x] I have considered the changes to public documentation needed to reflect this change
- [x] I have considered the changes to the project wiki needed to reflect this change
