### PR TITLE
update azure signing tool and fix new breaking change

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -20,6 +20,9 @@
         "AzureKeyVaultCertificateName": {
           "type": "string"
         },
+        "AzureKeyVaultTenantId": {
+          "type": "string"
+        },
         "AzureKeyVaultUrl": {
           "type": "string"
         },
@@ -95,6 +98,7 @@
               "BuildLinux",
               "BuildOsx",
               "BuildWindows",
+              "CalculateVersion",
               "Clean",
               "CopyToLocalPackages",
               "Default",
@@ -134,6 +138,7 @@
               "BuildLinux",
               "BuildOsx",
               "BuildWindows",
+              "CalculateVersion",
               "Clean",
               "CopyToLocalPackages",
               "Default",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -69,6 +69,7 @@ partial class Build : NukeBuild
 
     [Parameter] public static string AzureKeyVaultUrl = "";
     [Parameter] public static string AzureKeyVaultAppId = "";
+    [Parameter] public static string AzureKeyVaultTenantId = "";
     [Secret] [Parameter] public static string AzureKeyVaultAppSecret = "";
     [Parameter] public static string AzureKeyVaultCertificateName = "";
 

--- a/build/Signing.cs
+++ b/build/Signing.cs
@@ -35,6 +35,7 @@ public static class Signing
 
             if (string.IsNullOrEmpty(Build.AzureKeyVaultUrl)
                 && string.IsNullOrEmpty(Build.AzureKeyVaultAppId)
+                && string.IsNullOrEmpty(Build.AzureKeyVaultTenantId)
                 && string.IsNullOrEmpty(Build.AzureKeyVaultAppSecret)
                 && string.IsNullOrEmpty(Build.AzureKeyVaultCertificateName))
             { 
@@ -108,6 +109,7 @@ public static class Signing
                     var arguments = "sign " +
                         $"--azure-key-vault-url \"{Build.AzureKeyVaultUrl}\" " +
                         $"--azure-key-vault-client-id \"{Build.AzureKeyVaultAppId}\" " +
+                        $"--azure-key-vault-tenant-id \"{Build.AzureKeyVaultTenantId}\" " +
                         $"--azure-key-vault-client-secret \"{Build.AzureKeyVaultAppSecret}\" " +
                         $"--azure-key-vault-certificate \"{Build.AzureKeyVaultCertificateName}\" " +
                         "--file-digest sha256 " +

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="AzureSignTool" Version="[2.0.17]" />
+    <PackageDownload Include="AzureSignTool" Version="[3.0.0]" />
     <PackageDownload Include="Chocolatey" Version="[0.10.14]" />
     <PackageDownload Include="WiX" Version="[3.11.2]" />
     <PackageDownload Include="OctopusTools" Version="[7.4.3289]" />


### PR DESCRIPTION
**_Are you a customer of Octopus Deploy? Please contact [our support team](https://octopus.com/support) so we can triage your PR, so that we can make sure it's handled appropriately._**

# Background

AZ signing tool was breaking the nightly builds with a requirement for older donet sdks which are not in our build servers.

https://octopusdeploy.slack.com/archives/C01HH8T16G3/p1656285647847579 (internal link)

# Results

Bumping version for the tool and adding in the tenant parameters 

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.