### PR TITLE
Prevent tests from rebuilding binaries

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -18,17 +18,14 @@ partial class Build
 {
     [PublicAPI]
     Target TestWindows => _ => _
-        .DependsOn(BuildWindows)
         .Executes(() => RunTests(TestFramework, TestRuntime));
 
     [PublicAPI]
     Target TestLinux => _ => _
-        .DependsOn(BuildLinux)
         .Executes(() => RunTests(TestFramework, TestRuntime));
 
     [PublicAPI]
     Target TestOsx => _ => _
-        .DependsOn(BuildOsx)
         .Executes(() => RunTests(TestFramework, TestRuntime));
 
     [PublicAPI]


### PR DESCRIPTION
Currently we build the Tentacle solution and publish binaries as artifacts. Our tests depend on the artifacts, but then rebuild each time a test runs. We are not testing the binaries that we ship. This PR removes the build phase from our tests.