### PR TITLE
Update Docker readme to match online copy

### DIFF
--- a/docker/Tests/OpenPorts.Tests.ps1
+++ b/docker/Tests/OpenPorts.Tests.ps1
@@ -11,10 +11,10 @@ Describe 'Port 10933' {
 
 	BeforeAll {
 		$networkName = $script:ProjectName + "_default";
-		$octopusServerContainer = $script:ProjectName + "_octopus-server_1";
-		$octopusListeningTentacleContainer = $script:ProjectName + "_listening-tentacle_1";
-		$octopusPollingTentacleContainer = $script:ProjectName + "_polling-tentacle_1";
-		$octopusDBContainer = $script:ProjectName + "_db_1";
+		$octopusServerContainer = $script:ProjectName + "-octopus-server-1";
+		$octopusListeningTentacleContainer = $script:ProjectName + "-listening-tentacle-1";
+		$octopusPollingTentacleContainer = $script:ProjectName + "-polling-tentacle-1";
+		$octopusDBContainer = $script:ProjectName + "-db-1";
 	}
 
 	Context 'Listening Tentacle' {

--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -1,6 +1,9 @@
 function Get-IPAddress() {
     param ([ValidateNotNullOrEmpty()][string]$network, [ValidateNotNullOrEmpty()][string]$container)
-
+	
+	#debug
+	docker inspect $container
+	
     $docker = (docker inspect $container | convertfrom-json)[0]
     return $docker.NetworkSettings.Networks.$network.IpAddress
 }

--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -1,9 +1,5 @@
 function Get-IPAddress() {
     param ([ValidateNotNullOrEmpty()][string]$network, [ValidateNotNullOrEmpty()][string]$container)
-	
-	#debug
-	docker inspect $container
-	
     $docker = (docker inspect $container | convertfrom-json)[0]
     return $docker.NetworkSettings.Networks.$network.IpAddress
 }

--- a/docker/run-tests.ps1
+++ b/docker/run-tests.ps1
@@ -20,12 +20,12 @@ Add-Type -Path (Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Direc
 . .\common.ps1
 
 $networkName = "${ProjectName}_default"
-$octopusServerContainerName = "${ProjectName}_octopus-server_1"
+$octopusServerContainerName = "${ProjectName}-octopus-server-1"
 Write-Host "Octopus Server container is $octopusServerContainerName"
 $octopusServerIpAddress = Get-IPAddress $networkName $octopusServerContainerName
 Write-Host "Octopus Server hosted at $octopusServerIpAddress"
-$listeningTentacleContainerName = "${ProjectName}_listening-tentacle_1"
-$pollingTentacleContainerName = "${ProjectName}_polling-tentacle_1"
+$listeningTentacleContainerName = "${ProjectName}-listening-tentacle-1"
+$pollingTentacleContainerName = "${ProjectName}-polling-tentacle-1"
 
 Wait-ForServiceToPassHealthCheck $octopusServerContainerName
 Wait-ForServiceToPassHealthCheck $listeningTentacleContainerName

--- a/docker/run-tests.ps1
+++ b/docker/run-tests.ps1
@@ -19,7 +19,7 @@ Add-Type -Path (Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Direc
 
 . .\common.ps1
 
-$networkName = "${ProjectName}-default"
+$networkName = "${ProjectName}_default"
 $octopusServerContainerName = "${ProjectName}-octopus-server-1"
 Write-Host "Octopus Server container is $octopusServerContainerName"
 $octopusServerIpAddress = Get-IPAddress $networkName $octopusServerContainerName


### PR DESCRIPTION
The copy in this file, and the copy viewable at https://hub.docker.com/r/octopusdeploy/tentacle, are synced manually. This commit just updates the repo copy to match the updated online copy.

Fixes internal issue [sc-44418]