### PR TITLE
Add support for testing listening tentacles with TentacleClient

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Legacy/HalibutRuntimeExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Contracts/Legacy/HalibutRuntimeExtensionMethods.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Halibut;
+
+namespace Octopus.Tentacle.Contracts.Legacy
+{
+    public static class HalibutRuntimeExtensionMethods
+    {
+        public static HalibutRuntimeBuilder WithLegacyContractSupport(this HalibutRuntimeBuilder builder)
+        {
+            return builder.WithMessageSerializer(s => s.WithLegacyContractSupport());
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/ListeningTentacleTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ListeningTentacleTests.cs
@@ -18,22 +18,21 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
                 .WithServerCertificate(Support.Certificates.Server)
-                .WithMessageSerializer(s => s.WithLegacyContractSupport())
+                .WithLegacyContractSupport()
                 .Build();
 
             octopus.Trust(Support.Certificates.TentaclePublicThumbprint);
 
-            using (var runningTentacle = await new ListeningTentacleBuilder(Support.Certificates.ServerPublicThumbprint)
-                       .Build(CancellationToken.None))
-            {
-                var tentacleClient = new TentacleClientBuilder(octopus)
-                    .WithServiceUri(runningTentacle.ServiceUri)
-                    .WithRemoteThumbprint(runningTentacle.Thumbprint)
-                    .Build(CancellationToken.None);
+            using var runningTentacle = await new ListeningTentacleBuilder(Support.Certificates.ServerPublicThumbprint)
+                .Build(CancellationToken.None);
 
-                var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
-                res.ExitCode.Should().Be(0);
-            }
+            var tentacleClient = new TentacleClientBuilder(octopus)
+                .WithServiceUri(runningTentacle.ServiceUri)
+                .WithRemoteThumbprint(runningTentacle.Thumbprint)
+                .Build(CancellationToken.None);
+
+            var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
+            res.ExitCode.Should().Be(0);
         }
 
         [Test]
@@ -41,7 +40,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
                 .WithServerCertificate(Support.Certificates.Server)
-                .WithMessageSerializer(s => s.WithLegacyContractSupport())
+                .WithLegacyContractSupport()
                 .Build();
 
             octopus.Trust(Support.Certificates.TentaclePublicThumbprint);
@@ -49,18 +48,17 @@ namespace Octopus.Tentacle.Tests.Integration
             using var tmp = new TemporaryDirectory();
             var oldTentacleExe = await TentacleFetcher.GetTentacleVersion(tmp.DirectoryPath, "6.3.451");
 
-            using (var runningTentacle = await new ListeningTentacleBuilder(Support.Certificates.ServerPublicThumbprint)
-                       .WithTentacleExe(oldTentacleExe)
-                       .Build(CancellationToken.None))
-            {
-                var tentacleClient = new TentacleClientBuilder(octopus)
-                    .WithServiceUri(runningTentacle.ServiceUri)
-                    .WithRemoteThumbprint(runningTentacle.Thumbprint)
-                    .Build(CancellationToken.None);
+            using var runningTentacle = await new ListeningTentacleBuilder(Support.Certificates.ServerPublicThumbprint)
+                .WithTentacleExe(oldTentacleExe)
+                .Build(CancellationToken.None);
 
-                var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
-                res.ExitCode.Should().Be(0);
-            }
+            var tentacleClient = new TentacleClientBuilder(octopus)
+                .WithServiceUri(runningTentacle.ServiceUri)
+                .WithRemoteThumbprint(runningTentacle.Thumbprint)
+                .Build(CancellationToken.None);
+
+            var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
+            res.ExitCode.Should().Be(0);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/ListeningTentacleTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ListeningTentacleTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut;
+using NUnit.Framework;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.Legacy;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.TentacleClient;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    public class ListeningTentacleTests
+    {
+        [Test]
+        public async Task BasicCommunicationsWithWithAPollingTentacle()
+        {
+            using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
+                .WithServerCertificate(Support.Certificates.Server)
+                .WithMessageSerializer(s => s.WithLegacyContractSupport())
+                .Build();
+
+            //var port = octopus.Listen();
+            octopus.Trust(Support.Certificates.TentaclePublicThumbprint);
+
+            using (var runningTentacle = await new ListeningTentacleBuilder(Support.Certificates.ServerPublicThumbprint)
+                       .Build(CancellationToken.None))
+            {
+                var tentacleClient = new TentacleClientBuilder(octopus)
+                    .WithServiceUri(new Uri($"https://localhost:{runningTentacle.Port}"))
+                    .WithRemoteThumbprint(runningTentacle.Thumbprint)
+                    .Build(CancellationToken.None);
+
+                var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
+                res.ExitCode.Should().Be(0);
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/ListeningTentacleTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ListeningTentacleTests.cs
@@ -14,21 +14,47 @@ namespace Octopus.Tentacle.Tests.Integration
     public class ListeningTentacleTests
     {
         [Test]
-        public async Task BasicCommunicationsWithWithAPollingTentacle()
+        public async Task BasicCommunicationsWithAListeningTentacle()
         {
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
                 .WithServerCertificate(Support.Certificates.Server)
                 .WithMessageSerializer(s => s.WithLegacyContractSupport())
                 .Build();
 
-            //var port = octopus.Listen();
             octopus.Trust(Support.Certificates.TentaclePublicThumbprint);
 
             using (var runningTentacle = await new ListeningTentacleBuilder(Support.Certificates.ServerPublicThumbprint)
                        .Build(CancellationToken.None))
             {
                 var tentacleClient = new TentacleClientBuilder(octopus)
-                    .WithServiceUri(new Uri($"https://localhost:{runningTentacle.Port}"))
+                    .WithServiceUri(runningTentacle.ServiceUri)
+                    .WithRemoteThumbprint(runningTentacle.Thumbprint)
+                    .Build(CancellationToken.None);
+
+                var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
+                res.ExitCode.Should().Be(0);
+            }
+        }
+
+        [Test]
+        public async Task BasicCommunicationsWithAnOldListeningTentacle()
+        {
+            using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
+                .WithServerCertificate(Support.Certificates.Server)
+                .WithMessageSerializer(s => s.WithLegacyContractSupport())
+                .Build();
+
+            octopus.Trust(Support.Certificates.TentaclePublicThumbprint);
+
+            using var tmp = new TemporaryDirectory();
+            var oldTentacleExe = await TentacleFetcher.GetTentacleVersion(tmp.DirectoryPath, "6.3.451");
+
+            using (var runningTentacle = await new ListeningTentacleBuilder(Support.Certificates.ServerPublicThumbprint)
+                       .WithTentacleExe(oldTentacleExe)
+                       .Build(CancellationToken.None))
+            {
+                var tentacleClient = new TentacleClientBuilder(octopus)
+                    .WithServiceUri(runningTentacle.ServiceUri)
                     .WithRemoteThumbprint(runningTentacle.Thumbprint)
                     .Build(CancellationToken.None);
 

--- a/source/Octopus.Tentacle.Tests.Integration/PollingTentacleTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/PollingTentacleTest.cs
@@ -1,15 +1,12 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut;
-using Halibut.ServiceModel;
 using NUnit.Framework;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Legacy;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.TentacleClient;
-using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration
 {
@@ -20,22 +17,21 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
                 .WithServerCertificate(Support.Certificates.Server)
-                .WithMessageSerializer(s => s.WithLegacyContractSupport())
+                .WithLegacyContractSupport()
                 .Build();
 
             var port = octopus.Listen();
             octopus.Trust(Support.Certificates.TentaclePublicThumbprint);
 
-            using (var runningTentacle = await new PollingTentacleBuilder(port, Support.Certificates.ServerPublicThumbprint)
-                       .Build(CancellationToken.None))
-            {
-                var tentacleClient = new TentacleClientBuilder(octopus)
-                    .ForRunningTentacle(runningTentacle)
-                    .Build(CancellationToken.None);
+            using var runningTentacle = await new PollingTentacleBuilder(port, Support.Certificates.ServerPublicThumbprint)
+                .Build(CancellationToken.None);
 
-                var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
-                res.ExitCode.Should().Be(0);
-            }
+            var tentacleClient = new TentacleClientBuilder(octopus)
+                .ForRunningTentacle(runningTentacle)
+                .Build(CancellationToken.None);
+
+            var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
+            res.ExitCode.Should().Be(0);
         }
 
         [Test]
@@ -43,7 +39,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
                 .WithServerCertificate(Support.Certificates.Server)
-                .WithMessageSerializer(s => s.WithLegacyContractSupport())
+                .WithLegacyContractSupport()
                 .Build();
 
             var port = octopus.Listen();
@@ -52,17 +48,16 @@ namespace Octopus.Tentacle.Tests.Integration
             using var tmp = new TemporaryDirectory();
             var oldTentacleExe = await TentacleFetcher.GetTentacleVersion(tmp.DirectoryPath, "6.3.451");
 
-            using (var runningTentacle = await new PollingTentacleBuilder(port, Support.Certificates.ServerPublicThumbprint)
-                       .WithTentacleExe(oldTentacleExe)
-                       .Build(CancellationToken.None))
-            {
-                var tentacleClient = new TentacleClientBuilder(octopus)
-                    .ForRunningTentacle(runningTentacle)
-                    .Build(CancellationToken.None);
+            using var runningTentacle = await new PollingTentacleBuilder(port, Support.Certificates.ServerPublicThumbprint)
+                .WithTentacleExe(oldTentacleExe)
+                .Build(CancellationToken.None);
 
-                var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
-                res.ExitCode.Should().Be(0);
-            }
+            var tentacleClient = new TentacleClientBuilder(octopus)
+                .ForRunningTentacle(runningTentacle)
+                .Build(CancellationToken.None);
+
+            var res = tentacleClient.ScriptService.GetStatus(new ScriptStatusRequest(new ScriptTicket("1212"), 111));
+            res.ExitCode.Should().Be(0);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -1,235 +1,50 @@
 ﻿using System;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac;
-using Nito.AsyncEx.Interop;
-using NUnit.Framework;
 using Octopus.Client.Model;
 using Octopus.Tentacle.Configuration;
-using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
-    public class ListeningTentacleBuilder
+    public class ListeningTentacleBuilder : TentacleBuilder<ListeningTentacleBuilder>
     {
-        readonly string octopusThumbprint;
-        private string? tentacleExePath;
-
-        private string? CertificatePfxPath;
-        private string? TentacleThumbprint;
-
-        public ListeningTentacleBuilder(string octopusThumbprint)
+        public ListeningTentacleBuilder(string serverThumbprint)
         {
-            this.octopusThumbprint = octopusThumbprint;
+            ServerThumbprint = serverThumbprint;
         }
 
-        public ListeningTentacleBuilder WithCertificate(string CertificatePfxPath, string TentacleThumbprint)
-        {
-            this.CertificatePfxPath = CertificatePfxPath;
-            this.TentacleThumbprint = TentacleThumbprint;
-            return this;
-        }
-
-        public ListeningTentacleBuilder WithTentacleExe(string tentacleExe)
-        {
-            tentacleExePath = tentacleExe;
-            return this;
-        }
-
-        internal async Task<RunningTestListeningTentacle> Build(CancellationToken cancellationToken)
+        internal async Task<RunningTentacle> Build(CancellationToken cancellationToken)
         {
             var tempDirectory = new TemporaryDirectory();
             var instanceName = Guid.NewGuid().ToString("N");
             var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
-            var tentacleExe = tentacleExePath ?? TentacleExeFinder.FindTentacleExe();
-            var CertificatePfxPath = this.CertificatePfxPath ?? Certificates.TentaclePfxPath;
-            var tentacleThumbprint = TentacleThumbprint ?? Certificates.TentaclePublicThumbprint;
+            var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
+
             CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
-            AddCertificateToTentacle(tentacleExe, configFilePath, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
-            ConfigureTentacleToListen(configFilePath, octopusThumbprint ?? Certificates.ServerPublicThumbprint);
+            AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
+            ConfigureTentacleToListen(configFilePath);
 
-            Func<CancellationToken, Task<(string, Task)>> startTentacle = token => RunningTentacle(tentacleExe, configFilePath, instanceName, tempDirectory, token);
-            var runningTentacle =  new RunningTestListeningTentacle(tempDirectory, startTentacle, tentacleThumbprint);
-            
-            try
-            {
-                await runningTentacle.Start(cancellationToken);
-                return runningTentacle;
-            }
-            catch (Exception)
-            {
-                try
-                {
-                    runningTentacle.Dispose();
-                }
-                catch (Exception e)
-                {
-                    TestContext.WriteLine(e);
-                }
-
-                // Throw the interesting exception
-                throw;
-            }
+            return await StartTentacle(
+                null,
+                tentacleExe,
+                instanceName,
+                tempDirectory,
+                TentacleThumbprint,
+                cancellationToken);
         }
 
-        private static Regex listeningPortRegex = new Regex(@"^listen:\/\/.+:(\d+)\/");
-
-        private async Task<(string, Task)> RunningTentacle(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        private void ConfigureTentacleToListen(string configFilePath)
         {
-            var hasTentacleStarted = new ManualResetEventSlim();
-            hasTentacleStarted.Reset();
+            var writableTentacleConfiguration = GetWritableTentacleConfiguration(configFilePath);
 
-            string listeningPort = null;
-
-            var runningTentacle = Task.Run(() =>
-            {
-                try
-                {
-                    RunTentacleCommandOutOfProcess(tentacleExe, new[] {"agent", $"--instance={instanceName}", "--noninteractive"}, tmp,
-                        s =>
-                        {
-                            if (s.Contains("Agent will not listen") || s.Contains("Agent listening on"))
-                            {
-                                hasTentacleStarted.Set();
-                            }
-                            else if (s.Contains("Listener started"))
-                            {
-                                listeningPort = listeningPortRegex.Match(s).Groups[1].Value;
-                            }
-                        }, cancellationToken);
-                }
-                catch (Exception e)
-                {
-                    TestContext.WriteLine(e);
-                    throw;
-                }
-            }, cancellationToken);
-
-            await Task.WhenAny(runningTentacle, WaitHandleAsyncFactory.FromWaitHandle(hasTentacleStarted.WaitHandle, TimeSpan.FromMinutes(1)));
-
-            // Will throw.
-            if (runningTentacle.IsCompleted) await runningTentacle;
-
-            if (!hasTentacleStarted.IsSet)
-            {
-                throw new Exception("Tentacle did not appear to start correctly");
-            }
-
-            return (listeningPort, runningTentacle);
-        }
-
-        private void ConfigureTentacleToListen(string configFilePath, string octopusThumbprint)
-        {
-            var startUpConfigFileInstanceRequest = new StartUpConfigFileInstanceRequest(configFilePath);
-            using var container = new Program(new string[] { }).BuildContainer(startUpConfigFileInstanceRequest);
-
-            var writableTentacleConfiguration = container.Resolve<IWritableTentacleConfiguration>();
-            writableTentacleConfiguration.AddOrUpdateTrustedOctopusServer(new OctopusServerConfiguration(octopusThumbprint)
+            writableTentacleConfiguration.AddOrUpdateTrustedOctopusServer(new OctopusServerConfiguration(ServerThumbprint)
             {
                 CommunicationStyle = CommunicationStyle.TentaclePassive,
             });
-            writableTentacleConfiguration.SetApplicationDirectory(Path.Combine(new DirectoryInfo(configFilePath).Parent.FullName, "appdir"));
+
             writableTentacleConfiguration.SetServicesPortNumber(0); // Find a random available port
             writableTentacleConfiguration.SetNoListen(false);
-        }
-
-        private void AddCertificateToTentacle(string tentacleExe, string configFilePath, string instanceName, string tentaclePfxPath, TemporaryDirectory tmp, CancellationToken cancellationToken)
-        {
-            RunTentacleCommand(tentacleExe, new[] {"import-certificate", $"--from-file={tentaclePfxPath}", $"--instance={instanceName}"}, tmp, cancellationToken);
-        }
-
-        private void CreateInstance(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
-        {
-            RunTentacleCommand(tentacleExe, new[] {"create-instance", "--config", configFilePath, $"--instance={instanceName}"}, tmp, cancellationToken);
-        }
-
-        private void RunTentacleCommand(string tentacleExe, string[] args, TemporaryDirectory tmp, CancellationToken cancellationToken)
-        {
-            RunTentacleCommandOutOfProcess(tentacleExe, args, tmp, s =>
-            {
-            }, cancellationToken);
-        }
-
-        private void RunTentacleCommandOutOfProcess(string tentacleExe,
-            string[] args,
-            TemporaryDirectory tmp,
-            Action<string> CommandOutput,
-            CancellationToken cancellationToken)
-        {
-            Action<string> allOutput = s =>
-            {
-                TestContext.WriteLine(s);
-                CommandOutput(s);
-            };
-            var exitCode = SilentProcessRunner.ExecuteCommand(
-                tentacleExe,
-                String.Join(" ", args),
-                tmp.DirectoryPath,
-                allOutput,
-                allOutput,
-                allOutput,
-                cancellationToken);
-
-            if (cancellationToken.IsCancellationRequested) return;
-
-            if (exitCode != 0)
-            {
-                throw new Exception("Tentacle returns non zero exit code: " + exitCode);
-            }
-        }
-    }
-
-    class RunningTestListeningTentacle : IDisposable
-    {
-        private readonly IDisposable TemporaryDirectory;
-        private CancellationTokenSource cts;
-        private Task? RunningTentacleTask { get; set; }
-        private Func<CancellationToken, Task<(string, Task)>> startTentacle;
-        public string Thumbprint { get; }
-        public Uri ServiceUri { get; private set; }
-
-        public RunningTestListeningTentacle( 
-            IDisposable temporaryDirectory,
-            Func<CancellationToken, Task<(string, Task)>> startTentacle,
-            string thumbprint)
-        {
-            TemporaryDirectory = temporaryDirectory;
-            this.startTentacle = startTentacle;
-            Thumbprint = thumbprint;
-        }
-        
-        public async Task Start(CancellationToken cancellationToken)
-        {
-            await Task.CompletedTask;
-            if (RunningTentacleTask != null) throw new Exception("Tentacle is already running, call stop() first");
-
-            cts = new CancellationTokenSource();
-
-            var (port, stopTask) = await startTentacle(cts.Token);
-            RunningTentacleTask = stopTask;
-            ServiceUri = new Uri($"https://localhost:{port}");
-        }
-
-        public async Task Stop(CancellationToken cancellationToken)
-        {
-            if (cts != null)
-            {
-                cts.Cancel();
-                cts.Dispose();
-                cts = null;
-            }
-
-            var t = RunningTentacleTask;
-            RunningTentacleTask = null;
-            await t;
-        }
-
-        public void Dispose()
-        {
-            if (RunningTentacleTask != null) Stop(CancellationToken.None).GetAwaiter().GetResult();
-            TemporaryDirectory.Dispose();
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -1,0 +1,238 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Nito.AsyncEx.Interop;
+using NUnit.Framework;
+using Octopus.Client.Model;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public class ListeningTentacleBuilder
+    {
+        readonly string octopusThumbprint;
+        private string? tentacleExePath;
+
+        private string? CertificatePfxPath;
+        private string? TentacleThumbprint;
+
+        public ListeningTentacleBuilder(string octopusThumbprint)
+        {
+            this.octopusThumbprint = octopusThumbprint;
+        }
+
+        public ListeningTentacleBuilder WithCertificate(string CertificatePfxPath, string TentacleThumbprint)
+        {
+            this.CertificatePfxPath = CertificatePfxPath;
+            this.TentacleThumbprint = TentacleThumbprint;
+            return this;
+        }
+
+        public ListeningTentacleBuilder WithTentacleExe(string tentacleExe)
+        {
+            tentacleExePath = tentacleExe;
+            return this;
+        }
+
+        internal async Task<RunningTestListeningTentacle> Build(CancellationToken cancellationToken)
+        {
+            var tempDirectory = new TemporaryDirectory();
+            var instanceName = Guid.NewGuid().ToString("N");
+            var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
+            var tentacleExe = tentacleExePath ?? TentacleExeFinder.FindTentacleExe();
+            var CertificatePfxPath = this.CertificatePfxPath ?? Certificates.TentaclePfxPath;
+            var tentacleThumbprint = TentacleThumbprint ?? Certificates.TentaclePublicThumbprint;
+            CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
+            AddCertificateToTentacle(tentacleExe, configFilePath, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
+            ConfigureTentacleToListen(configFilePath, octopusThumbprint ?? Certificates.ServerPublicThumbprint);
+
+            Func<CancellationToken, Task<(int, Task)>> startTentacle = token => RunningTentacle(tentacleExe, configFilePath, instanceName, tempDirectory, token);
+            var runningTentacle =  new RunningTestListeningTentacle(tempDirectory, startTentacle, tentacleThumbprint);
+            
+            try
+            {
+                await runningTentacle.Start(cancellationToken);
+                return runningTentacle;
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    runningTentacle.Dispose();
+                }
+                catch (Exception e)
+                {
+                    TestContext.WriteLine(e);
+                }
+
+                // Throw the interesting exception
+                throw;
+            }
+        }
+
+        private static Regex listeningPortRegex = new Regex(@"^listen:\/\/.+:(\d+)\/");
+
+        private async Task<(int, Task)> RunningTentacle(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        {
+            var hasTentacleStarted = new ManualResetEventSlim();
+            hasTentacleStarted.Reset();
+
+            int listeningPort = -1;
+
+            var runningTentacle = Task.Run(() =>
+            {
+                try
+                {
+                    RunTentacleCommandOutOfProcess(tentacleExe, new[] {"agent", $"--instance={instanceName}", "--noninteractive"}, tmp,
+                        s =>
+                        {
+                            if (s.Contains("Agent will not listen") || s.Contains("Agent listening on"))
+                            {
+                                hasTentacleStarted.Set();
+                            }
+                            else if (s.Contains("Listener started"))
+                            {
+                                string port = listeningPortRegex.Match(s).Groups[1].Value;
+                                listeningPort = Int32.Parse(port);
+                            }
+                        }, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    TestContext.WriteLine(e);
+                    throw;
+                }
+            }, cancellationToken);
+
+            await Task.WhenAny(runningTentacle, WaitHandleAsyncFactory.FromWaitHandle(hasTentacleStarted.WaitHandle, TimeSpan.FromMinutes(1)));
+
+            // Will throw.
+            if (runningTentacle.IsCompleted) await runningTentacle;
+
+            if (!hasTentacleStarted.IsSet)
+            {
+                throw new Exception("Tentacle did not appear to start correctly");
+            }
+
+            return (listeningPort, runningTentacle);
+        }
+
+        private void ConfigureTentacleToListen(string configFilePath, string octopusThumbprint)
+        {
+            var startUpConfigFileInstanceRequest = new StartUpConfigFileInstanceRequest(configFilePath);
+            using var container = new Program(new string[] { }).BuildContainer(startUpConfigFileInstanceRequest);
+
+            var writableTentacleConfiguration = container.Resolve<IWritableTentacleConfiguration>();
+            writableTentacleConfiguration.AddOrUpdateTrustedOctopusServer(new OctopusServerConfiguration(octopusThumbprint)
+            {
+                CommunicationStyle = CommunicationStyle.TentaclePassive,
+            });
+            writableTentacleConfiguration.SetApplicationDirectory(Path.Combine(new DirectoryInfo(configFilePath).Parent.FullName, "appdir"));
+            writableTentacleConfiguration.SetServicesPortNumber(0); // Find a random available port
+            writableTentacleConfiguration.SetNoListen(false);
+        }
+
+        private void AddCertificateToTentacle(string tentacleExe, string configFilePath, string instanceName, string tentaclePfxPath, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        {
+            RunTentacleCommand(tentacleExe, new[] {"import-certificate", $"--from-file={tentaclePfxPath}", $"--instance={instanceName}"}, tmp, cancellationToken);
+        }
+
+        private void CreateInstance(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        {
+            RunTentacleCommand(tentacleExe, new[] {"create-instance", "--config", configFilePath, $"--instance={instanceName}"}, tmp, cancellationToken);
+        }
+
+        private void RunTentacleCommand(string tentacleExe, string[] args, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        {
+            RunTentacleCommandOutOfProcess(tentacleExe, args, tmp, s =>
+            {
+            }, cancellationToken);
+        }
+
+        private void RunTentacleCommandOutOfProcess(string tentacleExe,
+            string[] args,
+            TemporaryDirectory tmp,
+            Action<string> CommandOutput,
+            CancellationToken cancellationToken)
+        {
+            Action<string> allOutput = s =>
+            {
+                TestContext.WriteLine(s);
+                CommandOutput(s);
+            };
+            var exitCode = SilentProcessRunner.ExecuteCommand(
+                tentacleExe,
+                String.Join(" ", args),
+                tmp.DirectoryPath,
+                allOutput,
+                allOutput,
+                allOutput,
+                cancellationToken);
+
+            if (cancellationToken.IsCancellationRequested) return;
+
+            if (exitCode != 0)
+            {
+                throw new Exception("Tentacle returns non zero exit code: " + exitCode);
+            }
+        }
+    }
+
+    public class RunningTestListeningTentacle : IDisposable
+    {
+        private readonly IDisposable TemporaryDirectory;
+        private CancellationTokenSource cts;
+        private Task? RunningTentacleTask { get; set; }
+        private Func<CancellationToken, Task<(int, Task)>> startTentacle;
+        public string Thumbprint { get; }
+        public int Port { get; private set; }
+
+        public RunningTestListeningTentacle( 
+            IDisposable temporaryDirectory,
+            Func<CancellationToken, Task<(int, Task)>> startTentacle,
+            string thumbprint)
+        {
+            TemporaryDirectory = temporaryDirectory;
+            this.startTentacle = startTentacle;
+            Thumbprint = thumbprint;
+        }
+        
+        public async Task Start(CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            if (RunningTentacleTask != null) throw new Exception("Tentacle is already running, call stop() first");
+
+            cts = new CancellationTokenSource();
+
+            var (port, stopTask) = await startTentacle(cts.Token);
+            RunningTentacleTask = stopTask;
+            Port = port;
+        }
+
+        public async Task Stop(CancellationToken cancellationToken)
+        {
+            if (cts != null)
+            {
+                cts.Cancel();
+                cts.Dispose();
+                cts = null;
+            }
+
+            var t = RunningTentacleTask;
+            RunningTentacleTask = null;
+            await t;
+        }
+
+        public void Dispose()
+        {
+            if (RunningTentacleTask != null) Stop(CancellationToken.None).GetAwaiter().GetResult();
+            TemporaryDirectory.Dispose();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -50,7 +50,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 CommunicationStyle = CommunicationStyle.TentacleActive,
                 SubscriptionId = subscriptionId.ToString()
             });
-
+            
+            writableTentacleConfiguration.SetApplicationDirectory(Path.Combine(new DirectoryInfo(configFilePath).Parent.FullName, "appdir"));
             writableTentacleConfiguration.SetNoListen(true);
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -2,239 +2,56 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Autofac;
-using Nito.AsyncEx.Interop;
-using NUnit.Framework;
 using Octopus.Client.Model;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
-    public class PollingTentacleBuilder
+    public class PollingTentacleBuilder : TentacleBuilder<PollingTentacleBuilder>
     {
-        readonly int octopusHalibutPort;
-        readonly string octopusThumbprint;
-        Uri? tentaclePollSubscriptionId;
-        private string? tentacleExePath;
+        readonly int pollingPort;
 
-        private string? CertificatePfxPath;
-        private string? TentacleThumbprint;
-
-        public PollingTentacleBuilder(int octopusHalibutPort, string octopusThumbprint)
+        public PollingTentacleBuilder(int pollingPort, string serverThumbprint)
         {
-            this.octopusHalibutPort = octopusHalibutPort;
-            this.octopusThumbprint = octopusThumbprint;
+            this.pollingPort = pollingPort;
+
+            ServerThumbprint = serverThumbprint;
         }
 
-        public PollingTentacleBuilder WithTentaclePollSubscription(Uri tentaclePollSubscriptionId)
-        {
-            this.tentaclePollSubscriptionId = tentaclePollSubscriptionId;
-            return this;
-        }
-
-        public PollingTentacleBuilder WithCertificate(string CertificatePfxPath, string TentacleThumbprint)
-        {
-            this.CertificatePfxPath = CertificatePfxPath;
-            this.TentacleThumbprint = TentacleThumbprint;
-            return this;
-        }
-
-        public PollingTentacleBuilder WithTentacleExe(string tentacleExe)
-        {
-            tentacleExePath = tentacleExe;
-            return this;
-        }
-
-        internal async Task<RunningTestTentacle> Build(CancellationToken cancellationToken)
+        internal async Task<RunningTentacle> Build(CancellationToken cancellationToken)
         {
             var tempDirectory = new TemporaryDirectory();
             var instanceName = Guid.NewGuid().ToString("N");
             var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
-            var tentacleExe = tentacleExePath ?? TentacleExeFinder.FindTentacleExe();
-            var subscriptionId = tentaclePollSubscriptionId ?? PollingSubscriptionId.Generate();
-            var CertificatePfxPath = this.CertificatePfxPath ?? Certificates.TentaclePfxPath;
-            var tentacleThumbprint = TentacleThumbprint ?? Certificates.TentaclePublicThumbprint;
+            var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
+            var subscriptionId = PollingSubscriptionId.Generate();
+
             CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
-            AddCertificateToTentacle(tentacleExe, configFilePath, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
-            ConfigureTentacleToPollOctopusServer(
-                configFilePath,
-                octopusHalibutPort,
-                octopusThumbprint ?? Certificates.ServerPublicThumbprint,
-                subscriptionId);
+            AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
+            ConfigureTentacleToPollOctopusServer(configFilePath, subscriptionId);
 
-            Func<CancellationToken, Task<Task>> startTentacle = token => RunningTentacle(tentacleExe, configFilePath, instanceName, tempDirectory, token);  
-            var runningTentacle =  new RunningTestTentacle(subscriptionId, tempDirectory, startTentacle, tentacleThumbprint);
-            try
-            {
-                await runningTentacle.Start(cancellationToken);
-                return runningTentacle;
-            }
-            catch (Exception)
-            {
-                try
-                {
-                    runningTentacle.Dispose();
-                }
-                catch (Exception e)
-                {
-                    TestContext.WriteLine(e);
-                }
-
-                // Throw the interesting exception
-                throw;
-            }
+            return await StartTentacle(
+                subscriptionId,
+                tentacleExe,
+                instanceName,
+                tempDirectory,
+                TentacleThumbprint,
+                cancellationToken);
         }
 
-        private async Task<Task> RunningTentacle(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        private void ConfigureTentacleToPollOctopusServer(string configFilePath, Uri subscriptionId)
         {
-            var hasTentacleStarted = new ManualResetEventSlim();
-            hasTentacleStarted.Reset();
+            var writableTentacleConfiguration = GetWritableTentacleConfiguration(configFilePath);
 
-            var runningTentacle = Task.Run(() =>
+            writableTentacleConfiguration.AddOrUpdateTrustedOctopusServer(new OctopusServerConfiguration(ServerThumbprint)
             {
-                try
-                {
-                    RunTentacleCommandOutOfProcess(tentacleExe, new[] {"agent", $"--instance={instanceName}", "--noninteractive"}, tmp,
-                        s =>
-                        {
-                            if (s.Contains("Agent will not listen") || s.Contains("Agent listening on"))
-                            {
-                                hasTentacleStarted.Set();
-                            }
-                        }, cancellationToken);
-                }
-                catch (Exception e)
-                {
-                    TestContext.WriteLine(e);
-                    throw;
-                }
-            }, cancellationToken);
-
-            await Task.WhenAny(runningTentacle, WaitHandleAsyncFactory.FromWaitHandle(hasTentacleStarted.WaitHandle, TimeSpan.FromMinutes(1)));
-
-            // Will throw.
-            if (runningTentacle.IsCompleted) await runningTentacle;
-
-            if (!hasTentacleStarted.IsSet)
-            {
-                throw new Exception("Tentacle did not appear to start correctly");
-            }
-
-            return runningTentacle;
-        }
-
-        private void ConfigureTentacleToPollOctopusServer(string configFilePath, int octopusHalibutPort, string octopusThumbprint, Uri tentaclePollSubscriptionId)
-        {
-            var startUpConfigFileInstanceRequest = new StartUpConfigFileInstanceRequest(configFilePath);
-            using var container = new Program(new string[] { }).BuildContainer(startUpConfigFileInstanceRequest);
-
-            var writableTentacleConfiguration = container.Resolve<IWritableTentacleConfiguration>();
-            writableTentacleConfiguration.AddOrUpdateTrustedOctopusServer(new OctopusServerConfiguration(octopusThumbprint)
-            {
-                Address = new Uri("https://localhost:" + octopusHalibutPort),
+                Address = new Uri("https://localhost:" + pollingPort),
                 CommunicationStyle = CommunicationStyle.TentacleActive,
-                SubscriptionId = tentaclePollSubscriptionId.ToString()
+                SubscriptionId = subscriptionId.ToString()
             });
-            writableTentacleConfiguration.SetApplicationDirectory(Path.Combine(new DirectoryInfo(configFilePath).Parent.FullName, "appdir"));
 
             writableTentacleConfiguration.SetNoListen(true);
-        }
-
-        private void AddCertificateToTentacle(string tentacleExe, string configFilePath, string instanceName, string tentaclePfxPath, TemporaryDirectory tmp, CancellationToken cancellationToken)
-        {
-            RunTentacleCommand(tentacleExe, new[] {"import-certificate", $"--from-file={tentaclePfxPath}", $"--instance={instanceName}"}, tmp, cancellationToken);
-        }
-
-        private void CreateInstance(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
-        {
-            RunTentacleCommand(tentacleExe, new[] {"create-instance", "--config", configFilePath, $"--instance={instanceName}"}, tmp, cancellationToken);
-        }
-
-        private void RunTentacleCommand(string tentacleExe, string[] args, TemporaryDirectory tmp, CancellationToken cancellationToken)
-        {
-            RunTentacleCommandOutOfProcess(tentacleExe, args, tmp, s =>
-            {
-            }, cancellationToken);
-        }
-
-        private void RunTentacleCommandOutOfProcess(string tentacleExe,
-            string[] args,
-            TemporaryDirectory tmp,
-            Action<string> CommandOutput,
-            CancellationToken cancellationToken)
-        {
-            Action<string> allOutput = s =>
-            {
-                TestContext.WriteLine(s);
-                CommandOutput(s);
-            };
-            var exitCode = SilentProcessRunner.ExecuteCommand(
-                tentacleExe,
-                String.Join(" ", args),
-                tmp.DirectoryPath,
-                allOutput,
-                allOutput,
-                allOutput,
-                cancellationToken);
-
-            if (cancellationToken.IsCancellationRequested) return;
-
-            if (exitCode != 0)
-            {
-                throw new Exception("Tentacle returns non zero exit code: " + exitCode);
-            }
-        }
-    }
-
-    public class RunningTestTentacle : IDisposable
-    {
-        public Uri ServiceUri { get; }
-        private readonly IDisposable TemporaryDirectory;
-        private CancellationTokenSource cts;
-        private Task? RunningTentacleTask { get; set; }
-        private Func<CancellationToken, Task<Task>> startTentacle;
-        public string Thumbprint { get; }
-
-        public RunningTestTentacle(Uri serviceUri, 
-            IDisposable temporaryDirectory,
-            Func<CancellationToken, Task<Task>> startTentacle,
-            string thumbprint)
-        {
-            TemporaryDirectory = temporaryDirectory;
-            this.startTentacle = startTentacle;
-            Thumbprint = thumbprint;
-            ServiceUri = serviceUri;
-        }
-        
-        public async Task Start(CancellationToken cancellationToken)
-        {
-            await Task.CompletedTask;
-            if (RunningTentacleTask != null) throw new Exception("Tentacle is already running, call stop() first");
-
-            cts = new CancellationTokenSource();
-
-            RunningTentacleTask = await startTentacle(cts.Token);
-        }
-
-        public async Task Stop(CancellationToken cancellationToken)
-        {
-            if (cts != null)
-            {
-                cts.Cancel();
-                cts.Dispose();
-                cts = null;
-            }
-
-            var t = RunningTentacleTask;
-            RunningTentacleTask = null;
-            await t;
-        }
-
-        public void Dispose()
-        {
-            if (RunningTentacleTask != null) Stop(CancellationToken.None).GetAwaiter().GetResult();
-            TemporaryDirectory.Dispose();
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -1,0 +1,244 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Nito.AsyncEx.Interop;
+using NUnit.Framework;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public abstract class TentacleBuilder<T> where T : TentacleBuilder<T>
+    {
+        protected string? ServerThumbprint;
+        protected string? TentacleExePath;
+        protected string CertificatePfxPath = Certificates.TentaclePfxPath;
+        protected string TentacleThumbprint = Certificates.TentaclePublicThumbprint;
+        private readonly Regex listeningPortRegex = new Regex(@"^listen:\/\/.+:(\d+)\/");
+
+        public T WithCertificate(string certificatePfxPath, string tentacleThumbprint)
+        {
+            CertificatePfxPath = certificatePfxPath;
+            TentacleThumbprint = tentacleThumbprint;
+
+            return (T)this;
+        }
+
+        public T WithTentacleExe(string tentacleExe)
+        {
+            TentacleExePath = tentacleExe;
+
+            return (T)this;
+        }
+
+        internal IWritableTentacleConfiguration GetWritableTentacleConfiguration(string configFilePath)
+        {
+            var startUpConfigFileInstanceRequest = new StartUpConfigFileInstanceRequest(configFilePath);
+            using var container = new Program(Array.Empty<string>()).BuildContainer(startUpConfigFileInstanceRequest);
+
+            var writableTentacleConfiguration = container.Resolve<IWritableTentacleConfiguration>();
+            return writableTentacleConfiguration;
+        }
+
+        internal async Task<RunningTentacle> StartTentacle(
+            Uri? serviceUri,
+            string tentacleExe,
+            string instanceName,
+            TemporaryDirectory tempDirectory,
+            string tentacleThumbprint,
+            CancellationToken cancellationToken)
+        {
+            Task<(Task, Uri?)> StartTentacleFunction(CancellationToken ct) => RunTentacle(serviceUri, tentacleExe, instanceName, tempDirectory, ct);
+
+            var runningTentacle = new RunningTentacle(
+                tempDirectory,
+                StartTentacleFunction,
+                tentacleThumbprint);
+
+            try
+            {
+                await runningTentacle.Start(cancellationToken);
+                return runningTentacle;
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    runningTentacle.Dispose();
+                }
+                catch (Exception e)
+                {
+                    TestContext.WriteLine(e);
+                }
+
+                throw;
+            }
+        }
+
+        internal async Task<(Task task, Uri serviceUri)> RunTentacle(
+            Uri? serviceUri,
+            string tentacleExe,
+            string instanceName,
+            TemporaryDirectory tempDirectory,
+            CancellationToken cancellationToken)
+        {
+            var hasTentacleStarted = new ManualResetEventSlim();
+            hasTentacleStarted.Reset();
+            int? listeningPort = null;
+
+            var runningTentacle = Task.Run(() =>
+            {
+                try
+                {
+                    RunTentacleCommandOutOfProcess(tentacleExe, new[] { "agent", $"--instance={instanceName}", "--noninteractive" }, tempDirectory,
+                        s =>
+                        {
+                            if (s.Contains("Listener started"))
+                            {
+                                listeningPort = Convert.ToInt32(listeningPortRegex.Match(s).Groups[1].Value);
+                            }
+                            else if (s.Contains("Agent will not listen") || s.Contains("Agent listening on"))
+                            {
+                                hasTentacleStarted.Set();
+                            }
+                        }, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    TestContext.WriteLine(e);
+                    throw;
+                }
+            }, cancellationToken);
+
+            await Task.WhenAny(runningTentacle, WaitHandleAsyncFactory.FromWaitHandle(hasTentacleStarted.WaitHandle, TimeSpan.FromMinutes(1)));
+
+            // Will throw.
+            if (runningTentacle.IsCompleted)
+            {
+                await runningTentacle;
+            }
+
+            if (!hasTentacleStarted.IsSet)
+            {
+                throw new Exception("Tentacle did not appear to start correctly");
+            }
+
+            if (serviceUri == null && listeningPort != null)
+            {
+                serviceUri = new Uri($"https://localhost:{listeningPort}");
+            }
+
+            return (runningTentacle, serviceUri);
+        }
+
+
+        internal void AddCertificateToTentacle(string tentacleExe, string instanceName, string tentaclePfxPath, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        {
+            RunTentacleCommand(tentacleExe, new[] { "import-certificate", $"--from-file={tentaclePfxPath}", $"--instance={instanceName}" }, tmp, cancellationToken);
+        }
+
+        internal void CreateInstance(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        {
+            RunTentacleCommand(tentacleExe, new[] { "create-instance", "--config", configFilePath, $"--instance={instanceName}" }, tmp, cancellationToken);
+        }
+
+        private void RunTentacleCommand(string tentacleExe, string[] args, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        {
+            RunTentacleCommandOutOfProcess(tentacleExe, args, tmp, s =>
+            {
+            }, cancellationToken);
+        }
+
+        private void RunTentacleCommandOutOfProcess(string tentacleExe,
+            string[] args,
+            TemporaryDirectory tmp,
+            Action<string> commandOutput,
+            CancellationToken cancellationToken)
+        {
+            void AllOutput(string s)
+            {
+                TestContext.WriteLine(s);
+                commandOutput(s);
+            }
+
+            var exitCode = SilentProcessRunner.ExecuteCommand(
+                tentacleExe,
+                string.Join(" ", args),
+                tmp.DirectoryPath,
+                AllOutput,
+                AllOutput,
+                AllOutput,
+                cancellationToken);
+
+            if (cancellationToken.IsCancellationRequested) return;
+
+            if (exitCode != 0)
+            {
+                throw new Exception("Tentacle returns non zero exit code: " + exitCode);
+            }
+        }
+    }
+
+    public class RunningTentacle : IDisposable
+    {
+        private readonly IDisposable temporaryDirectory;
+        private CancellationTokenSource? cancellationTokenSource;
+        private Task? runningTentacleTask;
+        private readonly Func<CancellationToken, Task<(Task runningTentacleTask, Uri serviceUri)>> startTentacleFunction;
+
+        public RunningTentacle(
+            IDisposable temporaryDirectory,
+            Func<CancellationToken, Task<(Task, Uri)>> startTentacleFunction,
+            string thumbprint)
+        {
+            this.startTentacleFunction = startTentacleFunction;
+            this.temporaryDirectory = temporaryDirectory;
+
+            Thumbprint = thumbprint;
+        }
+
+        public Uri ServiceUri { get; private set; }
+        public string Thumbprint { get; }
+
+        public async Task Start(CancellationToken cancellationToken)
+        {
+            if (runningTentacleTask != null)
+            {
+                throw new Exception("Tentacle is already running, call stop() first");
+            }
+
+            cancellationTokenSource = new CancellationTokenSource();
+
+            var (rtt, serviceUri) = await startTentacleFunction(cancellationTokenSource.Token);
+
+            runningTentacleTask = rtt;
+            ServiceUri = serviceUri;
+        }
+
+        public async Task Stop(CancellationToken cancellationToken)
+        {
+            if (cancellationTokenSource != null)
+            {
+                cancellationTokenSource.Cancel();
+                cancellationTokenSource.Dispose();
+                cancellationTokenSource = null;
+            }
+
+            var t = runningTentacleTask;
+            runningTentacleTask = null;
+            await t;
+        }
+
+        public void Dispose()
+        {
+            if (runningTentacleTask != null)
+            {
+                Stop(CancellationToken.None).GetAwaiter().GetResult();
+            }
+
+            temporaryDirectory.Dispose();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleClientBuilderExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleClientBuilderExtensionMethods.cs
@@ -4,11 +4,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 {
     public static class TentacleClientBuilderExtensionMethods
     {
-        public static TentacleClientBuilder ForRunningTentacle(this TentacleClientBuilder tentacleClientBuilder, RunningTestTentacle runningTestTentacle)
+        public static TentacleClientBuilder ForRunningTentacle(this TentacleClientBuilder tentacleClientBuilder, RunningTentacle runningTentacle)
         {
             return tentacleClientBuilder
-                .WithServiceUri(runningTestTentacle.ServiceUri)
-                .WithRemoteThumbprint(runningTestTentacle.Thumbprint);
+                .WithServiceUri(runningTentacle.ServiceUri)
+                .WithRemoteThumbprint(runningTentacle.Thumbprint);
         }
     }
 }


### PR DESCRIPTION
This PR adds the ability to test a listening tentacle with the TentacleClient, as part of [[sc-46171]](https://app.shortcut.com/octopusdeploy/story/46171/tentacle-client-tests)

* Add `ListeningTentacleBuilder`
* Add basic comms tests to ensure that TentacleClient can connect/communicate with a listening tentacle.
* Refactor builder classes to remove code duplication

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.