### PR TITLE
Making TimedOperation constructor public

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Observability/TimedOperation.cs
+++ b/source/Octopus.Tentacle.Contracts/Observability/TimedOperation.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Contracts.Observability
 
         public bool Succeeded => Exception is null;
 
-        private TimedOperation(DateTimeOffset start, DateTimeOffset end, Exception? exception, bool wasCancelled)
+        public TimedOperation(DateTimeOffset start, DateTimeOffset end, Exception? exception, bool wasCancelled)
         {
             Start = start;
             End = end;


### PR DESCRIPTION
[sc-46303]

# Background

While writing unit tests in Octopus Server, we needed to craft the `TimedOperation` appropriately.

# Results
Fixes https://github.com/OctopusDeploy/Issues/issues/8229

## Before
There was no way of changing the values of a `TimedOperation`

## After

The constructor is now public, allowing us to make the appropriate scenarios in Octopus Server

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.