### PR TITLE
Adds a capabilities service to Tentacle.

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -116,7 +116,6 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="FluentValidation" Version="7.2.1" />
-    <PackageReference Include="Halibut" Version="5.0.236" />
     <PackageReference Include="MaterialDesignColors" Version="1.2.0" />
     <PackageReference Include="MaterialDesignThemes" Version="2.5.0.1205" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleCapabilitiesDecorator.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleCapabilitiesDecorator.cs
@@ -12,11 +12,11 @@ namespace Octopus.Tentacle.Contracts.Capabilities
             this.inner = inner;
         }
 
-        public CapabilitiesResponse GetCapabilities()
+        public CapabilitiesResponse SupportedCapabilities()
         {
             try
             {
-                return inner.GetCapabilities();
+                return inner.SupportedCapabilities();
             }
             catch (NoMatchingServiceOrMethodHalibutClientException)
             {

--- a/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleCapabilitiesDecorator.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleCapabilitiesDecorator.cs
@@ -12,11 +12,11 @@ namespace Octopus.Tentacle.Contracts.Capabilities
             this.inner = inner;
         }
 
-        public CapabilitiesResponse SupportedCapabilities()
+        public CapabilitiesResponse GetCapabilities()
         {
             try
             {
-                return inner.SupportedCapabilities();
+                return inner.GetCapabilities();
             }
             catch (NoMatchingServiceOrMethodHalibutClientException)
             {

--- a/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleCapabilitiesDecorator.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleCapabilitiesDecorator.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Halibut.Exceptions;
+
+namespace Octopus.Tentacle.Contracts.Capabilities
+{
+    public class BackwardsCompatibleCapabilitiesDecorator : ICapabilitiesService
+    {
+        private readonly ICapabilitiesService inner;
+
+        public BackwardsCompatibleCapabilitiesDecorator(ICapabilitiesService inner)
+        {
+            this.inner = inner;
+        }
+
+        public CapabilitiesResponse GetCapabilities()
+        {
+            try
+            {
+                return inner.GetCapabilities();
+            }
+            catch (NoMatchingServiceOrMethodHalibutClientException)
+            {
+                return new CapabilitiesResponse(new List<string>());
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesService.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesService.cs
@@ -4,6 +4,6 @@ namespace Octopus.Tentacle.Contracts.Capabilities
 {
     public interface ICapabilitiesService
     {
-        public CapabilitiesResponse SupportedCapabilities();
+        public CapabilitiesResponse GetCapabilities();
     }
 }

--- a/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesService.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesService.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Octopus.Tentacle.Contracts.Capabilities
+{
+    public interface ICapabilitiesService
+    {
+        public CapabilitiesResponse GetCapabilities();
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesService.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesService.cs
@@ -4,6 +4,6 @@ namespace Octopus.Tentacle.Contracts.Capabilities
 {
     public interface ICapabilitiesService
     {
-        public CapabilitiesResponse GetCapabilities();
+        public CapabilitiesResponse SupportedCapabilities();
     }
 }

--- a/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesServiceExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesServiceExtensionMethods.cs
@@ -1,0 +1,10 @@
+namespace Octopus.Tentacle.Contracts.Capabilities
+{
+    public static class ICapabilitiesServiceExtensionMethods
+    {
+        public static ICapabilitiesService WithBackwardsCompatability(this ICapabilitiesService capabilitiesService)
+        {
+            return new BackwardsCompatibleCapabilitiesDecorator(capabilitiesService);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/CapabilitiesResponse.cs
+++ b/source/Octopus.Tentacle.Contracts/CapabilitiesResponse.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Octopus.Tentacle.Contracts
+{
+    public class CapabilitiesResponse
+    {
+        public IReadOnlyList<string> capabilities { get; }
+
+        public CapabilitiesResponse(IReadOnlyList<string> capabilities)
+        {
+            this.capabilities = capabilities;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/CapabilitiesResponse.cs
+++ b/source/Octopus.Tentacle.Contracts/CapabilitiesResponse.cs
@@ -4,11 +4,11 @@ namespace Octopus.Tentacle.Contracts
 {
     public class CapabilitiesResponse
     {
-        public IReadOnlyList<string> capabilities { get; }
+        public IReadOnlyList<string> SupportedCapabilities { get; }
 
-        public CapabilitiesResponse(IReadOnlyList<string> capabilities)
+        public CapabilitiesResponse(IReadOnlyList<string> supportedCapabilities)
         {
-            this.capabilities = capabilities;
+            this.SupportedCapabilities = supportedCapabilities;
         }
     }
 }

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="5.0.236" />
+    <PackageReference Include="Halibut" Version="5.0.451-pull-226" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="5.0.451-pull-226" />
+    <PackageReference Include="Halibut" Version="5.0.464" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Tests/Capabilities/BackwardsCompatibleCapabilitiesDecoratorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Capabilities/BackwardsCompatibleCapabilitiesDecoratorFixture.cs
@@ -12,7 +12,7 @@ namespace Octopus.Tentacle.Tests.Capabilities
         public void ShouldWrapServiceNotFoundExceptionToNoCapabilities()
         {
             var backwardsCompatibleCapabilitiesService = new ThrowsServiceNotFoundCapabilitiesService().WithBackwardsCompatability();
-            backwardsCompatibleCapabilitiesService.GetCapabilities().capabilities.Count.Should().Be(0);
+            backwardsCompatibleCapabilitiesService.SupportedCapabilities().capabilities.Count.Should().Be(0);
         }
 
         public class ThrowsServiceNotFoundCapabilitiesService : ICapabilitiesService

--- a/source/Octopus.Tentacle.Tests/Capabilities/BackwardsCompatibleCapabilitiesDecoratorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Capabilities/BackwardsCompatibleCapabilitiesDecoratorFixture.cs
@@ -12,7 +12,7 @@ namespace Octopus.Tentacle.Tests.Capabilities
         public void ShouldWrapServiceNotFoundExceptionToNoCapabilities()
         {
             var backwardsCompatibleCapabilitiesService = new ThrowsServiceNotFoundCapabilitiesService().WithBackwardsCompatability();
-            backwardsCompatibleCapabilitiesService.SupportedCapabilities().capabilities.Count.Should().Be(0);
+            backwardsCompatibleCapabilitiesService.GetCapabilities().SupportedCapabilities.Count.Should().Be(0);
         }
 
         public class ThrowsServiceNotFoundCapabilitiesService : ICapabilitiesService

--- a/source/Octopus.Tentacle.Tests/Capabilities/BackwardsCompatibleCapabilitiesDecoratorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Capabilities/BackwardsCompatibleCapabilitiesDecoratorFixture.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using Halibut.Exceptions;
+using NUnit.Framework;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.Capabilities;
+
+namespace Octopus.Tentacle.Tests.Capabilities
+{
+    public class BackwardsCompatibleCapabilitiesDecoratorFixture
+    {
+        [Test]
+        public void ShouldWrapServiceNotFoundExceptionToNoCapabilities()
+        {
+            var backwardsCompatibleCapabilitiesService = new ThrowsServiceNotFoundCapabilitiesService().WithBackwardsCompatability();
+            backwardsCompatibleCapabilitiesService.GetCapabilities().capabilities.Count.Should().Be(0);
+        }
+
+        public class ThrowsServiceNotFoundCapabilitiesService : ICapabilitiesService
+        {
+            public CapabilitiesResponse GetCapabilities()
+            {
+                throw new ServiceNotFoundHalibutClientException("Nope", "Can't find it");
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Capabilities/CapabilitiesServiceFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Capabilities/CapabilitiesServiceFixture.cs
@@ -1,0 +1,19 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.Services.Capabilities;
+
+namespace Octopus.Tentacle.Tests.Capabilities
+{
+    public class CapabilitiesServiceFixture
+    {
+        [Test]
+        public void CapabilitiesAreReturned()
+        {
+            new CapabilitiesService()
+                .GetCapabilities()
+                .SupportedCapabilities
+                .Count
+                .Should().Be(0);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -41,7 +41,6 @@
 		<DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS;REQUIRES_EXPLICIT_LOG_CONFIG;REQUIRES_CODE_PAGE_PROVIDER;USER_INTERACTIVE_DOES_NOT_WORK;DEFAULT_PROXY_IS_NOT_AVAILABLE;HAS_NULLABLE_REF_TYPES</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Halibut" Version="5.0.236" />
 		<PackageReference Include="Octopus.Client" Version="11.3.3453" />
 	</ItemGroup>
 	<ItemGroup>

--- a/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesService.cs
+++ b/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesService.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.Capabilities;
+
+namespace Octopus.Tentacle.Services.Capabilities
+{
+    [Service]
+    public class CapabilitiesService : ICapabilitiesService
+    {
+        public CapabilitiesResponse GetCapabilities()
+        {
+            return new CapabilitiesResponse(new List<string>());
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesService.cs
+++ b/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesService.cs
@@ -7,7 +7,7 @@ namespace Octopus.Tentacle.Services.Capabilities
     [Service]
     public class CapabilitiesService : ICapabilitiesService
     {
-        public CapabilitiesResponse GetCapabilities()
+        public CapabilitiesResponse SupportedCapabilities()
         {
             return new CapabilitiesResponse(new List<string>());
         }

--- a/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesService.cs
+++ b/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesService.cs
@@ -7,7 +7,7 @@ namespace Octopus.Tentacle.Services.Capabilities
     [Service]
     public class CapabilitiesService : ICapabilitiesService
     {
-        public CapabilitiesResponse SupportedCapabilities()
+        public CapabilitiesResponse GetCapabilities()
         {
             return new CapabilitiesResponse(new List<string>());
         }


### PR DESCRIPTION
# Background

Adds a capabilities service to make it easier to discover what capabilities the remote Tentacle supports. This will make it easier for clients to work out what it can do with the Tentacle.

# Results

Adds a backwards compatible capabilities service. The service returns a list of the capabilities of tentacle. Currently it returns an empty list which mean tentacle supports the current set of tentacle features.

The capabilities service is backwards compatible with older Tentacles which do not have a capabilities service. This is done by wrapping a Halibut created `ICapabilitiesDecorator` with a `BackwardsCompatibleCapabilitiesDecorator`. That can be done with the extension method `WithBackwardsCompatability`. See the test for an example.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.