### PR TITLE
Use Process.Kill recursive API when cancelling scripts in .NET 6

### DIFF
--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
@@ -507,7 +507,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             foreach (var log in logs)
             {
-                TestContext.Out.WriteLine($"{0:yyyy-MM-dd HH:mm:ss}: {1}", log.Occurred, log.Text);
+                TestContext.Out.WriteLine("{0:yyyy-MM-dd HH:mm:ss K}: {1}", log.Occurred.ToLocalTime(), log.Text);
             }
         }
 

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
@@ -507,7 +507,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             foreach (var log in logs)
             {
-                TestContext.Out.WriteLine(log.Text);
+                TestContext.Out.WriteLine($"{0:yyyy-MM-dd HH:mm:ss}: {1}", log.Occurred, log.Text);
             }
         }
 

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
@@ -269,47 +269,44 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task CancelScriptShouldCancelAnExecutingScript()
         {
-            for (int i = 0; i < 100; i++)
+            var bashScript = "sleep 60";
+            var windowsScript = "Start-Sleep -Seconds 60";
+
+            var startScriptCommand = new StartScriptCommandV2Builder()
+                .WithScriptBodyForCurrentOs(windowsScript, bashScript)
+                .Build();
+
+            var cancellationTimer = new Stopwatch();
+            var response = service.StartScript(startScriptCommand);
+            var logs = new List<ProcessOutput>(response.Logs);
+
+            while (response.State != ProcessState.Complete)
             {
-                var bashScript = "sleep 60";
-                var windowsScript = "Start-Sleep -Seconds 60";
+                response = service.GetStatus(new ScriptStatusRequestV2(startScriptCommand.ScriptTicket, response.NextLogSequence));
+                logs.AddRange(response.Logs);
 
-                var startScriptCommand = new StartScriptCommandV2Builder()
-                    .WithScriptBodyForCurrentOs(windowsScript, bashScript)
-                    .Build();
-
-                var cancellationTimer = new Stopwatch();
-                var response = service.StartScript(startScriptCommand);
-                var logs = new List<ProcessOutput>(response.Logs);
-
-                while (response.State != ProcessState.Complete)
+                if (response.State == ProcessState.Running && !cancellationTimer.IsRunning)
                 {
-                    response = service.GetStatus(new ScriptStatusRequestV2(startScriptCommand.ScriptTicket, response.NextLogSequence));
+                    cancellationTimer.Start();
+                    response = service.CancelScript(new CancelScriptCommandV2(startScriptCommand.ScriptTicket, response.NextLogSequence));
                     logs.AddRange(response.Logs);
-
-                    if (response.State == ProcessState.Running && !cancellationTimer.IsRunning)
-                    {
-                        cancellationTimer.Start();
-                        response = service.CancelScript(new CancelScriptCommandV2(startScriptCommand.ScriptTicket, response.NextLogSequence));
-                        logs.AddRange(response.Logs);
-                    }
-
-                    if (response.State != ProcessState.Complete)
-                    {
-                        await Task.Delay(TimeSpan.FromMilliseconds(100));
-                    }
                 }
 
-                cancellationTimer.Stop();
-
-                service.CompleteScript(new CompleteScriptCommandV2(startScriptCommand.ScriptTicket));
-
-                WriteLogsToConsole(logs);
-
-                response.State.Should().Be(ProcessState.Complete);
-                response.ExitCode.Should().NotBe(0, "The exit code varies based on the OS and flakiness with killing the running script");
-                cancellationTimer.Elapsed.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(5));
+                if (response.State != ProcessState.Complete)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100));
+                }
             }
+
+            cancellationTimer.Stop();
+
+            service.CompleteScript(new CompleteScriptCommandV2(startScriptCommand.ScriptTicket));
+
+            WriteLogsToConsole(logs);
+
+            response.State.Should().Be(ProcessState.Complete);
+            response.ExitCode.Should().NotBe(0, "The exit code varies based on the OS and flakiness with killing the running script");
+            cancellationTimer.Elapsed.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(5));
         }
 
         [Test]

