### PR TITLE
bump nuke to net6

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>


### PR DESCRIPTION
**_Are you a customer of Octopus Deploy? Please contact [our support team](https://octopus.com/support) so we can triage your PR, so that we can make sure it's handled appropriately._**

# Background

Net5 is EOL, build agents will no longer include it

# Results

Nuke is still on net5, bumped it to net6

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
