### PR TITLE
Added ability to specify a different server address for the tentacle comms

### DIFF
--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -199,7 +199,7 @@ namespace Octopus.Tentacle.Commands
         Uri GetActiveTentacleAddress()
         {
             if (string.IsNullOrWhiteSpace(serverWebSocketAddress))
-                return new Uri($"https://{new Uri(serverCommsAddress!).Host}:{serverCommsPort}");
+                return new Uri($"https://{new Uri(serverCommsAddress).Host}:{serverCommsPort}");
 
             if (!HalibutRuntime.OSSupportsWebSockets)
                 throw new ControlledFailureException("Websockets is only supported on Windows Server 2012 and later");

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -35,6 +35,7 @@ namespace Octopus.Tentacle.Commands
         bool allowOverwrite;
         string comms = "TentaclePassive";
         int serverCommsPort = 10943;
+        string serverCommsAddress = null!;
         string proxy = null!;
         string spaceName = null!;
         string serverWebSocketAddress = null!;
@@ -69,6 +70,7 @@ namespace Octopus.Tentacle.Commands
             Options.Add("proxy=", "When using passive communication, the name of a proxy that Octopus should connect to the Tentacle through - e.g., 'Proxy ABC' where the proxy name is already configured in Octopus; the default is to connect to the machine directly", s => proxy = s);
             Options.Add("space=", "The name of the space within which this command will be executed. E.g. 'Finance Department' where Finance Department is the name of an existing space. The default space will be used if omitted.", s => spaceName = s);
             Options.Add("server-comms-port=", "When using active communication, the comms port on the Octopus Server; the default is " + serverCommsPort, s => serverCommsPort = int.Parse(s));
+            Options.Add("server-comms-address=", "When using active communication, the comms port on the Octopus Server; the default is " + serverCommsAddress, s => serverCommsAddress = s);
             Options.Add("server-web-socket=", "When using active communication over websockets, the address of the Octopus Server, eg 'wss://example.com/OctopusComms'. Refer to http://g.octopushq.com/WebSocketComms", s => serverWebSocketAddress = s);
             Options.Add("tentacle-comms-port=", "When using passive communication, the comms port that the Octopus Server is instructed to call back on to reach this machine; defaults to the configured listening port", s => tentacleCommsPort = int.Parse(s));
         }
@@ -93,6 +95,8 @@ namespace Octopus.Tentacle.Commands
             if (communicationStyle == CommunicationStyle.TentacleActive && !string.IsNullOrWhiteSpace(proxy))
                 throw new ControlledFailureException("Option --proxy can only be used with --comms-style=TentaclePassive.  To set a proxy for a polling Tentacle use the polling-proxy command first and then register the Tentacle with register-with.");
 
+            if (string.IsNullOrEmpty(serverCommsAddress)) serverCommsAddress = api.Server;
+            
             Uri? serverAddress = null;
 
             var useDefaultProxy = communicationStyle == CommunicationStyle.TentacleActive
@@ -195,7 +199,7 @@ namespace Octopus.Tentacle.Commands
         Uri GetActiveTentacleAddress()
         {
             if (string.IsNullOrWhiteSpace(serverWebSocketAddress))
-                return new Uri($"https://{api.ServerUri.Host}:{serverCommsPort}");
+                return new Uri($"https://{new Uri(serverCommsAddress!).Host}:{serverCommsPort}");
 
             if (!HalibutRuntime.OSSupportsWebSockets)
                 throw new ControlledFailureException("Websockets is only supported on Windows Server 2012 and later");


### PR DESCRIPTION
# Background

[We are adding polling tentacles over standard ports (443) to Octopus Cloud](https://docs.google.com/document/d/1iOigyxajs1rLbGGUZSwl9AR8HMJFkww5MSvZoiRU6eM/edit#heading=h.g165efrlab8g). For that, we need the polling tentacle to use a different server address for the web traffic and the tentacle traffic.

This PR is just a start. We should add the same option to [the Tentacle Manager](https://github.com/OctopusDeploy/OctopusTentacle/tree/main/source/Octopus.Manager.Tentacle) and [Tentacle docker images](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/docker). Anything else that I've missed here?

# Results

## Before

The same address was used for both the web and tentacle traffic.

## After

```C#
.\tentacle.exe register-worker  .... --server "https://pawel-stable3.testoctopus.app"  --server-comms-port "443" --server-comms-address "https://polling.pawel-stable3.testoctopus.app"
```

![image](https://user-images.githubusercontent.com/347637/190338728-27f4b918-6cfc-437d-b1db-cbc516153b18.png)

