### PR TITLE
Script execution now returns a dedicated type.

### DIFF
--- a/source/Octopus.Tentacle.Client/ITentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleClient.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut;
 using Octopus.Diagnostics;
+using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
@@ -13,7 +14,7 @@ namespace Octopus.Tentacle.Client
         Task<UploadResult> UploadFile(string fileName, string path, DataStream package, ILog logger, CancellationToken cancellationToken);
         Task<DataStream?> DownloadFile(string remotePath, ILog logger, CancellationToken cancellationToken);
 
-        Task<ScriptStatusResponseV2> ExecuteScript(
+        Task<ScriptExecutionResult> ExecuteScript(
             StartScriptCommandV2 startScriptCommand,
             Action<ScriptStatusResponseV2> onScriptStatusResponseReceived,
             Func<CancellationToken, Task> onScriptCompleted,

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionResult.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionResult.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Client.Scripts
+{
+    public class ScriptExecutionResult
+    {
+        public ScriptExecutionResult(ScriptTicket ticket,
+            ProcessState state,
+            int exitCode)
+        {
+            Ticket = ticket;
+            State = state;
+            ExitCode = exitCode;
+        }
+
+        public ScriptTicket Ticket { get; }
+
+        public ProcessState State { get; }
+
+        public int ExitCode { get; }
+    }
+}

--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -92,7 +92,7 @@ namespace Octopus.Tentacle.Client
             return (DataStream?)dataStream;
         }
 
-        public async Task<ScriptStatusResponseV2> ExecuteScript(
+        public async Task<ScriptExecutionResult> ExecuteScript(
             StartScriptCommandV2 startScriptCommand,
             Action<ScriptStatusResponseV2> onScriptStatusResponseReceived,
             Func<CancellationToken, Task> onScriptCompleted,
@@ -111,7 +111,8 @@ namespace Octopus.Tentacle.Client
                 onScriptCompleted,
                 logger);
 
-            return await orchestrator.ExecuteScript(cancellationToken);
+            var result = await orchestrator.ExecuteScript(cancellationToken);
+            return new ScriptExecutionResult(result.Ticket, result.State, result.ExitCode);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Halibut;
 using NUnit.Framework;
 using Octopus.Tentacle.Client;
+using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
@@ -235,7 +236,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
     static class TentacleClientExtensionMethods
     {
-        public static async Task<ScriptStatusResponseV2> ExecuteScriptAssumingException(
+        public static async Task<ScriptExecutionResult> ExecuteScriptAssumingException(
             this TentacleClient tentacleClient,
             StartScriptCommandV2 startScriptCommand,
             List<ProcessOutput> logs,

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TentacleClientExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TentacleClientExtensionMethods.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut;
 using Octopus.Tentacle.Client;
+using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Tests.Integration.Support;
@@ -13,7 +14,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders
 {
     public static class TentacleClientExtensionMethods
     {
-        public static async Task<(ScriptStatusResponseV2, List<ProcessOutput>)> ExecuteScript(
+        public static async Task<(ScriptExecutionResult, List<ProcessOutput>)> ExecuteScript(
             this TentacleClient tentacleClient,
             StartScriptCommandV2 startScriptCommand,
             CancellationToken token,


### PR DESCRIPTION
# Background

Script Execution used to return a `ScriptStatusResponseV2`. These meant that running a script with `ExecuteScript()` would return a result that contains `logs` which was always empty and `nextSequence` which is useless.

The change here is to return a new type which doesn't have those misleading property in the object. Doing so should prevent clients from accidentally using the empty logs property.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.