### PR TITLE
Add arm64 OSX build for M1 macs

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -244,8 +244,6 @@ partial class Build : NukeBuild
             .SetConfiguration(configuration)
             .SetFramework(framework)
             .SetRuntime(runtimeId)
-            // .When(runtimeId != "win", x => x.EnableSelfContained())
-            // .When(runtimeId == "win", x => x.DisableSelfContained())
             .EnableNoRestore()
             .SetVersion(OctoVersionInfo.FullSemVer));
     }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -244,6 +244,7 @@ partial class Build : NukeBuild
             .SetConfiguration(configuration)
             .SetFramework(framework)
             .SetRuntime(runtimeId)
+            .DisableSelfContained()
             .EnableNoRestore()
             .SetVersion(OctoVersionInfo.FullSemVer));
     }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -84,7 +84,7 @@ partial class Build : NukeBuild
 
     const string NetFramework = "net48";
     const string NetCore = "net6.0";
-    readonly string[] RuntimeIds = { "win", "win-x86", "win-x64", "linux-x64", "linux-musl-x64", "linux-arm64", "linux-arm", "osx-x64" };
+    readonly string[] RuntimeIds = { "win", "win-x86", "win-x64", "linux-x64", "linux-musl-x64", "linux-arm64", "linux-arm", "osx-x64", "osx-arm64" };
 
     [PublicAPI]
     Target CalculateVersion => _ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -244,7 +244,7 @@ partial class Build : NukeBuild
             .SetConfiguration(configuration)
             .SetFramework(framework)
             .SetRuntime(runtimeId)
-            .EnableSelfContained()
+            .When(runtimeId != "win", x => x.EnableSelfContained())
             .EnableNoRestore()
             .SetVersion(OctoVersionInfo.FullSemVer));
     }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -245,6 +245,7 @@ partial class Build : NukeBuild
             .SetFramework(framework)
             .SetRuntime(runtimeId)
             .When(runtimeId != "win", x => x.EnableSelfContained())
+            .When(runtimeId == "win", x => x.DisableSelfContained())
             .EnableNoRestore()
             .SetVersion(OctoVersionInfo.FullSemVer));
     }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -244,8 +244,8 @@ partial class Build : NukeBuild
             .SetConfiguration(configuration)
             .SetFramework(framework)
             .SetRuntime(runtimeId)
-            .When(runtimeId != "win", x => x.EnableSelfContained())
-            .When(runtimeId == "win", x => x.DisableSelfContained())
+            // .When(runtimeId != "win", x => x.EnableSelfContained())
+            // .When(runtimeId == "win", x => x.DisableSelfContained())
             .EnableNoRestore()
             .SetVersion(OctoVersionInfo.FullSemVer));
     }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -244,7 +244,7 @@ partial class Build : NukeBuild
             .SetConfiguration(configuration)
             .SetFramework(framework)
             .SetRuntime(runtimeId)
-            .DisableSelfContained()
+            .EnableSelfContained()
             .EnableNoRestore()
             .SetVersion(OctoVersionInfo.FullSemVer));
     }

--- a/source/Octopus.Tentacle.Client/Octopus.Tentacle.Client.csproj
+++ b/source/Octopus.Tentacle.Client/Octopus.Tentacle.Client.csproj
@@ -20,7 +20,7 @@
         </When>
         <Otherwise>
             <PropertyGroup>
-                <RuntimeIdentifiers>win-x86;win-x64;linux-x64;osx-x64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
+                <RuntimeIdentifiers>win-x86;win-x64;linux-x64;osx-x64;osx-arm64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
             </PropertyGroup>
         </Otherwise>
     </Choose>

--- a/source/Octopus.Tentacle.CommonTestUtils/Octopus.Tentacle.CommonTestUtils.csproj
+++ b/source/Octopus.Tentacle.CommonTestUtils/Octopus.Tentacle.CommonTestUtils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <RuntimeIdentifiers>win;win-x86;win-x64;linux-x64;osx-x64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win;win-x86;win-x64;linux-x64;osx-x64;osx-arm64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
         <LangVersion>8</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -23,7 +23,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <RuntimeIdentifiers>win-x86;win-x64;linux-x64;osx-x64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win-x86;win-x64;linux-x64;osx-x64;osx-arm64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -8,7 +8,7 @@
         <OutputPath>bin</OutputPath>
         <PublishDir>../../_build/$(AssemblyName)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
         <RootNamespace>Octopus.Tentacle.Tests.Integration</RootNamespace>
-        <RuntimeIdentifiers>win;win-x86;win-x64;linux-x64;osx-x64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win;win-x86;win-x64;linux-x64;osx-x64;osx-arm64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <LangVersion>9</LangVersion>
         <Nullable>annotations</Nullable>

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -7,7 +7,7 @@
     <OutputPath>bin</OutputPath>
     <PublishDir>../../_build/$(AssemblyName)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
     <RootNamespace>Octopus.Tentacle.Tests</RootNamespace>
