### PR TITLE
fix invariant

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -78,6 +78,7 @@
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
 		<RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+		<RuntimeHostConfigurationOption Include="System.Globalization.PredefinedCulturesOnly" Value="false" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
 		<Reference Include="System.IdentityModel" />


### PR DESCRIPTION
# Background

We're seeing the `CultureNotFoundException` in some cases after upgrading to net6.

> Only the invariant culture is supported in globalization-invariant mode. See https://aka.ms/GlobalizationInvariantMode for more information. (Parameter 'name')
> en is an invalid culture identifier.
> System.Globalization.CultureNotFoundException
>    at System.Globalization.CultureInfo..ctor(String name, Boolean useUserOverride)
>    at System.Globalization.CultureInfo..ctor(String name)
>    at System.Globalization.CultureInfo.CreateSpecificCulture(String name)
>    at Microsoft.Win32.TaskScheduler.Trigger..cctor()

This is probably due to https://learn.microsoft.com/en-us/dotnet/core/compatibility/globalization/6.0/culture-creation-invariant-mode

# Results

Allow the existing behaviour to continue without exception, to be consistent with pre-net6.

## Before

`CultureNotFoundException`

## After

No exception.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.