### PR TITLE
Fixes failing service installation tests on Linux

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
@@ -151,19 +151,9 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
             Console.WriteLine($"Status of service {serviceName}");
             foreach (var info in result.Infos)
                 Console.WriteLine(info);
-            var infoSplits = result.Infos.Select(x => x.Split(new[] { '=' }, 2, StringSplitOptions.None)).ToList();
-            foreach (var infoSplit in infoSplits)
-            {
-                if (infoSplit.Length == 0)
-                {
-                    Console.Write("Split returned an empty array when it shouldn't have!!");
-                }
-                else
-                {
-                    Console.WriteLine(string.Join(" --> ", infoSplit));
-                }
-            }
-            return infoSplits.ToDictionary(x => x[0], x => x[1]);
+            return result.Infos
+                .Select(x => x.Split(new[] { '=' }, 2, StringSplitOptions.None))
+                .ToDictionary(x => x[0], x => x[1]);
         }
 
         bool IsServiceRunning(string serviceName)

--- a/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
@@ -151,7 +151,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
             Console.WriteLine($"Status of service {serviceName}");
             foreach (var info in result.Infos)
                 Console.WriteLine(info);
-            var infoSplits = result.Infos.Select(x => x.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries)).ToList();
+            var infoSplits = result.Infos.Select(x => x.Split(new[] { '=' }, 2, StringSplitOptions.None)).ToList();
             foreach (var infoSplit in infoSplits)
             {
                 if (infoSplit.Length == 0)

--- a/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
@@ -151,9 +151,12 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
             Console.WriteLine($"Status of service {serviceName}");
             foreach (var info in result.Infos)
                 Console.WriteLine(info);
-            return result.Infos
-                .Select(x => x.Split(new [] {'='}, 2, StringSplitOptions.RemoveEmptyEntries))
-                .ToDictionary(x => x[0], x => x[1]);
+            var infoSplits = result.Infos.Select(x => x.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries)).ToList();
+            foreach (var infoSplit in infoSplits)
+            {
+                Console.WriteLine(string.Join(" --> ", infoSplit));
+            }
+            return infoSplits.ToDictionary(x => x[0], x => x[1]);
         }
 
         bool IsServiceRunning(string serviceName)

--- a/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
@@ -154,7 +154,14 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
             var infoSplits = result.Infos.Select(x => x.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries)).ToList();
             foreach (var infoSplit in infoSplits)
             {
-                Console.WriteLine(string.Join(" --> ", infoSplit));
+                if (infoSplit.Length == 0)
+                {
+                    Console.Write("Split returned an empty array when it shouldn't have!!");
+                }
+                else
+                {
+                    Console.WriteLine(string.Join(" --> ", infoSplit));
+                }
             }
             return infoSplits.ToDictionary(x => x[0], x => x[1]);
         }


### PR DESCRIPTION
# Background

Two integration tests have been failing for Linux since the agent on which the tests run got updated from Ubuntu 16 to 18.
- CanInstallServiceAsRoot
- CanInstallServiceAsUser

These have been failing with an error message "System.IndexOutOfRangeException : Index was outside the bounds of the array.". The tests attempt to install the tentacle service and then check a bunch of properties using `systemctl`. Changing to Ubuntu 18 looks like its added in a couple of properties that have an empty string as their value:

<img width="269" alt="image" src="https://user-images.githubusercontent.com/2915931/235071738-67732756-1c78-44a8-a475-cebeb11df0e3.png">

The test hasn't handled these well and caused the failure.

# Results

This PR fixes the test so that it allows values with empty strings to return in the property set that is gathered from the installed service. We only check a few specific properties, so allowing others that we don't care about to have empty strings so that we don't fail the test shouldn't impact the behaviour of the test.

Shortcut: [sc-37201]

## Before

Tests fail with index out of bounds error

<img width="721" alt="image" src="https://user-images.githubusercontent.com/2915931/235072209-fa6988ef-75d1-49e9-a48a-2389b0101b83.png">

## After

Tests continue as expected and pass

<img width="377" alt="image" src="https://user-images.githubusercontent.com/2915931/235072110-23987c65-863b-40ec-ace4-9f9c2f6cc50f.png">

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.