### PR TITLE
Adding which service was called to RPC metrics

### DIFF
--- a/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
+++ b/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
@@ -22,14 +22,14 @@ namespace Octopus.Tentacle.Client.Execution
         public TimeSpan RetryTimeout => rpcCallRetryHandler.RetryTimeout;
 
         public async Task<T> ExecuteWithRetries<T>(
-            string rpcCallName,
+            RpcCall rpcCall,
             Func<CancellationToken, T> action,
             ILog logger,
             bool abandonActionOnCancellation,
             ClientOperationMetricsBuilder clientOperationMetricsBuilder,
             CancellationToken cancellationToken)
         {
-            var rpcCallMetricsBuilder = RpcCallMetricsBuilder.StartWithRetries(rpcCallName, rpcCallRetryHandler.RetryTimeout);
+            var rpcCallMetricsBuilder = RpcCallMetricsBuilder.StartWithRetries(rpcCall, rpcCallRetryHandler.RetryTimeout);
 
             try
             {
@@ -85,12 +85,12 @@ namespace Octopus.Tentacle.Client.Execution
         }
 
         public T Execute<T>(
-            string rpcCallName,
+            RpcCall rpcCall,
             Func<CancellationToken, T> action,
             ClientOperationMetricsBuilder clientOperationMetricsBuilder,
             CancellationToken cancellationToken)
         {
-            var rpcCallMetricsBuilder = RpcCallMetricsBuilder.StartWithoutRetries(rpcCallName);
+            var rpcCallMetricsBuilder = RpcCallMetricsBuilder.StartWithoutRetries(rpcCall);
             var start = DateTimeOffset.UtcNow;
 
             try
@@ -115,12 +115,12 @@ namespace Octopus.Tentacle.Client.Execution
         }
 
         public void Execute(
-            string rpcCallName,
+            RpcCall rpcCall,
             Action<CancellationToken> action,
             ClientOperationMetricsBuilder clientOperationMetricsBuilder,
             CancellationToken cancellationToken)
         {
-            var rpcCallMetricsBuilder = RpcCallMetricsBuilder.StartWithoutRetries(rpcCallName);
+            var rpcCallMetricsBuilder = RpcCallMetricsBuilder.StartWithoutRetries(rpcCall);
             var start = DateTimeOffset.UtcNow;
 
             try

--- a/source/Octopus.Tentacle.Client/Observability/RpcCallMetricsBuilder.cs
+++ b/source/Octopus.Tentacle.Client/Observability/RpcCallMetricsBuilder.cs
@@ -7,7 +7,7 @@ namespace Octopus.Tentacle.Client.Observability
 {
     internal class RpcCallMetricsBuilder
     {
-        private readonly string rpcCallName;
+        private readonly RpcCall rpcCall;
         private readonly DateTimeOffset start;
         private readonly TimeSpan retryTimeout;
         private readonly bool withRetries;
@@ -16,27 +16,27 @@ namespace Octopus.Tentacle.Client.Observability
         private Exception? exception;
         private bool wasCancelled;
 
-        private RpcCallMetricsBuilder(string rpcCallName, DateTimeOffset start, bool withRetries, TimeSpan retryTimeout)
+        private RpcCallMetricsBuilder(RpcCall rpcCall, DateTimeOffset start, bool withRetries, TimeSpan retryTimeout)
         {
-            this.rpcCallName = rpcCallName;
+            this.rpcCall = rpcCall;
             this.start = start;
             this.retryTimeout = retryTimeout;
             this.withRetries = withRetries;
         }
 
-        public static RpcCallMetricsBuilder StartWithRetries(string rpcCallName, TimeSpan retryTimeout)
+        public static RpcCallMetricsBuilder StartWithRetries(RpcCall rpcCall, TimeSpan retryTimeout)
         {
             var start = DateTimeOffset.UtcNow;
 
-            var builder = new RpcCallMetricsBuilder(rpcCallName, start, true, retryTimeout);
+            var builder = new RpcCallMetricsBuilder(rpcCall, start, true, retryTimeout);
             return builder;
         }
 
-        public static RpcCallMetricsBuilder StartWithoutRetries(string rpcCallName)
+        public static RpcCallMetricsBuilder StartWithoutRetries(RpcCall rpcCall)
         {
             var start = DateTimeOffset.UtcNow;
 
-            var builder = new RpcCallMetricsBuilder(rpcCallName, start, false, TimeSpan.Zero);
+            var builder = new RpcCallMetricsBuilder(rpcCall, start, false, TimeSpan.Zero);
             return builder;
         }
 
@@ -60,7 +60,7 @@ namespace Octopus.Tentacle.Client.Observability
             var end = DateTimeOffset.UtcNow;
 
             var rpcCallMetrics = new RpcCallMetrics(
-                rpcCallName,
+                rpcCall,
                 start,
                 end,
                 withRetries,

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionOrchestrator.cs
@@ -10,6 +10,7 @@ using Octopus.Tentacle.Client.Execution;
 using Octopus.Tentacle.Client.Observability;
 using Octopus.Tentacle.Client.Retries;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.Observability;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using ILog = Octopus.Diagnostics.ILog;
 
@@ -74,7 +75,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 try
                 {
                     scriptStatusResponse = await rpcCallExecutor.ExecuteWithRetries(
-                        nameof(scriptServiceV2.StartScript),
+                        RpcCall.Create<IClientScriptServiceV2>(nameof(IClientScriptServiceV2.StartScript)),
                         ct =>
                         {
                             ++startScriptCallCount;
@@ -117,7 +118,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 var startScriptCommandV1 = Map(startScriptCommand);
 
                 var scriptTicket = rpcCallExecutor.Execute(
-                    nameof(scriptServiceV1.StartScript),
+                    RpcCall.Create<IClientScriptService>(nameof(IClientScriptService.StartScript)),
                     ct => scriptServiceV1.StartScript(startScriptCommandV1, new HalibutProxyRequestOptions(ct)),
                     clientOperationMetricsBuilder,
                     scriptExecutionCancellationToken);
@@ -141,7 +142,7 @@ namespace Octopus.Tentacle.Client.Scripts
             logger.Verbose("Determining ScriptService version to use");
 
             var tentacleCapabilities = await rpcCallExecutor.ExecuteWithRetries(
-                nameof(capabilitiesServiceV2.GetCapabilities),
+                RpcCall.Create<IClientCapabilitiesServiceV2>(nameof(IClientCapabilitiesServiceV2.GetCapabilities)),
                 ct =>
                 {
                     return capabilitiesServiceV2.GetCapabilities(new HalibutProxyRequestOptions(ct));
@@ -244,7 +245,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 try
                 {
                     return await rpcCallExecutor.ExecuteWithRetries(
-                        nameof(scriptServiceV2.GetStatus),
+                        RpcCall.Create<IClientScriptServiceV2>(nameof(IClientScriptServiceV2.GetStatus)),
                         ct =>
                         {
                             return scriptServiceV2.GetStatus(new ScriptStatusRequestV2(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence), new HalibutProxyRequestOptions(ct));
@@ -264,7 +265,7 @@ namespace Octopus.Tentacle.Client.Scripts
             else
             {
                 var scriptStatusResponseV1 = rpcCallExecutor.Execute(
-                    nameof(scriptServiceV1.GetStatus),
+                    RpcCall.Create<IClientScriptService>(nameof(IClientScriptService.GetStatus)),
                     ct => scriptServiceV1.GetStatus(new ScriptStatusRequest(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence), new HalibutProxyRequestOptions(ct)),
                     clientOperationMetricsBuilder,
                     cancellationToken);
@@ -282,7 +283,7 @@ namespace Octopus.Tentacle.Client.Scripts
             if (scriptServiceVersionToUse == ScriptServiceVersion.Version2)
             {
                 return await rpcCallExecutor.ExecuteWithRetries(
-                    nameof(scriptServiceV2.CancelScript),
+                    RpcCall.Create<IClientScriptServiceV2>(nameof(IClientScriptServiceV2.CancelScript)),
                     ct =>
                     {
                         return scriptServiceV2.CancelScript(new CancelScriptCommandV2(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence), new HalibutProxyRequestOptions(ct));
@@ -296,7 +297,7 @@ namespace Octopus.Tentacle.Client.Scripts
             else
             {
                 var scriptStatusResponseV1 = rpcCallExecutor.Execute(
-                    nameof(scriptServiceV1.CancelScript),
+                    RpcCall.Create<IClientScriptService>(nameof(IClientScriptService.CancelScript)),
                     ct => scriptServiceV1.CancelScript(new CancelScriptCommand(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence), new HalibutProxyRequestOptions(ct)),
                     clientOperationMetricsBuilder,
                     cancellationToken);
@@ -320,7 +321,7 @@ namespace Octopus.Tentacle.Client.Scripts
                     var actionTask = Task.Run(() =>
                     {
                         rpcCallExecutor.Execute(
-                            nameof(scriptServiceV2.CompleteScript),
+                            RpcCall.Create<IClientScriptServiceV2>(nameof(IClientScriptServiceV2.CompleteScript)),
                             ct => scriptServiceV2.CompleteScript(new CompleteScriptCommandV2(lastStatusResponse.Ticket), new HalibutProxyRequestOptions(ct)),
                             clientOperationMetricsBuilder,
                             CancellationToken.None);
@@ -356,7 +357,7 @@ namespace Octopus.Tentacle.Client.Scripts
             else
             {
                 var completeStatusV1 = rpcCallExecutor.Execute(
-                    nameof(scriptServiceV1.CompleteScript),
+                    RpcCall.Create<IClientScriptService>(nameof(IClientScriptService.CompleteScript)),
                     ct => scriptServiceV1.CompleteScript(new CompleteScriptCommand(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence), new HalibutProxyRequestOptions(ct)),
                     clientOperationMetricsBuilder,
                     CancellationToken.None);

--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -8,13 +8,11 @@ using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Client.Decorators;
 using Octopus.Tentacle.Client.Execution;
 using Octopus.Tentacle.Client.Observability;
-using Octopus.Tentacle.Client.Retries;
 using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.Observability;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
-using Polly.Timeout;
 using ILog = Octopus.Diagnostics.ILog;
 
 namespace Octopus.Tentacle.Client
@@ -82,7 +80,7 @@ namespace Octopus.Tentacle.Client
             try
             {
                 return await rpcCallExecutor.ExecuteWithRetries(
-                    nameof(fileTransferServiceV1.UploadFile),
+                    RpcCall.Create<IClientFileTransferService>(nameof(IClientFileTransferService.UploadFile)),
                     ct =>
                     {
                         logger.Info($"Beginning upload of {fileName} to Tentacle");
@@ -114,7 +112,7 @@ namespace Octopus.Tentacle.Client
             try
             {
                 var dataStream = await rpcCallExecutor.ExecuteWithRetries(
-                    nameof(fileTransferServiceV1.DownloadFile),
+                    RpcCall.Create<IClientFileTransferService>(nameof(IClientFileTransferService.DownloadFile)),
                     ct =>
                     {
                         logger.Info($"Beginning download of {Path.GetFileName(remotePath)} from Tentacle");

--- a/source/Octopus.Tentacle.Contracts/Observability/RpcCall.cs
+++ b/source/Octopus.Tentacle.Contracts/Observability/RpcCall.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Octopus.Tentacle.Contracts.Observability
+{
+    public class RpcCall
+    {
+        public string Service { get; }
+        public string Name { get; }
+
+        public RpcCall(string service, string name)
+        {
+            Service = service;
+            Name = name;
+        }
+
+        public override string ToString() => $"{Service}.{Name}";
+
+        public static RpcCall Create<T>(string name) => new(typeof(T).Name, name);
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/Observability/RpcCallMetrics.cs
+++ b/source/Octopus.Tentacle.Contracts/Observability/RpcCallMetrics.cs
@@ -6,7 +6,7 @@ namespace Octopus.Tentacle.Contracts.Observability
 {
     public class RpcCallMetrics
     {
-        public string RpcCallName { get; }
+        public RpcCall RpcCall { get; }
         public DateTimeOffset Start { get; }
         public DateTimeOffset End { get; }
         public bool WithRetries { get; }
@@ -23,7 +23,7 @@ namespace Octopus.Tentacle.Contracts.Observability
 
 
         public RpcCallMetrics(
-            string rpcCallName,
+            RpcCall rpcCall,
             DateTimeOffset start,
             DateTimeOffset end,
             bool withRetries,
@@ -32,7 +32,7 @@ namespace Octopus.Tentacle.Contracts.Observability
             bool wasCancelled,
             IReadOnlyList<TimedOperation> attempts)
         {
-            RpcCallName = rpcCallName;
+            RpcCall = rpcCall;
             Start = start;
             End = end;
             WithRetries = withRetries;

--- a/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
@@ -44,10 +44,10 @@ namespace Octopus.Tentacle.Tests.Integration
             ThenClientOperationMetricsShouldBeSuccessful(executeScriptMetrics);
 
             tentacleClientObserver.RpcCallMetrics.Should().NotBeEmpty();
-            tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCallName == nameof(IClientCapabilitiesServiceV2.GetCapabilities));
-            tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCallName == nameof(IClientScriptServiceV2.StartScript));
-            tentacleClientObserver.RpcCallMetrics.Should().Contain(m => m.RpcCallName == nameof(IClientScriptServiceV2.GetStatus));
-            tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCallName == nameof(IClientScriptServiceV2.CompleteScript));
+            tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCall.Name == nameof(IClientCapabilitiesServiceV2.GetCapabilities));
+            tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCall.Name == nameof(IClientScriptServiceV2.StartScript));
+            tentacleClientObserver.RpcCallMetrics.Should().Contain(m => m.RpcCall.Name == nameof(IClientScriptServiceV2.GetStatus));
+            tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCall.Name == nameof(IClientScriptServiceV2.CompleteScript));
             tentacleClientObserver.RpcCallMetrics.Should().AllSatisfy(m => m.Succeeded.Should().BeTrue());
         }
 
@@ -80,7 +80,7 @@ namespace Octopus.Tentacle.Tests.Integration
             ThenClientOperationMetricsShouldBeFailed(executeScriptMetrics, exception);
 
             tentacleClientObserver.RpcCallMetrics.Should().NotBeEmpty();
-            var startScriptMetric = tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCallName == "StartScript").Subject;
+            var startScriptMetric = tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCall.Name == "StartScript").Subject;
             startScriptMetric.Succeeded.Should().BeFalse();
         }
 
@@ -106,7 +106,8 @@ namespace Octopus.Tentacle.Tests.Integration
 
             tentacleClientObserver.RpcCallMetrics.Should().HaveCountGreaterThan(0);
             var metric = tentacleClientObserver.RpcCallMetrics.Last();
-            metric.RpcCallName.Should().Be(nameof(IClientFileTransferService.UploadFile));
+            metric.RpcCall.Name.Should().Be(nameof(IClientFileTransferService.UploadFile));
+            metric.RpcCall.Service.Should().Be(nameof(IClientFileTransferService));
             metric.Succeeded.Should().BeTrue();
         }
 
@@ -136,7 +137,8 @@ namespace Octopus.Tentacle.Tests.Integration
 
             tentacleClientObserver.RpcCallMetrics.Should().NotBeEmpty();
             var metric = tentacleClientObserver.RpcCallMetrics.Last();
-            metric.RpcCallName.Should().Be(nameof(IClientFileTransferService.UploadFile));
+            metric.RpcCall.Name.Should().Be(nameof(IClientFileTransferService.UploadFile));
+            metric.RpcCall.Service.Should().Be(nameof(IClientFileTransferService));
             metric.Succeeded.Should().BeFalse();
         }
 
@@ -163,7 +165,8 @@ namespace Octopus.Tentacle.Tests.Integration
 
             tentacleClientObserver.RpcCallMetrics.Should().HaveCountGreaterThan(1); // the first one will be the upload
             var metric = tentacleClientObserver.RpcCallMetrics.Last();
-            metric.RpcCallName.Should().Be(nameof(IClientFileTransferService.DownloadFile));
+            metric.RpcCall.Name.Should().Be(nameof(IClientFileTransferService.DownloadFile));
+            metric.RpcCall.Service.Should().Be(nameof(IClientFileTransferService));
             metric.Succeeded.Should().BeTrue();
         }
 
@@ -194,7 +197,8 @@ namespace Octopus.Tentacle.Tests.Integration
 
             tentacleClientObserver.RpcCallMetrics.Should().HaveCountGreaterThan(1); // the first one will be the upload
             var metric = tentacleClientObserver.RpcCallMetrics.Last();
-            metric.RpcCallName.Should().Be(nameof(IClientFileTransferService.DownloadFile));
+            metric.RpcCall.Name.Should().Be(nameof(IClientFileTransferService.DownloadFile));
+            metric.RpcCall.Service.Should().Be(nameof(IClientFileTransferService));
             metric.Succeeded.Should().BeFalse();
         }
 

--- a/source/Octopus.Tentacle.Tests/Client/RpcCallExecutorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Client/RpcCallExecutorFixture.cs
@@ -18,6 +18,7 @@ namespace Octopus.Tentacle.Tests.Client
     public class RpcCallExecutorFixture
     {
         private const string RpcCallName = "GetStatus";
+        private const string RpcService = "ScriptService";
         private static readonly TimeSpan RetryDuration = TimeSpan.FromMinutes(1);
 
         [Test]
@@ -293,7 +294,7 @@ namespace Octopus.Tentacle.Tests.Client
             var sut = RpcCallExecutorFactory.Create(retryDuration, tentacleClientObserver);
 
             await sut.ExecuteWithRetries(
-                RpcCallName,
+                new RpcCall(RpcService, RpcCallName),
                 action,
                 Substitute.For<ILog>(),
                 false,
@@ -311,7 +312,7 @@ namespace Octopus.Tentacle.Tests.Client
             var sut = RpcCallExecutorFactory.Create(retryDuration, tentacleClientObserver);
 
             return sut.Execute(
-                RpcCallName,
+                new RpcCall(RpcService, RpcCallName),
                 action,
                 clientOperationMetricsBuilder,
                 cancellationToken);
@@ -327,7 +328,7 @@ namespace Octopus.Tentacle.Tests.Client
             var sut = RpcCallExecutorFactory.Create(retryDuration, tentacleClientObserver);
 
             sut.Execute(
-                RpcCallName,
+                new RpcCall(RpcService, RpcCallName),
                 action,
                 clientOperationMetricsBuilder,
                 cancellationToken);
@@ -353,7 +354,8 @@ namespace Octopus.Tentacle.Tests.Client
             metric.Duration.Should().Be(metric.End - metric.Start);
 
             metric.RetryTimeout.Should().Be(expectedRetryDuration);
-            metric.RpcCallName.Should().Be(RpcCallName);
+            metric.RpcCall.Name.Should().Be(RpcCallName);
+            metric.RpcCall.Service.Should().Be(RpcService);
             metric.WithRetries.Should().Be(expectedWithRetries);
         }
 
@@ -370,7 +372,8 @@ namespace Octopus.Tentacle.Tests.Client
             metric.Duration.Should().Be(metric.End - metric.Start);
 
             metric.RetryTimeout.Should().Be(expectedRetryDuration);
-            metric.RpcCallName.Should().Be(RpcCallName);
+            metric.RpcCall.Name.Should().Be(RpcCallName);
+            metric.RpcCall.Service.Should().Be(RpcService);
             metric.WithRetries.Should().Be(expectedWithRetries);
         }
 


### PR DESCRIPTION
[sc-52746]

# Background

We need to know if our new feature is being used. To populate the respective metrics in Octopus Server, we will achieve this by knowing which service was called.

# Results

Related to https://github.com/OctopusDeploy/Issues/issues/8229

## Before

Only the method name was recorded in the metrics.

## After
The service name is added as well.

We went with the name of the interface instead of the object, as the object tends to be a decorator and other unhelpful classes.

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.