### PR TITLE
Dont only check free space on the root of the drive

### DIFF
--- a/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
@@ -257,7 +257,7 @@ namespace Octopus.Tentacle.Util
             if (IsUncPath(directoryPath))
                 return;
 
-            var driveInfo = new DriveInfo(Directory.GetDirectoryRoot(directoryPath));
+            var driveInfo = new DriveInfo(directoryPath);
 
             var required = requiredSpaceInBytes < 0 ? 0 : (ulong)requiredSpaceInBytes;
             // Make sure there is 10% (and a bit extra) more than we need

--- a/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
@@ -261,7 +261,7 @@ namespace Octopus.Tentacle.Util
             if (!Path.IsPathRooted(directoryPath))
                 return;
             
-            var driveInfo = SafelyDriveInfo(directoryPath);
+            var driveInfo = SafelyGetDriveInfo(directoryPath);
 
             var required = requiredSpaceInBytes < 0 ? 0 : (ulong)requiredSpaceInBytes;
             // Make sure there is 10% (and a bit extra) more than we need
@@ -278,7 +278,7 @@ namespace Octopus.Tentacle.Util
         /// New behaviour is to directly check the free disk space on that directory, but we're feeling a bit
         /// risk averse here (once bitten, twice shy), so we fall back to the old behaviour
         /// </remarks>
-        static DriveInfo SafelyDriveInfo(string directoryPath)
+        static DriveInfo SafelyGetDriveInfo(string directoryPath)
         {
             DriveInfo driveInfo;
             try

--- a/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -257,13 +258,39 @@ namespace Octopus.Tentacle.Util
             if (IsUncPath(directoryPath))
                 return;
 
-            var driveInfo = new DriveInfo(directoryPath);
+            if (!Path.IsPathRooted(directoryPath))
+                return;
+            
+            var driveInfo = SafelyDriveInfo(directoryPath);
 
             var required = requiredSpaceInBytes < 0 ? 0 : (ulong)requiredSpaceInBytes;
             // Make sure there is 10% (and a bit extra) more than we need
             required += required / 10 + 1024 * 1024;
             if ((ulong)driveInfo.AvailableFreeSpace < required)
-                throw new IOException($"The drive containing the directory '{directoryPath}' on machine '{Environment.MachineName}' does not have enough free disk space available for this operation to proceed. The disk only has {driveInfo.AvailableFreeSpace.ToFileSizeString()} available; please free up at least {required.ToFileSizeString()}.");
+                throw new IOException($"The drive '{driveInfo.Name}' containing the directory '{directoryPath}' on machine '{Environment.MachineName}' does not have enough free disk space available for this operation to proceed. " +
+                    $"The disk only has {driveInfo.AvailableFreeSpace.ToFileSizeString()} available; please free up at least {required.ToFileSizeString()}.");
+        }
+
+        /// <remarks>
+        /// Previously, we used to get the directory root (ie, `c:\` or `/`) before asking for the drive info
+        /// However, that doesn't work well with mount points, as there might be enough space in that mount point,
+        /// but not enough on the root of the drive.
+        /// New behaviour is to directly check the free disk space on that directory, but we're feeling a bit
+        /// risk averse here (once bitten, twice shy), so we fall back to the old behaviour
+        /// </remarks>
+        static DriveInfo SafelyDriveInfo(string directoryPath)
+        {
+            DriveInfo driveInfo;
+            try
+            {
+                driveInfo = new DriveInfo(directoryPath);
+            }
+            catch
+            {
+                driveInfo = new DriveInfo(Directory.GetDirectoryRoot(directoryPath));
+            }
+
+            return driveInfo;
         }
 
         public string GetFullPath(string relativeOrAbsoluteFilePath)


### PR DESCRIPTION
# Background

Our current free space calculation is very windows focused, and makes assumptions that are nearly always true in the windows world, but much less common in the linux world.

Specifically, it  checks for free disk space on the drive root, rather than the specified directory.

So, if we're on windows and we're checking for diskspace on the drive that contains `c:\octopus\tentacle\work`, we're checking how much space `c:\` has. This is nearly always safe, as it's comparitively rare [citation needed] for symlinks to be used on windows.

On linux, when we check for diskspace on the drive that contains `/data/octopus/Tentacle/Work/20221216053244-31899-1`, we end up checking `/`, which may be a completely different drive.

On one of my servers, `/data` is a mount point 

```
df
Filesystem                    1K-blocks    Used Available Use% Mounted on
aufs-root                       3030800 2427816    555144  82% /
...
/dev/mmcblk2q3                  7470560 4702112   2752064  64% /data
```

So it ends up with an error:

```
The step failed: Activity Grab latest flooble file on MyServer failed with error 'The drive containing the directory '/data/octopus/Tentacle/Work/20221216053244-31899-1' on machine 'MyServer' does not have enough free disk space available for this operation to proceed. The disk only has 542.117 MB available; please free up at least 551 MB. 


Server exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. 
---> System.IO.IOException: The drive containing the directory '/data/octopus/Tentacle/Work/20221216053244-31899-1' on machine 'MyServer' does not have enough free disk space available for this operation to proceed. The disk only has 542.117 MB available; please free up at least 551 MB.
  at Octopus.Shared.Util.OctopusPhysicalFileSystem.EnsureDiskHasEnoughFreeSpace(String directoryPath, Int64 requiredSpaceInBytes)
  at Octopus.Shared.Util.OctopusPhysicalFileSystem.EnsureDiskHasEnoughFreeSpace(String directoryPath)
  at Octopus.Shared.Scripts.ScriptWorkspace..ctor(String workingDirectory, IOctopusFileSystem fileSystem)
  at Octopus.Shared.Scripts.BashScriptWorkspace..ctor(String workingDirectory, IOctopusFileSystem fileSystem)
  at Octopus.Shared.Scripts.ScriptWorkspaceFactory.GetWorkspace(ScriptTicket ticket)
  at Octopus.Tentacle.Services.Scripts.ScriptService.PrepareWorkspace(StartScriptCommand command, ScriptTicket ticket) in /opt/buildagent/work/f090214449efab33/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs:line 47
  at Octopus.Tentacle.Services.Scripts.ScriptService.StartScript(StartScriptCommand command) in /opt/buildagent/work/f090214449efab33/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs:line 37 --- End of inner exception stack trace ---
  at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
  at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
  at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
  at Halibut.ServiceModel.ServiceInvoker.Invoke(RequestMessage requestMessage)
  at Halibut.HalibutRuntime.HandleIncomingRequest(RequestMessage request)
  at Halibut.Transport.Protocol.MessageExchangeProtocol.InvokeAndWrapAnyExceptions(RequestMessage request, Func`2 incomingRequestProcessor)'.
```

# Results

We now check for free disk space for the directory directly, rather than getting the root first.

On Windows, this [ends up calling](https://github.com/dotnet/dotnet/blob/main/src/runtime/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs#L46-L66) `GetDiskFreeSpaceEx`, for which [the docs](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdiskfreespaceexa) say:

> This parameter does not have to specify the root directory on a disk. The function accepts any directory on a disk.

On *nix, this [ends up calling](https://github.com/dotnet/dotnet/blob/main/src/runtime/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Unix.cs#L52-L60) `GetSpaceInfoForMountPoint`, which (based on the name) appears to be able to deal with directory names. Testing confirms this hypothesis too.

Relates to https://github.com/OctopusDeploy/Issues/issues/7962

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.