### PR TITLE
Adds the Port Forwarder test util to tentacle.

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -19,6 +19,11 @@
     <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
         <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
+        <DefineConstants>$(DefineConstants);DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS</DefineConstants>
+    </PropertyGroup>
+    
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <ProjectReference Include="..\Octopus.Tentacle.Client\Octopus.Tentacle.Client.csproj" />

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -28,8 +28,10 @@
         <PackageReference Include="Assent" Version="1.8.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
+        <PackageReference Include="Serilog" Version="2.12.0" />
         <Reference Include="System.DirectoryServices.AccountManagement" Condition="'$(TargetFramework)' == 'net48'" />
         <Reference Include="System.IdentityModel" Condition="'$(TargetFramework)' == 'net48'" />
         <Reference Include="System.ServiceProcess" Condition="'$(TargetFramework)' == 'net48'" />
@@ -46,5 +48,8 @@
         <None Update="Certificates\Tentacle.pfx">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+    </ItemGroup>
+    <ItemGroup>
+      <Folder Include="Util\TcpUtils" />
     </ItemGroup>
 </Project>

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -49,7 +49,4 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
-    <ItemGroup>
-      <Folder Include="Util\TcpUtils" />
-    </ItemGroup>
 </Project>

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PortForwarderBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PortForwarderBuilder.cs
@@ -1,0 +1,25 @@
+using System;
+using Octopus.Tentacle.Tests.Integration.Util.TcpUtils;
+
+namespace Octopus.Tentacle.Tests.Integration.Util
+{
+    public class PortForwarderBuilder
+    {
+        private Uri originServer;
+
+        public PortForwarderBuilder(Uri originServer)
+        {
+            this.originServer = originServer;
+        }
+
+        public static PortForwarderBuilder ForwardingToLocalPort(int localPort)
+        {
+            return new PortForwarderBuilder(new Uri("https://localhost:" + localPort));
+        }
+
+        public PortForwarder Build()
+        {
+            return new PortForwarder(originServer, TimeSpan.Zero);
+        } 
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
@@ -1,0 +1,21 @@
+using Halibut.Diagnostics;
+using Serilog;
+using Serilog.Core;
+using Serilog.Formatting.Display;
+using Serilog.Sinks.NUnit;
+
+namespace Octopus.Tentacle.Tests.Integration.Util
+{
+    public class SerilogLoggerBuilder
+    {
+        const string OutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}";
+        
+        public ILogger Build()
+        {
+            return new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.Sink(new NUnitSink(new MessageTemplateTextFormatter(OutputTemplate)))
+                .CreateLogger();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/PortForwarder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/PortForwarder.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
+{
+    public class PortForwarder : IDisposable
+    {
+        readonly Uri originServer;
+        readonly Socket listeningSocket;
+        readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        readonly List<TcpPump> pumps = new List<TcpPump>();
+        readonly ILogger logger;
+        readonly TimeSpan sendDelay;
+        
+        public int ListeningPort { get; }
+
+        public PortForwarder(Uri originServer, TimeSpan sendDelay)
+        {
+            logger = new SerilogLoggerBuilder().Build().ForContext<PortForwarder>();
+            this.originServer = originServer;
+            this.sendDelay = sendDelay;
+            var scheme = originServer.Scheme;
+
+            listeningSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listeningSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listeningSocket.Listen(0);
+            logger.Information("Listening on {LoadBalancerEndpoint}", listeningSocket.LocalEndPoint?.ToString());
+
+            ListeningPort = ((IPEndPoint)listeningSocket.LocalEndPoint).Port;
+            PublicEndpoint = new UriBuilder(scheme, "localhost", ListeningPort).Uri;
+
+            Task.Factory.StartNew(() => WorkerTask(cancellationTokenSource.Token).ConfigureAwait(false), TaskCreationOptions.LongRunning);
+        }
+
+        public Uri PublicEndpoint { get; }
+
+        async Task WorkerTask(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Yield();
+
+                try
+                {
+                    var clientSocket = await listeningSocket.AcceptAsync();
+
+                    var originEndPoint = new DnsEndPoint(originServer.Host, originServer.Port);
+                    var originSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+
+                    var pump = new TcpPump(clientSocket, originSocket, originEndPoint, sendDelay, logger);
+                    pump.Stopped += OnPortForwarderStopped;
+                    lock (pumps)
+                    {
+                        pumps.Add(pump);
+                    }
+
+                    pump.Start();
+                }
+                catch (SocketException ex)
+                {
+                    // This will occur normally on teardown.
+                    logger.Verbose(ex, "Socket Error accepting new connection {Message}", ex.Message);
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, "Error accepting new connection {Message}", ex.Message);
+                }
+            }
+        }
+
+        void OnPortForwarderStopped(object sender, EventArgs e)
+        {
+            if (sender is TcpPump portForwarder)
+            {
+                portForwarder.Stopped -= OnPortForwarderStopped;
+                lock (pumps)
+                {
+                    pumps.Remove(portForwarder);
+                }
+
+                portForwarder.Dispose();
+            }
+        }
+
+        public void PauseExistingConnections()
+        {
+            lock (pumps)
+            {
+                foreach (var pump in pumps)
+                {
+                    pump.Pause();
+                }
+            }
+        }
+
+        public void CloseExistingConnections()
+        {
+            DisposePumps();
+        }
+
+        List<Exception> DisposePumps()
+        {
+            var exceptions = new List<Exception>();
+
+            lock (pumps)
+            {
+                var clone = pumps.ToArray();
+                pumps.Clear();
+                foreach (var pump in clone)
+                {
+                    try
+                    {
+                        pump.Dispose();
+                    }
+                    catch (Exception e)
+                    {
+                        exceptions.Add(e);
+                    }
+                }
+            }
+
+            return exceptions;
+        }
+
+        public void Dispose()
+        {
+            if(!cancellationTokenSource.IsCancellationRequested) cancellationTokenSource.Cancel();
+            listeningSocket.Close();
+
+            var exceptions = DisposePumps();
+
+            try
+            {
+                listeningSocket.Dispose();
+            }
+            catch (Exception e)
+            {
+                exceptions.Add(e);
+            }
+
+            try
+            {
+                cancellationTokenSource.Dispose();
+            }
+            catch (Exception e)
+            {
+                exceptions.Add(e);
+            }
+
+            if (exceptions.Count > 0)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/SocketPump.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/SocketPump.cs
@@ -69,7 +69,6 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 ArraySegment<byte> outputBuffer = new ArraySegment<byte>(inputBuffer, offset, totalBytesToSend - offset);
-                ReadOnlyMemory<byte> readOnlyMemory = outputBuffer;
 #if DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS
                 offset += await writeTo.SendAsync(outputBuffer, SocketFlags.None).ConfigureAwait(false);
 #else

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/SocketPump.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/SocketPump.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
+{
+
+    public class SocketPump
+    {
+        public delegate bool IsPumpPaused();
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        MemoryStream buffer = new MemoryStream();
+        IsPumpPaused isPumpPaused;
+        readonly TimeSpan sendDelay;
+
+        public SocketPump(IsPumpPaused isPumpPaused, TimeSpan sendDelay)
+        {
+            this.isPumpPaused = isPumpPaused;
+            this.sendDelay = sendDelay;
+        }
+
+        public async Task<SocketStatus> PumpBytes(Socket readFrom, Socket writeTo, CancellationToken cancellationToken)
+        {
+            await PausePump(cancellationToken);
+
+            // Only read if we have nothing to send or if data exists 
+            if (readFrom.Available > 0 || buffer.Length == 0)
+            {
+                var receivedByteCount = await ReadFromSocket(readFrom, buffer, cancellationToken);
+                if (receivedByteCount == 0) return SocketStatus.SOCKET_CLOSED;
+                stopwatch = Stopwatch.StartNew();
+            }
+
+
+            await PausePump(cancellationToken);
+
+            if ((readFrom.Available == 0 && stopwatch.Elapsed >= sendDelay) || buffer.Length > 100 * 1024 * 1024)
+            {
+                // Send the data
+                await WriteToSocket(writeTo, buffer.GetBuffer(), (int)buffer.Length, cancellationToken);
+                buffer.SetLength(0);
+            }
+            else
+            {
+                await Task.Delay(1, cancellationToken);
+            }
+
+            return SocketStatus.SOCKET_OPEN;
+        }
+
+        async Task PausePump(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            while (isPumpPaused())
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+
+        static async Task WriteToSocket(Socket writeTo, byte[] inputBuffer, int totalBytesToSend, CancellationToken cancellationToken)
+        {
+            var offset = 0;
+            while (totalBytesToSend - offset > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                ArraySegment<byte> outputBuffer = new ArraySegment<byte>(inputBuffer, offset, totalBytesToSend - offset);
+                ReadOnlyMemory<byte> readOnlyMemory = outputBuffer;
+#if DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS
+                offset += await writeTo.SendAsync(outputBuffer, SocketFlags.None).ConfigureAwait(false);
+#else
+                offset += await writeTo.SendAsync(outputBuffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+#endif
+            }
+
+        }
+
+        static async Task<int> ReadFromSocket(Socket readFrom, MemoryStream memoryStream, CancellationToken cancellationToken)
+        {
+            var inputBuffer = new byte[readFrom.ReceiveBufferSize];
+            ArraySegment<byte> inputBufferArraySegment = new ArraySegment<byte>(inputBuffer);
+#if DOES_NOT_SUPPORT_CANCELLATION_ON_SOCKETS
+            var receivedByteCount = await readFrom.ReceiveAsync(inputBufferArraySegment, SocketFlags.None).ConfigureAwait(false);
+#else
+            var receivedByteCount = await readFrom.ReceiveAsync(inputBufferArraySegment, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+#endif
+
+            memoryStream.Write(inputBuffer, 0, receivedByteCount);
+            return receivedByteCount;
+        }
+
+
+        public enum SocketStatus
+        {
+            SOCKET_CLOSED,
+            SOCKET_OPEN
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/TCPListenerWhichKillsNewConnections.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/TCPListenerWhichKillsNewConnections.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
+{
+    
+    /// <summary>
+    /// A TCP listener which when a client connects (and so a new TCP connection is created) this
+    /// immediately kills that new connection.
+    /// </summary>
+    public class TCPListenerWhichKillsNewConnections : IDisposable
+    {
+        readonly Socket listeningSocket;
+        readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        readonly ILogger logger = Log.ForContext<PortForwarder>();
+        
+        public int Port { get; private set; }
+        
+        public TCPListenerWhichKillsNewConnections()
+        {
+            listeningSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listeningSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listeningSocket.Listen(0);
+            Port = ((IPEndPoint)listeningSocket.LocalEndPoint).Port;
+            Task.Factory.StartNew(() => WorkerTask(cancellationTokenSource.Token).ConfigureAwait(false), TaskCreationOptions.LongRunning);
+        }
+        
+        async Task WorkerTask(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Yield();
+
+                try
+                {
+                    var clientSocket = await listeningSocket.AcceptAsync();
+                    clientSocket.Close();
+                }
+                catch (SocketException ex)
+                {
+                    // This will occur normally on teardown.
+                    logger.Verbose(ex, "Socket Error accepting new connection {Message}", ex.Message);
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, "Error accepting new connection {Message}", ex.Message);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            cancellationTokenSource.Cancel();
+            listeningSocket?.Dispose();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/TcpPump.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/TcpPump.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
+{
+    public class TcpPump : IDisposable
+    {
+        readonly Socket clientSocket;
+        readonly EndPoint clientEndPoint;
+        readonly Socket originSocket;
+        readonly EndPoint originEndPoint;
+        readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        readonly ILogger logger;
+        readonly TimeSpan sendDelay;
+        bool isDisposing;
+        bool isDisposed;
+        public bool IsPaused { get; set; }
+        
+
+        public TcpPump(Socket clientSocket, Socket originSocket, EndPoint originEndPoint, TimeSpan sendDelay, ILogger logger)
+        {
+            this.logger = logger.ForContext<TcpPump>(); 
+            this.clientSocket = clientSocket ?? throw new ArgumentNullException(nameof(clientSocket));
+            this.originSocket = originSocket ?? throw new ArgumentNullException(nameof(originSocket));
+            this.originEndPoint = originEndPoint ?? throw new ArgumentNullException(nameof(originEndPoint));
+            this.sendDelay = sendDelay;
+            clientEndPoint = clientSocket.RemoteEndPoint ?? throw new ArgumentException("Remote endpoint is null", nameof(clientSocket));
+        }
+
+        public event EventHandler<EventArgs> Stopped;
+
+        public void Start()
+        {
+            var cancellationToken = cancellationTokenSource.Token;
+
+            Task.Run(
+                async () =>
+                {
+                    logger.Verbose("Forwarding connection from {ClientEndPoint} to {OriginEndPoint}.", clientEndPoint.ToString(), originEndPoint.ToString());
+
+                    try
+                    {
+                        await originSocket.ConnectAsync(originEndPoint).ConfigureAwait(false);
+
+                        // If the connection was ok, then set-up a pump both ways
+                        var pump1 = Task.Run(async () => await PumpBytes(clientSocket, originSocket, new SocketPump(() => this.IsPaused, sendDelay), cancellationToken).ConfigureAwait(false), cancellationToken);
+                        var pump2 = Task.Run(async () => await PumpBytes(originSocket, clientSocket, new SocketPump(() => this.IsPaused, sendDelay), cancellationToken).ConfigureAwait(false), cancellationToken);
+
+                        // When one is finished, they are both "done" so stop them
+                        await Task.WhenAny(pump1, pump2).ConfigureAwait(false);
+                        logger.Verbose("Stopping connection forwarding from {ClientEndPoint} to {OriginEndPoint}.", clientEndPoint.ToString(), originEndPoint.ToString());
+                        if (!cancellationTokenSource.IsCancellationRequested)
+                        {
+                            cancellationTokenSource.Cancel();
+                        }
+
+                        // Wait for both pumps to be complete
+                        await Task.WhenAll(pump1, pump2).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Verbose(ex, "Forwarding between {ClientEndPoint} and {OriginEndPoint} failed.", clientEndPoint.ToString(), originEndPoint.ToString());
+                    }
+
+                    // We are done. Close everything.
+                    logger.Verbose("Stopped connection forwarding from {ClientEndPoint} to {OriginEndPoint}.", clientEndPoint.ToString(), originEndPoint.ToString());
+                    clientSocket.Close();
+                    originSocket.Close();
+
+                    // Let the users know we are done
+                    Stopped?.Invoke(this, EventArgs.Empty);
+                },
+                cancellationToken);
+        }
+
+        async Task PumpBytes(Socket readFrom, Socket writeTo, SocketPump socketPump, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                await Task.Yield();
+
+                if (cancellationToken.IsCancellationRequested) break;
+                if (!readFrom.Connected) break;
+                if (!writeTo.Connected) break;
+
+                try
+                {
+
+                    var socketStatus = await socketPump.PumpBytes(readFrom, writeTo, cancellationToken);
+                    if(socketStatus == SocketPump.SocketStatus.SOCKET_CLOSED) break;
+                }
+                catch (SocketException socketException)
+                {
+                    logger.Verbose(socketException, "Received socket error {SocketErrorCode} {ReadEndPoint}.", socketException.SocketErrorCode, readFrom.ToString());
+                }
+                catch (OperationCanceledException canceledException)
+                {
+                    logger.Verbose(canceledException, "Received pump cancellation {ReadEndPoint}.", readFrom.ToString());
+                }
+                catch (Exception ex)
+                {
+                    logger.Warning(ex, "Received pump exception: {Message}.", ex.Message);
+                }
+            }
+        }
+
+
+        public void Dispose()
+        {
+            if (isDisposing || isDisposed) return;
+            isDisposing = true;
+
+            logger.Verbose("Port forwarder disposed.");
+            cancellationTokenSource.Cancel();
+            cancellationTokenSource.Dispose();
+            isDisposed = true;
+            
+            clientSocket.Close();
+            originSocket.Close();
+        }
+
+        public void Pause()
+        {
+            IsPaused = true;
+        }
+    }
+}


### PR DESCRIPTION
# Background

This will allow us to test retries when the network connection has an issue.

The portforwarder itself comes from Halibut see [here](https://github.com/OctopusDeploy/Halibut/pull/235). Eventually it will be rolled into its own solution and nuget package but until then this lets us write the tests we need now.
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.