### PR TITLE
Remove Debian `oldoldstable` from linux test packages list

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -81,7 +81,11 @@ partial class Build
             List<TestConfigurationOnLinuxDistribution> testOnLinuxDistributions = new()
             {
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:buster", "deb"),
-                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldoldstable-slim", "deb"),
+
+                // Debian dist oldoldstable appears to have been removed on 23/4/2023, maybe temporarily whilst a new stable release is created. 
+                // TODO: Revisit this when/if the dist becomes available again and reinstate if possible.
+                // new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldoldstable-slim", "deb"),
+
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:oldstable-slim", "deb"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:stable-slim", "deb"),
                 new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "linuxmintd/mint19.3-amd64", "deb"),


### PR DESCRIPTION
# Background

Automated package installation tests against the Debian distribution `oldoldstable` have started failing from 24/4/2023 ([example failing build](https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacleNet48_SensibleDefaultsTestLinuxPackages/7563276?buildTab=tests&expandedTest=build%3A%28id%3A7563276%29%2Cid%3A1715) - internal link). This distribution was linked to Debian 9 (Stretch) which is EOL as of June 2022. 

It appears that the link was removed from http://deb.debian.org/debian causing the test failures, although we haven't been able to find any announcements about this. We believe this is likely because a new major version of Debian will be released in the new few months.

These failures are blocking our ability to ship any changes for Tentacle.

See https://octopusdeploy.slack.com/archives/C04GAH78491/p1682637964671919 and https://octopusdeploy.slack.com/archives/C27FNL3QW/p1682641971955289 for more context (internal links).

# Results

This PR comments out testing on Debian `oldoldstable` as a way to unblock our ability to ship changes. We plan to revisit this on a regular basis in the coming months to check if the distribution is re-linked so that we can re-instate the tests. The tests themselves only test that the tentacle package can be installed correctly on the latest version of the distribution, there are no other functional tests against the distribution. The Stretch distribution is no longer supported anyway, so the risk of removing this test feels on the lower end.

Shortcut: [sc-47543]

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.