### PR TITLE
Xxkel sd/multiple spaces

### DIFF
--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -212,15 +212,25 @@ function registerTentacle() {
 	tentacle "${ARGS[@]}"
 }
 
-echo "==============================================="
-echo "Configuring Octopus Deploy Tentacle"
-
-validateVariables
-
-echo "==============================================="
-
-configureTentacle
-registerTentacle
+if [[ -z "${ConfigDir}" ]]; then
+  echo "==============================================="
+  echo "Configuring Octopus Deploy Tentacle"
+  validateVariables
+  echo "==============================================="
+  configureTentacle
+  registerTentacle
+else
+  echo "==============================================="
+  echo "Configuring Octopus Deploy Tentacle"
+  echo "==============================================="
+  configureTentacle
+  for filename in $(realpath ${CONFIG_DIR}/*.conf); do
+    echo "processing $filename"
+	. $filename
+    validateVariables
+    registerTentacle
+  done  
+fi
 
 touch $alreadyConfiguredSemaphore
 

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -59,6 +59,15 @@ docker run --publish 10931:10933 --tty --interactive --env "ListeningPort=10931"
 - **ListeningPort**: The port that the Octopus Server will connect back to the Tentacle with. Defaults to 10933. Implies a listening Tentacle.
 - **PublicHostNameConfiguration**: How the url that the Octopus server will use to communicate with the Tentacle is determined. Can be `PublicIp`, `FQDN`, `ComputerName` or `Custom`. Defaults to `PublicIp`.
 - **CustomPublicHostName**: If `PublicHostNameConfiguration` is set to `Custom`, the host name that the Octopus Server should use to communicate with the Tentacle.
+- **ConfigDir**: If specified all files matching *.conf in this directory will be used for configuring the tentacle. Each .conf file allows overriding the environment variables specified for the container. If there's no override the environment variable for the container will be used. This will allow for multiple configurations of the same tentacle and could be used for registering the same tentacle in multiple spaces.
+
+#### Example on a .conf file:
+```
+Space=MySpace
+TargetName=Testing
+TargetWorkerPool=MyWorkerPool
+```
+
 
 ### Ports
 


### PR DESCRIPTION
**_Are you a customer of Octopus Deploy? Please contact [our support team](https://octopus.com/support) so we can triage your PR, so that we can make sure it's handled appropriately._**

# Background

Add ability to apply multiple configurations for a tentacle - for instance have the tentacle registered in multiple spaces.

# Results

<!-- Describe the result of the change -->

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/377

# How to review this PR

Test that change is backwards compatible by not using the new ConfigDir environment variable
Test that using the new ConfigDir environment variable will apply the configurations in the ConfigDir - once for each .conf file. This should be tested for Linux as well as Windows. 

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ x ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ x ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ x ] I have considered appropriate testing for my change.