### PR TITLE
Allow only one msi when upgrading to slim down Tentacle upgrade

### DIFF
--- a/source/Octopus.Tentacle.Upgrader/Program.cs
+++ b/source/Octopus.Tentacle.Upgrader/Program.cs
@@ -89,10 +89,21 @@ namespace Octopus.Tentacle.Upgrader
 
         static string SelectAppropriateMsi(IList<string> args)
         {
-            var msi = args.Count == 2 ? args[1] : Environment.Is64BitOperatingSystem ? args[2] : args[1];
+            var msi = IsMoreThanOneMsiProvided(args) ? GetMsiBasedOnArchitecture(args) : args[1];
+
             if (!File.Exists(msi))
                 throw new FileNotFoundException("Expected to find an MSI at " + msi);
             return msi;
+        }
+
+        static bool IsMoreThanOneMsiProvided(IList<string> args)
+        {
+            return args.Count > 2;
+        }
+
+        static string GetMsiBasedOnArchitecture(IList<string> args)
+        {
+            return Environment.Is64BitOperatingSystem ? args[2] : args[1];
         }
     }
 }

--- a/source/Octopus.Tentacle.Upgrader/Program.cs
+++ b/source/Octopus.Tentacle.Upgrader/Program.cs
@@ -35,7 +35,7 @@ namespace Octopus.Tentacle.Upgrader
         static int PerformUpgrade(string[] args)
         {
             LogStartupParameters(args);
-            if (args.Length < 3)
+            if (args.Length < 2)
             {
                 Log.Upgrade.Info("Error: Invalid arguments");
                 return 1;

--- a/source/Octopus.Tentacle.Upgrader/Program.cs
+++ b/source/Octopus.Tentacle.Upgrader/Program.cs
@@ -89,7 +89,7 @@ namespace Octopus.Tentacle.Upgrader
 
         static string SelectAppropriateMsi(IList<string> args)
         {
-            var msi = Environment.Is64BitOperatingSystem ? args[2] : args[1];
+            var msi = args.Count == 2 ? args[1] : Environment.Is64BitOperatingSystem ? args[2] : args[1];
             if (!File.Exists(msi))
                 throw new FileNotFoundException("Expected to find an MSI at " + msi);
             return msi;


### PR DESCRIPTION
# Background

As part of the Tentacle upgrade work, this reduces the need to upload both msi files when we already know the architecture of a machine.

# Results

Relates to https://github.com/OctopusDeploy/Issues/issues/7082

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/388 (this is mainly so we can get a "meaningful change" for this Tentacle release so that the release is publicly available)

# How to review this PR

Quality :heavy_check_mark:
