### PR TITLE
Add CalculateVersion target

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -86,6 +86,13 @@ partial class Build : NukeBuild
     readonly string[] RuntimeIds = { "win", "win-x86", "win-x64", "linux-x64", "linux-musl-x64", "linux-arm64", "linux-arm", "osx-x64" };
 
     [PublicAPI]
+    Target CalculateVersion => _ => _
+        .Executes(() =>
+        {
+            // This is here just so that TeamCity has a target to call. The OctoVersion attribute generates the version for us
+        });
+
+    [PublicAPI]
     Target Clean => _ => _
         .Executes(() =>
         {


### PR DESCRIPTION
Tentacle is using the OctoVersion TeamCity plugin. This overwrites the `-nightly` suffix resulting in nightly builds getting pushed to release. We should rely on `OctoVersion.Tool` generating the version for us instead.