### PR TITLE
Use Fedora 35 image in test

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -29,7 +29,8 @@ partial class Build
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:trusty", "deb"), // 14.04
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:xenial", "deb"), // 16.04
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "centos:7", "rpm"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"),
+        // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"), // Fedora 36 doesn't support netcore, related https://github.com/dotnet/core/issues/7467 (there is no issue for Fedora 36)
+        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:35", "rpm"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel7", "rpm"),
         new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel8", "rpm"),
     };


### PR DESCRIPTION
# Background

The `fedora:latest` image was updated to Fedora 36 on [May 13](https://build.octopushq.com/buildConfiguration/OctopusDeploy_OctopusTentacle_TestLinuxPackages/4305431?expandBuildProblemsSection=true&hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false). I'm pretty certain Fedora 36 doesn't support dotnet core yet but there's only an issue for Fedora 37 for some reason - https://github.com/dotnet/core/issues/7467. It has the same issue as https://github.com/OctopusDeploy/OctopusTentacle/pull/364 where it's unable to install libssl1.1.

## Before

🔴 https://build.octopushq.com/buildConfiguration/OctopusDeploy_OctopusTentacle_TestLinuxPackages?mode=builds#all-projects

## After

Hopefully 🟢 

# Testing

Here are the steps I used to test this pull request:

- TeamCity build passes

# Review

Firstly, thanks for reviewing this pull request! :tada:

# Checks

- [ ] :green_heart: All automated builds and tests are passing
- [ ] Scripts that automate Tentacle installation and configuration will continue working after updating to this version of Tentacle
- [ ] Existing installations will continue working after updating to this version of Tentacle
- [ ] I have considered the changes to public documentation needed to reflect this change
- [ ] I have considered the changes to the project wiki needed to reflect this change
