### PR TITLE
Ensure test results are written to separate files

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -211,7 +211,7 @@ partial class Build
         // By doing things this way, we can have a seamless experience between local and remote builds.
         var octopusTentacleTestsDirectory = BuildDirectory / "Octopus.Tentacle.Tests" / testFramework / testRuntime;
         var testAssembliesPath = octopusTentacleTestsDirectory.GlobFiles("*.Tests.dll");
-        var testResultsPath = ArtifactsDirectory / "teamcity" / $"TestResults-{testFramework}-{testRuntime}.xml";
+        var testResultsPath = ArtifactsDirectory / "teamcity" / $"TestResults-Tests-{testFramework}-{testRuntime}.xml";
         
         try
         {
@@ -243,7 +243,7 @@ partial class Build
         // By doing things this way, we can have a seamless experience between local and remote builds.
         var octopusTentacleTestsDirectory = BuildDirectory / "Octopus.Tentacle.Tests.Integration" / testFramework / testRuntime;
         var testAssembliesPath = octopusTentacleTestsDirectory.GlobFiles("*.Tests*.dll");
-        var testResultsPath = ArtifactsDirectory / "teamcity" / $"TestResults-{testFramework}-{testRuntime}.xml";
+        var testResultsPath = ArtifactsDirectory / "teamcity" / $"TestResults-Tests-Integration-{testFramework}-{testRuntime}.xml";
 
         try
         {


### PR DESCRIPTION
# Background

The nightly build for Tentacle has been intermittently failing with the error
```
The process cannot access the file because it is being used by another process
```
[sc-53315]

# Investigation

We identify that the test output files for both `Octopus.Tentacle.Tests` project and `Octopus.Tentacle.Tests.Integration` project are written to the same file (identical file name). This might be the reason why Tentacle build intermittently encounter the above error when trying to access that file.

`Octopus.Tentacle.Tests`
https://github.com/OctopusDeploy/OctopusTentacle/blob/73cc874c420d06dc7e77edf4a50679de7396bcce/build/Build.Tests.cs#L214C3-L214C3

`Octopus.Tentacle.Tests.Integration`
https://github.com/OctopusDeploy/OctopusTentacle/blob/73cc874c420d06dc7e77edf4a50679de7396bcce/build/Build.Tests.cs#L245C18-L245C18

# Results

This PR ensures that the test results from the two above projects are written into separate files to avoid confliction.

# How to review this PR


Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.