--- a/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
@@ -267,14 +267,19 @@ namespace Octopus.Tentacle.Util
                 //process.Kill() doesnt seem to work in netcore 2.2 there have been some improvments in netcore 3.0 as well as also allowing to kill child processes
                 //https://github.com/dotnet/corefx/pull/34147
                 //In netcore 2.2 if the process is terminated we still get stuck on process.WaitForExit(); we need to manually check to see if the process has exited and then close it.
-                if (process.HasExited)
+                for (int i = 0; i < 5; i++)
                 {
-                    debug($"Closing process to clean up resources: {process.Id}");
-                    process.Close();
-                }
-                else
-                {
-                    debug($"Process hadn't exited for some reason: {process.Id}");
+                    if (process.HasExited)
+                    {
+                        debug($"Closing process to clean up resources: {process.Id}");
+                        process.Close();
+                        break;
+                    }
+                    else
+                    {
+                        debug($"Process hasn't exited yet, retrying {i+1} of 5 times with a small wait to see if it has exited: {process.Id}");
+                        Thread.Sleep(100);
+                    }
                 }
             }
 

--- a/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
@@ -261,7 +261,10 @@ namespace Octopus.Tentacle.Util
 
             static void TryKillLinuxProcessAndChildrenRecursively(Process process, Action<string> debug)
             {
+#if !NETFRAMEWORK
                 process.Kill(true);
+#endif
+                // .NET framework doesn't run on Linux/OSX, so nothing else to do here
                 //debug($"Attempting to kill Linux process and children recursively: {process.Id}");
                 //var result = ExecuteCommand(new CommandLineInvocation("/bin/bash", $"-c \"kill -TERM {process.Id}\""));
                 //result.Validate();
@@ -338,8 +341,8 @@ namespace Octopus.Tentacle.Util
                 {
                     // Process already exited.
                 }
-            }
 #endif
+            }
         }
 
         internal class EncodingDetector

