### PR TITLE
Fixes ClientScriptExecutionCanBeCancelled from being flaky

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelled.cs
@@ -381,7 +381,7 @@ namespace Octopus.Tentacle.Tests.Integration
             if (expectedFlow == ExpectedFlow.CancelRpcThenCancelScriptThenCompleteScript)
             {
                 // This last call includes the time it takes to cancel and hence is why I kept pushing it up
-                lastCallDuration.Should().BeLessOrEqualTo(TimeSpan.FromSeconds((rpcCall == RpcCall.RetryingCall ? 6 : 12) + 2)); // + 2 TODO 
+                lastCallDuration.Should().BeLessOrEqualTo(TimeSpan.FromSeconds((rpcCall == RpcCall.RetryingCall ? 6 : 12) + 2)); // + 2 seconds for some error of margin 
             }
 
             // Or if the rpc call could not be cancelled it cancelled fairly quickly e.g. we are not waiting for an rpc call to timeout

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelled.cs
@@ -28,7 +28,7 @@ namespace Octopus.Tentacle.Tests.Integration
     public class ClientScriptExecutionCanBeCancelled : IntegrationTest
     {
         [Test]
-        [RetryInconclusive(5)]
+        // [RetryInconclusive(5)]
         [TestCase(TentacleType.Polling, RpcCallStage.InFlight, RpcCall.FirstCall)]
         [TestCase(TentacleType.Polling, RpcCallStage.Connecting, RpcCall.FirstCall)]
         [TestCase(TentacleType.Listening, RpcCallStage.InFlight, RpcCall.FirstCall)]
@@ -122,7 +122,7 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [RetryInconclusive(5)]
+        // [RetryInconclusive(5)]
         [TestCase(TentacleType.Polling, RpcCallStage.Connecting, RpcCall.FirstCall, ExpectedFlow.CancelRpcAndExitImmediately)]
         [TestCase(TentacleType.Listening, RpcCallStage.Connecting, RpcCall.FirstCall, ExpectedFlow.CancelRpcAndExitImmediately)]
         [TestCase(TentacleType.Polling, RpcCallStage.Connecting, RpcCall.RetryingCall, ExpectedFlow.CancelRpcThenCancelScriptThenCompleteScript)]
@@ -245,7 +245,7 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [RetryInconclusive(5)]
+        // [RetryInconclusive(5)]
         [TestCase(TentacleType.Polling, RpcCallStage.Connecting, RpcCall.FirstCall, ExpectedFlow.CancelRpcThenCancelScriptThenCompleteScript)]
         [TestCase(TentacleType.Listening, RpcCallStage.Connecting, RpcCall.FirstCall, ExpectedFlow.CancelRpcThenCancelScriptThenCompleteScript)]
         [TestCase(TentacleType.Polling, RpcCallStage.Connecting, RpcCall.RetryingCall, ExpectedFlow.CancelRpcThenCancelScriptThenCompleteScript)]
@@ -354,7 +354,7 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [RetryInconclusive(5)]
+        // [RetryInconclusive(5)]
         [TestCase(TentacleType.Polling, RpcCallStage.Connecting)]
         [TestCase(TentacleType.Listening, RpcCallStage.Connecting)]
         [TestCase(TentacleType.Polling, RpcCallStage.InFlight)]
@@ -416,7 +416,7 @@ namespace Octopus.Tentacle.Tests.Integration
             {
                 Logger.Information("Killing the port forwarder so the next RPCs are in the connecting state when being cancelled");
                 //portForwarder.Stop();
-                portForwarder.EnterKillAllMode();
+                portForwarder.EnterKillNewAndExistingConnectionsMode();
                 rpcCallHasStarted.Value = true;
             }
             else

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelled.cs
@@ -415,7 +415,8 @@ namespace Octopus.Tentacle.Tests.Integration
             if (rpcCallStage == RpcCallStage.Connecting)
             {
                 Logger.Information("Killing the port forwarder so the next RPCs are in the connecting state when being cancelled");
-                portForwarder.Stop();
+                //portForwarder.Stop();
+                portForwarder.EnterKillAllMode();
                 rpcCallHasStarted.Value = true;
             }
             else
@@ -430,7 +431,8 @@ namespace Octopus.Tentacle.Tests.Integration
             if (rpcCallStage == RpcCallStage.Connecting)
             {
                 Logger.Information("Starting the PortForwarder as we stopped it to get the StartScript RPC call in the Connecting state");
-                portForwarder.Value.Start();
+                //portForwarder.Value.Start();
+                portForwarder.Value.ReturnToNormalMode();
             }
             else if (tentacleType == TentacleType.Polling)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -56,7 +56,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 {
                                     // Kill the port forwarder so the next requests are in the connecting state when retries timeout
                                     Logger.Information("Killing PortForwarder");
-                                    portForwarder.Value.Stop();
+                                    portForwarder.Value.EnterKillNewAndExistingConnectionsMode();
                                 }
                                 else
                                 {
@@ -122,7 +122,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 {
                                     // Kill the port forwarder so the next requests are in the connecting state when retries timeout
                                     Logger.Information("Killing PortForwarder");
-                                    portForwarder.Value.Stop();
+                                    portForwarder.Value.EnterKillNewAndExistingConnectionsMode();
                                 }
                                 else
                                 {
@@ -191,7 +191,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 {
                                     // Kill the port forwarder so the next requests are in the connecting state when retries timeout
                                     Logger.Information("Killing PortForwarder");
-                                    portForwarder.Value.Stop();
+                                    portForwarder.Value.EnterKillNewAndExistingConnectionsMode();
                                 }
                                 else
                                 {
@@ -262,7 +262,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 {
                                     // Kill the port forwarder so the next requests are in the connecting state when retries timeout
                                     Logger.Information("Killing PortForwarder");
-                                    portForwarder.Value.Stop();
+                                    portForwarder.Value.EnterKillNewAndExistingConnectionsMode();
                                 }
                                 else
                                 {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/AllCombinations.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/AllCombinations.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
@@ -19,10 +20,21 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             return new AllCombinations().And(sequence);
         }
 
+        public static AllCombinations AllValuesOf(Type enumType)
+        {
+            return new AllCombinations().AndAllValuesOf(enumType);
+        }
+
         public AllCombinations And(IEnumerable sequence)
         {
             sequences.Add(sequence);
             return this;
+        }
+        
+        public AllCombinations AndAllValuesOf(Type enumType)
+        {
+
+            return And(Enum.GetValues(enumType));
         }
 
         public AllCombinations And(params string[] sequence)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/AllCombinations.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/AllCombinations.cs
@@ -8,6 +8,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     public class AllCombinations
     {
         private readonly List<IEnumerable> sequences = new ();
+
+        public static AllCombinations Of(params object[] sequence)
+        {
+            return new AllCombinations().And(sequence);
+        }
         
         public static AllCombinations Of(IEnumerable sequence)
         {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -28,8 +28,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var subscriptionId = PollingSubscriptionId.Generate();
 
             CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
-            AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
             ConfigureTentacleToPollOctopusServer(configFilePath, subscriptionId);
+            AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
+            
 
             return await StartTentacle(
                 subscriptionId,

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -57,7 +57,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 tempDirectory,
                 StartTentacleFunction,
                 tentacleThumbprint,
-                ct => DeleteInstance(tentacleExe, instanceName, tempDirectory, ct));
+                ct => DeleteInstanceIgnoringFailure(tentacleExe, instanceName, tempDirectory, ct));
 
             try
             {
@@ -145,7 +145,19 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         {
             RunTentacleCommand(tentacleExe, new[] { "create-instance", "--config", configFilePath, $"--instance={instanceName}" }, tmp, cancellationToken);
         }
-        
+
+        internal void DeleteInstanceIgnoringFailure(string tentacleExe, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
+        {
+            try
+            {
+                DeleteInstance(tentacleExe, instanceName, tmp, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                new SerilogLoggerBuilder().Build().Warning(e, "Could not delete instance: {InstanceName}", instanceName);
+                throw;
+            }
+        }
         internal void DeleteInstance(string tentacleExe, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
         {
             RunTentacleCommand(tentacleExe, new[] {"delete-instance", $"--instance={instanceName}"}, tmp, cancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -143,7 +143,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         protected void CreateInstance(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
         {
-            RunTentacleCommand(tentacleExe, new[] { "create-instance", "--config", configFilePath, $"--instance={instanceName}" }, tmp, cancellationToken);
+            RunTentacleCommand(tentacleExe, new[] { "create-instance", "--config", $"\"{configFilePath}\"", $"--instance={instanceName}" }, tmp, cancellationToken);
         }
 
         internal void DeleteInstanceIgnoringFailure(string tentacleExe, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationObservingPendingRequestQueueFactory.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationObservingPendingRequestQueueFactory.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Halibut.Diagnostics;
+using Halibut.ServiceModel;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
+{
+    public class CancellationObservingPendingRequestQueueFactory : IPendingRequestQueueFactory
+    {
+
+        public IPendingRequestQueue CreateQueue(Uri endpoint)
+        {
+            return new CancellationTokenObservingPendingRequestQueueDecorator(new PendingRequestQueue(new LogFactory().ForEndpoint(endpoint)));
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationTokenObservingPendingRequestQueueDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationTokenObservingPendingRequestQueueDecorator.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Halibut;
+using Halibut.ServiceModel;
+using Halibut.Transport.Protocol;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
+{
+    public class CancellationTokenObservingPendingRequestQueueDecorator : IPendingRequestQueue
+    {
+        private IPendingRequestQueue pendingRequestQueue;
+
+        public CancellationTokenObservingPendingRequestQueueDecorator(IPendingRequestQueue pendingRequestQueue)
+        {
+            this.pendingRequestQueue = pendingRequestQueue;
+        }
+
+        public void ApplyResponse(ResponseMessage response, ServiceEndPoint destination)
+        {
+            pendingRequestQueue.ApplyResponse(response, destination);
+        }
+
+        public RequestMessage Dequeue()
+        {
+            return pendingRequestQueue.Dequeue();
+        }
+
+        public Task<RequestMessage> DequeueAsync()
+        {
+            return pendingRequestQueue.DequeueAsync();
+        }
+
+        public Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return pendingRequestQueue.QueueAndWaitAsync(request, cancellationToken);
+        }
+
+        public bool IsEmpty => pendingRequestQueue.IsEmpty;
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/PendingRequestQueueWorkarounds.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/PendingRequestQueueWorkarounds.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers;
+using Serilog;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
+{
+    public static class PendingRequestQueueWorkarounds
+    {
+        public static void EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IClientScriptServiceV2 service, ILogger logger)
+        {
+            logger.Log().Information("Call GetStatus to work around an issue where the polling queue will send work to a disconnected tentacle");
+            DoIgnoringException(() => service.GetStatus(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), ProxyRequestOptions()));
+            logger.Log().Information("Finished GetStatus work around call");
+        }
+
+        private static HalibutProxyRequestOptions ProxyRequestOptions()
+        {
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromMilliseconds(500));
+            return new HalibutProxyRequestOptions(cts.Token);
+        }
+
+        public static void EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IClientCapabilitiesServiceV2 service, ILogger logger)
+        {
+            logger.Log().Information("Call GetCapabilities to work around an issue where the polling queue will send work to a disconnected tentacle");
+            DoIgnoringException(() => service.GetCapabilities(ProxyRequestOptions()));
+            logger.Log().Information("Finished GetCapabilities work around call");
+        }
+
+        public static void EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IClientFileTransferService service, ILogger logger)
+        {
+            logger.Log().Information("Call DownloadFile to work around an issue where the polling queue will send work to a disconnected tentacle");
+            DoIgnoringException(() => service.DownloadFile("nope", ProxyRequestOptions()));
+            logger.Log().Information("Finished DownloadFile work around call");
+        }
+
+        private static ILogger Log(this ILogger logger)
+        {
+            return logger.ForContext(typeof(PendingRequestQueueWorkarounds));
+        }
+        
+        private static void DoIgnoringException(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception)
+            {
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
@@ -57,7 +57,6 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                 _formatter.Format(logEvent, output);
                 // This is the change, call this instead of: TestContext.Progress
                 TestContext.Write(output.ToString());
-                WriteNunitLogsToFile.write(output.ToString());
             }
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
@@ -57,6 +57,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                 _formatter.Format(logEvent, output);
                 // This is the change, call this instead of: TestContext.Progress
                 TestContext.Write(output.ToString());
+                WriteNunitLogsToFile.write(output.ToString());
             }
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
@@ -8,7 +8,6 @@ using Octopus.Tentacle.Tests.Integration.Support;
 using Serilog;
 using Serilog.Core;
 using Serilog.Formatting.Display;
-using Serilog.Templates;
 
 namespace Octopus.Tentacle.Tests.Integration.Util
 {
@@ -30,8 +29,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
             var outputTemplate = 
                 testName
                 + "{Message}{NewLine}{Exception}";
-
-            new ExpressionTemplate(outputTemplate);
+            
             return new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .WriteTo.Sink(new NonProgressNUnitSink(

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ResponseMessageTcpKillerWorkarounds.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ResponseMessageTcpKillerWorkarounds.cs
@@ -12,23 +12,23 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
     {
         public static void EnsureTentacleIsConnectedToServer(this IClientScriptServiceV2 service, ILogger logger)
         {
-            logger.Information("Call GetStatus to work around an issue where the tcp killer kills setup of new connections");
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Call GetStatus to work around an issue where the tcp killer kills setup of new connections");
             service.GetStatus(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), new HalibutProxyRequestOptions(CancellationToken.None));
-            logger.Information("Finished GetStatus work around call");
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished GetStatus work around call");
         }
 
         public static void EnsureTentacleIsConnectedToServer(this IClientCapabilitiesServiceV2 service, ILogger logger)
         {
-            logger.Information("Call GetCapabilities to work around an issue where the tcp killer kills setup of new connections");
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Call GetCapabilities to work around an issue where the tcp killer kills setup of new connections");
             service.GetCapabilities(new HalibutProxyRequestOptions(CancellationToken.None));
-            logger.Information("Finished GetCapabilities work around call");
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished GetCapabilities work around call");
         }
 
         public static void EnsureTentacleIsConnectedToServer(this IClientFileTransferService service, ILogger logger)
         {
-            logger.Information("Call DownloadFile to work around an issue where the tcp killer kills setup of new connections");
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Call DownloadFile to work around an issue where the tcp killer kills setup of new connections");
             service.DownloadFile("nope", new HalibutProxyRequestOptions(CancellationToken.None));
-            logger.Information("Finished DownloadFile work around call");
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished DownloadFile work around call");
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/PortForwarder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpUtils/PortForwarder.cs
@@ -40,14 +40,14 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
             Task.Factory.StartNew(() => WorkerTask(cancellationTokenSource.Token).ConfigureAwait(false), TaskCreationOptions.LongRunning);
         }
 
-        public void Start()
+        private void Start()
         {
             if (active)
             {
                 throw new InvalidOperationException("PortForwarder is already started");
             }
 
-            CreateNewSocketIfNeeded();
+            listeningSocket ??= new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
             listeningSocket!.Bind(new IPEndPoint(IPAddress.Loopback, ListeningPort));
 
@@ -64,7 +64,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
             active = true;
         }
 
-        public void Stop()
+        private void Stop()
         {
             active = false;
             listeningSocket?.Dispose();
@@ -73,27 +73,19 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
             CloseExistingConnections();
         }
 
-        private void CreateNewSocketIfNeeded()
-        {
-            if (listeningSocket == null)
-            {
-                listeningSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            }
-        }
-
         public Uri PublicEndpoint { get; set; }
 
-        public bool InKillAllMode { get; set; }
+        public bool KillNewConnectionsImmediatlyMode { get; set; }
 
-        public void EnterKillAllMode()
+        public void EnterKillNewAndExistingConnectionsMode()
         {
-            InKillAllMode = true;
+            KillNewConnectionsImmediatlyMode = true;
             this.CloseExistingConnections();
         }
         
         public void ReturnToNormalMode()
         {
-            InKillAllMode = false;
+            KillNewConnectionsImmediatlyMode = false;
         }
 
         async Task WorkerTask(CancellationToken cancellationToken)
@@ -107,40 +99,20 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
                     {
                         var clientSocket = await listeningSocket?.AcceptAsync();
 
-                        if (!active || InKillAllMode)
+                        if (!active || KillNewConnectionsImmediatlyMode || cancellationToken.IsCancellationRequested)
                         {
 
-                            try
-                            {
-                                clientSocket.Shutdown(SocketShutdown.Both);
-                            }
-                            catch (Exception)
-                            {
-                            }
-
-                            clientSocket.Close(0);
-                            clientSocket.Dispose();
-                            clientSocket = null;
+                            CloseSocketIgnoringErrors(clientSocket);
 
                             if(!active) throw new OperationCanceledException("Port forwarder is not active");
                             continue;
                         }
 
-                        cancellationToken.ThrowIfCancellationRequested();
-                        
-
                         var originEndPoint = new DnsEndPoint(originServer.Host, originServer.Port);
                         var originSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
 
                         var pump = new TcpPump(clientSocket, originSocket, originEndPoint, sendDelay, factory, logger);
-                        pump.Stopped += OnPortForwarderStopped;
-                        lock (pumps)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-                            pumps.Add(pump);
-                        }
-
-                        pump.Start();
+                        AddNewPump(pump, cancellationToken);
                     }
                     catch (SocketException ex)
                     {
@@ -157,6 +129,39 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
                     await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
                 }
             }
+        }
+
+        private static void CloseSocketIgnoringErrors(Socket clientSocket)
+        {
+            DoIgnoringException(() => clientSocket.Shutdown(SocketShutdown.Both));
+            DoIgnoringException(() => clientSocket.Close(0));
+            DoIgnoringException(() => clientSocket.Dispose());
+        }
+
+        private void AddNewPump(TcpPump pump, CancellationToken cancellationToken)
+        {
+            
+            lock (pumps)
+            {
+                if (cancellationToken.IsCancellationRequested || !active || KillNewConnectionsImmediatlyMode)
+                {
+                    try
+                    {
+                        pump.Dispose();
+                    }
+                    catch (Exception)
+                    {
+                        
+                    }
+                }
+                else
+                {
+                    pump.Stopped += OnPortForwarderStopped;
+                    pumps.Add(pump);
+                }
+            }
+
+            pump.Start();
         }
 
         void OnPortForwarderStopped(object sender, EventArgs e)
@@ -274,6 +279,17 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpUtils
                     !(x is SocketException && x.Message.Contains("A request to send or receive data was disallowed because the socket is not connected"))) > 0)
             {
                 logger.Warning(new AggregateException(exceptions), "Exceptions where thrown when Disposing of the PortForwarder");
+            }
+        }
+
+        private static void DoIgnoringException(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception)
+            {
             }
         }
     }

--- a/source/Octopus.Tentacle/Util/SemaphoreSlimExtensions.cs
+++ b/source/Octopus.Tentacle/Util/SemaphoreSlimExtensions.cs
@@ -17,5 +17,17 @@ namespace Octopus.Tentacle.Util
             await semaphore.WaitAsync();
             return new SemaphoreSlimReleaser(semaphore);
         }
+        
+        public static async Task<IDisposable> LockAsync(this SemaphoreSlim semaphore, CancellationToken cancellationToken)
+        {
+            await semaphore.WaitAsync(cancellationToken);
+            return new SemaphoreSlimReleaser(semaphore);
+        }
+        
+        public static async Task WithLockAsync(this SemaphoreSlim semaphore, Action actionToPerformWhileTheLockIsHeld, CancellationToken cancellationToken)
+        {
+            using var _ = await semaphore.LockAsync(cancellationToken);
+            actionToPerformWhileTheLockIsHeld();
+        }
     }
 }


### PR DESCRIPTION
# Background

`ClientScriptExecutionCanBeCancelled` was flaky , the following changes address that:
* Introduced a new mode to the Port Forwarder in which new and existing connections will be terminated immediately.
* Updated  all tests which previously stopped and started the Port Forwarder to use that. Preventing Port is already in use errors from occurring. 
* `AddCertificateToTentacle` is now done after configuring the Application dir, which reduces race conditions in running tentacle externally. The issue here is tentacles lists all instances of tentacle on a machine including those not completely setup.
* Exceptions thrown from deleting an instance after a test has run is now ignored, avoiding the race condition above from affecting the tests.
* Added a `CancellationObservingPendingRequestQueueFactory` which checks the `CancellationToken` before putting something on to the queue. This helps mitigate test failures where the `CancellationToken` is cancelled AND tentacle is no longer connected resulting in the request being sent to a disconnected tentacle rather than the request being cancelled.
* Added `PendingRequestQueueWorkarounds` Which also works around the issue described above.
* Potentially fixed a bug in the Port Forwarder in which a newly accepted socket was not closed correctly. It requires shutdown to be called first before close and dispose.
* Potentially fixes some race conditions in the Port Forwarder where disposing of it, can result in some recently accepted connections from being closed.
* Thanks to Steve tentacle integration tests can no run when the path contains a space.
* For the changes within `ClientScriptExecutionCanBeCancelled` itself:
    * To ensure the correct exception is thrown cancellation of a scripted is only permitted while the RPC call is being made. Otherwise poly retry can detect the cancellation and handle it resulting in the last exception seen in the RPC call being a Halibut exception which occurs because the request failed since we killed the TCP connection.
    * When testing cancellation on the first call in listening mode, the listening retry timeout and number of attempts is increased so that halibut will continue to retry comms with tentacle until the cancellation is triggered.
    * The test now only pauses or stops the port forwarder once, since doing it more often seemed to result in tests failing.
    * The tests make use of `PendingRequestQueueWorkarounds` to ensure the queue is cleared just after causing a network failure.
    * Expected RPC calls assertions are changed to be 2 or more when testing retries since we may retry many times before failure.
    * Increased the amount of time the last request can take. Since it seems to be tied to how long we wait before cancelling. Which was also increased since doing so revealed more flake (which is fixed) in the tests.
    * Removed the inconclusive checks and retries since the tests are no longer flaky, touch ALL THE WOOD.


This also makes some other improvements:
* Log messages are now preceded with the time since the test started rather than the current time. This makes it easier to see how long operations are taking in tests.
* Log messages no longer have the full name (including package name) for the context of a log message. e.g. before `[com.foo.Bar] message` -> Now `[Bar] message`
* `AllCombinations` can now be passed an enum type, and it will expand that to all values of the enum.
* `ResponseMessageTcpKillerWorkarounds` now logs to the correct context.

# Results


The tests appear to be reliable see:
https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacleNet48_IntegrationTestWindows/8108293?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandPull+Request+Details=true
https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacleNet48_IntegrationTestNetFramework/8108298?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandPull+Request+Details=true
https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacleNet48_IntegrationTestLinux/8107579?buildTab=perfmon

Note that in those runs the cancellation tests are run about 5 times within each execution. This was done to try to flesh out any unreliability. 

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.