### PR TITLE
Make use of passing the cancellation token to proxy methods.

### DIFF
--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
@@ -1,6 +1,7 @@
 using System;
 using Halibut;
-using Octopus.Tentacle.Contracts;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
@@ -11,22 +12,22 @@ namespace Octopus.Tentacle.Client.Decorators
     /// </summary>
     internal class HalibutExceptionTentacleServiceDecorator : ITentacleServiceDecorator
     {
-        public IScriptService Decorate(IScriptService service)
+        public IClientScriptService Decorate(IClientScriptService service)
         {
             return service;
         }
 
-        public IScriptServiceV2 Decorate(IScriptServiceV2 service)
+        public IClientScriptServiceV2 Decorate(IClientScriptServiceV2 service)
         {
             return new HalibutExceptionScriptServiceV2Decorator(service);
         }
 
-        public IFileTransferService Decorate(IFileTransferService service)
+        public IClientFileTransferService Decorate(IClientFileTransferService service)
         {
             return service;
         }
 
-        public ICapabilitiesServiceV2 Decorate(ICapabilitiesServiceV2 service)
+        public IClientCapabilitiesServiceV2 Decorate(IClientCapabilitiesServiceV2 service)
         {
             return new HalibutExceptionCapabilitiesServiceV2Decorator(service);
         }
@@ -37,20 +38,20 @@ namespace Octopus.Tentacle.Client.Decorators
         }
     }
 
