### PR TITLE
Adds the ability to start and stop tentacles in Integration Tests

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -63,19 +63,18 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 octopusThumbprint ?? Certificates.ServerPublicThumbprint,
                 subscriptionId);
 
-            CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-
+            Func<CancellationToken, Task<Task>> startTentacle = token => RunningTentacle(tentacleExe, configFilePath, instanceName, tempDirectory, token);  
+            var runningTentacle =  new RunningTestTentacle(subscriptionId, tempDirectory, startTentacle, tentacleThumbprint);
             try
             {
-                var runningTentacle = await RunningTentacle(tentacleExe, configFilePath, instanceName, tempDirectory, cts.Token);
-                return new RunningTestTentacle(subscriptionId, tempDirectory, cts, runningTentacle, tentacleThumbprint);
+                await runningTentacle.Start(cancellationToken);
+                return runningTentacle;
             }
             catch (Exception)
             {
                 try
                 {
-                    cts.Cancel();
-                    tempDirectory.Dispose();
+                    runningTentacle.Dispose();
                 }
                 catch (Exception e)
                 {
@@ -192,25 +191,50 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         public Uri ServiceUri { get; }
         private readonly IDisposable TemporaryDirectory;
-        private readonly CancellationTokenSource cts;
-        private Task RunningTentacleTask { get; }
+        private CancellationTokenSource cts;
+        private Task? RunningTentacleTask { get; set; }
+        private Func<CancellationToken, Task<Task>> startTentacle;
         public string Thumbprint { get; }
 
-        public RunningTestTentacle(Uri serviceUri, IDisposable temporaryDirectory, CancellationTokenSource cts, Task RunningTentacleTask, string thumbprint)
+        public RunningTestTentacle(Uri serviceUri, 
+            IDisposable temporaryDirectory,
+            Func<CancellationToken, Task<Task>> startTentacle,
+            string thumbprint)
         {
             TemporaryDirectory = temporaryDirectory;
-            this.cts = cts;
-            this.RunningTentacleTask = RunningTentacleTask;
+            this.startTentacle = startTentacle;
             Thumbprint = thumbprint;
             ServiceUri = serviceUri;
+        }
+        
+        public async Task Start(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            if (RunningTentacleTask != null) throw new Exception("Tentacle is already running, call stop() first");
+
+            cts = new CancellationTokenSource();
+
+            RunningTentacleTask = await startTentacle(cts.Token);
+        }
+
+        public async Task Stop(CancellationToken cancellationToken)
+        {
+            if (cts != null)
+            {
+                cts.Cancel();
+                cts.Dispose();
+                cts = null;
+            }
+
+            var t = RunningTentacleTask;
+            RunningTentacleTask = null;
+            await t;
         }
 
         public void Dispose()
         {
-            cts.Cancel();
-            cts.Dispose();
+            if (RunningTentacleTask != null) Stop(CancellationToken.None).GetAwaiter().GetResult();
             TemporaryDirectory.Dispose();
-            RunningTentacleTask.GetAwaiter().GetResult();
         }
     }
 }


### PR DESCRIPTION
# Background

This enables as to test what happens when tentacle is terminated while running a script and is later started up again.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.