### PR TITLE
Use full path for sc.exe file 

### DIFF
--- a/source/Octopus.Tentacle.Upgrader/ServiceBouncer.cs
+++ b/source/Octopus.Tentacle.Upgrader/ServiceBouncer.cs
@@ -97,9 +97,11 @@ namespace Octopus.Tentacle.Upgrader
             var arguments = string.Join(" ", "config", $"\"{service.ServiceName}\"", "binpath=", $"\"\\\"{tentacleExePath}\\\" run --instance=\\\"{GetInstanceName(service)}\\\"\"");
 
             Log.Upgrade.Info("Running SC.exe " + arguments);
+            
+            var serviceControlPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "sc.exe");
             using (var process = new Process())
             {
-                process.StartInfo.FileName = "sc.exe";
+                process.StartInfo.FileName = serviceControlPath;
                 process.StartInfo.Arguments = arguments;
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.CreateNoWindow = true;

--- a/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Management;
 using System.ServiceProcess;
@@ -335,8 +336,11 @@ namespace Octopus.Tentacle.Startup
             var outputBuilder = new StringBuilder();
             var argumentsToLog = string.Join(" ", arguments);
 
+            var system32 = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            var sc = Path.Combine(system32, "sc.exe");
+
             logFileOnlyLogger.Info($"Executing sc.exe {argumentsToLog}");
-            var exitCode = SilentProcessRunner.ExecuteCommand("sc.exe",
+            var exitCode = SilentProcessRunner.ExecuteCommand(sc,
                 arguments,
                 Environment.CurrentDirectory,
                 output => outputBuilder.AppendLine(output),


### PR DESCRIPTION
Background
Server was taking sc.exe files from locations other than system32 path, where that file should always be. This could lead to server picking up maliciously downloaded files.

Server fix: https://github.com/OctopusDeploy/OctopusDeploy/pull/18247
Fixes [[sc-39057](https://app.shortcut.com/octopusdeploy/story/39057)]

Results
Use full path of sc.exe as it should always be in the same location

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.