### PR TITLE
Support Async Halibut in Tentacle Client

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -119,7 +119,7 @@
     <PackageReference Include="MaterialDesignColors" Version="1.2.0" />
     <PackageReference Include="MaterialDesignThemes" Version="2.5.0.1205" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.2.0" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />

--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -119,7 +119,6 @@
     <PackageReference Include="MaterialDesignColors" Version="1.2.0" />
     <PackageReference Include="MaterialDesignThemes" Version="2.5.0.1205" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.2.0" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />

--- a/source/Octopus.Tentacle.Client/Services/SyncAndAsyncClientCapabilitiesServiceV2.cs
+++ b/source/Octopus.Tentacle.Client/Services/SyncAndAsyncClientCapabilitiesServiceV2.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Services
+{
+    public class SyncAndAsyncClientCapabilitiesServiceV2 : SyncAndAsyncService<IClientCapabilitiesServiceV2, IAsyncClientCapabilitiesServiceV2>
+    {
+        public SyncAndAsyncClientCapabilitiesServiceV2(IClientCapabilitiesServiceV2? syncService, IAsyncClientCapabilitiesServiceV2? asyncService) : base(syncService, asyncService)
+        {
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Services/SyncAndAsyncClientFileTransferServiceV1.cs
+++ b/source/Octopus.Tentacle.Client/Services/SyncAndAsyncClientFileTransferServiceV1.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Services
+{
+    public class SyncAndAsyncClientFileTransferServiceV1 : SyncAndAsyncService<IClientFileTransferService, IAsyncClientFileTransferService>
+    {
+        public SyncAndAsyncClientFileTransferServiceV1(IClientFileTransferService? syncService, IAsyncClientFileTransferService? asyncService) : base(syncService, asyncService)
+        {
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Services/SyncAndAsyncClientScriptServiceV1.cs
+++ b/source/Octopus.Tentacle.Client/Services/SyncAndAsyncClientScriptServiceV1.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Services
+{
+    public class SyncAndAsyncClientScriptServiceV1 : SyncAndAsyncService<IClientScriptService, IAsyncClientScriptService>
+    {
+        public SyncAndAsyncClientScriptServiceV1(IClientScriptService? syncService, IAsyncClientScriptService? asyncService) : base(syncService, asyncService)
+        {
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Services/SyncAndAsyncClientScriptServiceV2.cs
+++ b/source/Octopus.Tentacle.Client/Services/SyncAndAsyncClientScriptServiceV2.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Services
+{
+    public class SyncAndAsyncClientScriptServiceV2 : SyncAndAsyncService<IClientScriptServiceV2, IAsyncClientScriptServiceV2>
+    {
+        public SyncAndAsyncClientScriptServiceV2(IClientScriptServiceV2? syncService, IAsyncClientScriptServiceV2? asyncService) : base(syncService, asyncService)
+        {
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Services/SyncAndAsyncService.cs
+++ b/source/Octopus.Tentacle.Client/Services/SyncAndAsyncService.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace Octopus.Tentacle.Client.Services
+{
+    public abstract class SyncAndAsyncService<TSync, TAsync>
+    {
+        private readonly TSync? syncService;
+        private readonly TAsync? asyncService;
+
+        public TSync SyncService
+        {
+            get
+            {
+                if (syncService == null)
+                {
+                    throw new ArgumentNullException(nameof(SyncService));
+                }
+
+                return syncService;
+            }
+        }
+        
+        public TAsync AsyncService
+        {
+            get
+            {
+                if (asyncService == null)
+                {
+                    throw new ArgumentNullException(nameof(AsyncService));
+                }
+
+                return asyncService;
+            }
+        }
+
+        public SyncAndAsyncService(TSync? syncService, TAsync? asyncService)
+        {
+            this.syncService = syncService;
+            this.asyncService = asyncService;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -4,14 +4,18 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut;
 using Halibut.ServiceModel;
+using Halibut.Util;
 using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Client.Decorators;
 using Octopus.Tentacle.Client.Execution;
 using Octopus.Tentacle.Client.Observability;
 using Octopus.Tentacle.Client.Retries;
 using Octopus.Tentacle.Client.Scripts;
+using Octopus.Tentacle.Client.Services;
+using Octopus.Tentacle.Client.Utils;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.Observability;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using ILog = Octopus.Diagnostics.ILog;
@@ -23,11 +27,13 @@ namespace Octopus.Tentacle.Client
         readonly IScriptObserverBackoffStrategy scriptObserverBackOffStrategy;
         readonly ITentacleClientObserver tentacleClientObserver;
         readonly RpcCallExecutor rpcCallExecutor;
-        readonly IClientScriptService scriptServiceV1;
-        readonly IClientScriptServiceV2 scriptServiceV2;
-        readonly IClientFileTransferService fileTransferServiceV1;
-        readonly IClientCapabilitiesServiceV2 capabilitiesServiceV2;
         readonly RpcRetrySettings rpcRetrySettings;
+        readonly AsyncHalibutFeature asyncHalibutFeature;
+
+        readonly SyncAndAsyncClientScriptServiceV1 scriptServiceV1;
+        readonly SyncAndAsyncClientScriptServiceV2 scriptServiceV2;
+        readonly SyncAndAsyncClientFileTransferServiceV1 clientFileTransferServiceV1;
+        readonly SyncAndAsyncClientCapabilitiesServiceV2 capabilitiesServiceV2;
 
         public static void CacheServiceWasNotFoundResponseMessages(IHalibutRuntime halibutRuntime)
         {
@@ -65,6 +71,7 @@ namespace Octopus.Tentacle.Client
             this.scriptObserverBackOffStrategy = scriptObserverBackOffStrategy;
             this.tentacleClientObserver = tentacleClientObserver;
             this.rpcRetrySettings = rpcRetrySettings;
+            this.asyncHalibutFeature = halibutRuntime.AsyncHalibutFeature;
 
             if (halibutRuntime.OverrideErrorResponseMessageCaching == null)
             {
@@ -73,21 +80,53 @@ namespace Octopus.Tentacle.Client
                 throw new ArgumentException("Ensure that TentacleClient.CacheServiceWasNotFoundResponseMessages has been called for the HalibutRuntime", nameof(halibutRuntime));
             }
 
-            scriptServiceV1 = halibutRuntime.CreateClient<IScriptService, IClientScriptService>(serviceEndPoint);
-            scriptServiceV2 = halibutRuntime.CreateClient<IScriptServiceV2, IClientScriptServiceV2>(serviceEndPoint);
-            fileTransferServiceV1 = halibutRuntime.CreateClient<IFileTransferService, IClientFileTransferService>(serviceEndPoint);
-            capabilitiesServiceV2 = halibutRuntime.CreateClient<ICapabilitiesServiceV2, IClientCapabilitiesServiceV2>(serviceEndPoint).WithBackwardsCompatability();
-
-            var exceptionDecorator = new HalibutExceptionTentacleServiceDecorator();
-            scriptServiceV2 = exceptionDecorator.Decorate(scriptServiceV2);
-            capabilitiesServiceV2 = exceptionDecorator.Decorate(capabilitiesServiceV2);
-
-            if (tentacleServicesDecorator != null)
+            if (asyncHalibutFeature == AsyncHalibutFeature.Disabled)
             {
-                scriptServiceV1 = tentacleServicesDecorator.Decorate(scriptServiceV1);
-                scriptServiceV2 = tentacleServicesDecorator.Decorate(scriptServiceV2);
-                fileTransferServiceV1 = tentacleServicesDecorator.Decorate(fileTransferServiceV1);
-                capabilitiesServiceV2 = tentacleServicesDecorator.Decorate(capabilitiesServiceV2);
+                var syncScriptServiceV1 = halibutRuntime.CreateClient<IScriptService, IClientScriptService>(serviceEndPoint);
+                var syncScriptServiceV2 = halibutRuntime.CreateClient<IScriptServiceV2, IClientScriptServiceV2>(serviceEndPoint);
+                var syncFileTransferServiceV1 = halibutRuntime.CreateClient<IFileTransferService, IClientFileTransferService>(serviceEndPoint);
+                var syncCapabilitiesServiceV2 = halibutRuntime.CreateClient<ICapabilitiesServiceV2, IClientCapabilitiesServiceV2>(serviceEndPoint).WithBackwardsCompatability();
+
+                var exceptionDecorator = new HalibutExceptionTentacleServiceDecorator();
+                syncScriptServiceV2 = exceptionDecorator.Decorate(syncScriptServiceV2);
+                syncCapabilitiesServiceV2 = exceptionDecorator.Decorate(syncCapabilitiesServiceV2);
+
+                if (tentacleServicesDecorator != null)
+                {
+                    syncScriptServiceV1 = tentacleServicesDecorator.Decorate(syncScriptServiceV1);
+                    syncScriptServiceV2 = tentacleServicesDecorator.Decorate(syncScriptServiceV2);
+                    syncFileTransferServiceV1 = tentacleServicesDecorator.Decorate(syncFileTransferServiceV1);
+                    syncCapabilitiesServiceV2 = tentacleServicesDecorator.Decorate(syncCapabilitiesServiceV2);
+                }
+
+                scriptServiceV1 = new(syncScriptServiceV1, null);
+                scriptServiceV2 = new(syncScriptServiceV2, null);
+                clientFileTransferServiceV1 = new(syncFileTransferServiceV1, null);
+                capabilitiesServiceV2 = new(syncCapabilitiesServiceV2, null);
+            }
+            else
+            {
+                var asyncScriptServiceV1 = halibutRuntime.CreateAsyncClient<IScriptService, IAsyncClientScriptService>(serviceEndPoint);
+                var asyncScriptServiceV2 = halibutRuntime.CreateAsyncClient<IScriptServiceV2, IAsyncClientScriptServiceV2>(serviceEndPoint);
+                var asyncFileTransferServiceV1 = halibutRuntime.CreateAsyncClient<IFileTransferService, IAsyncClientFileTransferService>(serviceEndPoint);
+                var asyncCapabilitiesServiceV2 = halibutRuntime.CreateAsyncClient<ICapabilitiesServiceV2, IAsyncClientCapabilitiesServiceV2>(serviceEndPoint).WithBackwardsCompatability();
+                
+                var exceptionDecorator = new HalibutExceptionTentacleServiceDecorator();
+                asyncScriptServiceV2 = exceptionDecorator.Decorate(asyncScriptServiceV2);
+                asyncCapabilitiesServiceV2 = exceptionDecorator.Decorate(asyncCapabilitiesServiceV2);
+
+                if (tentacleServicesDecorator != null)
+                {
+                    asyncScriptServiceV1 = tentacleServicesDecorator.Decorate(asyncScriptServiceV1);
+                    asyncScriptServiceV2 = tentacleServicesDecorator.Decorate(asyncScriptServiceV2);
+                    asyncFileTransferServiceV1 = tentacleServicesDecorator.Decorate(asyncFileTransferServiceV1);
+                    asyncCapabilitiesServiceV2 = tentacleServicesDecorator.Decorate(asyncCapabilitiesServiceV2);
+                }
+
+                scriptServiceV1 = new(null, asyncScriptServiceV1);
+                scriptServiceV2 = new(null, asyncScriptServiceV2);
+                clientFileTransferServiceV1 = new(null, asyncFileTransferServiceV1);
+                capabilitiesServiceV2 = new(null, asyncCapabilitiesServiceV2);
             }
 
             rpcCallExecutor = RpcCallExecutorFactory.Create(rpcRetrySettings.RetryDuration, tentacleClientObserver);
@@ -104,7 +143,11 @@ namespace Octopus.Tentacle.Client
                 await Task.CompletedTask.ConfigureAwait(false);
 
                 logger.Info($"Beginning upload of {fileName} to Tentacle");
-                var result = fileTransferServiceV1.UploadFile(path, package, new HalibutProxyRequestOptions(ct));
+
+                var result = await asyncHalibutFeature
+                    .WhenDisabled(() => clientFileTransferServiceV1.SyncService.UploadFile(path, package, new HalibutProxyRequestOptions(ct, CancellationToken.None)))
+                    .WhenEnabled(async () => await clientFileTransferServiceV1.AsyncService.UploadFileAsync(path, package, new HalibutProxyRequestOptions(ct, CancellationToken.None)));
+
                 logger.Info("Upload complete");
                 return result;
             }
@@ -152,7 +195,11 @@ namespace Octopus.Tentacle.Client
                 await Task.CompletedTask.ConfigureAwait(false);
 
                 logger.Info($"Beginning download of {Path.GetFileName(remotePath)} from Tentacle");
-                var result = fileTransferServiceV1.DownloadFile(remotePath, new HalibutProxyRequestOptions(ct));
+
+                var result = await asyncHalibutFeature
+                    .WhenDisabled(() => clientFileTransferServiceV1.SyncService.DownloadFile(remotePath, new HalibutProxyRequestOptions(ct, CancellationToken.None)))
+                    .WhenEnabled(async () => await clientFileTransferServiceV1.AsyncService.DownloadFileAsync(remotePath, new HalibutProxyRequestOptions(ct, CancellationToken.None)));
+                
                 logger.Info("Download complete");
                 return result;
             }
@@ -214,6 +261,7 @@ namespace Octopus.Tentacle.Client
                     onScriptCompleted,
                     OnCancellationAbandonCompleteScriptAfter,
                     rpcRetrySettings,
+                    asyncHalibutFeature,
                     logger);
 
                 var result = await orchestrator.ExecuteScript(scriptExecutionCancellationToken).ConfigureAwait(false);

--- a/source/Octopus.Tentacle.Client/Utils/AsyncHalibutFeatureExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Client/Utils/AsyncHalibutFeatureExtensionMethods.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Threading.Tasks;
+using Halibut.Util;
+
+namespace Octopus.Tentacle.Client.Utils
+{
+    public static class AsyncHalibutFeatureExtensionMethods
+    {
+        public static AsyncHalibutFeatureWithoutResult WhenDisabled(this AsyncHalibutFeature asyncHalibutFeature, Action action)
+        {
+            if (asyncHalibutFeature == AsyncHalibutFeature.Disabled)
+            {
+                action();
+            }
+
+            return new(asyncHalibutFeature);
+        }
+
+        public static AsyncHalibutFeatureWithResult<T> WhenDisabled<T>(this AsyncHalibutFeature asyncHalibutFeature, Func<T> action)
+        {
+            if (asyncHalibutFeature == AsyncHalibutFeature.Disabled)
+            {
+                return new AsyncHalibutFeatureWithResult<T>(asyncHalibutFeature, action());
+            }
+
+            return new AsyncHalibutFeatureWithResult<T>(asyncHalibutFeature, default);
+        }
+
+        public static void WhenEnabled(this AsyncHalibutFeatureWithoutResult asyncHalibutFeatureWithoutResult, Action action)
+        {
+            if (asyncHalibutFeatureWithoutResult.AsyncHalibutFeature == AsyncHalibutFeature.Enabled)
+            {
+                action();
+            }
+        }
+
+        public static async Task WhenEnabled(this AsyncHalibutFeatureWithoutResult asyncHalibutFeatureWithoutResult, Func<Task> action)
+        {
+            if (asyncHalibutFeatureWithoutResult.AsyncHalibutFeature == AsyncHalibutFeature.Enabled)
+            {
+                await action();
+            }
+        }
+
+        public static async Task<T> WhenEnabled<T>(this AsyncHalibutFeatureWithResult<T> asyncHalibutFeatureWithResult, Func<Task<T>> action)
+        {
+            if (asyncHalibutFeatureWithResult.AsyncHalibutFeature == AsyncHalibutFeature.Enabled)
+            {
+                return await action();
+            }
+
+            return asyncHalibutFeatureWithResult.Result!;
+        }
+    }
+
+    public class AsyncHalibutFeatureWithoutResult
+    {
+        public AsyncHalibutFeature AsyncHalibutFeature { get; }
+
+        public AsyncHalibutFeatureWithoutResult(AsyncHalibutFeature asyncHalibutFeature)
+        {
+            AsyncHalibutFeature = asyncHalibutFeature;
+        }
+    }
+
+    public class AsyncHalibutFeatureWithResult<T>
+    {
+        public AsyncHalibutFeature AsyncHalibutFeature { get; }
+        public T? Result { get; }
+
+        public AsyncHalibutFeatureWithResult(AsyncHalibutFeature asyncHalibutFeature, T? result)
+        {
+            AsyncHalibutFeature = asyncHalibutFeature;
+            Result = result;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleAsyncCapabilitiesV2Decorator.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleAsyncCapabilitiesV2Decorator.cs
@@ -1,16 +1,15 @@
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Halibut;
 using Halibut.Exceptions;
 
 namespace Octopus.Tentacle.Contracts.Capabilities
 {
-    public class BackwardsCompatibleCapabilitiesV2Decorator : ICapabilitiesServiceV2
+    public class BackwardsCompatibleAsyncCapabilitiesV2Decorator : ICapabilitiesServiceV2
     {
         private readonly ICapabilitiesServiceV2 inner;
 
-        public BackwardsCompatibleCapabilitiesV2Decorator(ICapabilitiesServiceV2 inner)
+        public BackwardsCompatibleAsyncCapabilitiesV2Decorator(ICapabilitiesServiceV2 inner)
         {
             this.inner = inner;
         }
@@ -18,24 +17,6 @@ namespace Octopus.Tentacle.Contracts.Capabilities
         public CapabilitiesResponseV2 GetCapabilities()
         {
             return WithBackwardsCompatability(inner.GetCapabilities);
-        }
-
-        internal static async Task<CapabilitiesResponseV2> WithBackwardsCompatabilityAsync(Func<Task<CapabilitiesResponseV2>> inner)
-        {
-            try
-            {
-                return await inner();
-            }
-            catch (NoMatchingServiceOrMethodHalibutClientException)
-            {
-                return new CapabilitiesResponseV2(new List<string>() { nameof(IScriptService), nameof(IFileTransferService) });
-            }
-            catch (HalibutClientException e) when
-            (
-                ExceptionLooksLikeTheServiceWasNotFound(e))
-            {
-                return new CapabilitiesResponseV2(new List<string>() { nameof(IScriptService), nameof(IFileTransferService) });
-            }
         }
 
         internal static CapabilitiesResponseV2 WithBackwardsCompatability(Func<CapabilitiesResponseV2> inner)

--- a/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleAsyncClientCapabilitiesV2Decorator.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/BackwardsCompatibleAsyncClientCapabilitiesV2Decorator.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Contracts.Capabilities
+{
+    public class BackwardsCompatibleAsyncClientCapabilitiesV2Decorator : IAsyncClientCapabilitiesServiceV2
+    {
+        private readonly IAsyncClientCapabilitiesServiceV2 inner;
+
+        public BackwardsCompatibleAsyncClientCapabilitiesV2Decorator(IAsyncClientCapabilitiesServiceV2 inner)
+        {
+            this.inner = inner;
+        }
+
+        public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return await BackwardsCompatibleCapabilitiesV2Decorator.WithBackwardsCompatabilityAsync(async () => await inner.GetCapabilitiesAsync(halibutProxyRequestOptions));
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesServiceV2ExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesServiceV2ExtensionMethods.cs
@@ -1,4 +1,5 @@
 using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
 
 namespace Octopus.Tentacle.Contracts.Capabilities
 {
@@ -12,6 +13,11 @@ namespace Octopus.Tentacle.Contracts.Capabilities
         public static IClientCapabilitiesServiceV2 WithBackwardsCompatability(this IClientCapabilitiesServiceV2 capabilitiesService)
         {
             return new BackwardsCompatibleClientCapabilitiesV2Decorator(capabilitiesService);
+        }
+
+        public static IAsyncClientCapabilitiesServiceV2 WithBackwardsCompatability(this IAsyncClientCapabilitiesServiceV2 capabilitiesService)
+        {
+            return new BackwardsCompatibleAsyncClientCapabilitiesV2Decorator(capabilitiesService);
         }
     }
 }

--- a/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientCapabilitiesServiceV2.cs
+++ b/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientCapabilitiesServiceV2.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
 using Halibut.Transport.Caching;
 using Octopus.Tentacle.Contracts.Capabilities;

--- a/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientFileTransferService.cs
+++ b/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientFileTransferService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Halibut;
 using Halibut.ServiceModel;

--- a/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientScriptService.cs
+++ b/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientScriptService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Halibut.ServiceModel;
 
 namespace Octopus.Tentacle.Contracts.ClientServices

--- a/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientScriptServiceV2.cs
+++ b/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientScriptServiceV2.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Halibut.ServiceModel;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="6.0.258" />
+    <PackageReference Include="Halibut" Version="6.0.1069" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Tests.Integration/BumpThreadPoolForAllTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/BumpThreadPoolForAllTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading;
+using NUnit.Framework;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    public class BumpThreadPoolForAllTests
+    {
+        [SetUpFixture]
+        public class TestsSetupClass
+        {
+            [OneTimeSetUp]
+            public void GlobalSetup()
+            {
+                var minWorkerPoolThreads = 5000;
+                var minCompletionPortThreads = 5000;
+                ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionPortThreads);
+                ThreadPool.SetMaxThreads(Math.Max(minWorkerPoolThreads, maxWorkerThreads), Math.Max(minCompletionPortThreads, maxCompletionPortThreads));
+                ThreadPool.SetMinThreads(minWorkerPoolThreads, minCompletionPortThreads);
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
@@ -22,14 +22,14 @@ namespace Octopus.Tentacle.Tests.Integration
     public class ClientFileTransferRetriesTimeout : IntegrationTest
     {
         [Test]
-        [TestCase(TentacleType.Polling, false)] // Timeout an in-flight request
-        [TestCase(TentacleType.Polling, true)] // Timeout trying to connect
-        [TestCase(TentacleType.Listening, false)] // Timeout an in-flight request
-        [TestCase(TentacleType.Listening, true)] // Timeout trying to connect
-        public async Task WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(TentacleType tentacleType, bool stopPortForwarderAfterFirstCall)
+        public async Task WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(
+            [Values]TentacleType tentacleType, 
+            [Values]bool stopPortForwarderAfterFirstCall, 
+            [Values]SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             PortForwarder portForwarder = null!;
             using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
                 .WithPortForwarderDataLogging()
@@ -89,14 +89,14 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [TestCase(TentacleType.Polling, false)] // Timeout an in-flight request
-        [TestCase(TentacleType.Polling, true)] // Timeout trying to connect
-        [TestCase(TentacleType.Listening, false)] // Timeout an in-flight request
-        [TestCase(TentacleType.Listening, true)] // Timeout trying to connect
-        public async Task WhenRpcRetriesTimeOut_DuringDownloadFile_TheRpcCallIsCancelled(TentacleType tentacleType, bool stopPortForwarderAfterFirstCall)
+        public async Task WhenRpcRetriesTimeOut_DuringDownloadFile_TheRpcCallIsCancelled(
+            [Values]TentacleType tentacleType, 
+            [Values]bool stopPortForwarderAfterFirstCall, 
+            [Values]SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             PortForwarder portForwarder = null!;
             using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
                 .WithPortForwarderDataLogging()

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreNotRetriedWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreNotRetriedWhenRetriesAreDisabled.cs
@@ -16,9 +16,10 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task FailedUploadsAreNotRetriedAndFail(TentacleType tentacleType, Version? version)
+        public async Task FailedUploadsAreNotRetriedAndFail(TentacleType tentacleType, Version? version, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(version)
                 .WithRetriesDisabled()
                 .WithPortForwarderDataLogging()
@@ -56,9 +57,10 @@ namespace Octopus.Tentacle.Tests.Integration
 
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task FailedDownloadsAreNotRetriedAndFail(TentacleType tentacleType, Version? version)
+        public async Task FailedDownloadsAreNotRetriedAndFail(TentacleType tentacleType, Version? version, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(version)
                 .WithRetriesDisabled()
                 .WithPortForwarderDataLogging()

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
@@ -16,9 +16,10 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task FailedUploadsAreRetriedAndIsEventuallySuccessful(TentacleType tentacleType, Version? version)
+        public async Task FailedUploadsAreRetriedAndIsEventuallySuccessful(TentacleType tentacleType, Version? version, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(version)
                 .WithPortForwarderDataLogging()
                 .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)
@@ -53,9 +54,10 @@ namespace Octopus.Tentacle.Tests.Integration
 
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task FailedDownloadsAreRetriedAndIsEventuallySuccessful(TentacleType tentacleType, Version? version)
+        public async Task FailedDownloadsAreRetriedAndIsEventuallySuccessful(TentacleType tentacleType, Version? version, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(version)
                 .WithPortForwarderDataLogging()
                 .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)

--- a/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
@@ -22,11 +22,12 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task ExecuteScriptShouldGatherMetrics_WhenSucceeds(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task ExecuteScriptShouldGatherMetrics_WhenSucceeds(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .Build(CancellationToken);
@@ -55,12 +56,13 @@ namespace Octopus.Tentacle.Tests.Integration
         
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task ExecuteScriptShouldGatherMetrics_WhenFails(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task ExecuteScriptShouldGatherMetrics_WhenFails(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
             var exception = new HalibutClientException("Error");
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .WithRetryDuration(TimeSpan.FromSeconds(1))
@@ -88,11 +90,12 @@ namespace Octopus.Tentacle.Tests.Integration
 
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task UploadFileShouldGatherMetrics_WhenSucceeds(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task UploadFileShouldGatherMetrics_WhenSucceeds(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .Build(CancellationToken);
@@ -115,12 +118,13 @@ namespace Octopus.Tentacle.Tests.Integration
 
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task UploadFileShouldGatherMetrics_WhenFails(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task UploadFileShouldGatherMetrics_WhenFails(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
             var exception = new HalibutClientException("Error");
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .WithRetryDuration(TimeSpan.FromSeconds(1))
@@ -146,11 +150,12 @@ namespace Octopus.Tentacle.Tests.Integration
 
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task DownloadFileShouldGatherMetrics_WhenSucceeds(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task DownloadFileShouldGatherMetrics_WhenSucceeds(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .Build(CancellationToken);
@@ -174,12 +179,13 @@ namespace Octopus.Tentacle.Tests.Integration
 
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task DownloadFileShouldGatherMetrics_WhenFails(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task DownloadFileShouldGatherMetrics_WhenFails(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
             var exception = new HalibutClientException("Error");
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .WithRetryDuration(TimeSpan.FromSeconds(1))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
@@ -17,12 +17,13 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task AdditionalScriptsWork(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task AdditionalScriptsWork(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var tmp = new TemporaryDirectory();
             var path = Path.Combine(tmp.DirectoryPath, "file");
             
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
                     .CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts)
@@ -32,6 +33,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var scriptBuilder = new ScriptBuilder()
                 .CreateFile(path) // How files are made are different in bash and powershell, doing this ensures the client and tentacle really are using the correct script.
                 .Print("Hello");
+
             var startScriptCommand = new StartScriptCommandV2Builder()
                 .WithAdditionalScriptTypes(ScriptType.Bash, scriptBuilder.BuildBashScript())
                 // Additional Scripts don't actually work on tentacle for anything other than bash.

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -267,9 +267,14 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            syncOrAsyncHalibut.WhenSync(() => scriptServiceV2 = clientTentacle.Server.ServerHalibutRuntime.CreateClient<IScriptServiceV2, IClientScriptServiceV2>(clientTentacle.ServiceEndPoint))
-                .IgnoreResult()
-                .WhenAsync(() => asyncScriptServiceV2 = clientTentacle.Server.ServerHalibutRuntime.CreateAsyncClient<IScriptServiceV2, IAsyncClientScriptServiceV2>(clientTentacle.ServiceEndPoint));
+            syncOrAsyncHalibut.WhenSync(() =>
+                {
+                    scriptServiceV2 = clientTentacle.Server.ServerHalibutRuntime.CreateClient<IScriptServiceV2, IClientScriptServiceV2>(clientTentacle.ServiceEndPoint);
+                })
+                .WhenAsync(() =>
+                {
+                    asyncScriptServiceV2 = clientTentacle.Server.ServerHalibutRuntime.CreateAsyncClient<IScriptServiceV2, IAsyncClientScriptServiceV2>(clientTentacle.ServiceEndPoint);
+                });
 
             var startScriptCommand = new StartScriptCommandV2Builder()
                 .WithScriptBody(new ScriptBuilder().Print("hello"))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -25,19 +25,13 @@ namespace Octopus.Tentacle.Tests.Integration
     public class ClientScriptExecutionRetriesTimeout : IntegrationTest
     {
         [Test]
-        [TestCase(TentacleType.Polling, RpcCallStage.InFlight)]
-        [TestCase(TentacleType.Polling, RpcCallStage.Connecting)]
-        [TestCase(TentacleType.Listening, RpcCallStage.InFlight)]
-        [TestCase(TentacleType.Listening, RpcCallStage.Connecting)]
-        public async Task WhenRpcRetriesTimeOut_DuringGetCapabilities_TheRpcCallIsCancelled(TentacleType tentacleType, RpcCallStage rpcCallStage)
+        public async Task WhenRpcRetriesTimeOut_DuringGetCapabilities_TheRpcCallIsCancelled([Values]TentacleType tentacleType, [Values] RpcCallStage rpcCallStage, [Values] SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             IClientScriptServiceV2? scriptServiceV2 = null;
             IAsyncClientScriptServiceV2? asyncScriptServiceV2 = null;
 
-            // Temporarily hard code to Sync until tests are converted to both sync and async
-            var syncOrAsyncHalibut = SyncOrAsyncHalibut.Sync;
-
             using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
                 .WithPortForwarderDataLogging()
@@ -80,9 +74,9 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            syncOrAsyncHalibut.WhenSync(() => scriptServiceV2 = clientAndTentacle.Server.ServerHalibutRuntime.CreateClient<IScriptServiceV2, IClientScriptServiceV2>(clientAndTentacle.ServiceEndPoint));
-                //.IgnoreResult()
-                //.WhenAsync(() => asyncScriptServiceV2 = clientAndTentacle.Server.ServerHalibutRuntime.CreateAsyncClient<IScriptServiceV2, IAsyncClientScriptServiceV2>(clientAndTentacle.ServiceEndPoint));
+            syncOrAsyncHalibut.WhenSync(() => scriptServiceV2 = clientAndTentacle.Server.ServerHalibutRuntime.CreateClient<IScriptServiceV2, IClientScriptServiceV2>(clientAndTentacle.ServiceEndPoint))
+                .IgnoreResult()
+                .WhenAsync(() => asyncScriptServiceV2 = clientAndTentacle.Server.ServerHalibutRuntime.CreateAsyncClient<IScriptServiceV2, IAsyncClientScriptServiceV2>(clientAndTentacle.ServiceEndPoint));
 
             var startScriptCommand = new StartScriptCommandV2Builder()
                 .WithScriptBody(b => b
@@ -104,13 +98,10 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [TestCase(TentacleType.Polling, RpcCallStage.InFlight)]
-        [TestCase(TentacleType.Polling, RpcCallStage.Connecting)]
-        [TestCase(TentacleType.Listening, RpcCallStage.InFlight)]
-        [TestCase(TentacleType.Listening, RpcCallStage.Connecting)]
-        public async Task WhenRpcRetriesTimeOut_DuringStartScript_TheRpcCallIsCancelled(TentacleType tentacleType, RpcCallStage rpcCallStage)
+        public async Task WhenRpcRetriesTimeOut_DuringStartScript_TheRpcCallIsCancelled([Values] TentacleType tentacleType, [Values] RpcCallStage rpcCallStage, [Values] SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
                 .WithPortForwarderDataLogging()
@@ -173,13 +164,10 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [TestCase(TentacleType.Polling, RpcCallStage.InFlight)]
-        [TestCase(TentacleType.Polling, RpcCallStage.Connecting)]
-        [TestCase(TentacleType.Listening, RpcCallStage.InFlight)]
-        [TestCase(TentacleType.Listening, RpcCallStage.Connecting)]
-        public async Task WhenRpcRetriesTimeOut_DuringGetStatus_TheRpcCallIsCancelled(TentacleType tentacleType, RpcCallStage rpcCallStage)
+        public async Task WhenRpcRetriesTimeOut_DuringGetStatus_TheRpcCallIsCancelled([Values] TentacleType tentacleType, [Values] RpcCallStage rpcCallStage, [Values] SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
                 .WithPortForwarderDataLogging()
@@ -244,13 +232,10 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [TestCase(TentacleType.Polling, RpcCallStage.InFlight)]
-        [TestCase(TentacleType.Polling, RpcCallStage.Connecting)]
-        [TestCase(TentacleType.Listening, RpcCallStage.InFlight)]
-        [TestCase(TentacleType.Listening, RpcCallStage.Connecting)]
-        public async Task WhenRpcRetriesTimeOut_DuringCancelScript_TheRpcCallIsCancelled(TentacleType tentacleType, RpcCallStage rpcCallStage)
+        public async Task WhenRpcRetriesTimeOut_DuringCancelScript_TheRpcCallIsCancelled([Values] TentacleType tentacleType, [Values] RpcCallStage rpcCallStage, [Values] SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
                 .WithPortForwarderDataLogging()

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
@@ -16,9 +16,10 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task ArgumentsArePassedToTheScript(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task ArgumentsArePassedToTheScript(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
@@ -16,9 +16,10 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task ScriptFilesAreSent(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task ScriptFilesAreSent(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWorksWithMultipleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWorksWithMultipleVersions.cs
@@ -15,9 +15,10 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task CanRunScript(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task CanRunScript(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
@@ -15,9 +15,10 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         [Test]
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
-        public async Task TheScriptObserverBackoffShouldBeRespected(TentacleType tentacleType, Version? tentacleVersion)
+        public async Task TheScriptObserverBackoffShouldBeRespected(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithScriptObserverBackoffStrategy(new FuncScriptObserverBackoffStrategy(iters => TimeSpan.FromSeconds(20)))
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -31,7 +31,7 @@
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Assent" Version="1.8.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="Octopus.TestPortForwarder" Version="6.0.115" />
+        <PackageReference Include="Octopus.TestPortForwarder" Version="6.0.1069" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
@@ -19,9 +19,10 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         [Test]
         [TestCaseSource(typeof(TentacleTypesToTest))]
-        public async Task CanRunScript(TentacleType tentacleType)
+        public async Task CanRunScript(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder().CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts).Build())
                 .Build(CancellationToken);
 
@@ -51,9 +52,10 @@ namespace Octopus.Tentacle.Tests.Integration
 
         [Test]
         [TestCaseSource(typeof(TentacleTypesToTest))]
-        public async Task DelayInStartScriptSavesNetworkCalls(TentacleType tentacleType)
+        public async Task DelayInStartScriptSavesNetworkCalls(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder().CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts).Build())
                 .Build(CancellationToken);
 
@@ -82,9 +84,10 @@ namespace Octopus.Tentacle.Tests.Integration
 
         [Test]
         [TestCaseSource(typeof(TentacleTypesToTest))]
-        public async Task WhenTentacleRestartsWhileRunningAScript_TheExitCodeShouldBe_UnknownResultExitCode(TentacleType tentacleType)
+        public async Task WhenTentacleRestartsWhileRunningAScript_TheExitCodeShouldBe_UnknownResultExitCode(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder().CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts).Build())
                 .Build(CancellationToken);
 
@@ -127,9 +130,10 @@ namespace Octopus.Tentacle.Tests.Integration
 
         [Test]
         [TestCaseSource(typeof(TentacleTypesToTest))]
-        public async Task WhenALongRunningScriptIsCancelled_TheScriptShouldStop(TentacleType tentacleType)
+        public async Task WhenALongRunningScriptIsCancelled_TheScriptShouldStop(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder().CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts).Build())
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Halibut;
+using Halibut.Util;
 using Octopus.Tentacle.Client;
 using Octopus.Tentacle.Tests.Integration.Support.Legacy;
 using Octopus.TestPortForwarder;
@@ -16,9 +17,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public TentacleClient TentacleClient { get; }
         public TemporaryDirectory TemporaryDirectory { get; }
 
-        public LegacyTentacleClientBuilder LegacyTentacleClientBuilder()
+        public LegacyTentacleClientBuilder LegacyTentacleClientBuilder(AsyncHalibutFeature asyncHalibutFeature)
         {
-            return new LegacyTentacleClientBuilder(halibutRuntime, ServiceEndPoint);
+            return new LegacyTentacleClientBuilder(halibutRuntime, ServiceEndPoint, asyncHalibutFeature);
         }
 
         public ClientAndTentacle(

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/CancellationTokenExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/CancellationTokenExtensionMethods.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Octopus.Tentacle.Tests.Integration.Support
+namespace Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods
 {
     internal static class CancellationTokenExtensionMethods
     {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/DirectoryInfoExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/DirectoryInfoExtensionMethods.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 
-namespace Octopus.Tentacle.Tests.Integration.Support
+namespace Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods
 {
     internal static class DirectoryInfoExtensionMethods
     {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/FluentAssertionExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/FluentAssertionExtensionMethods.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Primitives;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods
+{
+    public static class FluentAssertionExtensionMethods
+    {
+        public static AndConstraint<ObjectAssertions> BeTaskOrOperationCancelledException(this ObjectAssertions should)
+        {
+            return should.Match(x => x is TaskCanceledException || x is OperationCanceledException);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/ServiceEndPointExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/ServiceEndPointExtensionMethods.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Halibut;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods
+{
+    public static class ServiceEndPointExtensionMethods
+    {
+        public static void TryAndConnectForALongTime(this ServiceEndPoint point)
+        {
+            point.RetryCountLimit = 1000000;
+            point.ConnectionErrorRetryTimeout = TimeSpan.FromDays(1);
+            point.PollingRequestQueueTimeout = TimeSpan.FromDays(1);
+            point.TcpClientConnectTimeout = TimeSpan.FromDays(1);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyTentacleClient.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyTentacleClient.cs
@@ -1,20 +1,19 @@
-using System;
-using Octopus.Tentacle.Contracts;
-using Octopus.Tentacle.Contracts.Capabilities;
-
 namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
 {
     public class LegacyTentacleClient
     {
-        public LegacyTentacleClient(IScriptService scriptService, IFileTransferService fileTransferService, ICapabilitiesServiceV2 capabilitiesServiceV2)
+        public LegacyTentacleClient(
+            SyncAndAsyncScriptServiceV1 scriptService, 
+            SyncAndAsyncFileTransferServiceV1 fileTransferService, 
+            SyncAndAsyncCapabilitiesServiceV2 capabilitiesServiceV2)
         {
             ScriptService = scriptService;
             FileTransferService = fileTransferService;
             CapabilitiesServiceV2 = capabilitiesServiceV2;
         }
 
-        public IScriptService ScriptService { get; }
-        public IFileTransferService FileTransferService { get; }
-        public ICapabilitiesServiceV2 CapabilitiesServiceV2 { get; }
+        public SyncAndAsyncScriptServiceV1 ScriptService { get; }
+        public SyncAndAsyncFileTransferServiceV1 FileTransferService { get; }
+        public SyncAndAsyncCapabilitiesServiceV2 CapabilitiesServiceV2 { get; }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyTentacleClientBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyTentacleClientBuilder.cs
@@ -1,7 +1,9 @@
 using System.Threading;
 using Halibut;
+using Halibut.Util;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
 
 namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
 {
@@ -9,20 +11,39 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
     {
         readonly IHalibutRuntime halibutRuntime;
         readonly ServiceEndPoint serviceEndPoint;
+        private readonly AsyncHalibutFeature asyncHalibutFeature;
 
-        public LegacyTentacleClientBuilder(IHalibutRuntime halibutRuntime, ServiceEndPoint serviceEndPoint)
+        public LegacyTentacleClientBuilder(IHalibutRuntime halibutRuntime, ServiceEndPoint serviceEndPoint, AsyncHalibutFeature asyncHalibutFeature)
         {
             this.halibutRuntime = halibutRuntime;
             this.serviceEndPoint = serviceEndPoint;
+            this.asyncHalibutFeature = asyncHalibutFeature;
         }
 
         public LegacyTentacleClient Build(CancellationToken cancellationToken)
         {
-            var scriptService = halibutRuntime.CreateClient<IScriptService>(serviceEndPoint, cancellationToken);
-            var fileTransferService = halibutRuntime.CreateClient<IFileTransferService>(serviceEndPoint, cancellationToken);
-            var capabilitiesServiceV2 = halibutRuntime.CreateClient<ICapabilitiesServiceV2>(serviceEndPoint, cancellationToken).WithBackwardsCompatability();
+            if (asyncHalibutFeature.IsDisabled())
+            {
+                var syncScriptService = halibutRuntime.CreateClient<IScriptService>(serviceEndPoint, cancellationToken);
+                var syncFileTransferService = halibutRuntime.CreateClient<IFileTransferService>(serviceEndPoint, cancellationToken);
+                var syncCapabilitiesServiceV2 = halibutRuntime.CreateClient<ICapabilitiesServiceV2>(serviceEndPoint, cancellationToken).WithBackwardsCompatability();
 
-            return new LegacyTentacleClient(scriptService, fileTransferService, capabilitiesServiceV2);
+                return new LegacyTentacleClient(
+                    new(syncScriptService, null),
+                    new(syncFileTransferService, null),
+                    new(syncCapabilitiesServiceV2, null));
+            }
+            else
+            {
+                var asyncScriptService = halibutRuntime.CreateAsyncClient<IScriptService, IAsyncClientScriptService>(serviceEndPoint);
+                var asyncFileTransferService = halibutRuntime.CreateAsyncClient<IFileTransferService, IAsyncClientFileTransferService>(serviceEndPoint);
+                var asyncCapabilitiesServiceV2 = halibutRuntime.CreateAsyncClient<ICapabilitiesServiceV2, IAsyncClientCapabilitiesServiceV2>(serviceEndPoint).WithBackwardsCompatability();
+
+                return new LegacyTentacleClient(
+                    new(null, asyncScriptService),
+                    new(null, asyncFileTransferService),
+                    new(null, asyncCapabilitiesServiceV2));
+            }
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/SyncAndAsyncCapabilitiesServiceV2.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/SyncAndAsyncCapabilitiesServiceV2.cs
@@ -1,0 +1,13 @@
+﻿using Octopus.Tentacle.Client.Services;
+using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
+{
+    public class SyncAndAsyncCapabilitiesServiceV2 : SyncAndAsyncService<ICapabilitiesServiceV2, IAsyncClientCapabilitiesServiceV2>
+    {
+        public SyncAndAsyncCapabilitiesServiceV2(ICapabilitiesServiceV2? syncService, IAsyncClientCapabilitiesServiceV2? asyncService) : base(syncService, asyncService)
+        {
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/SyncAndAsyncFileTransferServiceV1.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/SyncAndAsyncFileTransferServiceV1.cs
@@ -1,0 +1,13 @@
+﻿using Octopus.Tentacle.Client.Services;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
+{
+    public class SyncAndAsyncFileTransferServiceV1 : SyncAndAsyncService<IFileTransferService, IAsyncClientFileTransferService>
+    {
+        public SyncAndAsyncFileTransferServiceV1(IFileTransferService? syncService, IAsyncClientFileTransferService? asyncService) : base(syncService, asyncService)
+        {
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/SyncAndAsyncScriptServiceV1.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/SyncAndAsyncScriptServiceV1.cs
@@ -1,0 +1,13 @@
+﻿using Octopus.Tentacle.Client.Services;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
+{
+    public class SyncAndAsyncScriptServiceV1 : SyncAndAsyncService<IScriptService, IAsyncClientScriptService>
+    {
+        public SyncAndAsyncScriptServiceV1(IScriptService? syncService, IAsyncClientScriptService? asyncService) : base(syncService, asyncService)
+        {
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/SyncOrAsyncHalibut.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/SyncOrAsyncHalibut.cs
@@ -62,6 +62,16 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
             return syncOrAsyncWithResult.Result!;
         }
+
+        public static AsyncHalibutFeature ToAsyncHalibutFeature(this SyncOrAsyncHalibut syncOrAsyncHalibut)
+        {
+            return syncOrAsyncHalibut switch
+            {
+                SyncOrAsyncHalibut.Sync => AsyncHalibutFeature.Disabled,
+                SyncOrAsyncHalibut.Async => AsyncHalibutFeature.Enabled,
+                _ => throw new ArgumentOutOfRangeException(nameof(syncOrAsyncHalibut), syncOrAsyncHalibut, null)
+            };
+        }
     }
 
     public class SyncOrAsyncWithoutResult

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBinaryCache.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBinaryCache.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Util;
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTypesAndCommonVersionsToTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTypesAndCommonVersionsToTest.cs
@@ -16,6 +16,10 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
                     TentacleVersions.v7_0_1_ScriptServiceV2Added
                 )
+                .And(
+                    SyncOrAsyncHalibut.Sync,
+                    SyncOrAsyncHalibut.Async
+                )
                 .Build();
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTypesToTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTypesToTest.cs
@@ -3,17 +3,18 @@ using System.Collections.Generic;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
-    public class TentacleTypesToTest : IEnumerable<TentacleType>
+    public class TentacleTypesToTest : IEnumerable
     {
-        public IEnumerator<TentacleType> GetEnumerator()
-        {
-            yield return TentacleType.Polling;
-            yield return TentacleType.Listening;
-        }
-
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetEnumerator();
+            return AllCombinations
+                .Of(TentacleType.Polling,
+                    TentacleType.Listening)
+                .And(
+                    SyncOrAsyncHalibut.Sync,
+                    SyncOrAsyncHalibut.Async
+                )
+                .Build();
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TestAttributes/SyncOrAsyncTestCaseAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TestAttributes/SyncOrAsyncTestCaseAttribute.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class SyncAndAsyncTestCaseAttribute : TestCaseSourceAttribute
+    {
+        public SyncAndAsyncTestCaseAttribute(params object[] parameters) :
+            base(
+                typeof(SyncAndAsyncTestCase),
+                nameof(SyncAndAsyncTestCase.GetTestCases),
+                new object []{ parameters.ToArray() })
+        {
+        }
+
+        static class SyncAndAsyncTestCase
+        {
+            public static IEnumerable GetTestCases(object[] parameters)
+            {
+                var syncParameterList = new List<object>(parameters) { SyncOrAsyncHalibut.Sync };
+                var asyncParameterList = new List<object>(parameters) { SyncOrAsyncHalibut.Async };
+
+                yield return syncParameterList.ToArray();
+                yield return asyncParameterList.ToArray();
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceDecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceDecoratorBuilder.cs
@@ -68,6 +68,15 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             });
         }
 
+        public ScriptServiceDecoratorBuilder BeforeCancelScript(Func<IAsyncClientScriptService, CancelScriptCommand, Task> beforeCancelScript)
+        {
+            return DecorateCancelScriptWith(async (inner, command, options) =>
+            {
+                await beforeCancelScript(inner, command);
+                return await inner.CancelScriptAsync(command, options);
+            });
+        }
+
         public ScriptServiceDecoratorBuilder DecorateCompleteScriptWith(CompleteScriptClientDecorator completeScriptAction)
         {
             this.completeScriptAction = completeScriptAction;

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationObservingPendingRequestQueueFactory.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationObservingPendingRequestQueueFactory.cs
@@ -1,15 +1,29 @@
 ﻿using System;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
+using Octopus.Tentacle.Tests.Integration.Support;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
 {
     public class CancellationObservingPendingRequestQueueFactory : IPendingRequestQueueFactory
     {
+        private readonly SyncOrAsyncHalibut syncOrAsyncHalibut;
+
+        public CancellationObservingPendingRequestQueueFactory(SyncOrAsyncHalibut syncOrAsyncHalibut)
+        {
+            this.syncOrAsyncHalibut = syncOrAsyncHalibut;
+        }
 
         public IPendingRequestQueue CreateQueue(Uri endpoint)
         {
-            return new CancellationTokenObservingPendingRequestQueueDecorator(new PendingRequestQueue(new LogFactory().ForEndpoint(endpoint)));
+            if (syncOrAsyncHalibut == SyncOrAsyncHalibut.Sync)
+            {
+#pragma warning disable CS0612
+                return new CancellationTokenObservingPendingRequestQueueDecorator(new PendingRequestQueue(new LogFactory().ForEndpoint(endpoint)));
+#pragma warning restore CS0612
+            }
+
+            return new CancellationTokenObservingPendingRequestQueueDecorator(new PendingRequestQueueAsync(new LogFactory().ForEndpoint(endpoint)));
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/PendingRequestQueueWorkarounds.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/PendingRequestQueueWorkarounds.cs
@@ -22,7 +22,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
         {
             var cts = new CancellationTokenSource();
             cts.CancelAfter(TimeSpan.FromMilliseconds(500));
-            return new HalibutProxyRequestOptions(cts.Token);
+            return new HalibutProxyRequestOptions(cts.Token, null);
         }
 
         public static async Task EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IAsyncClientCapabilitiesServiceV2 service, ILogger logger)

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ResponseMessageTcpKillerWorkarounds.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ResponseMessageTcpKillerWorkarounds.cs
@@ -11,24 +11,31 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 {
     public static class ResponseMessageTcpKillerWorkarounds
     {
-        public static void EnsureTentacleIsConnectedToServer(this IClientScriptServiceV2 service, ILogger logger)
+        public static async Task EnsureTentacleIsConnectedToServer(this IAsyncClientScriptService service, ILogger logger)
         {
             logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Call GetStatus to work around an issue where the tcp killer kills setup of new connections");
-            service.GetStatus(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), new HalibutProxyRequestOptions(CancellationToken.None));
+            await service.GetStatusAsync(new ScriptStatusRequest(new ScriptTicket("nope"), 0), new HalibutProxyRequestOptions(CancellationToken.None, CancellationToken.None));
             logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished GetStatus work around call");
         }
 
+        public static void EnsureTentacleIsConnectedToServer(this IClientScriptServiceV2 service, ILogger logger)
+        {
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Call GetStatus to work around an issue where the tcp killer kills setup of new connections");
+            service.GetStatus(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), new HalibutProxyRequestOptions(CancellationToken.None, CancellationToken.None));
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished GetStatus work around call");
+        }
+        
         public static async Task EnsureTentacleIsConnectedToServer(this IAsyncClientScriptServiceV2 service, ILogger logger)
         {
             logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Call GetStatus to work around an issue where the tcp killer kills setup of new connections");
-            await service.GetStatusAsync(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), new HalibutProxyRequestOptions(CancellationToken.None));
+            await service.GetStatusAsync(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), new HalibutProxyRequestOptions(CancellationToken.None, CancellationToken.None));
             logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished GetStatus work around call");
         }
 
         public static async Task EnsureTentacleIsConnectedToServer(this IAsyncClientFileTransferService service, ILogger logger)
         {
             logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Call DownloadFile to work around an issue where the tcp killer kills setup of new connections");
-            await service.DownloadFileAsync("nope", new HalibutProxyRequestOptions(CancellationToken.None));
+            await service.DownloadFileAsync("nope", new HalibutProxyRequestOptions(CancellationToken.None, CancellationToken.None));
             logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished DownloadFile work around call");
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Wait.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Wait.cs
@@ -18,5 +18,17 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                 await Task.Delay(stopWatch.Elapsed + TimeSpan.FromMilliseconds(10), cancellationToken);
             }
         }
+
+        public static async Task For(Func<Task<bool>> toBeTrue, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                var stopWatch = Stopwatch.StartNew();
+                if (await toBeTrue()) return;
+                stopWatch.Stop();
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Delay(stopWatch.Elapsed + TimeSpan.FromMilliseconds(10), cancellationToken);
+            }
+        }
     }
 }

--- a/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
+++ b/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
@@ -41,6 +41,7 @@ namespace Octopus.Tentacle.Services.FileTransfer
             using (fileSystem.OpenFile(fullPath, FileAccess.Read, FileShare.ReadWrite))
             {}
 
+#pragma warning disable CS0612
             return new DataStream(fileSize, writer =>
             {
                 log.Trace("Begin streaming file download: " + fullPath);
@@ -51,6 +52,7 @@ namespace Octopus.Tentacle.Services.FileTransfer
                     log.Trace("Finished streaming file download: " + fullPath);
                 }
             });
+#pragma warning restore CS0612
         }
 
         public UploadResult UploadFile(string remotePath, DataStream upload)

--- a/source/Octopus.Tentacle/Util/SemaphoreSlimExtensions.cs
+++ b/source/Octopus.Tentacle/Util/SemaphoreSlimExtensions.cs
@@ -29,5 +29,11 @@ namespace Octopus.Tentacle.Util
             using var _ = await semaphore.LockAsync(cancellationToken);
             actionToPerformWhileTheLockIsHeld();
         }
+
+        public static async Task WithLockAsync(this SemaphoreSlim semaphore, Func<Task> actionToPerformWhileTheLockIsHeld, CancellationToken cancellationToken)
+        {
+            using var _ = await semaphore.LockAsync(cancellationToken);
+            await actionToPerformWhileTheLockIsHeld();
+        }
     }
 }


### PR DESCRIPTION
# Background

This PR adds support for Async Halibut to TentacleClient.

`TentacleClient` will use the configuration of the HalibutRuntime to control if sync or async RPC Calls should be made to Halibut

This PR also updates all relevant tests so that they run for both sync and async Halibut

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.