### PR TITLE
Remove mono.posix.netstandard

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -91,7 +91,6 @@
 		<PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
 		<PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0" />
 		<PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-		<PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
 		<PackageReference Include="NLog" Version="5.0.4" />
 		<PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
 		<PackageReference Include="System.Diagnostics.EventLog" Version="4.5.0" />


### PR DESCRIPTION
This repository looks to have just been left around form the Octopus.Shared migration, and even then its [not clear why](https://github.com/OctopusDeploy/OctopusShared/commit/a81c5f497e8471f2c10dd6f6e502b9287362bc1c#diff-2bdf99562d36573c1b83f6dde18db0b16fa58f16f4e1b3db754177eec45084e5R75) it would be needed.

A question has been raised by a customer if it is required, so removing from the project to remove any doubt.