### PR TITLE
Symlink iptables-nft instead of iptables-legacy for iptables based on availability

### DIFF
--- a/docker/linux/install-scripts/install-docker.sh
+++ b/docker/linux/install-scripts/install-docker.sh
@@ -56,9 +56,16 @@ dos2unix /usr/local/bin/dind
 chmod +x /usr/local/bin/dockerd-entrypoint.sh
 dos2unix /usr/local/bin/dockerd-entrypoint.sh
 
-# https://forums.docker.com/t/failing-to-start-dockerd-failed-to-create-nat-chain-docker/78269
-update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-update-alternatives --set iptables /usr/sbin/iptables-legacy
+if [ iptables -nL > /dev/null 2>&1 ]; then
+  # https://forums.docker.com/t/failing-to-start-dockerd-failed-to-create-nat-chain-docker/78269
+  update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+  update-alternatives --set iptables /usr/sbin/iptables-legacy
+else
+  # There can be issues with some (newer) operating systems are moving away from iptables to nftables, like RHEL.
+  # See https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1677028476905509 for more details
+  update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
+  update-alternatives --set iptables /usr/sbin/iptables-nft
+fi
 
 # Remove the apt cache
 apt-get clean


### PR DESCRIPTION
# Background
Some newer linux operating systems are moving away from iptables to iptables-nft. This can cause issues with running docker in docker when running tentacles inside a container.