-    <RuntimeIdentifiers>win;win-x86;win-x64;linux-x64;osx-x64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win;win-x86;win-x64;linux-x64;osx-x64;osx-arm64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>9</LangVersion>
     <Nullable>annotations</Nullable>

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -24,7 +24,7 @@
 		</When>
 		<Otherwise>
 			<PropertyGroup>
-				<RuntimeIdentifiers>win-x86;win-x64;linux-x64;osx-x64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
+				<RuntimeIdentifiers>win-x86;win-x64;linux-x64;osx-x64;osx-arm64;linux-arm64;linux-arm;linux-musl-x64</RuntimeIdentifiers>
 			</PropertyGroup>
 		</Otherwise>
 	</Choose>

--- a/source/Tentacle.sln
+++ b/source/Tentacle.sln
@@ -80,8 +80,8 @@ Global
 		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-win-x64|Any CPU.Build.0 = Release|Any CPU
 		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
 		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-win-x86|Any CPU.Build.0 = Release|Any CPU
-		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
-		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
+		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
+		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -95,7 +95,7 @@ Global
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-osx-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-win-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
-		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -116,8 +116,8 @@ Global
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-win-x64|Any CPU.Build.0 = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-win-x86|Any CPU.Build.0 = Debug|Any CPU
-		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
-		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
+		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
+		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -131,11 +131,11 @@ Global
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-osx-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-win-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
-		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
-		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
+		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
+		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release|Any CPU
 		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -156,8 +156,8 @@ Global
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-win-x64|Any CPU.Build.0 = Release|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-win-x86|Any CPU.Build.0 = Release|Any CPU
-		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
-		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
+		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
+		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -178,8 +178,8 @@ Global
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-win-x64|Any CPU.Build.0 = Debug|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Debug|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-win-x86|Any CPU.Build.0 = Debug|Any CPU
-		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
-		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
+		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
+		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -200,8 +200,8 @@ Global
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-win-x64|Any CPU.Build.0 = Release|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-win-x86|Any CPU.Build.0 = Release|Any CPU
-		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
-		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
+		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
+		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -222,8 +222,8 @@ Global
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-win-x64|Any CPU.Build.0 = Debug|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-win-x86|Any CPU.Build.0 = Debug|Any CPU
-		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
-		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
+		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
+		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Tentacle.sln
+++ b/source/Tentacle.sln
@@ -57,6 +57,7 @@ Global
 		Release-net6.0-osx-x64|Any CPU = Release-net6.0-osx-x64|Any CPU
 		Release-net6.0-win-x64|Any CPU = Release-net6.0-win-x64|Any CPU
 		Release-net6.0-win-x86|Any CPU = Release-net6.0-win-x86|Any CPU
+		Release-net6.0-osx-arm64|Any CPU = Release-net6.0-osx-arm64|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -79,6 +80,8 @@ Global
 		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-win-x64|Any CPU.Build.0 = Release|Any CPU
 		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
 		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-win-x86|Any CPU.Build.0 = Release|Any CPU
+		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{0FCA52BD-3D2C-4F05-9F87-42920C1FA4F4}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -92,6 +95,8 @@ Global
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-osx-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-win-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
+		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -112,6 +117,8 @@ Global
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-win-x64|Any CPU.Build.0 = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-win-x86|Any CPU.Build.0 = Debug|Any CPU
+		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -125,8 +132,12 @@ Global
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-osx-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-win-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
+		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release|Any CPU.ActiveCfg = Release|Any CPU		
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -147,6 +158,8 @@ Global
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-win-x64|Any CPU.Build.0 = Release|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-win-x86|Any CPU.Build.0 = Release|Any CPU
+		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -167,6 +180,8 @@ Global
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-win-x64|Any CPU.Build.0 = Debug|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Debug|Any CPU
 		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-win-x86|Any CPU.Build.0 = Debug|Any CPU
+		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{86C4288E-9982-4DC6-994F-461C95640C7D}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -187,6 +202,8 @@ Global
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-win-x64|Any CPU.Build.0 = Release|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
 		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-win-x86|Any CPU.Build.0 = Release|Any CPU
+		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{506D425E-10F0-49A1-826C-8B704B7140B2}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -207,6 +224,8 @@ Global
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-win-x64|Any CPU.Build.0 = Debug|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-win-x86|Any CPU.Build.0 = Debug|Any CPU
+		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
+		{D0F2DBE7-017B-4AF1-9CA7-8C746220C6F0}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Tentacle.sln
+++ b/source/Tentacle.sln
@@ -96,7 +96,6 @@ Global
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-win-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
 		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
-		{A9E01394-4A21-418F-9ACC-D5A164E8491B}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A33CADF-9D7F-4835-842C-B71700DB6A3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -137,7 +136,6 @@ Global
 		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release-net6.0-osx-arm64|Any CPU
-		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-osx-arm64|Any CPU.Build.0 = Release-net6.0-osx-arm64|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
# Background

Running E2E tests on an M1 Mac were failing, as it was trying to run the `osx-x64` version.

# Results

This adds a new publish target for `osx-arm64`

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.