### PR TITLE
add `ignoreSslErrors` to machine registration commands

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -135,8 +135,8 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />

--- a/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
@@ -11,6 +11,8 @@ namespace Octopus.Tentacle.Commands.OptionSets
         public string Username { get; private set; } = null!;
         public string Password { get; private set; } = null!;
 
+        public bool IgnoreSslErrors { get; private set; } = false;
+
         public bool Optional { private get; set; }
 
         public ApiEndpointOptions(OptionSet options)
@@ -19,6 +21,9 @@ namespace Octopus.Tentacle.Commands.OptionSets
             options.Add("apiKey=", "Your API key; you can get this from the Octopus web portal", s => ApiKey = s, sensitive: true);
             options.Add("u|username=|user=", "If not using API keys, your username", s => Username = s);
             options.Add("p|password=", "If not using API keys, your password", s => Password = s, sensitive: true);
+#if HTTP_CLIENT_SUPPORTS_SSL_OPTIONS
+            options.Add("ignoreSslErrors", "Set this flag if your Octopus Server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => IgnoreSslErrors = true);
+#endif
         }
 
         public Uri ServerUri => new Uri(Server);

--- a/source/Octopus.Tentacle/Commands/OptionSets/OctopusClientInitializer.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/OctopusClientInitializer.cs
@@ -20,7 +20,12 @@ namespace Octopus.Tentacle.Commands.OptionSets
             try
             {
                 var endpoint = GetEndpoint(apiEndpointOptions, overrideProxy);
-                var clientOptions = new OctopusClientOptions() { AllowDefaultProxy = useDefaultProxy };
+#if HTTP_CLIENT_SUPPORTS_SSL_OPTIONS
+                 var clientOptions = new OctopusClientOptions { AllowDefaultProxy = useDefaultProxy, IgnoreSslErrors = apiEndpointOptions.IgnoreSslErrors };
+#else
+                var clientOptions = new OctopusClientOptions { AllowDefaultProxy = useDefaultProxy};
+#endif
+
                 client = await OctopusAsyncClient.Create(endpoint, clientOptions).ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(apiEndpointOptions.ApiKey))

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<AppConfig Condition="'$(TargetFramework)' == 'net6.0'">app.netcore.config</AppConfig>
 		<ApplicationManifest>Tentacle.exe.manifest</ApplicationManifest>
@@ -38,11 +38,11 @@
 		<DefineConstants>$(DefineConstants);HAS_SYSTEM_IDENTITYMODEL_TOKENS;NLOG_HAS_EVENT_LOG_TARGET;NETFX;FULL_FRAMEWORK</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<DefineConstants>$(DefineConstants);REQUIRES_EXPLICIT_LOG_CONFIG;REQUIRES_CODE_PAGE_PROVIDER;USER_INTERACTIVE_DOES_NOT_WORK;DEFAULT_PROXY_IS_NOT_AVAILABLE;HAS_NULLABLE_REF_TYPES</DefineConstants>
+		<DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS;REQUIRES_EXPLICIT_LOG_CONFIG;REQUIRES_CODE_PAGE_PROVIDER;USER_INTERACTIVE_DOES_NOT_WORK;DEFAULT_PROXY_IS_NOT_AVAILABLE;HAS_NULLABLE_REF_TYPES</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Halibut" Version="5.0.236" />
-		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
+		<PackageReference Include="Octopus.Server.Client" Version="13.2.185" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="4.6.2" />


### PR DESCRIPTION
[sc-41739]

# Background

When registering a polling tentacle with an Octopus instance using an untrusted certificate, such as a self signed cert, the HTTP connection to complete the registration will fail with certificate errors.
There is also no workaround to register a polling tentacle. 

# Results

Added `--ignoreSslErrors` to the worker registration commands to allow users to opt in to avoiding the ssl errors
This argument is only added for .net 6 builds.


## Before

MacOS:
```
❯ ./Tentacle register-worker --instance Tentacle --server https://benpearcedb83 --apikey API-BMSPN8T7SIA80WVE1OPACOXAIHBL8XM --name ssl-test --workerPool "Default Worker Pool" --comms-
style TentacleActive --server-comms-port 10943
Checking connectivity on the server communications port 10943...
Connected successfully
Registering the tentacle with the server at https://benpearcedb83/
Detected automation environment: NoneOrUnknown
The following certificate errors were encountered when establishing the HTTPS connection to the server: RemoteCertificateNameMismatch, RemoteCertificateChainErrors
Certificate subject name: CN=benpearcedb83
Certificate thumbprint:   B7F25E731D540376D4570A199B5338B3C79B6484
```


Linux (in Docker):
```
root@d793d15c699b:/opt/octopus/tentacle# Tentacle register-worker --server https://benpearcedb83 --apikey API-BMSPN8T7SIA80WVE1OPACOXAIHBL8XM --workerPool "Default Worker Pool" --comms-style TentacleActive --server-comms-port 10943
Checking connectivity on the server communications port 10943...
Connected successfully
Registering the tentacle with the server at https://benpearcedb83/
Detected automation environment: NoneOrUnknown
The following certificate errors were encountered when establishing the HTTPS connection to the server: RemoteCertificateChainErrors
Certificate subject name: CN=benpearcedb83
Certificate thumbprint:   B7F25E731D540376D4570A199B5338B3C79B6484
The following certificate errors were encountered when establishing the HTTPS connection to the server: RemoteCertificateChainErrors
Certificate subject name: CN=benpearcedb83
Certificate thumbprint:   B7F25E731D540376D4570A199B5338B3C79B6484
^C
```

## After

MacOS:
```
❯ ./Tentacle register-worker --instance Tentacle --server https://benpearcedb83 --apikey API-BMSPN8T7SIA80WVE1OPACOXAIHBL8XM --name ssl-test --workerPool "Default Worker Pool" --comms-style TentacleActive --server-comms-port 10943  --ignoreSslErrors
Checking connectivity on the server communications port 10943...
Connected successfully
Registering the tentacle with the server at https://benpearcedb83/
Detected automation environment: NoneOrUnknown
The following certificate errors were encountered when establishing the HTTPS connection to the server: RemoteCertificateNameMismatch, RemoteCertificateChainErrors
Certificate subject name: CN=benpearcedb83
Certificate thumbprint:   B7F25E731D540376D4570A199B5338B3C79B6484
Because IgnoreSslErrors was set, this will be ignored.
Machine registered successfully
These changes require a restart of the Tentacle.
```

Linux (docker):
```
root@d793d15c699b:/opt/octopus/tentacle# Tentacle register-worker --server https://benpearcedb83 --apikey API-BMSPN8T7SIA80WVE1OPACOXAIHBL8XM --workerPool "Default Worker Pool" --comms-style TentacleActive --server-comms-port 10943 --ignoreSslErrors
Checking connectivity on the server communications port 10943...
Connected successfully
Registering the tentacle with the server at https://benpearcedb83/
Detected automation environment: NoneOrUnknown
The following certificate errors were encountered when establishing the HTTPS connection to the server: RemoteCertificateChainErrors
Certificate subject name: CN=benpearcedb83
Certificate thumbprint:   B7F25E731D540376D4570A199B5338B3C79B6484
Because IgnoreSslErrors was set, this will be ignored.
Machine registered successfully
These changes require a restart of the Tentacle.
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.