### PR TITLE
Write test result logs to TC console

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -211,7 +211,6 @@ partial class Build
         // By doing things this way, we can have a seamless experience between local and remote builds.
         var octopusTentacleTestsDirectory = BuildDirectory / "Octopus.Tentacle.Tests" / testFramework / testRuntime;
         var testAssembliesPath = octopusTentacleTestsDirectory.GlobFiles("*.Tests.dll");
-        var testResultsPath = ArtifactsDirectory / "teamcity" / $"TestResults-Tests-{testFramework}-{testRuntime}.xml";
         
         try
         {
@@ -222,7 +221,7 @@ partial class Build
                 DotNetTasks.DotNetTest(settings => settings
                     .SetProjectFile(projectPath)
                     .SetFramework(testFramework)
-                    .SetLoggers($"trx;LogFileName={testResultsPath}"))
+                    .SetLoggers("console;verbosity=normal", "teamcity"))
             );
         }
         catch (Exception e)
@@ -243,7 +242,6 @@ partial class Build
         // By doing things this way, we can have a seamless experience between local and remote builds.
         var octopusTentacleTestsDirectory = BuildDirectory / "Octopus.Tentacle.Tests.Integration" / testFramework / testRuntime;
         var testAssembliesPath = octopusTentacleTestsDirectory.GlobFiles("*.Tests*.dll");
-        var testResultsPath = ArtifactsDirectory / "teamcity" / $"TestResults-Tests-Integration-{testFramework}-{testRuntime}.xml";
 
         try
         {
@@ -254,7 +252,7 @@ partial class Build
                 DotNetTasks.DotNetTest(settings => settings
                     .SetProjectFile(projectPath)
                     .SetFramework(testFramework)
-                    .SetLoggers($"trx;LogFileName={testResultsPath}"))
+                    .SetLoggers("console;verbosity=normal", "teamcity"))
             );
         }
         catch (Exception e)


### PR DESCRIPTION
# Background

Test builds have been intermittently failing due to the "XML report processing" build feature.

> The process cannot access the file because it is being used by another process

Our investigation shows that the report files are locked concurrently within the build feature step itself so we are unable to ensure this error doesn't happen.

Hence, we'd like to remove this build feature and write the test output directly to TeamCity console.

# Result

Setting the logger to write to TC console helps remove the need of the "XML report processing" build feature.

[sc-53315]

TODO: clean up TeamCity configuration across all build template to remove the "XML report processing" build feature after this PR is merged.