### PR TITLE
Remove InteropServices from dependencies

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -155,8 +155,6 @@
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -43,8 +43,6 @@
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net48" />
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net48" />
-  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net48" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net48" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net48" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net48" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net48" />

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -28,7 +28,6 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-        <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
         <Reference Include="System.DirectoryServices.AccountManagement" Condition="'$(TargetFramework)' == 'net48'" />
         <Reference Include="System.IdentityModel" Condition="'$(TargetFramework)' == 'net48'" />

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
   </ItemGroup>
   <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">

--- a/source/Octopus.Tentacle.Upgrader/Octopus.Tentacle.Upgrader.csproj
+++ b/source/Octopus.Tentacle.Upgrader/Octopus.Tentacle.Upgrader.csproj
@@ -35,10 +35,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <Reference Include="System.ServiceProcess" />
 	</ItemGroup>
 

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -102,7 +102,6 @@
 		<PackageReference Include="NLog" Version="5.0.4" />
 		<PackageReference Include="Nito.AsyncEx" Version="3.0.1" />
 		<PackageReference Include="System.Runtime" Version="4.3.0" />
-		<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
 		<Reference Include="System.Security" />
 		<Reference Include="System.DirectoryServices" />
 		<Reference Include="System.IdentityModel" />


### PR DESCRIPTION
# Background

InteropServices is built into net4.8+

# How to review this PR

Quality :heavy_check_mark:

[sc-27778]