### PR TITLE
Only map existing contracts

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Legacy/MessageSerializerBuilderExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Contracts/Legacy/MessageSerializerBuilderExtensionMethods.cs
@@ -1,4 +1,5 @@
 ﻿using Halibut.Transport.Protocol;
+using Newtonsoft.Json;
 
 namespace Octopus.Tentacle.Contracts.Legacy
 {
@@ -10,10 +11,15 @@ namespace Octopus.Tentacle.Contracts.Legacy
         {
             return builder.WithSerializerSettings(settings =>
             {
-                var namespaceMappingBinder = new NamespaceMappingSerializationBinderDecorator(settings.SerializationBinder, LegacyNamespace, TentacleContracts.Namespace);
-                var assemblyMappingBinder = new AssemblyMappingSerializationBinderDecorator(namespaceMappingBinder, LegacyAssembly, TentacleContracts.AssemblyName);
-                settings.SerializationBinder = assemblyMappingBinder;
+                AddLegacyContractSupportToJsonSerializer(settings);
             });
+        }
+
+        public static void AddLegacyContractSupportToJsonSerializer(JsonSerializerSettings settings)
+        {
+            var namespaceMappingBinder = new NamespaceMappingSerializationBinderDecorator(settings.SerializationBinder, LegacyNamespace, TentacleContracts.Namespace);
+            var assemblyMappingBinder = new AssemblyMappingSerializationBinderDecorator(namespaceMappingBinder, LegacyAssembly, TentacleContracts.AssemblyName, LegacyNamespace, TentacleContracts.Namespace);
+            settings.SerializationBinder = assemblyMappingBinder;
         }
     }
 }

--- a/source/Octopus.Tentacle.Contracts/Legacy/NamespaceMappingSerializationBinderDecorator.cs
+++ b/source/Octopus.Tentacle.Contracts/Legacy/NamespaceMappingSerializationBinderDecorator.cs
@@ -8,17 +8,21 @@ namespace Octopus.Tentacle.Contracts.Legacy
         readonly ISerializationBinder inner;
         readonly string fromNamespace;
         readonly string toNamespace;
+        private readonly ReMappedLegacyTypes reMappedLegacyTypes;
 
         public NamespaceMappingSerializationBinderDecorator(ISerializationBinder? inner, string fromNamespace, string toNamespace)
         {
             this.inner = inner ?? new DefaultSerializationBinder();
             this.fromNamespace = fromNamespace;
             this.toNamespace = toNamespace;
+            this.reMappedLegacyTypes = new ReMappedLegacyTypes(fromNamespace, toNamespace);
         }
 
         public Type BindToType(string? assemblyName, string typeName)
         {
-            var mappedNamespace = typeName.Replace(fromNamespace, toNamespace);
+            var mappedNamespace = reMappedLegacyTypes.ShouldRemap(typeName)
+                ? typeName.Replace(fromNamespace, toNamespace)
+                : typeName;
 
             var type = inner.BindToType(assemblyName, mappedNamespace);
             return type;
@@ -27,7 +31,9 @@ namespace Octopus.Tentacle.Contracts.Legacy
         public void BindToName(Type serializedType, out string? assemblyName, out string? typeName)
         {
             inner.BindToName(serializedType, out assemblyName, out typeName);
-            typeName = typeName?.Replace(toNamespace, fromNamespace);
+            typeName = reMappedLegacyTypes.ShouldRemap(typeName)
+                ? typeName?.Replace(toNamespace, fromNamespace)
+                : typeName;
         }
     }
 }

