### PR TITLE
The service decorator interface is now internal

### DIFF
--- a/source/Octopus.Tentacle.Client/ITentacleServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleServiceDecorator.cs
@@ -5,7 +5,7 @@ using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
 namespace Octopus.Tentacle.Client
 {
-    public interface ITentacleServiceDecorator
+    internal interface ITentacleServiceDecorator
     {
         public IClientScriptService Decorate(IClientScriptService scriptService);
 

--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -32,6 +32,16 @@ namespace Octopus.Tentacle.Client
             IHalibutRuntime halibutRuntime,
             IScriptObserverBackoffStrategy scriptObserverBackOffStrategy,
             TimeSpan retryDuration,
+            ITentacleClientObserver tentacleClientObserver) : 
+                this(serviceEndPoint, halibutRuntime, scriptObserverBackOffStrategy, retryDuration, tentacleClientObserver, null)
+        {
+        }
+
+        internal TentacleClient(
+            ServiceEndPoint serviceEndPoint,
+            IHalibutRuntime halibutRuntime,
+            IScriptObserverBackoffStrategy scriptObserverBackOffStrategy,
+            TimeSpan retryDuration,
             ITentacleClientObserver tentacleClientObserver,
             ITentacleServiceDecorator? tentacleServicesDecorator)
         {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -44,7 +44,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             return this;
         }
 
-        public ClientAndTentacleBuilder WithTentacleServiceDecorator(ITentacleServiceDecorator tentacleServiceDecorator)
+        internal ClientAndTentacleBuilder WithTentacleServiceDecorator(ITentacleServiceDecorator tentacleServiceDecorator)
         {
             this.tentacleServiceDecorator = tentacleServiceDecorator;
 

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
@@ -64,7 +64,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             return this;
         }
 
-        public ITentacleServiceDecorator Build()
+        internal ITentacleServiceDecorator Build()
         {
             return new FooTentacleServiceDecorator(Combine(scriptServiceDecorator), Combine(scriptServiceV2Decorator), Combine(fileTransferServiceDecorator), Combine(capabilitiesServiceV2Decorator));
         }


### PR DESCRIPTION
# Background

Makes the service decorators internal, to avoid clients depending on it.

[SC-51186]
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.