### PR TITLE
Update Nuke build

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -6,12 +6,16 @@
     "build": {
       "type": "object",
       "properties": {
+        "AutoDetectBranch": {
+          "type": "boolean",
+          "description": "Whether to auto-detect the branch name - this is okay for a local build, but should not be used under CI"
+        },
         "AzureKeyVaultAppId": {
           "type": "string"
         },
         "AzureKeyVaultAppSecret": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secret [profile]'"
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "AzureKeyVaultCertificateName": {
           "type": "string"
@@ -51,6 +55,10 @@
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
         },
+        "OCTOVERSION_CurrentBranch": {
+          "type": "string",
+          "description": "Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable OCTOVERSION_CurrentBranch"
+        },
         "Partition": {
           "type": "string",
           "description": "Partition to use on CI"
@@ -72,7 +80,7 @@
         },
         "signing_certificate_password": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secret [profile]'"
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "signing_certificate_path": {
           "type": "string"

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -16,26 +16,6 @@ using Serilog;
 
 partial class Build
 {
-
-    readonly List<TestConfigurationOnLinuxDistribution> TestOnLinuxDistributions = new()
-    {
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:buster", "deb"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldoldstable-slim", "deb"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldstable-slim", "deb"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:stable-slim", "deb"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "linuxmintd/mint19.3-amd64", "deb"),
-        // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:latest", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
-        // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:rolling", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:focal", "deb"), // 20.04
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:trusty", "deb"), // 14.04
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:xenial", "deb"), // 16.04
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "centos:7", "rpm"),
-        // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"), // Fedora 36 doesn't support netcore, related https://github.com/dotnet/core/issues/7467 (there is no issue for Fedora 36)
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:35", "rpm"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel7", "rpm"),
-        new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel8", "rpm"),
-    };
-
     [PublicAPI]
     Target TestWindows => _ => _
         .DependsOn(BuildWindows)
@@ -97,7 +77,26 @@ partial class Build
                 });
             }
             
-            foreach (var testConfiguration in TestOnLinuxDistributions)
+            List<TestConfigurationOnLinuxDistribution> testOnLinuxDistributions = new()
+            {
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:buster", "deb"),
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldoldstable-slim", "deb"),
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldstable-slim", "deb"),
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:stable-slim", "deb"),
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "linuxmintd/mint19.3-amd64", "deb"),
+                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:latest", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
+                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:rolling", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:focal", "deb"), // 20.04
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:trusty", "deb"), // 14.04
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:xenial", "deb"), // 16.04
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "centos:7", "rpm"),
+                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"), // Fedora 36 doesn't support netcore, related https://github.com/dotnet/core/issues/7467 (there is no issue for Fedora 36)
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:35", "rpm"),
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel7", "rpm"),
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel8", "rpm"),
+            };
+            
+            foreach (var testConfiguration in testOnLinuxDistributions)
             {
                 RunLinuxPackageTestsFor(testConfiguration);
             }
@@ -221,7 +220,7 @@ partial class Build
         }
         catch (Exception e)
         {
-            Logger.Warn($"{e.Message}: {e}");
+            Log.Warning($"{e.Message}: {e}");
         }
     }
 }

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -12,6 +12,7 @@ using Nuke.Common.Tooling;
 using Nuke.Common.Tools.Docker;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Utilities.Collections;
+using Serilog;
 
 partial class Build
 {
@@ -71,11 +72,11 @@ partial class Build
                     if (string.IsNullOrEmpty(archSuffix)) throw new NotSupportedException();
 
                     var searchForTestFileDirectory = ArtifactsDirectory / testConfiguration.PackageType;
-                    Logger.Info($"Searching for files in {searchForTestFileDirectory}");
+                    Log.Information($"Searching for files in {searchForTestFileDirectory}");
                     var packageTypeFilePath = searchForTestFileDirectory.GlobFiles($"*{archSuffix}.{testConfiguration.PackageType}")
                         .Single();
                     var packageFile = Path.GetFileName(packageTypeFilePath);
-                    Logger.Info($"Testing Linux package file {packageFile}");
+                    Log.Information($"Testing Linux package file {packageFile}");
 
                     var testScriptsBindMountPoint = RootDirectory / "linux-packages" / "test-scripts";
 
@@ -129,17 +130,17 @@ partial class Build
                     UninstallMsi(installerPath);
                 }
                 