--- a/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
@@ -251,46 +251,17 @@ namespace Octopus.Tentacle.Util
         {
             public static void TryKillProcessAndChildrenRecursively(Process process, Action<string> debug)
             {
-                if (PlatformDetection.IsRunningOnNix || PlatformDetection.IsRunningOnMac)
-                    TryKillLinuxProcessAndChildrenRecursively(process, debug);
-                else if (PlatformDetection.IsRunningOnWindows)
-                    TryKillWindowsProcessAndChildrenRecursively(process.Id, debug);
-                else
-                    throw new Exception("Unknown platform, unable to kill process");
-            }
-
-            static void TryKillLinuxProcessAndChildrenRecursively(Process process, Action<string> debug)
-            {
-#if !NETFRAMEWORK
+#if NETFRAMEWORK
+                TryKillWindowsProcessAndChildrenRecursively(process.Id, debug);
+#endif
+#if NET6_0_OR_GREATER
+                // Since .NET Core 3.0 there is support for killing a process and it's children 
                 process.Kill(true);
 #endif
-                // .NET framework doesn't run on Linux/OSX, so nothing else to do here
-                //debug($"Attempting to kill Linux process and children recursively: {process.Id}");
-                //var result = ExecuteCommand(new CommandLineInvocation("/bin/bash", $"-c \"kill -TERM {process.Id}\""));
-                //result.Validate();
-                ////process.Kill() doesnt seem to work in netcore 2.2 there have been some improvments in netcore 3.0 as well as also allowing to kill child processes
-                ////https://github.com/dotnet/corefx/pull/34147
-                ////In netcore 2.2 if the process is terminated we still get stuck on process.WaitForExit(); we need to manually check to see if the process has exited and then close it.
-                ////for (int i = 0; i < 5; i++)
-                ////{
-                //    if (process.HasExited)
-                //    {
-                //        debug($"Closing process to clean up resources: {process.Id}");
-                //        process.Close();
-                //        //break;
-                //    }
-                //    else
-                //    {
-                //        debug($"Process hasn't exited yet: {process.Id}");
-                //        //debug($"Process hasn't exited yet, retrying {i+1} of 5 times with a small wait to see if it has exited: {process.Id}");
-                //        //Thread.Sleep(100);
-                //    }
-                ////}
             }
 
             static void TryKillWindowsProcessAndChildrenRecursively(int pid, Action<string> debug)
             {
-#if NETFRAMEWORK
                 try
                 {
                     debug($"Attempting to kill Windows process and children recursively via management objects: {pid}");
@@ -327,21 +298,6 @@ namespace Octopus.Tentacle.Util
                 {
                     // Process already exited.
                 }
-#endif
-#if !NETFRAMEWORK
-
-                try
-                {
-                    debug($"Attempting to kill Windows process via .Kill(): {pid}");
-
-                    var proc = Process.GetProcessById(pid);
-                    proc.Kill(true);
-                }
-                catch (ArgumentException)
-                {
-                    // Process already exited.
-                }
-#endif
             }
         }
 

--- a/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
@@ -267,20 +267,21 @@ namespace Octopus.Tentacle.Util
                 //process.Kill() doesnt seem to work in netcore 2.2 there have been some improvments in netcore 3.0 as well as also allowing to kill child processes
                 //https://github.com/dotnet/corefx/pull/34147
                 //In netcore 2.2 if the process is terminated we still get stuck on process.WaitForExit(); we need to manually check to see if the process has exited and then close it.
-                for (int i = 0; i < 5; i++)
-                {
+                //for (int i = 0; i < 5; i++)
+                //{
                     if (process.HasExited)
                     {
                         debug($"Closing process to clean up resources: {process.Id}");
                         process.Close();
-                        break;
+                        //break;
                     }
                     else
                     {
-                        debug($"Process hasn't exited yet, retrying {i+1} of 5 times with a small wait to see if it has exited: {process.Id}");
-                        Thread.Sleep(100);
+                        debug($"Process hasn't exited yet: {process.Id}");
+                        //debug($"Process hasn't exited yet, retrying {i+1} of 5 times with a small wait to see if it has exited: {process.Id}");
+                        //Thread.Sleep(100);
                     }
-                }
+                //}
             }
 
             static void TryKillWindowsProcessAndChildrenRecursively(int pid, Action<string> debug)


### PR DESCRIPTION
# Background

There's been a recent increase of intermittently failing integration tests for cancellation of running scripts on Linux. 

This has been tracked down to the way that we currently do process cleanup in Linux:
- Run a bash script `kill -TERM {pid}` and check this succeeded
- Check if the process has exited (`Process.HasExited`) and close the process to ensure that it releases any underlying resources (`Process.Close`). 
- Wait for the process to exit: `Process.WaitForExit()`.

It appears that sometimes `Process.HasExited` returns false and we don't close the underlying process resource, and this causes `WaitForExit` to block until the process finishes. Whether the process never really receives the call to exit properly, or there is some strange behaviour with child processes and output streams as outlined in this [runtime issue](https://github.com/dotnet/runtime/issues/29232) is a bit unclear. The behaviour we see is that the process runs until completion and result in our tests failing, but it's probable that cancellation just doesn't work sometimes in the wild.

# Results

This PR changes the way that processes are stopped by using the new overload `Process.Kill(recursive: true)` that exists in .NET 3.0 onwards. 

The .NET Framework doesn't have this new API so we continue to use the existing Windows specific method where we iterate the child processes through management object searching and clean them all up.

Shortcut [sc-48624]

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/528

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:

I confirmed the improved behaviour here by modifying the intermittently failing test to run in a loop 100 times, which surfaced the issue quite regularly, see [this test run](https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacleNet48_SensibleDefaultsChainFullChain/8445673?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandPull+Request+Details=true&expandBuildProblemsSection=true&expandBuildTestsSection=true) that also had some additional logging showing what was happening.

<img width="1184" alt="image" src="https://github.com/OctopusDeploy/OctopusTentacle/assets/2915931/209074dd-243e-4867-95e1-f2145087169f">

<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.