### PR TITLE
Remove the Alpha label from Script Service V2

### DIFF
--- a/source/Octopus.Tentacle.Client/Capabilities/CapabilitiesResponseV2ExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Client/Capabilities/CapabilitiesResponseV2ExtensionMethods.cs
@@ -13,8 +13,7 @@ namespace Octopus.Tentacle.Client.Capabilities
                 return false;
             }
 
-            return capabilities.SupportedCapabilities.Contains($"{nameof(IScriptServiceV2)}Alpha") ||
-                capabilities.SupportedCapabilities.Contains($"{nameof(IScriptServiceV2)}");
+            return capabilities.SupportedCapabilities.Contains($"{nameof(IScriptServiceV2)}");
         }
     }
 }

--- a/source/Octopus.Tentacle.Client/Capabilities/CapabilitiesResponseV2ExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Client/Capabilities/CapabilitiesResponseV2ExtensionMethods.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Client.Capabilities
                 return false;
             }
 
-            return capabilities.SupportedCapabilities.Contains($"{nameof(IScriptServiceV2)}");
+            return capabilities.SupportedCapabilities.Contains(nameof(IScriptServiceV2));
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
@@ -51,7 +51,7 @@ namespace Octopus.Tentacle.Tests.Integration
             capabilities.Should().Contain("IFileTransferService");
             if (version == null)
             {
-                capabilities.Should().Contain("IScriptServiceV2Alpha");
+                capabilities.Should().Contain("IScriptServiceV2");
                 capabilities.Count.Should().Be(3);
             }
             else

--- a/source/Octopus.Tentacle.Tests/Capabilities/CapabilitiesServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Capabilities/CapabilitiesServiceV2Fixture.cs
@@ -15,7 +15,7 @@ namespace Octopus.Tentacle.Tests.Capabilities
 
             capabilities.Should().Contain("IScriptService");
             capabilities.Should().Contain("IFileTransferService");
-            capabilities.Should().Contain("IScriptServiceV2Alpha");
+            capabilities.Should().Contain("IScriptServiceV2");
             capabilities.Count.Should().Be(3);
         }
     }

--- a/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesServiceV2.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Services.Capabilities
     {
         public CapabilitiesResponseV2 GetCapabilities()
         {
-            return new CapabilitiesResponseV2(new List<string>() {nameof(IScriptService), nameof(IFileTransferService), nameof(IScriptServiceV2) + "Alpha"});
+            return new CapabilitiesResponseV2(new List<string>() {nameof(IScriptService), nameof(IFileTransferService), nameof(IScriptServiceV2)});
         }
     }
 }


### PR DESCRIPTION
# Background

As part of rolling out RPC Retries, we will remove the Alpha label from ScriptServiceV2 before we rollout to Production.

This PR will not be merged until we reach [Stage II of rollout](https://docs.google.com/document/d/15drkongEmMkUP1viPKk-LyxFC2AxfnD5e5MgQK0VCs8/edit#heading=h.vhq8icw36cx7)

Related Server change https://github.com/OctopusDeploy/OctopusDeploy/pull/19057

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.