### PR TITLE
Renaming services to be inline with existing logging

### DIFF
--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -80,7 +80,7 @@ namespace Octopus.Tentacle.Client
             try
             {
                 return await rpcCallExecutor.ExecuteWithRetries(
-                    RpcCall.Create<IClientFileTransferService>(nameof(IClientFileTransferService.UploadFile)),
+                    RpcCall.Create<IFileTransferService>(nameof(IFileTransferService.UploadFile)),
                     ct =>
                     {
                         logger.Info($"Beginning upload of {fileName} to Tentacle");
@@ -112,7 +112,7 @@ namespace Octopus.Tentacle.Client
             try
             {
                 var dataStream = await rpcCallExecutor.ExecuteWithRetries(
-                    RpcCall.Create<IClientFileTransferService>(nameof(IClientFileTransferService.DownloadFile)),
+                    RpcCall.Create<IFileTransferService>(nameof(IFileTransferService.DownloadFile)),
                     ct =>
                     {
                         logger.Info($"Beginning download of {Path.GetFileName(remotePath)} from Tentacle");

--- a/source/Octopus.Tentacle.Tests/Client/RpcCallExecutorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Client/RpcCallExecutorFixture.cs
@@ -11,14 +11,15 @@ using Octopus.Tentacle.Client.Execution;
 using Octopus.Tentacle.Client.Observability;
 using Octopus.Tentacle.CommonTestUtils;
 using Octopus.Tentacle.Contracts.Observability;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
 namespace Octopus.Tentacle.Tests.Client
 {
     [TestFixture]
     public class RpcCallExecutorFixture
     {
-        private const string RpcCallName = "GetStatus";
-        private const string RpcService = "ScriptService";
+        private const string RpcCallName = nameof(IScriptServiceV2.GetStatus);
+        private const string RpcService = nameof(IScriptServiceV2);
         private static readonly TimeSpan RetryDuration = TimeSpan.FromMinutes(1);
 
         [Test]


### PR DESCRIPTION
[sc-53091]

# Background

The tentacle client observability work recorded the service names as `IClient....`

But to ensure the metrics continue from what was originally called, we need to remove the Client part.

# Results

Related to https://github.com/OctopusDeploy/Issues/issues/8229

## Before

Service names had the `Client` version of the service observed

## After

We now have the non-Client version of the service observed

# How to review this PR
A touch of code tidying was done. But not much.

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.