-                Logger.Info($"BUILTIN\\Users do not have write access to {destination}. Hooray!");
+                Log.Information($"BUILTIN\\Users do not have write access to {destination}. Hooray!");
             }
 
             void InstallMsi(AbsolutePath installerPath, AbsolutePath destination)
             {
                 var installLogName = Path.Combine(TestDirectory, $"{GetTestName(installerPath)}.install.log");
 
-                Logger.Info($"Installing {installerPath} to {destination}");
+                Log.Information($"Installing {installerPath} to {destination}");
 
                 var arguments = $"/i {installerPath} /QN INSTALLLOCATION={destination} /L*V {installLogName}";
-                Logger.Info($"Running msiexec {arguments}");
+                Log.Information($"Running msiexec {arguments}");
                 var installationProcess = ProcessTasks.StartProcess("msiexec", arguments);
                 installationProcess.WaitForExit();
                 FileSystemTasks.CopyFileToDirectory(installLogName, ArtifactsDirectory);
@@ -150,11 +151,11 @@ partial class Build
             
             void UninstallMsi(AbsolutePath installerPath)
             {
-                Logger.Info($"Uninstalling {installerPath}");
+                Log.Information($"Uninstalling {installerPath}");
                 var uninstallLogName = Path.Combine(TestDirectory, $"{GetTestName(installerPath)}.uninstall.log");
 
                 var arguments = $"/x {installerPath} /QN /L*V {uninstallLogName}";
-                Logger.Info($"Running msiexec {arguments}");
+                Log.Information($"Running msiexec {arguments}");
                 var uninstallProcess = ProcessTasks.StartProcess("msiexec", arguments);
                 uninstallProcess.WaitForExit();
                 FileSystemTasks.CopyFileToDirectory(uninstallLogName, ArtifactsDirectory);
@@ -194,7 +195,7 @@ partial class Build
     
     void RunTests(string testFramework, string testRuntime)
     {
-        Logger.Info($"Running test for Framework: {testFramework} and Runtime: {testRuntime}");
+        Log.Information($"Running test for Framework: {testFramework} and Runtime: {testRuntime}");
 
         FileSystemTasks.EnsureExistingDirectory(ArtifactsDirectory / "teamcity");
             

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -34,6 +34,7 @@ partial class Build
     [PublicAPI]
     Target TestLinuxPackages => _ => _
         .Description("Tests installing the .deb and .rpm packages onto all of the Linux target distributions.")
+        .DependsOn(BuildLinux)
         .Executes(() =>
         {
             void RunLinuxPackageTestsFor(TestConfigurationOnLinuxDistribution testConfiguration)
@@ -84,13 +85,13 @@ partial class Build
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldstable-slim", "deb"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:stable-slim", "deb"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "linuxmintd/mint19.3-amd64", "deb"),
-                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:latest", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
-                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:rolling", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:latest", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:rolling", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:focal", "deb"), // 20.04
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:trusty", "deb"), // 14.04
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:xenial", "deb"), // 16.04
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "centos:7", "rpm"),
-                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"), // Fedora 36 doesn't support netcore, related https://github.com/dotnet/core/issues/7467 (there is no issue for Fedora 36)
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"), // Fedora 36 doesn't support netcore, related https://github.com/dotnet/core/issues/7467 (there is no issue for Fedora 36)
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:35", "rpm"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel7", "rpm"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel8", "rpm"),
@@ -105,6 +106,7 @@ partial class Build
     [PublicAPI]
     //todo: move this out of the build script to a proper test project ("smoke tests"?)
     Target TestWindowsInstallerPermissions => _ => _
+        .DependsOn(BuildWindows)
         .Executes(() =>
         {
             string GetTestName(AbsolutePath installerPath) => Path.GetFileName(installerPath).Replace(".msi", "");

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -34,7 +34,6 @@ partial class Build
     [PublicAPI]
     Target TestLinuxPackages => _ => _
         .Description("Tests installing the .deb and .rpm packages onto all of the Linux target distributions.")
-        .DependsOn(PackLinux)
         .Executes(() =>
         {
             void RunLinuxPackageTestsFor(TestConfigurationOnLinuxDistribution testConfiguration)
@@ -106,7 +105,6 @@ partial class Build
     [PublicAPI]
     //todo: move this out of the build script to a proper test project ("smoke tests"?)
     Target TestWindowsInstallerPermissions => _ => _
-        .DependsOn(PackWindowsInstallers)
         .Executes(() =>
         {
             string GetTestName(AbsolutePath installerPath) => Path.GetFileName(installerPath).Replace(".msi", "");

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -34,7 +34,7 @@ partial class Build
     [PublicAPI]
     Target TestLinuxPackages => _ => _
         .Description("Tests installing the .deb and .rpm packages onto all of the Linux target distributions.")
-        .DependsOn(BuildLinux)
+        .DependsOn(PackLinux)
         .Executes(() =>
         {
             void RunLinuxPackageTestsFor(TestConfigurationOnLinuxDistribution testConfiguration)
@@ -106,7 +106,7 @@ partial class Build
     [PublicAPI]
     //todo: move this out of the build script to a proper test project ("smoke tests"?)
     Target TestWindowsInstallerPermissions => _ => _
-        .DependsOn(BuildWindows)
+        .DependsOn(PackWindowsInstallers)
         .Executes(() =>
         {
             string GetTestName(AbsolutePath installerPath) => Path.GetFileName(installerPath).Replace(".msi", "");

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -84,13 +84,14 @@ partial class Build
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldstable-slim", "deb"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:stable-slim", "deb"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "linuxmintd/mint19.3-amd64", "deb"),
-                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:latest", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
-                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:rolling", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
+                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:latest", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
+                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:rolling", "deb"), // 22.04 doesn't support netcore, https://github.com/dotnet/core/issues/7038
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:focal", "deb"), // 20.04
-                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:trusty", "deb"), // 14.04
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:bionic", "deb"), // 18.04
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:xenial", "deb"), // 16.04
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "ubuntu:trusty", "deb"), // 14.04
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "centos:7", "rpm"),
-                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"), // Fedora 36 doesn't support netcore, related https://github.com/dotnet/core/issues/7467 (there is no issue for Fedora 36)
+                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:latest", "rpm"), // Fedora 36 doesn't support netcore, related https://github.com/dotnet/core/issues/7467 (there is no issue for Fedora 36)
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "fedora:35", "rpm"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel7", "rpm"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "roboxes/rhel8", "rpm"),

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -35,8 +35,6 @@ partial class Build : NukeBuild
     /// - JetBrains Rider            https://nuke.build/rider
     /// - Microsoft VisualStudio     https://nuke.build/visualstudio
     /// - Microsoft VSCode           https://nuke.build/vscode
-    [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
-    readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
     [Solution(GenerateProjects = true)] readonly Solution Solution = null!;
 
@@ -231,10 +229,10 @@ partial class Build : NukeBuild
 
     void RunBuildFor(string framework, string runtimeId)
     {
-        var configuration = $"{Configuration}-{framework}-{runtimeId}";
+        var configuration = $"Release-{framework}-{runtimeId}";
         
         DotNetPublish(p => p
-            .SetProject(Solution.Octopus_Tentacle)
+            .SetProject(SourceDirectory / "Tentacle.sln")
             .SetConfiguration(configuration)
             .SetFramework(framework)
             .SetRuntime(runtimeId)

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -8,8 +8,8 @@ using Nuke.Common.Tooling;
 [TypeConverter(typeof(TypeConverter<Configuration>))]
 public class Configuration : Enumeration
 {
-    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
-    public static Configuration Release = new Configuration { Value = nameof(Release) };
+    public static Configuration Debug = new() { Value = nameof(Debug) };
+    public static Configuration Release = new() { Value = nameof(Release) };
 
     public static implicit operator string(Configuration configuration)
     {

--- a/build/Git.cs
+++ b/build/Git.cs
@@ -3,5 +3,5 @@ using System;
 
 public static class Git
 {
-    public static string DeriveGitBranch() => Environment.GetEnvironmentVariable("OCTOVERSION_CurrentBranch");
+    public static string? DeriveGitBranch() => Environment.GetEnvironmentVariable("OCTOVERSION_CurrentBranch");
 }

--- a/build/Logging.cs
+++ b/build/Logging.cs
@@ -45,7 +45,7 @@ public static class Logging
         catch (Exception ex)
         {
             if (TeamCity.Instance != null) Console.WriteLine($"##teamcity[testFailed name='{test}' message='{ex.Message}']");
-            Logger.Error(ex.ToString());
+            Log.Error(ex.ToString());
         }
         finally
         {

--- a/build/Logging.cs
+++ b/build/Logging.cs
@@ -2,6 +2,7 @@
 using System;
 using Nuke.Common;
 using Nuke.Common.CI.TeamCity;
+using Serilog;
 
 public static class Logging
 {
@@ -13,7 +14,7 @@ public static class Logging
         }
         else
         {
-            Logger.Info($"Starting {block}");
+            Log.Information($"Starting {block}");
         }
         try
         {
@@ -27,7 +28,7 @@ public static class Logging
             }
             else
             {
-                Logger.Info($"Finished {block}");
+                Log.Information($"Finished {block}");
             }
         }
     }

--- a/build/ModifiableFileWithRestoreContentsOnDispose.cs
+++ b/build/ModifiableFileWithRestoreContentsOnDispose.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Nuke.Common;
 using Nuke.Common.IO;
+using Serilog;
 
 public class ModifiableFileWithRestoreContentsOnDispose : IDisposable
 {
@@ -20,7 +21,7 @@ public class ModifiableFileWithRestoreContentsOnDispose : IDisposable
         
     public void Dispose()
     {
-        Logger.Info($"Restoring file {FilePath}");
+        Log.Information($"Restoring file {FilePath}");
         File.WriteAllText(FilePath, OriginalFileText);
     }
         

--- a/build/Signing.cs
+++ b/build/Signing.cs
@@ -7,6 +7,7 @@ using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.SignTool;
+using Serilog;
 
 public static class Signing
 {
@@ -27,7 +28,7 @@ public static class Signing
 
                 if (fileInfo.IsReadOnly)
                 {
-                    Logger.Info($"{file} is readonly. Making it writeable.");
+                    Log.Information($"{file} is readonly. Making it writeable.");
                     fileInfo.IsReadOnly = false;
                 }
             }
@@ -37,12 +38,12 @@ public static class Signing
                 && string.IsNullOrEmpty(Build.AzureKeyVaultAppSecret)
                 && string.IsNullOrEmpty(Build.AzureKeyVaultCertificateName))
             { 
-                Logger.Info("Signing files using signtool and the self-signed development code signing certificate.");
+                Log.Information("Signing files using signtool and the self-signed development code signing certificate.");
                 SignWithSignTool(files);
             }
             else
             {
-                Logger.Info("Signing files using azuresigntool and the production code signing certificate.");
+                Log.Information("Signing files using azuresigntool and the production code signing certificate.");
                 SignWithAzureSignTool(files);
             }
         });
@@ -116,7 +117,7 @@ public static class Signing
 
                     Build.AzureSignTool(arguments);
         
-                    Logger.Info($"Finished signing {files.Length} files.");
+                    Log.Information($"Finished signing {files.Length} files.");
                 }
                 catch (Exception e)
                 {

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,8 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.3.0" />
-    <PackageReference Include="Nuke.OctoVersion" Version="0.2.549" />
+    <PackageReference Include="Nuke.Common" Version="6.0.3" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.5.0" />
   </ItemGroup>
 
@@ -22,6 +21,7 @@
     <PackageDownload Include="Chocolatey" Version="[0.10.14]" />
     <PackageDownload Include="WiX" Version="[3.11.2]" />
     <PackageDownload Include="OctopusTools" Version="[7.4.3289]" />
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.2.1058]" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.204",
+    "version": "6.0.300",
     "rollForward": "latestFeature"
   }
 }

--- a/linux-packages/packaging-scripts/package.sh
+++ b/linux-packages/packaging-scripts/package.sh
@@ -48,7 +48,9 @@ FPM_OPTS=(
   --before-remove "$INPUT_PATH/before-uninstall.sh"
 )
 FPM_DEB_OPTS=(
+  --depends 'liblttng-ust0 | liblttng-ust1'
   --depends 'libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3'
+  --depends 'libicu52 | libicu55 | libicu57 | libicu60 | libicu63 | libicu66 | libicu67 | libicu70'
   --architecture "$DEB_PACKAGE_ARCHITECTURE"
 )
 FPM_RPM_OPTS=(

--- a/linux-packages/packaging-scripts/package.sh
+++ b/linux-packages/packaging-scripts/package.sh
@@ -48,9 +48,7 @@ FPM_OPTS=(
   --before-remove "$INPUT_PATH/before-uninstall.sh"
 )
 FPM_DEB_OPTS=(
-  --depends 'liblttng-ust0 | liblttng-ust1'
-  --depends 'libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3'
-  --depends 'libicu52 | libicu55 | libicu57 | libicu60 | libicu63 | libicu66 | libicu67 | libicu70'
+  --depends 'libssl1.0.0 | libssl1.0.2 | libssl1.1'
   --architecture "$DEB_PACKAGE_ARCHITECTURE"
 )
 FPM_RPM_OPTS=(

--- a/linux-packages/packaging-scripts/package.sh
+++ b/linux-packages/packaging-scripts/package.sh
@@ -48,7 +48,7 @@ FPM_OPTS=(
   --before-remove "$INPUT_PATH/before-uninstall.sh"
 )
 FPM_DEB_OPTS=(
-  --depends 'libssl1.0.0 | libssl1.0.2 | libssl1.1'
+  --depends 'libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3'
   --architecture "$DEB_PACKAGE_ARCHITECTURE"
 )
 FPM_RPM_OPTS=(


### PR DESCRIPTION
Changes:

- Moving methods around to flow more sequentially as you go down the file
- Reduce the number of duplicated dependencies
- Remove obsolete methods and replace with suggested ones (Nuke.Logger -> Serilog.Log, Nuke.ControlFlow -> Assert)
- Update versions of tools
- Update SDK version

Changes on TeamCity:

- Cloned old Tentacle project https://build.octopushq.com/admin/editProject.html?projectId=OctopusDeploy_OctopusTentacleSensibleDefaults
- Cleaned up agent requirements
- Cleaned up build steps (some running through bash were using `build.cmd` instead of `build.sh`)