-    class HalibutExceptionScriptServiceV2Decorator : IScriptServiceV2
+    class HalibutExceptionScriptServiceV2Decorator : IClientScriptServiceV2
     {
-        private readonly IScriptServiceV2 inner;
+        private readonly IClientScriptServiceV2 inner;
 
-        public HalibutExceptionScriptServiceV2Decorator(IScriptServiceV2 inner)
+        public HalibutExceptionScriptServiceV2Decorator(IClientScriptServiceV2 inner)
         {
             this.inner = inner;
         }
 
-        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command)
+        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
         {
             try
             {
-                return inner.StartScript(command);
+                return inner.StartScript(command, halibutProxyRequestOptions);
             }
             catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
             {
@@ -58,11 +59,11 @@ namespace Octopus.Tentacle.Client.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request)
+        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions halibutProxyRequestOptions)
         {
             try
             {
-                return inner.GetStatus(request);
+                return inner.GetStatus(request, halibutProxyRequestOptions);
             }
             catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
             {
@@ -70,11 +71,11 @@ namespace Octopus.Tentacle.Client.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command)
+        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
         {
             try
             {
-                return inner.CancelScript(command);
+                return inner.CancelScript(command, halibutProxyRequestOptions);
             }
             catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
             {
@@ -82,11 +83,11 @@ namespace Octopus.Tentacle.Client.Decorators
             }
         }
 
-        public void CompleteScript(CompleteScriptCommandV2 command)
+        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
         {
             try
             {
-                inner.CompleteScript(command);
+                inner.CompleteScript(command, halibutProxyRequestOptions);
             }
             catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
             {
@@ -95,20 +96,20 @@ namespace Octopus.Tentacle.Client.Decorators
         }
     }
 
-    class HalibutExceptionCapabilitiesServiceV2Decorator : ICapabilitiesServiceV2
+    class HalibutExceptionCapabilitiesServiceV2Decorator : IClientCapabilitiesServiceV2
     {
-        private readonly ICapabilitiesServiceV2 inner;
+        private readonly IClientCapabilitiesServiceV2 inner;
 
-        public HalibutExceptionCapabilitiesServiceV2Decorator(ICapabilitiesServiceV2 inner)
+        public HalibutExceptionCapabilitiesServiceV2Decorator(IClientCapabilitiesServiceV2 inner)
         {
             this.inner = inner;
         }
 
-        public CapabilitiesResponseV2 GetCapabilities()
+        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions halibutProxyRequestOptions)
         {
             try
             {
-                return inner.GetCapabilities();
+                return inner.GetCapabilities(halibutProxyRequestOptions);
             }
             catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
             {

--- a/source/Octopus.Tentacle.Client/ITentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleClient.cs
@@ -9,7 +9,7 @@ using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
 namespace Octopus.Tentacle.Client
 {
-    public interface ITentacleClient
+    public interface ITentacleClient : IDisposable
     {
         Task<UploadResult> UploadFile(string fileName, string path, DataStream package, ILog logger, CancellationToken cancellationToken);
         Task<DataStream?> DownloadFile(string remotePath, ILog logger, CancellationToken cancellationToken);

--- a/source/Octopus.Tentacle.Client/ITentacleServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleServiceDecorator.cs
@@ -1,3 +1,4 @@
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
@@ -6,12 +7,12 @@ namespace Octopus.Tentacle.Client
 {
     public interface ITentacleServiceDecorator
     {
-        public IScriptService Decorate(IScriptService scriptService);
+        public IClientScriptService Decorate(IClientScriptService scriptService);
 
-        public IScriptServiceV2 Decorate(IScriptServiceV2 scriptService);
+        public IClientScriptServiceV2 Decorate(IClientScriptServiceV2 scriptService);
 
-        public IFileTransferService Decorate(IFileTransferService service);
+        public IClientFileTransferService Decorate(IClientFileTransferService service);
 
-        public ICapabilitiesServiceV2 Decorate(ICapabilitiesServiceV2 service);
+        public IClientCapabilitiesServiceV2 Decorate(IClientCapabilitiesServiceV2 service);
     }
 }

--- a/source/Octopus.Tentacle.Client/Octopus.Tentacle.Client.csproj
+++ b/source/Octopus.Tentacle.Client/Octopus.Tentacle.Client.csproj
@@ -35,4 +35,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Octopus.Tentacle.Contracts\Octopus.Tentacle.Contracts.csproj" />
     </ItemGroup>
+    <ItemGroup>
+      <Folder Include="ClientServices" />
+    </ItemGroup>
 </Project>

--- a/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleCapabilitiesV2Decorator.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleCapabilitiesV2Decorator.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using Halibut;
 using Halibut.Exceptions;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 
 namespace Octopus.Tentacle.Contracts.Capabilities
 {
@@ -16,21 +18,27 @@ namespace Octopus.Tentacle.Contracts.Capabilities
 
         public CapabilitiesResponseV2 GetCapabilities()
         {
+            return WithBackwardsCompatability(inner.GetCapabilities);
+        }
+
+        internal static CapabilitiesResponseV2 WithBackwardsCompatability(Func<CapabilitiesResponseV2> inner)
+        {
             try
             {
-                return inner.GetCapabilities();
+                return inner();
             }
             catch (NoMatchingServiceOrMethodHalibutClientException)
             {
                 return new CapabilitiesResponseV2(new List<string>() {nameof(IScriptService), nameof(IFileTransferService)});
             }
             catch (HalibutClientException e) when 
-                (
-                    ExceptionLooksLikeTheServiceWasNotFound(e))
+            (
+                ExceptionLooksLikeTheServiceWasNotFound(e))
             {
                 return new CapabilitiesResponseV2(new List<string>() {nameof(IScriptService), nameof(IFileTransferService)});
             }
         }
+        
 
         private static bool ExceptionLooksLikeTheServiceWasNotFound(HalibutClientException e)
         {

--- a/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleClientCapabilitiesV2Decorator.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleClientCapabilitiesV2Decorator.cs
@@ -1,0 +1,20 @@
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+
+namespace Octopus.Tentacle.Contracts.Capabilities
+{
+    public class BackwardsCompatibleClientCapabilitiesV2Decorator : IClientCapabilitiesServiceV2
+    {
+        private readonly IClientCapabilitiesServiceV2 inner;
+
+        public BackwardsCompatibleClientCapabilitiesV2Decorator(IClientCapabilitiesServiceV2 inner)
+        {
+            this.inner = inner;
+        }
+
+        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return BackwardsCompatibleCapabilitiesV2Decorator.WithBackwardsCompatability(() => inner.GetCapabilities(halibutProxyRequestOptions));
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesServiceV2ExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesServiceV2ExtensionMethods.cs
@@ -1,3 +1,5 @@
+using Octopus.Tentacle.Client.ClientServices;
+
 namespace Octopus.Tentacle.Contracts.Capabilities
 {
     public static class ICapabilitiesServiceV2ExtensionMethods
@@ -5,6 +7,11 @@ namespace Octopus.Tentacle.Contracts.Capabilities
         public static ICapabilitiesServiceV2 WithBackwardsCompatability(this ICapabilitiesServiceV2 capabilitiesService)
         {
             return new BackwardsCompatibleCapabilitiesV2Decorator(capabilitiesService);
+        }
+        
+        public static IClientCapabilitiesServiceV2 WithBackwardsCompatability(this IClientCapabilitiesServiceV2 capabilitiesService)
+        {
+            return new BackwardsCompatibleClientCapabilitiesV2Decorator(capabilitiesService);
         }
     }
 }

--- a/source/Octopus.Tentacle.Contracts/ClientServices/IClientCapabilitiesServiceV2.cs
+++ b/source/Octopus.Tentacle.Contracts/ClientServices/IClientCapabilitiesServiceV2.cs
@@ -1,0 +1,10 @@
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts.Capabilities;
+
+namespace Octopus.Tentacle.Client.ClientServices
+{
+    public interface IClientCapabilitiesServiceV2
+    {
+        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions halibutProxyRequestOptions);
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/ClientServices/IClientFileTransferService.cs
+++ b/source/Octopus.Tentacle.Contracts/ClientServices/IClientFileTransferService.cs
@@ -1,0 +1,12 @@
+using Halibut;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Client.ClientServices
+{
+    public interface IClientFileTransferService
+    {
+        UploadResult UploadFile(string remotePath, DataStream upload, HalibutProxyRequestOptions proxyRequestOptions);
+        DataStream DownloadFile(string remotePath, HalibutProxyRequestOptions proxyRequestOptions);
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/ClientServices/IClientScriptService.cs
+++ b/source/Octopus.Tentacle.Contracts/ClientServices/IClientScriptService.cs
@@ -1,0 +1,13 @@
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Client.ClientServices
+{
+    public interface IClientScriptService
+    {
+        ScriptTicket StartScript(StartScriptCommand command, HalibutProxyRequestOptions proxyRequestOptions);
+        ScriptStatusResponse GetStatus(ScriptStatusRequest request, HalibutProxyRequestOptions proxyRequestOptions);
+        ScriptStatusResponse CancelScript(CancelScriptCommand command, HalibutProxyRequestOptions proxyRequestOptions);
+        ScriptStatusResponse CompleteScript(CompleteScriptCommand command, HalibutProxyRequestOptions proxyRequestOptions);
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/ClientServices/IClientScriptServiceV2.cs
+++ b/source/Octopus.Tentacle.Contracts/ClientServices/IClientScriptServiceV2.cs
@@ -1,0 +1,13 @@
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Octopus.Tentacle.Client.ClientServices
+{
+    public interface IClientScriptServiceV2
+    {
+        ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions);
+        ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions proxyRequestOptions);
+        ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions);
+        void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions);
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="6.0.87-pull-238" />
+    <PackageReference Include="Halibut" Version="6.0.89" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="6.0.57" />
+    <PackageReference Include="Halibut" Version="6.0.87-pull-238" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelled.cs
@@ -147,7 +147,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .LogAndCountAllCalls(out _, out _, out var scriptServiceV2CallCounts, out _)
                     .RecordAllExceptions(out _, out _, out var scriptServiceV2Exceptions, out _)
                     .DecorateScriptServiceV2With(d => d
-                        .DecorateStartScriptWith((service, command) =>
+                        .DecorateStartScriptWith((service, command, options) =>
                         {
                             service.EnsureTentacleIsConnectedToServer(Logger);
 
@@ -164,7 +164,7 @@ namespace Octopus.Tentacle.Tests.Integration
                             var timer = Stopwatch.StartNew();
                             try
                             {
-                                return service.StartScript(command);
+                                return service.StartScript(command, options);
                             }
                             finally
                             {
@@ -270,7 +270,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .LogAndCountAllCalls(out _, out _, out var scriptServiceV2CallCounts, out _)
                     .RecordAllExceptions(out _, out _, out var scriptServiceV2Exceptions, out _)
                     .DecorateScriptServiceV2With(d => d
-                        .DecorateGetStatusWith((service, request) =>
+                        .DecorateGetStatusWith((service, request, options) =>
                         {
                             service.EnsureTentacleIsConnectedToServer(Logger);
 
@@ -287,7 +287,7 @@ namespace Octopus.Tentacle.Tests.Integration
                             var timer = Stopwatch.StartNew();
                             try
                             {
-                                return service.GetStatus(request);
+                                return service.GetStatus(request, options);
                             }
                             finally
                             {

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
@@ -92,15 +92,13 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInScriptService(out var scriptServiceExceptions)
                     .CountCallsToScriptService(out var scriptServiceCallCounts)
                     .DecorateScriptServiceWith(new ScriptServiceDecoratorBuilder()
-                        .DecorateGetStatusWith((inner, request) =>
+                        .BeforeGetStatus((inner, request) =>
                         {
                             scriptStatusRequest = request;
                             if (scriptServiceExceptions.GetStatusLatestException == null)
                             {
                                 responseMessageTcpKiller.KillConnectionOnNextResponse();
                             }
-
-                            return inner.GetStatus(request);
                         })
                         .Build())
                     .Build())
@@ -150,11 +148,10 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInScriptService(out var scriptServiceExceptions)
                     .CountCallsToScriptService(out var scriptServiceCallCounts)
                     .DecorateScriptServiceWith(new ScriptServiceDecoratorBuilder()
-                        .DecorateGetStatusWith((inner, request) =>
+                        .BeforeGetStatus((inner, request) =>
                         {
                             cts.Cancel();
                             scriptStatusRequest = request;
-                            return inner.GetStatus(request);
                         })
                         .BeforeCancelScript(() =>
                         {
@@ -177,6 +174,8 @@ namespace Octopus.Tentacle.Tests.Integration
                 .Build();
 
             List<ProcessOutput> logs = new List<ProcessOutput>();
+
+            //Assert.CatchAsync(async () => await clientTentacle.TentacleClient.ExecuteScriptAssumingException(startScriptCommand, logs, cts.Token));
             Assert.ThrowsAsync<HalibutClientException>(async () => await clientTentacle.TentacleClient.ExecuteScriptAssumingException(startScriptCommand, logs, cts.Token));
 
             // Let the script finish.

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsCapabilitiesServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsCapabilitiesServiceV2Decorator.cs
@@ -1,6 +1,7 @@
+using System;
 using System.Threading;
-using Halibut;
-using Octopus.Tentacle.Contracts;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.Capabilities;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
@@ -12,24 +13,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public long GetCapabilitiesCallCountComplete;
     }
 
-    public class CountingCallsCapabilitiesServiceV2Decorator : ICapabilitiesServiceV2
+    public class CountingCallsCapabilitiesServiceV2Decorator : IClientCapabilitiesServiceV2
     {
-        private CapabilitiesServiceV2CallCounts counts;
+        private readonly CapabilitiesServiceV2CallCounts counts;
 
-        private ICapabilitiesServiceV2 inner;
+        private readonly IClientCapabilitiesServiceV2 inner;
 
-        public CountingCallsCapabilitiesServiceV2Decorator(ICapabilitiesServiceV2 inner, CapabilitiesServiceV2CallCounts counts)
+        public CountingCallsCapabilitiesServiceV2Decorator(IClientCapabilitiesServiceV2 inner, CapabilitiesServiceV2CallCounts counts)
         {
             this.inner = inner;
             this.counts = counts;
         }
 
-        public CapabilitiesResponseV2 GetCapabilities()
+        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.GetCapabilitiesCallCountStarted);
             try
             {
-                return inner.GetCapabilities();
+                return inner.GetCapabilities(options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsFileTransferServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsFileTransferServiceDecorator.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Threading;
 using Halibut;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
@@ -13,24 +16,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public long DownloadFileCallCountComplete;
     }
 
-    public class CountingCallsFileTransferServiceDecorator : IFileTransferService
+    public class CountingCallsFileTransferServiceDecorator : IClientFileTransferService
     {
-        private FileTransferServiceCallCounts counts;
+        private readonly FileTransferServiceCallCounts counts;
 
-        private IFileTransferService inner;
+        private readonly IClientFileTransferService inner;
 
-        public CountingCallsFileTransferServiceDecorator(IFileTransferService inner, FileTransferServiceCallCounts counts)
+        public CountingCallsFileTransferServiceDecorator(IClientFileTransferService inner, FileTransferServiceCallCounts counts)
         {
             this.inner = inner;
             this.counts = counts;
         }
 
-        public UploadResult UploadFile(string remotePath, DataStream upload)
+        public UploadResult UploadFile(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.UploadFileCallCountStarted);
             try
             {
-                return inner.UploadFile(remotePath, upload);
+                return inner.UploadFile(remotePath, upload, options);
             }
             finally
             {
@@ -38,12 +41,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public DataStream DownloadFile(string remotePath)
+        public DataStream DownloadFile(string remotePath, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.DownloadFileCallCountStarted);
             try
             {
-                return inner.DownloadFile(remotePath);
+                return inner.DownloadFile(remotePath, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsScriptServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsScriptServiceDecorator.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Threading;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
@@ -9,26 +12,27 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public long GetStatusCallCountStarted;
         public long CancelScriptCallCountStarted;
         public long CompleteScriptCallCountStarted;
-        
+
         public long StartScriptCallCountComplete;
     }
-    public class CountingCallsScriptServiceDecorator : IScriptService
+
+    public class CountingCallsScriptServiceDecorator : IClientScriptService
     {
         private readonly ScriptServiceCallCounts scriptServiceCallCounts;
-        private readonly IScriptService inner;
+        private readonly IClientScriptService inner;
 
-        public CountingCallsScriptServiceDecorator(IScriptService inner, ScriptServiceCallCounts scriptServiceCallCounts)
+        public CountingCallsScriptServiceDecorator(IClientScriptService inner, ScriptServiceCallCounts scriptServiceCallCounts)
         {
             this.inner = inner;
             this.scriptServiceCallCounts = scriptServiceCallCounts;
         }
 
-        public ScriptTicket StartScript(StartScriptCommand command)
+        public ScriptTicket StartScript(StartScriptCommand command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref scriptServiceCallCounts.StartScriptCallCountStarted);
             try
             {
-                return inner.StartScript(command);
+                return inner.StartScript(command, options);
             }
             finally
             {
@@ -36,25 +40,25 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse GetStatus(ScriptStatusRequest request)
+        public ScriptStatusResponse GetStatus(ScriptStatusRequest request, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref scriptServiceCallCounts.GetStatusCallCountStarted);
-            return inner.GetStatus(request);
+            return inner.GetStatus(request, options);
         }
 
-        public ScriptStatusResponse CancelScript(CancelScriptCommand command)
+        public ScriptStatusResponse CancelScript(CancelScriptCommand command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref scriptServiceCallCounts.CancelScriptCallCountStarted);
-            return inner.CancelScript(command);
+            return inner.CancelScript(command, options);
         }
 
-        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command)
+        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref scriptServiceCallCounts.CompleteScriptCallCountStarted);
-            return inner.CompleteScript(command);
+            return inner.CompleteScript(command, options);
         }
     }
-    
+
     public static class TentacleServiceDecoratorBuilderCountingCallsScriptServiceDecoratorExtensionMethods
     {
         public static TentacleServiceDecoratorBuilder CountCallsToScriptService(this TentacleServiceDecoratorBuilder tentacleServiceDecoratorBuilder, out ScriptServiceCallCounts scriptServiceCallCounts)

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsScriptServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsScriptServiceV2Decorator.cs
@@ -1,4 +1,6 @@
 using System.Threading;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
@@ -16,25 +18,25 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public long CompleteScriptCallCountCompleted;
     }
 
-    public class CountingCallsScriptServiceV2Decorator : IScriptServiceV2
+    public class CountingCallsScriptServiceV2Decorator : IClientScriptServiceV2
     {
         private ScriptServiceV2CallCounts counts;
 
 
-        private IScriptServiceV2 inner;
+        private IClientScriptServiceV2 inner;
 
-        public CountingCallsScriptServiceV2Decorator(IScriptServiceV2 inner, ScriptServiceV2CallCounts counts)
+        public CountingCallsScriptServiceV2Decorator(IClientScriptServiceV2 inner, ScriptServiceV2CallCounts counts)
         {
             this.inner = inner;
             this.counts = counts;
         }
 
-        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command)
+        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.StartScriptCallCountStarted);
             try
             {
-                return inner.StartScript(command);
+                return inner.StartScript(command, options);
             }
             finally
             {
@@ -42,12 +44,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request)
+        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.GetStatusCallCountStarted);
             try
             {
-                return inner.GetStatus(request);
+                return inner.GetStatus(request, options);
             }
             finally
             {
@@ -55,12 +57,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command)
+        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.CancelScriptCallCountStarted);
             try
             {
-                return inner.CancelScript(command);
+                return inner.CancelScript(command, options);
             }
             finally
             {
@@ -68,12 +70,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public void CompleteScript(CompleteScriptCommandV2 command)
+        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.CompleteScriptCallCountStarted);
             try
             {
-                inner.CompleteScript(command);
+                inner.CompleteScript(command, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingCapabilitiesServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingCapabilitiesServiceV2Decorator.cs
@@ -1,4 +1,6 @@
 using System;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Serilog;
 
@@ -9,24 +11,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public Exception? GetCapabilitiesLatestException { get; set; }
     }
 
-    public class ErrorRecordingCapabilitiesServiceV2Decorator : ICapabilitiesServiceV2
+    public class ErrorRecordingCapabilitiesServiceV2Decorator : IClientCapabilitiesServiceV2
     {
         private CapabilitiesServiceV2Exceptions errors;
-        private ICapabilitiesServiceV2 inner;
+        private IClientCapabilitiesServiceV2 inner;
         private ILogger logger;
 
-        public ErrorRecordingCapabilitiesServiceV2Decorator(ICapabilitiesServiceV2 inner, CapabilitiesServiceV2Exceptions errors)
+        public ErrorRecordingCapabilitiesServiceV2Decorator(IClientCapabilitiesServiceV2 inner, CapabilitiesServiceV2Exceptions errors)
         {
             this.inner = inner;
             this.errors = errors;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingCapabilitiesServiceV2Decorator>();
         }
 
-        public CapabilitiesResponseV2 GetCapabilities()
+        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.GetCapabilities();
+                return inner.GetCapabilities(options);
             }
             catch (Exception e)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingFileTransferServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingFileTransferServiceDecorator.cs
@@ -1,5 +1,7 @@
 using System;
 using Halibut;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
 using Serilog;
 
@@ -11,24 +13,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public Exception? DownloadFileLatestException { get; set; }
     }
 
-    public class ErrorRecordingFileTransferServiceDecorator : IFileTransferService
+    public class ErrorRecordingFileTransferServiceDecorator : IClientFileTransferService
     {
         private FileTransferServiceExceptions errors;
-        private IFileTransferService inner;
+        private IClientFileTransferService inner;
         private ILogger logger;
 
-        public ErrorRecordingFileTransferServiceDecorator(IFileTransferService inner, FileTransferServiceExceptions errors)
+        public ErrorRecordingFileTransferServiceDecorator(IClientFileTransferService inner, FileTransferServiceExceptions errors)
         {
             this.inner = inner;
             this.errors = errors;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingFileTransferServiceDecorator>();
         }
 
-        public UploadResult UploadFile(string remotePath, DataStream upload)
+        public UploadResult UploadFile(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.UploadFile(remotePath, upload);
+                return inner.UploadFile(remotePath, upload, options);
             }
             catch (Exception e)
             {
@@ -38,11 +40,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public DataStream DownloadFile(string remotePath)
+        public DataStream DownloadFile(string remotePath, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.DownloadFile(remotePath);
+                return inner.DownloadFile(remotePath, options);
             }
             catch (Exception e)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingScriptServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingScriptServiceDecorator.cs
@@ -1,4 +1,6 @@
 using System;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
 using Serilog;
 
@@ -13,24 +15,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public Exception? CompleteScriptLatestException { get; set; }
     }
 
-    public class ErrorRecordingScriptServiceDecorator : IScriptService
+    public class ErrorRecordingScriptServiceDecorator : IClientScriptService
     {
         private readonly ScriptServiceExceptions errors;
-        private readonly IScriptService inner;
+        private readonly IClientScriptService inner;
         private readonly ILogger logger;
 
-        public ErrorRecordingScriptServiceDecorator(IScriptService inner, ScriptServiceExceptions errors)
+        public ErrorRecordingScriptServiceDecorator(IClientScriptService inner, ScriptServiceExceptions errors)
         {
             this.inner = inner;
             this.errors = errors;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingScriptServiceDecorator>();
         }
 
-        public ScriptTicket StartScript(StartScriptCommand command)
+        public ScriptTicket StartScript(StartScriptCommand command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.StartScript(command);
+                return inner.StartScript(command, options);
             }
             catch (Exception e)
             {
@@ -40,11 +42,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse GetStatus(ScriptStatusRequest request)
+        public ScriptStatusResponse GetStatus(ScriptStatusRequest request, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.GetStatus(request);
+                return inner.GetStatus(request, options);
             }
             catch (Exception e)
             {
@@ -54,11 +56,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse CancelScript(CancelScriptCommand command)
+        public ScriptStatusResponse CancelScript(CancelScriptCommand command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.CancelScript(command);
+                return inner.CancelScript(command, options);
             }
             catch (Exception e)
             {
@@ -68,11 +70,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command)
+        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.CompleteScript(command);
+                return inner.CompleteScript(command, options);
             }
             catch (Exception e)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingScriptServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingScriptServiceV2Decorator.cs
@@ -1,4 +1,6 @@
 using System;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Serilog;
 
@@ -12,24 +14,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public Exception? CompleteScriptLatestException { get; set; }
     }
 
-    public class ErrorRecordingScriptServiceV2Decorator : IScriptServiceV2
+    public class ErrorRecordingScriptServiceV2Decorator : IClientScriptServiceV2
     {
         private ScriptServiceV2Exceptions errors;
-        private IScriptServiceV2 inner;
+        private IClientScriptServiceV2 inner;
         private ILogger logger;
 
-        public ErrorRecordingScriptServiceV2Decorator(IScriptServiceV2 inner, ScriptServiceV2Exceptions errors)
+        public ErrorRecordingScriptServiceV2Decorator(IClientScriptServiceV2 inner, ScriptServiceV2Exceptions errors)
         {
             this.inner = inner;
             this.errors = errors;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingScriptServiceV2Decorator>();
         }
 
-        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command)
+        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.StartScript(command);
+                return inner.StartScript(command, options);
             }
             catch (Exception e)
             {
@@ -39,11 +41,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request)
+        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.GetStatus(request);
+                return inner.GetStatus(request, options);
             }
             catch (Exception e)
             {
@@ -53,11 +55,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command)
+        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.CancelScript(command);
+                return inner.CancelScript(command, options);
             }
             catch (Exception e)
             {
@@ -67,11 +69,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public void CompleteScript(CompleteScriptCommandV2 command)
+        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             try
             {
-                inner.CompleteScript(command);
+                inner.CompleteScript(command, options);
             }
             catch (Exception e)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToCapabilitiesServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToCapabilitiesServiceDecorator.cs
@@ -1,25 +1,27 @@
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
-    public class LogCallsToCapabilitiesServiceDecorator : ICapabilitiesServiceV2
+    public class LogCallsToCapabilitiesServiceDecorator : IClientCapabilitiesServiceV2
     {
-        private ICapabilitiesServiceV2 inner;
+        private IClientCapabilitiesServiceV2 inner;
         private ILogger logger;
 
-        public LogCallsToCapabilitiesServiceDecorator(ICapabilitiesServiceV2 inner)
+        public LogCallsToCapabilitiesServiceDecorator(IClientCapabilitiesServiceV2 inner)
         {
             this.inner = inner;
             logger = new SerilogLoggerBuilder().Build().ForContext<LogCallsToCapabilitiesServiceDecorator>();
         }
 
-        public CapabilitiesResponseV2 GetCapabilities()
+        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions options)
         {
             logger.Information("GetCapabilities call started");
             try
             {
-                return inner.GetCapabilities();
+                return inner.GetCapabilities(options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToFileTransferServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToFileTransferServiceDecorator.cs
@@ -1,26 +1,28 @@
 using Halibut;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
-    public class LogCallsToFileTransferServiceDecorator : IFileTransferService
+    public class LogCallsToFileTransferServiceDecorator : IClientFileTransferService
     {
-        private IFileTransferService inner;
+        private IClientFileTransferService inner;
         private ILogger logger;
 
-        public LogCallsToFileTransferServiceDecorator(IFileTransferService inner)
+        public LogCallsToFileTransferServiceDecorator(IClientFileTransferService inner)
         {
             this.inner = inner;
             logger = new SerilogLoggerBuilder().Build().ForContext<LogCallsToFileTransferServiceDecorator>();
         }
 
-        public UploadResult UploadFile(string remotePath, DataStream upload)
+        public UploadResult UploadFile(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
         {
             logger.Information("UploadFile call started");
             try
             {
-                return inner.UploadFile(remotePath, upload);
+                return inner.UploadFile(remotePath, upload, options);
             }
             finally
             {
@@ -28,12 +30,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public DataStream DownloadFile(string remotePath)
+        public DataStream DownloadFile(string remotePath, HalibutProxyRequestOptions options)
         {
             logger.Information("DownloadFile call started");
             try
             {
-                return inner.DownloadFile(remotePath);
+                return inner.DownloadFile(remotePath, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToScriptServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToScriptServiceDecorator.cs
@@ -1,26 +1,28 @@
 using System;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
-    public class LogCallsToScriptServiceDecorator : IScriptService
+    public class LogCallsToScriptServiceDecorator : IClientScriptService
     {
-        private readonly IScriptService inner;
+        private readonly IClientScriptService inner;
         private readonly ILogger logger;
 
-        public LogCallsToScriptServiceDecorator(IScriptService inner)
+        public LogCallsToScriptServiceDecorator(IClientScriptService inner)
         {
             this.inner = inner;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingScriptServiceDecorator>();
         }
 
-        public ScriptTicket StartScript(StartScriptCommand command)
+        public ScriptTicket StartScript(StartScriptCommand command, HalibutProxyRequestOptions options)
         {
             logger.Information("StartScript call started");
             try
             {
-                return inner.StartScript(command);
+                return inner.StartScript(command, options);
             }
             finally
             {
@@ -28,12 +30,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse GetStatus(ScriptStatusRequest request)
+        public ScriptStatusResponse GetStatus(ScriptStatusRequest request, HalibutProxyRequestOptions options)
         {
             logger.Information("GetStatus call started");
             try
             {
-                return inner.GetStatus(request);
+                return inner.GetStatus(request, options);
             }
             finally
             {
@@ -41,12 +43,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse CancelScript(CancelScriptCommand command)
+        public ScriptStatusResponse CancelScript(CancelScriptCommand command, HalibutProxyRequestOptions options)
         {
             logger.Information("CancelScript call started");
             try
             {
-                return inner.CancelScript(command);
+                return inner.CancelScript(command, options);
             }
             finally
             {
@@ -54,12 +56,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command)
+        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command, HalibutProxyRequestOptions options)
         {
             logger.Information("CompleteScript call started");
             try
             {
-                return inner.CompleteScript(command);
+                return inner.CompleteScript(command, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToScriptServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToScriptServiceV2Decorator.cs
@@ -1,25 +1,27 @@
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
-    public class LogCallsToScriptServiceV2Decorator : IScriptServiceV2
+    public class LogCallsToScriptServiceV2Decorator : IClientScriptServiceV2
     {
-        private IScriptServiceV2 inner;
+        private IClientScriptServiceV2 inner;
         private ILogger logger;
 
-        public LogCallsToScriptServiceV2Decorator(IScriptServiceV2 inner)
+        public LogCallsToScriptServiceV2Decorator(IClientScriptServiceV2 inner)
         {
             this.inner = inner;
             logger = new SerilogLoggerBuilder().Build().ForContext<LogCallsToScriptServiceV2Decorator>();
         }
 
-        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command)
+        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             logger.Information("StartScript call started");
             try
             {
-                return inner.StartScript(command);
+                return inner.StartScript(command, options);
             }
             finally
             {
@@ -27,12 +29,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request)
+        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
         {
             logger.Information("GetStatus call started");
             try
             {
-                return inner.GetStatus(request);
+                return inner.GetStatus(request, options);
             }
             finally
             {
@@ -40,12 +42,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command)
+        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             logger.Information("CancelScript call started");
             try
             {
-                return inner.CancelScript(command);
+                return inner.CancelScript(command, options);
             }
             finally
             {
@@ -53,12 +55,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public void CompleteScript(CompleteScriptCommandV2 command)
+        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             logger.Information("CompleteScript call started");
             try
             {
-                inner.CompleteScript(command);
+                inner.CompleteScript(command, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Octopus.Tentacle.Client;
+using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
@@ -10,18 +11,18 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
     public class TentacleServiceDecoratorBuilder
     {
 
-        private List<Func<IScriptService, IScriptService>> scriptServiceDecorator = new ();
-        private List<Func<IScriptServiceV2, IScriptServiceV2>> scriptServiceV2Decorator = new ();
-        private List<Func<IFileTransferService, IFileTransferService>> fileTransferServiceDecorator = new ();
-        private List<Func<ICapabilitiesServiceV2, ICapabilitiesServiceV2>> capabilitiesServiceV2Decorator = new ();
+        private List<Func<IClientScriptService, IClientScriptService>> scriptServiceDecorator = new ();
+        private List<Func<IClientScriptServiceV2, IClientScriptServiceV2>> scriptServiceV2Decorator = new ();
+        private List<Func<IClientFileTransferService, IClientFileTransferService>> fileTransferServiceDecorator = new ();
+        private List<Func<IClientCapabilitiesServiceV2, IClientCapabilitiesServiceV2>> capabilitiesServiceV2Decorator = new ();
 
-        public TentacleServiceDecoratorBuilder DecorateScriptServiceWith(Func<IScriptService, IScriptService> scriptServiceDecorator)
+        public TentacleServiceDecoratorBuilder DecorateScriptServiceWith(Func<IClientScriptService, IClientScriptService> scriptServiceDecorator)
         {
             this.scriptServiceDecorator.Add(scriptServiceDecorator);
             return this;
         }
 
-        public TentacleServiceDecoratorBuilder DecorateScriptServiceV2With(Func<IScriptServiceV2, IScriptServiceV2> scriptServiceV2Decorator)
+        public TentacleServiceDecoratorBuilder DecorateScriptServiceV2With(Func<IClientScriptServiceV2, IClientScriptServiceV2> scriptServiceV2Decorator)
         {
             this.scriptServiceV2Decorator.Add(scriptServiceV2Decorator);
             return this;
@@ -35,7 +36,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             return this;
         }
 
-        public TentacleServiceDecoratorBuilder DecorateFileTransferServiceWith(Func<IFileTransferService, IFileTransferService> fileTransferServiceDecorator)
+        public TentacleServiceDecoratorBuilder DecorateFileTransferServiceWith(Func<IClientFileTransferService, IClientFileTransferService> fileTransferServiceDecorator)
         {
             this.fileTransferServiceDecorator.Add(fileTransferServiceDecorator);
             return this;
@@ -49,7 +50,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             return this;
         }
 
-        public TentacleServiceDecoratorBuilder DecorateCapabilitiesServiceV2With(Func<ICapabilitiesServiceV2, ICapabilitiesServiceV2> capabilitiesServiceV2Decorator)
+        public TentacleServiceDecoratorBuilder DecorateCapabilitiesServiceV2With(Func<IClientCapabilitiesServiceV2, IClientCapabilitiesServiceV2> capabilitiesServiceV2Decorator)
         {
             this.capabilitiesServiceV2Decorator.Add(capabilitiesServiceV2Decorator);
             return this;
@@ -87,12 +88,15 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 
         private class FooTentacleServiceDecorator : ITentacleServiceDecorator
         {
-            private Func<IScriptService, IScriptService> scriptServiceDecorator;
-            private Func<IScriptServiceV2, IScriptServiceV2> scriptServiceV2Decorator;
-            private Func<IFileTransferService, IFileTransferService> fileTransferServiceDecorator;
-            private Func<ICapabilitiesServiceV2, ICapabilitiesServiceV2> capabilitiesServiceV2Decorator;
+            private Func<IClientScriptService, IClientScriptService> scriptServiceDecorator;
+            private Func<IClientScriptServiceV2, IClientScriptServiceV2> scriptServiceV2Decorator;
+            private Func<IClientFileTransferService, IClientFileTransferService> fileTransferServiceDecorator;
+            private Func<IClientCapabilitiesServiceV2, IClientCapabilitiesServiceV2> capabilitiesServiceV2Decorator;
 
-            public FooTentacleServiceDecorator(Func<IScriptService, IScriptService> scriptServiceDecorator, Func<IScriptServiceV2, IScriptServiceV2> scriptServiceV2Decorator, Func<IFileTransferService, IFileTransferService> fileTransferServiceDecorator, Func<ICapabilitiesServiceV2, ICapabilitiesServiceV2> capabilitiesServiceV2Decorator)
+            public FooTentacleServiceDecorator(Func<IClientScriptService, IClientScriptService> scriptServiceDecorator, 
+                Func<IClientScriptServiceV2, IClientScriptServiceV2> scriptServiceV2Decorator,
+                Func<IClientFileTransferService, IClientFileTransferService> fileTransferServiceDecorator,
+                Func<IClientCapabilitiesServiceV2, IClientCapabilitiesServiceV2> capabilitiesServiceV2Decorator)
             {
                 this.scriptServiceDecorator = scriptServiceDecorator;
                 this.scriptServiceV2Decorator = scriptServiceV2Decorator;
@@ -100,22 +104,22 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
                 this.capabilitiesServiceV2Decorator = capabilitiesServiceV2Decorator;
             }
 
-            public IScriptService Decorate(IScriptService scriptService)
+            public IClientScriptService Decorate(IClientScriptService scriptService)
             {
                 return scriptServiceDecorator(scriptService);
             }
 
-            public IScriptServiceV2 Decorate(IScriptServiceV2 scriptService)
+            public IClientScriptServiceV2 Decorate(IClientScriptServiceV2 scriptService)
             {
                 return scriptServiceV2Decorator(scriptService);
             }
 
-            public IFileTransferService Decorate(IFileTransferService service)
+            public IClientFileTransferService Decorate(IClientFileTransferService service)
             {
                 return fileTransferServiceDecorator(service);
             }
 
-            public ICapabilitiesServiceV2 Decorate(ICapabilitiesServiceV2 service)
+            public IClientCapabilitiesServiceV2 Decorate(IClientCapabilitiesServiceV2 service)
             {
                 return capabilitiesServiceV2Decorator(service);
             }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ResponseMessageTcpKillerWorkarounds.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ResponseMessageTcpKillerWorkarounds.cs
@@ -1,4 +1,7 @@
-﻿using Serilog;
+﻿using System.Threading;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Serilog;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
@@ -7,24 +10,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 {
     public static class ResponseMessageTcpKillerWorkarounds
     {
-        public static void EnsureTentacleIsConnectedToServer(this IScriptServiceV2 service, ILogger logger)
+        public static void EnsureTentacleIsConnectedToServer(this IClientScriptServiceV2 service, ILogger logger)
         {
             logger.Information("Call GetStatus to work around an issue where the tcp killer kills setup of new connections");
-            service.GetStatus(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0));
+            service.GetStatus(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), new HalibutProxyRequestOptions(CancellationToken.None));
             logger.Information("Finished GetStatus work around call");
         }
 
-        public static void EnsureTentacleIsConnectedToServer(this ICapabilitiesServiceV2 service, ILogger logger)
+        public static void EnsureTentacleIsConnectedToServer(this IClientCapabilitiesServiceV2 service, ILogger logger)
         {
             logger.Information("Call GetCapabilities to work around an issue where the tcp killer kills setup of new connections");
-            service.GetCapabilities();
+            service.GetCapabilities(new HalibutProxyRequestOptions(CancellationToken.None));
             logger.Information("Finished GetCapabilities work around call");
         }
 
-        public static void EnsureTentacleIsConnectedToServer(this IFileTransferService service, ILogger logger)
+        public static void EnsureTentacleIsConnectedToServer(this IClientFileTransferService service, ILogger logger)
         {
             logger.Information("Call DownloadFile to work around an issue where the tcp killer kills setup of new connections");
-            service.DownloadFile("nope");
+            service.DownloadFile("nope", new HalibutProxyRequestOptions(CancellationToken.None));
             logger.Information("Finished DownloadFile work around call");
         }
     }


### PR DESCRIPTION
# Background

Makes use of the new ability to cancel requests via the generated proxy client on the method call.

This simplifies the code since we don't need to hold references to to cancellation tokens and register and unregister call backs etc.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.