### PR TITLE
POC Use long running tasks for RPC calls

### DIFF
--- a/source/Octopus.Tentacle.Client/Execution/RpcCallExecutorFactory.cs
+++ b/source/Octopus.Tentacle.Client/Execution/RpcCallExecutorFactory.cs
@@ -7,10 +7,10 @@ namespace Octopus.Tentacle.Client.Execution
 {
     internal static class RpcCallExecutorFactory
     {
-        internal static RpcCallExecutor Create(TimeSpan retryDuration, ITentacleClientObserver tentacleClientObserver)
+        internal static RpcCallExecutor Create(TimeSpan retryDuration, ITentacleClientObserver tentacleClientObserver, bool useTaskCreationOptionsLongRunning)
         {
             var rpcCallRetryHandler = new RpcCallRetryHandler(retryDuration, TimeoutStrategy.Pessimistic);
-            var rpcCallExecutor = new RpcCallExecutor(rpcCallRetryHandler, tentacleClientObserver);
+            var rpcCallExecutor = new RpcCallExecutor(rpcCallRetryHandler, tentacleClientObserver, useTaskCreationOptionsLongRunning);
 
             return rpcCallExecutor;
         }

--- a/source/Octopus.Tentacle.Client/Retries/CancellationTokenExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Client/Retries/CancellationTokenExtensionMethods.cs
@@ -8,7 +8,7 @@ namespace Octopus.Tentacle.Client.Retries
     {
         public static Task<TResult> AsTask<TResult>(this CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<TResult>();
+            var tcs = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             IDisposable? registration = null;
             registration = cancellationToken.Register(() =>
@@ -22,7 +22,7 @@ namespace Octopus.Tentacle.Client.Retries
 
         public static Task AsTask(this CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<VoidResult>();
+            var tcs = new TaskCompletionSource<VoidResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             IDisposable? registration = null;
             registration = cancellationToken.Register(() =>

--- a/source/Octopus.Tentacle.Client/Retries/RpcCallRetryHandler.cs
+++ b/source/Octopus.Tentacle.Client/Retries/RpcCallRetryHandler.cs
@@ -128,7 +128,14 @@ namespace Octopus.Tentacle.Client.Retries
                         try
                         {
                             var actionTask = action(ct);
-                            return await (await Task.WhenAny(actionTask, abandonTask).ConfigureAwait(false)).ConfigureAwait(false);
+                            var completedTask = await Task.WhenAny(actionTask, abandonTask).ConfigureAwait(false);
+
+                            if (actionTask != completedTask)
+                            {
+                                actionTask.IgnoreUnobservedExceptions();
+                            }
+
+                            return await completedTask.ConfigureAwait(false);
                         }
                         catch (Exception e) when (e is OperationCanceledException)
                         {

--- a/source/Octopus.Tentacle.Client/Retries/TaskExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Client/Retries/TaskExtensionMethods.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+
+namespace Octopus.Tentacle.Client.Retries
+{
+    static class TaskExtensionMethods
+    {
+        public static void IgnoreUnobservedExceptions(this Task task)
+        {
+            if (task.IsCompleted)
+            {
+                if (task.IsFaulted)
+                {
+                    var observedException = task.Exception;
+                }
+
+                return;
+            }
+
+            task.ContinueWith(
+                t =>
+                {
+                    var observedException = t.Exception;
+                },
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionOrchestrator.cs
@@ -119,11 +119,11 @@ namespace Octopus.Tentacle.Client.Scripts
             {
                 var startScriptCommandV1 = Map(startScriptCommand);
 
-                var scriptTicket = rpcCallExecutor.Execute(
+                var scriptTicket = await rpcCallExecutor.Execute(
                     RpcCall.Create<IScriptService>(nameof(IScriptService.StartScript)),
                     ct => scriptServiceV1.StartScript(startScriptCommandV1, new HalibutProxyRequestOptions(ct)),
                     clientOperationMetricsBuilder,
-                    scriptExecutionCancellationToken);
+                    scriptExecutionCancellationToken).ConfigureAwait(false);
 
                 scriptStatusResponse = Map(scriptTicket);
             }
@@ -266,12 +266,12 @@ namespace Octopus.Tentacle.Client.Scripts
             }
             else
             {
-                var scriptStatusResponseV1 = rpcCallExecutor.Execute(
+                var scriptStatusResponseV1 = await rpcCallExecutor.Execute(
                     RpcCall.Create<IScriptService>(nameof(IScriptService.GetStatus)),
                     ct => scriptServiceV1.GetStatus(new ScriptStatusRequest(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence), new HalibutProxyRequestOptions(ct)),
                     clientOperationMetricsBuilder,
-                    cancellationToken);
-                
+                    cancellationToken).ConfigureAwait(false);
+
                 return Map(scriptStatusResponseV1);
             }
         }
@@ -298,12 +298,12 @@ namespace Octopus.Tentacle.Client.Scripts
             }
             else
             {
-                var scriptStatusResponseV1 = rpcCallExecutor.Execute(
+                var scriptStatusResponseV1 = await rpcCallExecutor.Execute(
                     RpcCall.Create<IScriptService>(nameof(IScriptService.CancelScript)),
                     ct => scriptServiceV1.CancelScript(new CancelScriptCommand(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence), new HalibutProxyRequestOptions(ct)),
                     clientOperationMetricsBuilder,
-                    cancellationToken);
-                
+                    cancellationToken).ConfigureAwait(false);
+
                 return Map(scriptStatusResponseV1);
             }
         }
@@ -320,14 +320,11 @@ namespace Octopus.Tentacle.Client.Scripts
                 // Best effort cleanup of Tentacle
                 try
                 {
-                    var actionTask = Task.Run(() =>
-                    {
-                        rpcCallExecutor.Execute(
+                    var actionTask = rpcCallExecutor.Execute(
                             RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.CompleteScript)),
                             ct => scriptServiceV2.CompleteScript(new CompleteScriptCommandV2(lastStatusResponse.Ticket), new HalibutProxyRequestOptions(ct)),
                             clientOperationMetricsBuilder,
                             CancellationToken.None);
-                    }, CancellationToken.None);
 
                     var abandonCancellationTokenSource = new CancellationTokenSource();
 
@@ -358,12 +355,12 @@ namespace Octopus.Tentacle.Client.Scripts
             }
             else
             {
-                var completeStatusV1 = rpcCallExecutor.Execute(
+                var completeStatusV1 = await rpcCallExecutor.Execute(
                     RpcCall.Create<IScriptService>(nameof(IScriptService.CompleteScript)),
                     ct => scriptServiceV1.CompleteScript(new CompleteScriptCommand(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence), new HalibutProxyRequestOptions(ct)),
                     clientOperationMetricsBuilder,
-                    CancellationToken.None);
-                
+                    CancellationToken.None).ConfigureAwait(false);
+
                 completeStatus = Map(completeStatusV1);
                 onScriptStatusResponseReceived(completeStatus);
             }

--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -32,8 +32,9 @@ namespace Octopus.Tentacle.Client
             IHalibutRuntime halibutRuntime,
             IScriptObserverBackoffStrategy scriptObserverBackOffStrategy,
             TimeSpan retryDuration,
-            ITentacleClientObserver tentacleClientObserver) : 
-                this(serviceEndPoint, halibutRuntime, scriptObserverBackOffStrategy, retryDuration, tentacleClientObserver, null)
+            ITentacleClientObserver tentacleClientObserver,
+            bool useTaskCreationOptionsLongRunning) :
+                this(serviceEndPoint, halibutRuntime, scriptObserverBackOffStrategy, retryDuration, tentacleClientObserver, null, useTaskCreationOptionsLongRunning)
         {
         }
 
@@ -43,7 +44,8 @@ namespace Octopus.Tentacle.Client
             IScriptObserverBackoffStrategy scriptObserverBackOffStrategy,
             TimeSpan retryDuration,
             ITentacleClientObserver tentacleClientObserver,
-            ITentacleServiceDecorator? tentacleServicesDecorator)
+            ITentacleServiceDecorator? tentacleServicesDecorator,
+            bool useTaskCreationOptionsLongRunning)
         {
             this.scriptObserverBackOffStrategy = scriptObserverBackOffStrategy;
             this.tentacleClientObserver = tentacleClientObserver;
@@ -77,8 +79,8 @@ namespace Octopus.Tentacle.Client
                 fileTransferServiceV1 = tentacleServicesDecorator.Decorate(fileTransferServiceV1);
                 capabilitiesServiceV2 = tentacleServicesDecorator.Decorate(capabilitiesServiceV2);
             }
-            
-            rpcCallExecutor = RpcCallExecutorFactory.Create(retryDuration, tentacleClientObserver);
+
+            rpcCallExecutor = RpcCallExecutorFactory.Create(retryDuration, tentacleClientObserver, useTaskCreationOptionsLongRunning);
         }
 
         public TimeSpan OnCancellationAbandonCompleteScriptAfter { get; set; } = TimeSpan.FromMinutes(1);

--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -27,6 +27,21 @@ namespace Octopus.Tentacle.Client
         readonly IClientFileTransferService fileTransferServiceV1;
         readonly IClientCapabilitiesServiceV2 capabilitiesServiceV2;
 
+        public static void CacheServiceWasNotFoundResponseMessages(IHalibutRuntime halibutRuntime)
+        {
+            var innerHandler = halibutRuntime.OverrideErrorResponseMessageCaching;
+            halibutRuntime.OverrideErrorResponseMessageCaching = response =>
+            {
+                if (BackwardsCompatibleCapabilitiesV2Helper.ExceptionTypeLooksLikeTheServiceWasNotFound(response.Error.HalibutErrorType) ||
+                    BackwardsCompatibleCapabilitiesV2Helper.ExceptionMessageLooksLikeTheServiceWasNotFound(response.Error.Message))
+                {
+                    return true;
+                }
+
+                return innerHandler?.Invoke(response) ?? false;
+            };
+        }
+
         public TentacleClient(
             ServiceEndPoint serviceEndPoint,
             IHalibutRuntime halibutRuntime,
@@ -50,18 +65,12 @@ namespace Octopus.Tentacle.Client
             this.scriptObserverBackOffStrategy = scriptObserverBackOffStrategy;
             this.tentacleClientObserver = tentacleClientObserver;
 
-            var innerHandler = halibutRuntime.OverrideErrorResponseMessageCaching;
-            halibutRuntime.OverrideErrorResponseMessageCaching = response =>
+            if (halibutRuntime.OverrideErrorResponseMessageCaching == null)
             {
-                if (BackwardsCompatibleCapabilitiesV2Helper.ExceptionTypeLooksLikeTheServiceWasNotFound(response.Error.HalibutErrorType) ||
-                    BackwardsCompatibleCapabilitiesV2Helper.ExceptionMessageLooksLikeTheServiceWasNotFound(response.Error.Message))
-                {
-                    return true;
-                }
-
-                // TentacleClient doesn't own the HalibutRuntime so allow other handlers to be configured that override the error caching behaviour
-                return innerHandler?.Invoke(response) ?? false;
-            };
+                // Best effort to make sure the HalibutRuntime has been configured to Cache ServiceNotFoundExceptions
+                // Do not configure the HalibutRuntime here as it should only be done once and configuring it here will result in it being performed a lot
+                throw new ArgumentException("Ensure that TentacleClient.CacheServiceWasNotFoundResponseMessages has been called for the HalibutRuntime", nameof(halibutRuntime));
+            }
 
             scriptServiceV1 = halibutRuntime.CreateClient<IScriptService, IClientScriptService>(serviceEndPoint);
             scriptServiceV2 = halibutRuntime.CreateClient<IScriptServiceV2, IClientScriptServiceV2>(serviceEndPoint);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -166,6 +166,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 serviceEndpointModifier(tentacleEndPoint);
             }
 
+            TentacleClient.CacheServiceWasNotFoundResponseMessages(server.ServerHalibutRuntime);
+
             var tentacleClient = new TentacleClient(
                 tentacleEndPoint,
                 server.ServerHalibutRuntime,

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -172,7 +172,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 scriptObserverBackoffStrategy,
                 retryDuration,
                 tentacleClientObserver,
-                tentacleServiceDecorator);
+                tentacleServiceDecorator,
+                true);
 
             return new ClientAndTentacle(server.ServerHalibutRuntime, tentacleEndPoint, server, portForwarder, runningTentacle, tentacleClient, temporaryDirectory);
         }


### PR DESCRIPTION
# Background

Allows the use of LongRunning Task for Async calls to see the impact on thread pool starvation

Includes 2 other commits for bug fixes so see this commit https://github.com/OctopusDeploy/OctopusTentacle/pull/542/commits/a6511fe18cdb764517d8a5eacdfa8fb354c5fc9e for the actual changes

TODO: Additional test coverage to ensure long running task on/off work as expected

This adds a considerable performance hit

## Test Setup

TaskCap: 250
Queued: 250 deployments
Tenants: 250
Deployment Targets: 500 Polling Tentacles
Workers: 1 listening worker
Min Worker Threads: Default

## Before

Max in Progress Tasks 250

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/ad110ddc-96f5-48a7-a13f-7cd065fb457b)


## After 

Max in Progress Tasks 160ish - IT NEVER GETS TO 250 indicating very slow allocation of WorkerThreads / some other bottleneck introduced

Same setup. 0 Thread Pool Exhaustion events or errors communicating with Tentacle 

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.