### PR TITLE
Use the updated (latest available) TeamCity.VSTest.TestAdapter.

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -35,7 +35,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
+        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <Reference Include="System.DirectoryServices.AccountManagement" Condition="'$(TargetFramework)' == 'net48'" />
         <Reference Include="System.IdentityModel" Condition="'$(TargetFramework)' == 'net48'" />

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
   </ItemGroup>
   <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
     <!--


### PR DESCRIPTION
# Background

The nightly build for Tentacle has been intermittently failing due to the test runner failing to parse the report file.

There's no exact area that can pinpoint the issue, however, one of the potential causes could be the outdated `TeamCity.VSTest.TestAdapter` plugin used in Tentacle.

# Results

Updating the version to the (latest available) `1.0.36`
- There're a number of [fixes](https://github.com/JetBrains/TeamCity.VSTest.TestAdapter/releases) since the `1.0.15` release

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.