### PR TITLE
Delete Test Tentacle instances.

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -17,7 +17,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         internal async Task<RunningTentacle> Build(CancellationToken cancellationToken)
         {
             var tempDirectory = new TemporaryDirectory();
-            var instanceName = Guid.NewGuid().ToString("N");
+            var instanceName = InstanceNameGenerator();
             var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -22,7 +22,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         internal async Task<RunningTentacle> Build(CancellationToken cancellationToken)
         {
             var tempDirectory = new TemporaryDirectory();
-            var instanceName = Guid.NewGuid().ToString("N");
+            var instanceName = InstanceNameGenerator();
             var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
             var subscriptionId = PollingSubscriptionId.Generate();

--- a/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
@@ -10,16 +10,18 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         private CancellationTokenSource? cancellationTokenSource;
         private Task? runningTentacleTask;
         private readonly Func<CancellationToken, Task<(Task runningTentacleTask, Uri serviceUri)>> startTentacleFunction;
+        private readonly Action<CancellationToken> deleteInstanceFunction;
 
         public RunningTentacle(
             IDisposable temporaryDirectory,
             Func<CancellationToken, Task<(Task, Uri)>> startTentacleFunction,
-            string thumbprint)
+            string thumbprint, Action<CancellationToken> deleteInstanceFunction)
         {
             this.startTentacleFunction = startTentacleFunction;
             this.temporaryDirectory = temporaryDirectory;
 
             Thumbprint = thumbprint;
+            this.deleteInstanceFunction = deleteInstanceFunction;
         }
 
         public Uri ServiceUri { get; private set; }
@@ -60,6 +62,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             {
                 Stop(CancellationToken.None).GetAwaiter().GetResult();
             }
+
+            deleteInstanceFunction(CancellationToken.None);
 
             temporaryDirectory.Dispose();
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -55,7 +55,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var runningTentacle = new RunningTentacle(
                 tempDirectory,
                 StartTentacleFunction,
-                tentacleThumbprint);
+                tentacleThumbprint,
+                ct => DeleteInstance(tentacleExe, instanceName, tempDirectory, ct));
 
             try
             {
@@ -142,6 +143,16 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         internal void CreateInstance(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
         {
             RunTentacleCommand(tentacleExe, new[] { "create-instance", "--config", configFilePath, $"--instance={instanceName}" }, tmp, cancellationToken);
+        }
+        
+        internal void DeleteInstance(string tentacleExe, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        {
+            RunTentacleCommand(tentacleExe, new[] {"delete-instance", $"--instance={instanceName}"}, tmp, cancellationToken);
+        }
+
+        internal string InstanceNameGenerator()
+        {
+            return $"TentacleIT-{Guid.NewGuid().ToString("N")}";
         }
 
         private void RunTentacleCommand(string tentacleExe, string[] args, TemporaryDirectory tmp, CancellationToken cancellationToken)


### PR DESCRIPTION
# Background

Also give test tentacle instances a better name.

[SC-46171]

# Results

Previously after a tentacle integration test run, a tentacle instance would be left on the host machine. With this change that tentacle instance will be deleted if the test completes (even in failure).


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.