### PR TITLE
Observe errors from task that are abandoned to stop UnobservedExceptions being handled by the Finalizer

### DIFF
--- a/source/Octopus.Tentacle.Client/Retries/RpcCallRetryHandler.cs
+++ b/source/Octopus.Tentacle.Client/Retries/RpcCallRetryHandler.cs
@@ -128,7 +128,14 @@ namespace Octopus.Tentacle.Client.Retries
                         try
                         {
                             var actionTask = action(ct);
-                            return await (await Task.WhenAny(actionTask, abandonTask).ConfigureAwait(false)).ConfigureAwait(false);
+                            var completedTask = await Task.WhenAny(actionTask, abandonTask).ConfigureAwait(false);
+
+                            if (actionTask != completedTask)
+                            {
+                                actionTask.IgnoreUnobservedExceptions();
+                            }
+
+                            return await completedTask.ConfigureAwait(false);
                         }
                         catch (Exception e) when (e is OperationCanceledException)
                         {

--- a/source/Octopus.Tentacle.Client/Retries/TaskExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Client/Retries/TaskExtensionMethods.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+
+namespace Octopus.Tentacle.Client.Retries
+{
+    static class TaskExtensionMethods
+    {
+        public static void IgnoreUnobservedExceptions(this Task task)
+        {
+            if (task.IsCompleted)
+            {
+                if (task.IsFaulted)
+                {
+                    var observedException = task.Exception;
+                }
+
+                return;
+            }
+
+            task.ContinueWith(
+                t =>
+                {
+                    var observedException = t.Exception;
+                },
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+        }
+    }
+}


### PR DESCRIPTION
# Background

As part of TentacleClient script execution, cancelling a script execution can result in the task performing the RPC call to be abandoned and not awaited.

If an error is thrown by this abandoned task, it will result in the Finalizer handling and rethrowing the exception as it has not been observed.

# Results

<!-- Describe the result of the change -->

## Before

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/770c25ac-f966-4df3-8e36-483245889dde)

## After

If the task is being abandoned and Fails, we wrap it in a ContinueWith to ensure the exception is observer

# How to review this PR

No automated Testing has been added for this issue, but it has been manually verified that the unobserved error no longer exists.

```
From 89f26012a742adb2888b8937f829c07bf4ee2a8a Mon Sep 17 00:00:00 2001
From: Nathan Willoughby <nathan.willoughby@octopus.com>
Date: Sat, 8 Jul 2023 21:25:15 +1000
Subject: [PATCH] Manually Test Unobserved Exception

---
 .../SetUpFixtures.cs                          | 29 ++++++++++++
 .../Support/IntegrationTest.cs                | 10 +++-
 .../UnobservervedExceptionFixture.cs          | 46 +++++++++++++++++++
 3 files changed, 84 insertions(+), 1 deletion(-)
 create mode 100644 source/Octopus.Tentacle.Tests.Integration/SetUpFixtures.cs
 create mode 100644 source/Octopus.Tentacle.Tests.Integration/UnobservervedExceptionFixture.cs

diff --git a/source/Octopus.Tentacle.Tests.Integration/SetUpFixtures.cs b/source/Octopus.Tentacle.Tests.Integration/SetUpFixtures.cs
new file mode 100644
index 00000000..5580f6a4
--- /dev/null
+++ b/source/Octopus.Tentacle.Tests.Integration/SetUpFixtures.cs
@@ -0,0 +1,29 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    internal class SetUpFixtures
+    {
+        [SetUpFixture]
+        public class TestsSetupClass
+        {
+            [OneTimeSetUp]
+            public void GlobalSetup()
+            {
+                TaskScheduler.UnobservedTaskException += (s, e) =>
+                {
+#pragma warning disable CS0219
+                    // Break here to observe e
+                    int i = 0;
+#pragma warning restore CS0219
+                };
+            }
+        }
+    }
+}
diff --git a/source/Octopus.Tentacle.Tests.Integration/Support/IntegrationTest.cs b/source/Octopus.Tentacle.Tests.Integration/Support/IntegrationTest.cs
index 1bfb4976..2a37c762 100644
--- a/source/Octopus.Tentacle.Tests.Integration/Support/IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/IntegrationTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Octopus.Tentacle.Tests.Integration.Util;
 using Serilog;
@@ -36,8 +37,15 @@ public void SetUp()
         }
 
         [TearDown]
-        public void TearDown()
+        public async Task TearDown()
         {
+            // invoking garbage collector explicitly
+            Console.WriteLine("GC..");
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
             Logger.Information("Tearing down");
             if (cancellationTokenSource != null)
             {
diff --git a/source/Octopus.Tentacle.Tests.Integration/UnobservervedExceptionFixture.cs b/source/Octopus.Tentacle.Tests.Integration/UnobservervedExceptionFixture.cs
new file mode 100644
index 00000000..f464b5dd
--- /dev/null
+++ b/source/Octopus.Tentacle.Tests.Integration/UnobservervedExceptionFixture.cs
@@ -0,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Octopus.Tentacle.Tests.Integration.Support;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    public class UnobservervedExceptionFixture : IntegrationTest
+    {
+        [Test]
+        public void ShouldCreateUnobservedException()
+        {
+            try
+            {
+#pragma warning disable CS4014
+                ThrowsAsyncHelper();
+#pragma warning restore CS4014
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Caught in try/catch  : {ex.Message}");
+            }
+        }
+
+#pragma warning disable CS1998
+        private static async Task ThrowsAsyncHelper()
+#pragma warning restore CS1998
+#pragma warning restore CS1998
+        {
+#pragma warning disable CS4014
+            ThrowsAsync();
+#pragma warning restore CS4014
+        }
+
+#pragma warning disable CS1998
+        private static async Task ThrowsAsync()
+#pragma warning restore CS1998
+        {
+            Console.WriteLine("Throwing...");
+            throw new Exception("Boom!");
+        }
+    }
+}
-- 
2.35.1.windows.2
```

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.