--- a/source/Octopus.Tentacle.Contracts/Legacy/ReMappedLegacyTypes.cs
+++ b/source/Octopus.Tentacle.Contracts/Legacy/ReMappedLegacyTypes.cs
@@ -7,7 +7,7 @@ namespace Octopus.Tentacle.Contracts.Legacy
 {
     public class ReMappedLegacyTypes
     {
-        private static IReadOnlyCollection<Type> Types = new HashSet<Type>(new[] { typeof(CancelScriptCommand),
+        private static IReadOnlyCollection<Type> LegacyContractTypes = new HashSet<Type>(new[] { typeof(CancelScriptCommand),
             typeof(CompleteScriptCommand),
             typeof(IFileTransferService),
             typeof(IScriptService),
@@ -23,13 +23,13 @@ namespace Octopus.Tentacle.Contracts.Legacy
 
         IReadOnlyCollection<string> FullNameOfTypesToRemap;
 
-        public ReMappedLegacyTypes(params string[] nameSpaces)
+        internal ReMappedLegacyTypes(params string[] nameSpaces)
         {
             var set = new HashSet<string>();
 
             foreach (var nameSpace in nameSpaces)
             {
-                foreach (var oldTypeName in Types.Select(t => nameSpace + "." + t.Name).ToHashSet())
+                foreach (var oldTypeName in LegacyContractTypes.Select(t => nameSpace + "." + t.Name).ToHashSet())
                 {
                     set.Add(oldTypeName);
                 }
@@ -38,7 +38,7 @@ namespace Octopus.Tentacle.Contracts.Legacy
             FullNameOfTypesToRemap = set;
         }
 
-        public bool ShouldRemap(string? fullTypeName)
+        internal bool ShouldRemap(string? fullTypeName)
         {
             if (fullTypeName == null) return false;
 

--- a/source/Octopus.Tentacle.Contracts/Legacy/ReMappedLegacyTypes.cs
+++ b/source/Octopus.Tentacle.Contracts/Legacy/ReMappedLegacyTypes.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.Tentacle.Contracts.Legacy
+{
+    public class ReMappedLegacyTypes
+    {
+        private static IReadOnlyCollection<Type> Types = new HashSet<Type>(new[] { typeof(CancelScriptCommand),
+            typeof(CompleteScriptCommand),
+            typeof(IFileTransferService),
+            typeof(IScriptService),
+            typeof(ScriptFile),
+            typeof(ScriptIsolationLevel),
+            typeof(ScriptStatusRequest),
+            typeof(ScriptStatusResponse),
+            typeof(ScriptTicket),
+            typeof(ScriptType),
+            typeof(StartScriptCommand),
+            typeof(TentacleContracts),
+            typeof(UploadResult)});
+
+        IReadOnlyCollection<string> FullNameOfTypesToRemap;
+
+        public ReMappedLegacyTypes(params string[] nameSpaces)
+        {
+            var set = new HashSet<string>();
+
+            foreach (var nameSpace in nameSpaces)
+            {
+                foreach (var oldTypeName in Types.Select(t => nameSpace + "." + t.Name).ToHashSet())
+                {
+                    set.Add(oldTypeName);
+                }
+            }
+
+            FullNameOfTypesToRemap = set;
+        }
+
+        public bool ShouldRemap(string? fullTypeName)
+        {
+            if (fullTypeName == null) return false;
+
+            return FullNameOfTypesToRemap.Contains(fullTypeName);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/Legacy/ReMappedLegacyTypes.cs
+++ b/source/Octopus.Tentacle.Contracts/Legacy/ReMappedLegacyTypes.cs
@@ -18,7 +18,6 @@ namespace Octopus.Tentacle.Contracts.Legacy
             typeof(ScriptTicket),
             typeof(ScriptType),
             typeof(StartScriptCommand),
-            typeof(TentacleContracts),
             typeof(UploadResult)});
 
         IReadOnlyCollection<string> FullNameOfTypesToRemap;

--- a/source/Octopus.Tentacle.Tests/Contracts/Legacy/AssemblyMappingSerializationBinderDecoratorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Contracts/Legacy/AssemblyMappingSerializationBinderDecoratorFixture.cs
@@ -14,7 +14,7 @@ namespace Octopus.Tentacle.Tests.Communications
         public void ShouldDeserializeToMappedAssembly()
         {
             var inner = new RecordingSerializationBinder();
-            var subject = new AssemblyMappingSerializationBinderDecorator(inner, "Octopus.Shared", "Octopus.Tentacle.Contracts");
+            var subject = new AssemblyMappingSerializationBinderDecorator(inner, "Octopus.Shared", "Octopus.Tentacle.Contracts", "Octopus.Shared.Contracts", "Octopus.Tentacle.Contracts");
             subject.BindToType("Octopus.Shared", "Octopus.Shared.Contracts.StartScriptCommand");
             inner.AssemblyName.Should().Be("Octopus.Tentacle.Contracts");
         }
@@ -23,7 +23,7 @@ namespace Octopus.Tentacle.Tests.Communications
         public void ShouldSerializeToMappedAssembly()
         {
             var inner = new RecordingSerializationBinder();
-            var subject = new AssemblyMappingSerializationBinderDecorator(inner, "Octopus.Shared", "Octopus.Tentacle.Contracts");
+            var subject = new AssemblyMappingSerializationBinderDecorator(inner, "Octopus.Shared", "Octopus.Tentacle.Contracts", "Octopus.Shared.Contracts", "Octopus.Tentacle.Contracts");
             subject.BindToName(typeof(StartScriptCommand), out var assemblyName, out _);
             assemblyName.Should().StartWith("Octopus.Shared");
         }

--- a/source/Octopus.Tentacle.Tests/Contracts/Legacy/CanSerializeAndDeserializeJsonWithLegacyNameSpace.cs
+++ b/source/Octopus.Tentacle.Tests/Contracts/Legacy/CanSerializeAndDeserializeJsonWithLegacyNameSpace.cs
@@ -22,17 +22,125 @@ namespace Octopus.Tentacle.Tests.Contracts.Legacy
                 "Octopus.Shared.Contracts.ScriptTicket, Octopus.Shared",
                 because: "It should make reference to the old namespace and assembly for backwards compatability with old tentacle or clients of tentacle.");
         }
-        
+
         [Test]
         public void BackwardsCompatabilityTest_CanDeserializeJsonThatReferencesOldAssemblies()
         {
             var json = @"{""theThing"":{""$type"":""Octopus.Shared.Contracts.ScriptTicket, Octopus.Shared"",""TaskId"":""foo""}}";
-            
+
             var serializer = CreateJsonSerializer();
 
-            
             var hasAThing = serializer.FromJson<HasAThing>(json);
             hasAThing.TheThing.GetType().Should().Be(typeof(ScriptTicket));
+        }
+
+        [Test]
+        public void BackwardsCompatabilityTest_CanDeserializeJson_WithLegacy_CancelScriptCommand()
+        {
+            var json = @"{""TheThing"":{""$type"":""Octopus.Shared.Contracts.CancelScriptCommand, Octopus.Shared"",""Ticket"":{""TaskId"":""F12""},""LastLogSequence"":12}}";
+
+            var serializer = CreateJsonSerializer();
+
+            var hasAThing = serializer.FromJson<HasAThing>(json);
+            hasAThing.TheThing.GetType().Should().Be(typeof(CancelScriptCommand));
+
+            var cancelScriptCommand = hasAThing.TheThing as CancelScriptCommand;
+            cancelScriptCommand.Ticket.TaskId.Should().Be("F12");
+            cancelScriptCommand.LastLogSequence.Should().Be(12L);
+        }
+
+        [Test]
+        public void BackwardsCompatabilityTest_CanDeserializeJson_WithLegacy_CompleteScriptCommand()
+        {
+            var json = @"{""TheThing"":{""$type"":""Octopus.Shared.Contracts.CompleteScriptCommand, Octopus.Shared"",""Ticket"":{""TaskId"":""F12""},""LastLogSequence"":12}}";
+
+            var serializer = CreateJsonSerializer();
+
+            var hasAThing = serializer.FromJson<HasAThing>(json);
+            hasAThing.TheThing.GetType().Should().Be(typeof(CompleteScriptCommand));
+
+            var completeScriptCommand = hasAThing.TheThing as CompleteScriptCommand;
+            completeScriptCommand.Ticket.TaskId.Should().Be("F12");
+            completeScriptCommand.LastLogSequence.Should().Be(12L);
+        }
+
+        [Test]
+        public void BackwardsCompatabilityTest_CanDeserializeJson_WithLegacy_ScriptFile()
+        {
+            var json = @"{""TheThing"":{""$type"":""Octopus.Shared.Contracts.ScriptFile, Octopus.Shared"",""Name"":""Alice"",""Contents"":{""id"":""06dfdd58-b843-431f-9521-fae3b72b9bcd"",""length"":3},""EncryptionPassword"":null}}";
+
+            var serializer = CreateJsonSerializer();
+
+            var hasAThing = serializer.FromJson<HasAThing>(json);
+            hasAThing.TheThing.GetType().Should().Be(typeof(ScriptFile));
+
+            var scriptFile = hasAThing.TheThing as ScriptFile;
+            scriptFile.Name.Should().Be("Alice");
+            // No need to check the DataStream, that is handled in a special way in halibut.
+        }
+
+        [Test]
+        public void BackwardsCompatabilityTest_CanDeserializeJson_WithLegacy_ScriptStatusRequest()
+        {
+            var json = @"{""TheThing"":{""$type"":""Octopus.Shared.Contracts.ScriptStatusRequest, Octopus.Shared"",""Ticket"":{""TaskId"":""ticket""},""LastLogSequence"":1337}}";
+
+            var serializer = CreateJsonSerializer();
+
+            var hasAThing = serializer.FromJson<HasAThing>(json);
+            hasAThing.TheThing.GetType().Should().Be(typeof(ScriptStatusRequest));
+
+            var scriptStatusRequest = hasAThing.TheThing as ScriptStatusRequest;
+            scriptStatusRequest.Ticket.TaskId.Should().Be("ticket");
+            scriptStatusRequest.LastLogSequence.Should().Be(1337L);
+        }
+
+        [Test]
+        public void BackwardsCompatabilityTest_CanDeserializeJson_WithLegacy_ScriptStatusResponse()
+        {
+            var json = @"{""TheThing"":{""$type"":""Octopus.Shared.Contracts.ScriptStatusResponse, Octopus.Shared"",""Ticket"":{""TaskId"":""foo""},""Logs"":[{""Source"":0,""Occurred"":""2023-04-21T03:51:31.7359531+00:00"",""Text"":""something""}],""NextLogSequence"":555,""State"":0,""ExitCode"":12}}";
+
+            var serializer = CreateJsonSerializer();
+
+            var hasAThing = serializer.FromJson<HasAThing>(json);
+            hasAThing.TheThing.GetType().Should().Be(typeof(ScriptStatusResponse));
+
+            var scriptStatusResponse = hasAThing.TheThing as ScriptStatusResponse;
+            scriptStatusResponse.Ticket.TaskId.Should().Be("foo");
+            scriptStatusResponse.State.Should().Be(ProcessState.Pending);
+            scriptStatusResponse.Logs.Count.Should().Be(1);
+            scriptStatusResponse.Logs[0].Text.Should().Be("something");
+        }
+
+        [Test]
+        public void BackwardsCompatabilityTest_CanDeserializeJson_WithLegacy_StartScriptCommand()
+        {
+            var json = @"{""TheThing"":{""$type"":""Octopus.Shared.Contracts.StartScriptCommand, Octopus.Shared"",""ScriptBody"":""echo hello"",""Isolation"":1,""Scripts"":{""Bash"":""bob""},""Files"":[],""Arguments"":[""arg1"",""arg2""],""TaskId"":""servertask-12"",""ScriptIsolationMutexTimeout"":""00:01:00"",""IsolationMutexName"":""mutex""}}";
+
+            var serializer = CreateJsonSerializer();
+
+            var hasAThing = serializer.FromJson<HasAThing>(json);
+            hasAThing.TheThing.GetType().Should().Be(typeof(StartScriptCommand));
+
+            var scriptStatusResponse = hasAThing.TheThing as StartScriptCommand;
+            scriptStatusResponse.ScriptBody.Should().Be("echo hello");
+            scriptStatusResponse.Isolation.Should().Be(ScriptIsolationLevel.FullIsolation);
+            scriptStatusResponse.Scripts.Count.Should().Be(1);
+            scriptStatusResponse.Scripts[ScriptType.Bash].Should().Be("bob");
+            scriptStatusResponse.IsolationMutexName.Should().Be("mutex");
+        }
+
+        [Test]
+        public void BackwardsCompatabilityTest_CanDeserializeJson_WithLegacy_UploadResult()
+        {
+            var json = @"{""TheThing"":{""$type"":""Octopus.Shared.Contracts.UploadResult, Octopus.Shared"",""FullPath"":""/the/path"",""Hash"":""thehash"",""Length"":1337}}";
+
+            var serializer = CreateJsonSerializer();
+
+            var hasAThing = serializer.FromJson<HasAThing>(json);
+            hasAThing.TheThing.GetType().Should().Be(typeof(UploadResult));
+
+            var scriptStatusResponse = hasAThing.TheThing as UploadResult;
+            scriptStatusResponse.FullPath.Should().Be("/the/path");
         }
 
         private static JsonSerializer CreateJsonSerializer()

--- a/source/Octopus.Tentacle.Tests/Contracts/Legacy/CanSerializeAndDeserializeJsonWithLegacyNameSpace.cs
+++ b/source/Octopus.Tentacle.Tests/Contracts/Legacy/CanSerializeAndDeserializeJsonWithLegacyNameSpace.cs
@@ -1,0 +1,63 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.Legacy;
+using Octopus.Tentacle.Tests.Util;
+
+namespace Octopus.Tentacle.Tests.Contracts.Legacy
+{
+    public class CanSerializeAndDeserializeJsonWithLegacyNameSpace
+    {
+        [Test]
+        public void ShouldSerializeLegacyTypeToLegacyNameSpaceAndAssemblies()
+        {
+            var serializer = CreateJsonSerializer();
+
+            var memoryStream = new MemoryStream();
+            var laJson = serializer.ToJson(new HasAThing(new ScriptTicket("foo")));
+            laJson.Should().Contain(
+                "Octopus.Shared.Contracts.ScriptTicket, Octopus.Shared",
+                because: "It should make reference to the old namespace and assembly for backwards compatability with old tentacle or clients of tentacle.");
+        }
+        
+        [Test]
+        public void BackwardsCompatabilityTest_CanDeserializeJsonThatReferencesOldAssemblies()
+        {
+            var json = @"{""theThing"":{""$type"":""Octopus.Shared.Contracts.ScriptTicket, Octopus.Shared"",""TaskId"":""foo""}}";
+            
+            var serializer = CreateJsonSerializer();
+
+            
+            var hasAThing = serializer.FromJson<HasAThing>(json);
+            hasAThing.TheThing.GetType().Should().Be(typeof(ScriptTicket));
+        }
+
+        private static JsonSerializer CreateJsonSerializer()
+        {
+            var jsonSerializerSettings = new JsonSerializerSettings
+            {
+                Formatting = Formatting.None,
+                TypeNameHandling = TypeNameHandling.Auto,
+                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+            };
+
+            MessageSerializerBuilderExtensionMethods.AddLegacyContractSupportToJsonSerializer(jsonSerializerSettings);
+            var serializer = JsonSerializer.Create(jsonSerializerSettings);
+            return serializer;
+        }
+    }
+
+    public class HasAThing
+    {
+        public HasAThing(object theThing)
+        {
+            TheThing = theThing;
+        }
+
+        public object TheThing { get; }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Contracts/Legacy/CanSerializeAndDeserializeJsonWithLegacyNameSpace.cs
+++ b/source/Octopus.Tentacle.Tests/Contracts/Legacy/CanSerializeAndDeserializeJsonWithLegacyNameSpace.cs
@@ -17,7 +17,7 @@ namespace Octopus.Tentacle.Tests.Contracts.Legacy
             var serializer = CreateJsonSerializer();
 
             var memoryStream = new MemoryStream();
-            var laJson = serializer.ToJson(new HasAThing(new ScriptTicket("foo")));
+            var laJson = serializer.ToJson(new HasAThing(new ScriptTicket("fo   o")));
             laJson.Should().Contain(
                 "Octopus.Shared.Contracts.ScriptTicket, Octopus.Shared",
                 because: "It should make reference to the old namespace and assembly for backwards compatability with old tentacle or clients of tentacle.");
@@ -47,6 +47,10 @@ namespace Octopus.Tentacle.Tests.Contracts.Legacy
             var cancelScriptCommand = hasAThing.TheThing as CancelScriptCommand;
             cancelScriptCommand.Ticket.TaskId.Should().Be("F12");
             cancelScriptCommand.LastLogSequence.Should().Be(12L);
+            
+            serializer.ToJson(hasAThing)
+                .Should().Contain("Octopus.Shared.Contracts")
+                .And.NotContain("Octopus.Tentacle.Contracts");
         }
 
         [Test]
@@ -62,6 +66,10 @@ namespace Octopus.Tentacle.Tests.Contracts.Legacy
             var completeScriptCommand = hasAThing.TheThing as CompleteScriptCommand;
             completeScriptCommand.Ticket.TaskId.Should().Be("F12");
             completeScriptCommand.LastLogSequence.Should().Be(12L);
+            
+            serializer.ToJson(hasAThing)
+                .Should().Contain("Octopus.Shared.Contracts")
+                .And.NotContain("Octopus.Tentacle.Contracts");
         }
 
         [Test]
@@ -77,6 +85,10 @@ namespace Octopus.Tentacle.Tests.Contracts.Legacy
             var scriptFile = hasAThing.TheThing as ScriptFile;
             scriptFile.Name.Should().Be("Alice");
             // No need to check the DataStream, that is handled in a special way in halibut.
+            
+            serializer.ToJson(hasAThing)
+                .Should().Contain("Octopus.Shared.Contracts")
+                .And.NotContain("Octopus.Tentacle.Contracts");
         }
 
         [Test]
@@ -92,6 +104,10 @@ namespace Octopus.Tentacle.Tests.Contracts.Legacy
             var scriptStatusRequest = hasAThing.TheThing as ScriptStatusRequest;
             scriptStatusRequest.Ticket.TaskId.Should().Be("ticket");
             scriptStatusRequest.LastLogSequence.Should().Be(1337L);
+            
+            serializer.ToJson(hasAThing)
+                .Should().Contain("Octopus.Shared.Contracts")
+                .And.NotContain("Octopus.Tentacle.Contracts");
         }
 
         [Test]
@@ -109,6 +125,10 @@ namespace Octopus.Tentacle.Tests.Contracts.Legacy
             scriptStatusResponse.State.Should().Be(ProcessState.Pending);
             scriptStatusResponse.Logs.Count.Should().Be(1);
             scriptStatusResponse.Logs[0].Text.Should().Be("something");
+            
+            serializer.ToJson(hasAThing)
+                .Should().Contain("Octopus.Shared.Contracts")
+                .And.NotContain("Octopus.Tentacle.Contracts");
         }
 
         [Test]
@@ -121,12 +141,16 @@ namespace Octopus.Tentacle.Tests.Contracts.Legacy
             var hasAThing = serializer.FromJson<HasAThing>(json);
             hasAThing.TheThing.GetType().Should().Be(typeof(StartScriptCommand));
 
-            var scriptStatusResponse = hasAThing.TheThing as StartScriptCommand;
-            scriptStatusResponse.ScriptBody.Should().Be("echo hello");
-            scriptStatusResponse.Isolation.Should().Be(ScriptIsolationLevel.FullIsolation);
-            scriptStatusResponse.Scripts.Count.Should().Be(1);
-            scriptStatusResponse.Scripts[ScriptType.Bash].Should().Be("bob");
-            scriptStatusResponse.IsolationMutexName.Should().Be("mutex");
+            var startScriptCommand = hasAThing.TheThing as StartScriptCommand;
+            startScriptCommand.ScriptBody.Should().Be("echo hello");
+            startScriptCommand.Isolation.Should().Be(ScriptIsolationLevel.FullIsolation);
+            startScriptCommand.Scripts.Count.Should().Be(1);
+            startScriptCommand.Scripts[ScriptType.Bash].Should().Be("bob");
+            startScriptCommand.IsolationMutexName.Should().Be("mutex");
+            
+            serializer.ToJson(hasAThing)
+                .Should().Contain("Octopus.Shared.Contracts")
+                .And.NotContain("Octopus.Tentacle.Contracts");
         }
 
         [Test]
@@ -139,8 +163,12 @@ namespace Octopus.Tentacle.Tests.Contracts.Legacy
             var hasAThing = serializer.FromJson<HasAThing>(json);
             hasAThing.TheThing.GetType().Should().Be(typeof(UploadResult));
 
-            var scriptStatusResponse = hasAThing.TheThing as UploadResult;
-            scriptStatusResponse.FullPath.Should().Be("/the/path");
+            var uploadResult = hasAThing.TheThing as UploadResult;
+            uploadResult.FullPath.Should().Be("/the/path");
+
+            serializer.ToJson(hasAThing)
+                .Should().Contain("Octopus.Shared.Contracts")
+                .And.NotContain("Octopus.Tentacle.Contracts");
         }
 
         private static JsonSerializer CreateJsonSerializer()

--- a/source/Octopus.Tentacle.Tests/Util/DataStreamExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests/Util/DataStreamExtensionMethods.cs
@@ -1,0 +1,34 @@
+using System.IO;
+using System.Text;
+using Halibut;
+
+namespace Octopus.Tentacle.Tests.Util
+{
+    public static class DataStreamExtensionMethods
+    {
+        public static byte[] ToBytes(this DataStream dataStream)
+        {
+            byte[] bytes = null;
+            dataStream.Receiver()
+                .Read(
+                    stream =>
+                    {
+                        if (stream is MemoryStream ms)
+                        {
+                            bytes = ms.ToArray();
+                        }
+                        else
+                        {
+                            using var memoryStream = new MemoryStream();
+
+                            stream.CopyTo(memoryStream);
+                            bytes = memoryStream.ToArray();
+                        }
+                    });
+
+            return bytes;
+        }
+
+        public static string GetString(this DataStream dataStream, Encoding encoding) => encoding.GetString(dataStream.ToBytes());
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Util/SerializationExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests/Util/SerializationExtensionMethods.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Octopus.Tentacle.Tests.Util
+{
+    public static class SerializationExtensionMethods
+    {
+        public static string ToJson<T>(this JsonSerializer jsonSerializer, T input)
+        {
+            var objectType = input != null ? input.GetType() : typeof(T);
+
+            var sb = new StringBuilder();
+            using var sw = new StringWriter(sb, CultureInfo.InvariantCulture);
+            using var jsonWriter = new JsonTextWriter(sw) { Formatting = jsonSerializer.Formatting };
+
+            jsonSerializer.Serialize(jsonWriter, input, objectType);
+            return sw.ToString();
+        }
+
+        public static T FromJson<T>(this JsonSerializer jsonSerializer, string json)
+        {
+            if (json is null) throw new ArgumentNullException(nameof(json));
+
+            var objectType = typeof(T);
+
+            return (T)jsonSerializer.FromJson(json, objectType);
+        }
+
+        public static object? FromJson(this JsonSerializer jsonSerializer, string json, Type objectType)
+        {
+            using var reader = new JsonTextReader(new StringReader(json));
+            var output = jsonSerializer.Deserialize(reader, objectType);
+            return output;
+        }
+
+        public static void Configure(this JsonSerializer jsonSerializer, JsonSerializerSettings settings)
+        {
+            // private static void ApplySerializerSettings(JsonSerializer serializer, JsonSerializerSettings settings)
+            var applySerializerSettingsMethod = typeof(JsonSerializer).GetMethod("ApplySerializerSettings", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var args = new object[] { jsonSerializer, settings };
+            applySerializerSettingsMethod.Invoke(null, args);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Util/SerializationExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests/Util/SerializationExtensionMethods.cs
@@ -36,13 +36,5 @@ namespace Octopus.Tentacle.Tests.Util
             var output = jsonSerializer.Deserialize(reader, objectType);
             return output;
         }
-
-        public static void Configure(this JsonSerializer jsonSerializer, JsonSerializerSettings settings)
-        {
-            // private static void ApplySerializerSettings(JsonSerializer serializer, JsonSerializerSettings settings)
-            var applySerializerSettingsMethod = typeof(JsonSerializer).GetMethod("ApplySerializerSettings", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var args = new object[] { jsonSerializer, settings };
-            applySerializerSettingsMethod.Invoke(null, args);
-        }
     }
 }


### PR DESCRIPTION
# Background

Prevents new tentacle contracts from being mapped to the old `Octopus.Shared` assembly and `Octopus.Shared.Contracts` namespace within halibut communications.

New classes will be serialized without the `$type` section of the json from being modified.

[SC-46982]

# Results

Any new classes added will be serialized and deserialized normally and wont require any hacking of namespaces or assemblies.

# How to review this PR

No test can be written for new types since, we don't have any new types to test with.

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.