> [...iptables-nft can supplant iptables-legacy...](https://developers.redhat.com/blog/2020/08/18/iptables-the-two-variants-and-their-relationship-with-nftables#summary)

# Results

Users are now able to run execution containers inside a tentacle, running on a container in some linux hosts on different kernel modules for iptables.
 

## Before
```
INFO[2023-06-18T21:13:35.633790633Z] unable to detect if iptables supports xlock: 'iptables --wait -L -n': `modprobe: FATAL: Module ip_tables not found in directory /lib/modules/4.18.0-348.el8.x86_64
iptables v1.8.7 (legacy): can't initialize iptables table `filter': Table does not exist (do you need to insmod?)
Perhaps iptables or your kernel needs to be upgraded.`  error="exit status 3"
INFO[2023-06-18T21:13:35.685789976Z] stopping event stream following graceful shutdown  error="<nil>" module=libcontainerd namespace=moby
INFO[2023-06-18T21:13:35.686135505Z] stopping healthcheck following graceful shutdown  module=libcontainerd
INFO[2023-06-18T21:13:35.686174208Z] stopping event stream following graceful shutdown  error="context canceled" module=libcontainerd namespace=plugins.moby
failed to start daemon: Error initializing network controller: error obtaining controller instance: failed to create NAT chain DOCKER: iptables failed: iptables -t nat -N DOCKER: modprobe: FATAL: Module ip_tables not found in directory /lib/modules/4.18.0-348.el8.x86_64
iptables v1.8.7 (legacy): can't initialize iptables table `nat': Table does not exist (do you need to insmod?)
Perhaps iptables or your kernel needs to be upgraded.
 (exit status 3)
```


## After
```
[root@chrisk-centos yk]# docker run --publish 10931:10933 \
>            ...
>            ...
>            ...
>            ...
>            ...
>            --env DISABLE_DIND="N" \
>            --env TargetWorkerPool="Centos" \
>            --env TargetName="centos8.5-2" \
>            ...
>            --env PublicHostNameConfiguration="PublicIP" \
>            docker.packages.octopushq.com/octopusdeploy/tentacle:6.4.50-pull-523-linux
Unable to find image 'docker.packages.octopushq.com/octopusdeploy/tentacle:6.4.50-pull-523-linux' locally
6.4.50-pull-523-linux: Pulling from octopusdeploy/tentacle
759700526b78: Already exists 
cafd06d60458: Already exists 
3776471c0e2a: Pull complete 
d11032a8c397: Pull complete 
26a8056289c3: Pull complete 
87a19d8f91f4: Pull complete 
a038cc5441d6: Pull complete 
f39a7480f4ad: Pull complete 
1f2c943ffebe: Pull complete 
cb20f101b61c: Pull complete 
a8e896e969ca: Pull complete 
161df3b19dd8: Pull complete 
Digest: sha256:7f3bb6339150d4dc221a5009b0b72924c37842b167f47f0ad17a8eb6bee863c0
Status: Downloaded newer image for docker.packages.octopushq.com/octopusdeploy/tentacle:6.4.50-pull-523-linux
===============================================
Configuring Octopus Deploy Tentacle
 - server endpoint 'https://deploy-fnm.testoctopus.app'
 - api key '##########'
 - communication mode 'Listening' (Passive)
 - registered port 10931
 - worker pool 'Centos'
 - host 'PublicIP'
 - name 'centos8.5-2'
 - space 'Default'
===============================================
Creating empty configuration file: /etc/octopus/tentacle.config
Setting home directory to: /etc/octopus
Saving instance: Tentacle
Setting directory paths ...
Application directory set to: /home/Octopus/Applications
These changes require a restart of the Tentacle.
Configuring communication type ...
Services listen port: 10933
Tentacle will listen on a TCP port
These changes require a restart of the Tentacle.
Updating trust ...
Removing all trusted Octopus Servers...
These changes require a restart of the Tentacle.
Creating certificate ...
A new certificate has been generated and installed. Thumbprint:
91A6D3BF585DC66AD6B3BB0A8633651710538C3D
These changes require a restart of the Tentacle.
Registering with server ...
Registering Tentacle with API key
Registering the tentacle with the server at https://deploy-fnm.testoctopus.app/
Detected automation environment: NoneOrUnknown
Machine registered successfully
These changes require a restart of the Tentacle.
Configuration successful.

+ [[ N == \Y ]]
+ echo 'Starting Docker-in-Docker daemon. This requires that this container be run in privileged mode.'
Starting Docker-in-Docker daemon. This requires that this container be run in privileged mode.
+ tentacle agent --instance Tentacle --noninteractive
+ nohup /usr/local/bin/dockerd-entrypoint.sh dockerd
time="2023-06-19T01:26:47.590190302Z" level=info msg="Starting up"
time="2023-06-19T01:26:47.591024270Z" level=info msg="containerd not running, starting managed containerd"
time="2023-06-19T01:26:47.592104558Z" level=info msg="started new containerd process" address=/var/run/docker/containerd/containerd.sock module=libcontainerd pid=122
time="2023-06-19T01:26:47.614792006Z" level=info msg="starting containerd" revision=3dce8eb055cbb6872793272b4f20ed16117344f8 version=1.6.21
time="2023-06-19T01:26:47.628541327Z" level=info msg="loading plugin \"io.containerd.content.v1.content\"..." type=io.containerd.content.v1
time="2023-06-19T01:26:47.628661037Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.aufs\"..." type=io.containerd.snapshotter.v1
time="2023-06-19T01:26:47.628823050Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.aufs\"..." error="aufs is not supported (modprobe aufs failed: exec: \"modprobe\": executable file not found in $PATH \"\"): skip plugin" type=io.containerd.snapshotter.v1
time="2023-06-19T01:26:47.628845352Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." type=io.containerd.snapshotter.v1
time="2023-06-19T01:26:47.629151077Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." error="path /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.btrfs (xfs) must be a btrfs filesystem to be used with the btrfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
time="2023-06-19T01:26:47.629176179Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.devmapper\"..." type=io.containerd.snapshotter.v1
time="2023-06-19T01:26:47.629197480Z" level=warning msg="failed to load plugin io.containerd.snapshotter.v1.devmapper" error="devmapper not configured"
time="2023-06-19T01:26:47.629224382Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.native\"..." type=io.containerd.snapshotter.v1
time="2023-06-19T01:26:47.629357293Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.overlayfs\"..." type=io.containerd.snapshotter.v1
time="2023-06-19T01:26:47.629803430Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.zfs\"..." type=io.containerd.snapshotter.v1
time="2023-06-19T01:26:47.630013147Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.zfs\"..." error="path /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.zfs must be a zfs filesystem to be used with the zfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
time="2023-06-19T01:26:47.630041149Z" level=info msg="loading plugin \"io.containerd.metadata.v1.bolt\"..." type=io.containerd.metadata.v1
time="2023-06-19T01:26:47.630129656Z" level=warning msg="could not use snapshotter devmapper in metadata plugin" error="devmapper not configured"
time="2023-06-19T01:26:47.630148158Z" level=info msg="metadata content store policy set" policy=shared
time="2023-06-19T01:26:47.639176893Z" level=info msg="loading plugin \"io.containerd.differ.v1.walking\"..." type=io.containerd.differ.v1
time="2023-06-19T01:26:47.639209896Z" level=info msg="loading plugin \"io.containerd.event.v1.exchange\"..." type=io.containerd.event.v1
time="2023-06-19T01:26:47.639223997Z" level=info msg="loading plugin \"io.containerd.gc.v1.scheduler\"..." type=io.containerd.gc.v1
time="2023-06-19T01:26:47.639267501Z" level=info msg="loading plugin \"io.containerd.service.v1.introspection-service\"..." type=io.containerd.service.v1
time="2023-06-19T01:26:47.639303904Z" level=info msg="loading plugin \"io.containerd.service.v1.containers-service\"..." type=io.containerd.service.v1
time="2023-06-19T01:26:47.639325206Z" level=info msg="loading plugin \"io.containerd.service.v1.content-service\"..." type=io.containerd.service.v1
time="2023-06-19T01:26:47.639362309Z" level=info msg="loading plugin \"io.containerd.service.v1.diff-service\"..." type=io.containerd.service.v1
time="2023-06-19T01:26:47.639386611Z" level=info msg="loading plugin \"io.containerd.service.v1.images-service\"..." type=io.containerd.service.v1
time="2023-06-19T01:26:47.639407912Z" level=info msg="loading plugin \"io.containerd.service.v1.leases-service\"..." type=io.containerd.service.v1
time="2023-06-19T01:26:47.639427714Z" level=info msg="loading plugin \"io.containerd.service.v1.namespaces-service\"..." type=io.containerd.service.v1
time="2023-06-19T01:26:47.639447015Z" level=info msg="loading plugin \"io.containerd.service.v1.snapshots-service\"..." type=io.containerd.service.v1
time="2023-06-19T01:26:47.639466817Z" level=info msg="loading plugin \"io.containerd.runtime.v1.linux\"..." type=io.containerd.runtime.v1
time="2023-06-19T01:26:47.639660533Z" level=info msg="loading plugin \"io.containerd.runtime.v2.task\"..." type=io.containerd.runtime.v2
time="2023-06-19T01:26:47.639879351Z" level=info msg="loading plugin \"io.containerd.monitor.v1.cgroups\"..." type=io.containerd.monitor.v1
time="2023-06-19T01:26:47.640820627Z" level=info msg="loading plugin \"io.containerd.service.v1.tasks-service\"..." type=io.containerd.service.v1
time="2023-06-19T01:26:47.640893833Z" level=info msg="loading plugin \"io.containerd.grpc.v1.introspection\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.640930436Z" level=info msg="loading plugin \"io.containerd.internal.v1.restart\"..." type=io.containerd.internal.v1
time="2023-06-19T01:26:47.641014243Z" level=info msg="loading plugin \"io.containerd.grpc.v1.containers\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.641046146Z" level=info msg="loading plugin \"io.containerd.grpc.v1.content\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.641073248Z" level=info msg="loading plugin \"io.containerd.grpc.v1.diff\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.641101550Z" level=info msg="loading plugin \"io.containerd.grpc.v1.events\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.641131253Z" level=info msg="loading plugin \"io.containerd.grpc.v1.healthcheck\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.641160855Z" level=info msg="loading plugin \"io.containerd.grpc.v1.images\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.641188557Z" level=info msg="loading plugin \"io.containerd.grpc.v1.leases\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.641215860Z" level=info msg="loading plugin \"io.containerd.grpc.v1.namespaces\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.641666396Z" level=info msg="loading plugin \"io.containerd.internal.v1.opt\"..." type=io.containerd.internal.v1
time="2023-06-19T01:26:47.642084030Z" level=info msg="loading plugin \"io.containerd.grpc.v1.snapshots\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.642117333Z" level=info msg="loading plugin \"io.containerd.grpc.v1.tasks\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.642137235Z" level=info msg="loading plugin \"io.containerd.grpc.v1.version\"..." type=io.containerd.grpc.v1
time="2023-06-19T01:26:47.642160437Z" level=info msg="loading plugin \"io.containerd.tracing.processor.v1.otlp\"..." type=io.containerd.tracing.processor.v1
time="2023-06-19T01:26:47.642184439Z" level=info msg="skip loading plugin \"io.containerd.tracing.processor.v1.otlp\"..." error="no OpenTelemetry endpoint: skip plugin" type=io.containerd.tracing.processor.v1
time="2023-06-19T01:26:47.642197740Z" level=info msg="loading plugin \"io.containerd.internal.v1.tracing\"..." type=io.containerd.internal.v1
time="2023-06-19T01:26:47.642214441Z" level=error msg="failed to initialize a tracing processor \"otlp\"" error="no OpenTelemetry endpoint: skip plugin"
time="2023-06-19T01:26:47.642501564Z" level=info msg=serving... address=/var/run/docker/containerd/containerd-debug.sock
time="2023-06-19T01:26:47.642635975Z" level=info msg=serving... address=/var/run/docker/containerd/containerd.sock.ttrpc
time="2023-06-19T01:26:47.642738984Z" level=info msg=serving... address=/var/run/docker/containerd/containerd.sock
time="2023-06-19T01:26:47.642764186Z" level=info msg="containerd successfully booted in 0.029073s"
time="2023-06-19T01:26:47.699991849Z" level=info msg="Loading containers: start."
time="2023-06-19T01:26:47.700280673Z" level=warning msg="Running modprobe bridge br_netfilter failed with message: , error: exec: \"modprobe\": executable file not found in $PATH"
time="2023-06-19T01:26:47.831292548Z" level=info msg="Loading containers: done."
time="2023-06-19T01:26:47.847845097Z" level=warning msg="WARNING: bridge-nf-call-iptables is disabled"
time="2023-06-19T01:26:47.847871900Z" level=warning msg="WARNING: bridge-nf-call-ip6tables is disabled"
time="2023-06-19T01:26:47.847899102Z" level=info msg="Docker daemon" commit=659604f graphdriver=overlay2 version=24.0.2
time="2023-06-19T01:26:47.848049514Z" level=info msg="Daemon has completed initialization"
time="2023-06-19T01:26:47.889149363Z" level=info msg="API listen on /var/run/docker.sock"

```

# How to review this PR
To verify the changes, run a tentacle container in CentOS (or RHEL) using the image built from this PR with DIND enabled like the following:
```
docker run --publish 10931:10933 \
           --privileged \
           --env ListeningPort="10931" \
           --env ServerApiKey="{apiKey}" \
           --env ServerUrl="{serverUrl" \
           --env ACCEPT_EULA="Y" \
           --env DISABLE_DIND="N" \
           --env TargetWorkerPool="{targetWorkerPool}" \
           --env TargetName="{targetName}" \
           --env CustomPublicHostName="{ip}" \
           --env PublicHostNameConfiguration="PublicIP" \
           docker.packages.octopushq.com/octopusdeploy/tentacle:6.4.50-pull-523-linux
```
The log output should indicate that the docker daemon is running.

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.

[sc-41072]