### PR TITLE
Sast/script service v2 fix net48

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -26,8 +26,6 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringStartScript_TheClientIsAbleToSuccessfullyCompleteTheScript()
         {
-            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
-            
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
@@ -94,7 +92,6 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringGetStatus_TheClientIsAbleToSuccessfullyCompleteTheScript()
         {
-            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
@@ -182,7 +179,6 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringCompleteScript_TheClientIsAbleToSuccessfullyCompleteTheScript()
         {
-            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
@@ -235,7 +231,6 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringCancelScript_TheClientIsAbleToSuccessfullyCancelTheScript()
         {
-            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
@@ -321,7 +316,6 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringGetCapabilities_TheClientIsAbleToSuccessfullyCompleteTheScript()
         {
-            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
             var queue = new IsTentacleWaitingPendingRequestQueueDecoratorFactory();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -26,7 +26,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringStartScript_TheClientIsAbleToSuccessfullyCompleteTheScript()
         {
-            if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
+            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
             
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
@@ -94,7 +94,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringGetStatus_TheClientIsAbleToSuccessfullyCompleteTheScript()
         {
-            if (NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
+            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
@@ -182,7 +182,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringCompleteScript_TheClientIsAbleToSuccessfullyCompleteTheScript()
         {
-            if (NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
+            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
@@ -235,7 +235,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringCancelScript_TheClientIsAbleToSuccessfullyCancelTheScript()
         {
-            if (NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
+            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
             using IHalibutRuntime octopus = new HalibutRuntimeBuilder()
@@ -321,7 +321,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenANetworkFailureOccurs_DuringGetCapabilities_TheClientIsAbleToSuccessfullyCompleteTheScript()
         {
-            if (NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
+            // if(NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs() == "net48") return;
             var token = TestCancellationToken.Token();
             var logger = new SerilogLoggerBuilder().Build();
             var queue = new IsTentacleWaitingPendingRequestQueueDecoratorFactory();

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/TcpPump.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/TcpPump.cs
@@ -121,9 +121,18 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
             cancellationTokenSource.Cancel();
             cancellationTokenSource.Dispose();
             isDisposed = true;
+
+            try
+            {
+                clientSocket.Shutdown(SocketShutdown.Both);
+                clientSocket.Close();
+            }
+            finally
+            {
+                originSocket.Shutdown(SocketShutdown.Both);
+                originSocket.Close();
+            }
             
-            clientSocket.Close();
-            originSocket.Close();
         }
 
         public void Pause()


### PR DESCRIPTION
# Background

Fixes the network related tests in net48.

Previously tentacle was not receiving a TCP fin and so the tests needed a timeout to occur which would take a very long time either after 1 minute or 10 minutes.

# Results

Tests in net48 take much less time since the port forwarder appears to properly kill the connections.


## After

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/7076477/d3f51c14-b938-4d9f-a041-98fb32771e8b)

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/7076477/22696b45-5f2c-4267-b353-d1935e01cd6c)

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/7076477/35b341b4-a8ee-4b70-a073-35ce474a84cb)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.