### PR TITLE
Update contracts to use the latest version of Halibut that fixes x509 issue

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="6.0.89" />
+    <PackageReference Include="Halibut" Version="6.0.125-pull-243" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="6.0.125-pull-243" />
+    <PackageReference Include="Halibut" Version="6.0.128" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">


### PR DESCRIPTION
# Background

Microsoft published a [security update](https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b) on 13th June 2023 regarding how .NET applications import x509 certificates.

This PR updates Octopus Tentacle to the [updated version of Halibut](https://github.com/OctopusDeploy/Halibut/pull/243), which supports these changes.

The changes are as per the [recommended approach](https://support.microsoft.com/en-us/topic/kb5025823-change-in-how-net-applications-import-x-509-certificates-bf81c936-af2b-446e-9f7a-016f4713b46b#:~:text=//%20RECOMMENDED%20WORKAROUND%20%2D%20different%20ctor%20overload%20suppresses%20additional%20security%20checks%20X509Certificate2%20certB%20%3D%20new%20X509Certificate2(blobToImport%2C%20(string)null)%3B) from Microsoft to mitigate the issue.

# Github Issue
https://github.com/OctopusDeploy/Issues/issues/8198

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.