### PR TITLE
Make the TentacleClient decorators async and add a proxy so that sync calls can use the async decorators

### DIFF
--- a/source/Octopus.Tentacle.Client/ITentacleServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleServiceDecorator.cs
@@ -1,7 +1,5 @@
 using Octopus.Tentacle.Client.ClientServices;
-using Octopus.Tentacle.Contracts;
-using Octopus.Tentacle.Contracts.Capabilities;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ClientServices;
 
 namespace Octopus.Tentacle.Client
 {
@@ -9,10 +7,18 @@ namespace Octopus.Tentacle.Client
     {
         public IClientScriptService Decorate(IClientScriptService scriptService);
 
+        public IAsyncClientScriptService Decorate(IAsyncClientScriptService scriptService);
+
         public IClientScriptServiceV2 Decorate(IClientScriptServiceV2 scriptService);
+
+        public IAsyncClientScriptServiceV2 Decorate(IAsyncClientScriptServiceV2 scriptService);
 
         public IClientFileTransferService Decorate(IClientFileTransferService service);
 
+        public IAsyncClientFileTransferService Decorate(IAsyncClientFileTransferService service);
+
         public IClientCapabilitiesServiceV2 Decorate(IClientCapabilitiesServiceV2 service);
+
+        public IAsyncClientCapabilitiesServiceV2 Decorate(IAsyncClientCapabilitiesServiceV2 service);
     }
 }

--- a/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesServiceV2.cs
+++ b/source/Octopus.Tentacle.Contracts/Capabilities/ICapabilitiesServiceV2.cs
@@ -5,6 +5,6 @@ namespace Octopus.Tentacle.Contracts.Capabilities
     public interface ICapabilitiesServiceV2
     {
         [CacheResponse(600)]
-        public CapabilitiesResponseV2 GetCapabilities();
+        CapabilitiesResponseV2 GetCapabilities();
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -72,8 +73,10 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithTentacleVersion(version)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
                     .DecorateCapabilitiesServiceV2With(d => d
-                        .AfterGetCapabilities((response) =>
+                        .AfterGetCapabilities(async (response) =>
                         {
+                            await Task.CompletedTask;
+
                             capabilitiesResponses.Add(response);
 
                             if (resumePortForwarder)

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
@@ -39,9 +39,9 @@ namespace Octopus.Tentacle.Tests.Integration
                     .CountCallsToFileTransferService(out var fileTransferServiceCallCounts)
                     .RecordExceptionThrownInFileTransferService(out var fileTransferServiceException)
                     .DecorateFileTransferServiceWith(d => d
-                        .BeforeUploadFile((service, _, _) =>
+                        .BeforeUploadFile(async (service, _, _) =>
                         {
-                            service.EnsureTentacleIsConnectedToServer(Logger);
+                            await service.EnsureTentacleIsConnectedToServer(Logger);
 
                             // Kill the first UploadFile call to force the rpc call into retries
                             if (fileTransferServiceException.UploadLatestException == null)
@@ -106,9 +106,9 @@ namespace Octopus.Tentacle.Tests.Integration
                     .CountCallsToFileTransferService(out var fileTransferServiceCallCounts)
                     .RecordExceptionThrownInFileTransferService(out var fileTransferServiceException)
                     .DecorateFileTransferServiceWith(d => d
-                        .BeforeDownloadFile((service, _) =>
+                        .BeforeDownloadFile(async (service, _) =>
                         {
-                            service.EnsureTentacleIsConnectedToServer(Logger);
+                            await service.EnsureTentacleIsConnectedToServer(Logger);
 
                             // Kill the first DownloadFile call to force the rpc call into retries
                             if (fileTransferServiceException.DownloadFileLatestException == null)

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreNotRetriedWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreNotRetriedWhenRetriesAreDisabled.cs
@@ -29,9 +29,9 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInFileTransferService(out var fileTransferServiceException)
                     .DecorateFileTransferServiceWith(b =>
                     {
-                        b.BeforeUploadFile((service, _, ds) =>
+                        b.BeforeUploadFile(async (service, _, ds) =>
                         {
-                            service.EnsureTentacleIsConnectedToServer(Logger);
+                            await service.EnsureTentacleIsConnectedToServer(Logger);
                             // Only kill the connection the first time, causing the upload
                             // to succeed - and therefore failing the test - if retries are attempted
                             if (fileTransferServiceException.UploadLatestException == null)
@@ -69,9 +69,9 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInFileTransferService(out var fileTransferServiceException)
                     .DecorateFileTransferServiceWith(b =>
                     {
-                        b.BeforeDownloadFile((service, _) =>
+                        b.BeforeDownloadFile(async (service, _) =>
                         {
-                            service.EnsureTentacleIsConnectedToServer(Logger);
+                            await service.EnsureTentacleIsConnectedToServer(Logger);
                             // Only kill the connection the first time, causing the download
                             // to succeed - and therefore failing the test - if retries are attempted
                             if (fileTransferServiceException.DownloadFileLatestException == null)

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
@@ -28,9 +28,9 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInFileTransferService(out var fileTransferServiceException)
                     .DecorateFileTransferServiceWith(b =>
                     {
-                        b.BeforeUploadFile((service, _, ds) =>
+                        b.BeforeUploadFile(async (service, _, ds) =>
                         {
-                            service.EnsureTentacleIsConnectedToServer(Logger);
+                            await service.EnsureTentacleIsConnectedToServer(Logger);
                             if (fileTransferServiceException.UploadLatestException == null)
                             {
                                 responseMessageTcpKiller.KillConnectionOnNextResponse();
@@ -65,9 +65,9 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInFileTransferService(out var fileTransferServiceException)
                     .DecorateFileTransferServiceWith(b =>
                     {
-                        b.BeforeDownloadFile((service, _) =>
+                        b.BeforeDownloadFile(async (service, _) =>
                         {
-                            service.EnsureTentacleIsConnectedToServer(Logger);
+                            await service.EnsureTentacleIsConnectedToServer(Logger);
                             if (fileTransferServiceException.DownloadFileLatestException == null)
                             {
                                 responseMessageTcpKiller.KillConnectionOnNextResponse();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
@@ -427,16 +427,16 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [TestCase(TentacleType.Polling, RpcCallStage.Connecting, SyncOrAsyncHalibut.Sync)]
-        [TestCase(TentacleType.Listening, RpcCallStage.Connecting, SyncOrAsyncHalibut.Sync)]
-        [TestCase(TentacleType.Polling, RpcCallStage.InFlight, SyncOrAsyncHalibut.Sync)]
-        [TestCase(TentacleType.Listening, RpcCallStage.InFlight, SyncOrAsyncHalibut.Sync)]
+        [TestCase(TentacleType.Polling, RpcCallStage.Connecting)]
+        [TestCase(TentacleType.Listening, RpcCallStage.Connecting)]
+        [TestCase(TentacleType.Polling, RpcCallStage.InFlight)]
+        [TestCase(TentacleType.Listening, RpcCallStage.InFlight)]
 
-        [TestCase(TentacleType.Polling, RpcCallStage.Connecting, SyncOrAsyncHalibut.Async)]
-        [TestCase(TentacleType.Listening, RpcCallStage.Connecting, SyncOrAsyncHalibut.Async)]
-        [TestCase(TentacleType.Polling, RpcCallStage.InFlight, SyncOrAsyncHalibut.Async)]
-        [TestCase(TentacleType.Listening, RpcCallStage.InFlight, SyncOrAsyncHalibut.Async)]
-        public async Task DuringCompleteScript_ScriptExecutionCanBeCancelled(TentacleType tentacleType, RpcCallStage rpcCallStage, SyncOrAsyncHalibut syncOrAsyncHalibut)
+        [TestCase(TentacleType.Polling, RpcCallStage.Connecting)]
+        [TestCase(TentacleType.Listening, RpcCallStage.Connecting)]
+        [TestCase(TentacleType.Polling, RpcCallStage.InFlight)]
+        [TestCase(TentacleType.Listening, RpcCallStage.InFlight)]
+        public async Task DuringCompleteScript_ScriptExecutionCanBeCancelled(TentacleType tentacleType, RpcCallStage rpcCallStage)
         {
             // ARRANGE
             var rpcCallHasStarted = new Reference<bool>(false);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
@@ -11,6 +11,7 @@ using Octopus.Tentacle.Client.Retries;
 using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Util;
@@ -42,6 +43,11 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             // ARRANGE
             IClientScriptServiceV2? scriptServiceV2 = null;
+            IAsyncClientScriptServiceV2? asyncScriptServiceV2 = null;
+
+            // Temporarily hard code to Sync until tests are converted to both sync and async
+            var syncOrAsyncHalibut = SyncOrAsyncHalibut.Sync;
+
             var rpcCallHasStarted = new Reference<bool>(false);
             var hasPausedOrStoppedPortForwarder = false;
             SemaphoreSlim ensureCancellationOccursDuringAnRpcCall = new SemaphoreSlim(0, 1);
@@ -60,37 +66,46 @@ namespace Octopus.Tentacle.Tests.Integration
                     .LogAndCountAllCalls(out var capabilitiesServiceV2CallCounts, out _, out var scriptServiceV2CallCounts, out _)
                     .RecordAllExceptions(out var capabilityServiceV2Exceptions, out _, out _, out _)
                     .DecorateCapabilitiesServiceV2With(d => d
-                        .DecorateGetCapabilitiesWith((service, options) =>
+                        .DecorateGetCapabilitiesWith(async (service, options) =>
                         {
                             ensureCancellationOccursDuringAnRpcCall.Release();
                             try
                             {
                                 if (rpcCall == RpcCall.RetryingCall && capabilityServiceV2Exceptions.GetCapabilitiesLatestException == null)
                                 {
-                                    scriptServiceV2.EnsureTentacleIsConnectedToServer(Logger);
+                                    await syncOrAsyncHalibut.WhenSync(() => scriptServiceV2.EnsureTentacleIsConnectedToServer(Logger))
+                                        .WhenAsync(async () => await asyncScriptServiceV2.EnsureTentacleIsConnectedToServer(Logger));
+
                                     // Kill the first GetCapabilities call to force the rpc call into retries
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
                                 else if (!hasPausedOrStoppedPortForwarder)
                                 {
                                     hasPausedOrStoppedPortForwarder = true;
-                                    scriptServiceV2.EnsureTentacleIsConnectedToServer(Logger);
+                                    await syncOrAsyncHalibut.WhenSync(() => scriptServiceV2.EnsureTentacleIsConnectedToServer(Logger))
+                                        .WhenAsync(async () => await asyncScriptServiceV2.EnsureTentacleIsConnectedToServer(Logger));
+
                                     PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
-                                    if (rpcCallStage == RpcCallStage.Connecting) service.EnsurePollingQueueWontSendMessageToDisconnectedTentacles(Logger);
+                                    if (rpcCallStage == RpcCallStage.Connecting)
+                                    {
+                                        await service.EnsurePollingQueueWontSendMessageToDisconnectedTentacles(Logger);
+                                    }
                                 }
 
-                                return service.GetCapabilities(options);
+                                return await service.GetCapabilitiesAsync(options);
                             }
                             finally
                             {
-                                ensureCancellationOccursDuringAnRpcCall.Wait(CancellationToken);
+                                await ensureCancellationOccursDuringAnRpcCall.WaitAsync(CancellationToken);
                             }
                         })
                         .Build())
                     .Build())
                 .Build(CancellationToken);
 
-            scriptServiceV2 = clientAndTentacle.Server.ServerHalibutRuntime.CreateClient<IScriptServiceV2, IClientScriptServiceV2>(clientAndTentacle.ServiceEndPoint);
+            syncOrAsyncHalibut.WhenSync(() => scriptServiceV2 = clientAndTentacle.Server.ServerHalibutRuntime.CreateClient<IScriptServiceV2, IClientScriptServiceV2>(clientAndTentacle.ServiceEndPoint));
+                //.IgnoreResult()
+                //.WhenAsync(() => asyncScriptServiceV2 = clientAndTentacle.Server.ServerHalibutRuntime.CreateAsyncClient<IScriptServiceV2, IAsyncClientScriptServiceV2>(clientAndTentacle.ServiceEndPoint));
 
             var startScriptCommand = new StartScriptCommandV2Builder()
                 .WithScriptBody(b => b
@@ -165,14 +180,14 @@ namespace Octopus.Tentacle.Tests.Integration
                     .LogAndCountAllCalls(out _, out _, out var scriptServiceV2CallCounts, out _)
                     .RecordAllExceptions(out _, out _, out var scriptServiceV2Exceptions, out _)
                     .DecorateScriptServiceV2With(d => d
-                        .DecorateStartScriptWith((service, command, options) =>
+                        .DecorateStartScriptWith(async (service, command, options) =>
                         {
                             ensureCancellationOccursDuringAnRpcCall.Release();
                             try
                             {
                                 if (rpcCall == RpcCall.RetryingCall && scriptServiceV2Exceptions.StartScriptLatestException == null)
                                 {
-                                    service.EnsureTentacleIsConnectedToServer(Logger);
+                                    await service.EnsureTentacleIsConnectedToServer(Logger);
                                     // Kill the first StartScript call to force the rpc call into retries
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
@@ -181,16 +196,19 @@ namespace Octopus.Tentacle.Tests.Integration
                                     if (!hasPausedOrStoppedPortForwarder)
                                     {
                                         hasPausedOrStoppedPortForwarder = true;
-                                        service.EnsureTentacleIsConnectedToServer(Logger);
+                                        await service.EnsureTentacleIsConnectedToServer(Logger);
                                         PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
-                                        if (rpcCallStage == RpcCallStage.Connecting) service.EnsurePollingQueueWontSendMessageToDisconnectedTentacles(Logger);
+                                        if (rpcCallStage == RpcCallStage.Connecting)
+                                        {
+                                            await service.EnsurePollingQueueWontSendMessageToDisconnectedTentacles(Logger);
+                                        }
                                     }
                                 }
 
                                 var timer = Stopwatch.StartNew();
                                 try
                                 {
-                                    return service.StartScript(command, options);
+                                    return await service.StartScriptAsync(command, options);
                                 }
                                 finally
                                 {
@@ -203,8 +221,10 @@ namespace Octopus.Tentacle.Tests.Integration
                                 ensureCancellationOccursDuringAnRpcCall.Wait(CancellationToken);
                             }
                         })
-                        .BeforeCancelScript(() =>
+                        .BeforeCancelScript(async () =>
                         {
+                            await Task.CompletedTask;
+
                             if (!restartedPortForwarderForCancel)
                             {
                                 restartedPortForwarderForCancel = true;
@@ -305,14 +325,14 @@ namespace Octopus.Tentacle.Tests.Integration
                     .LogAndCountAllCalls(out _, out _, out var scriptServiceV2CallCounts, out _)
                     .RecordAllExceptions(out _, out _, out var scriptServiceV2Exceptions, out _)
                     .DecorateScriptServiceV2With(d => d
-                        .DecorateGetStatusWith((service, request, options) =>
+                        .DecorateGetStatusWith(async (service, request, options) =>
                         {
                             ensureCancellationOccursDuringAnRpcCall.Release();
                             try
                             {
                                 if (rpcCall == RpcCall.RetryingCall && scriptServiceV2Exceptions.GetStatusLatestException == null)
                                 {
-                                    service.EnsureTentacleIsConnectedToServer(Logger);
+                                    await service.EnsureTentacleIsConnectedToServer(Logger);
                                     // Kill the first StartScript call to force the rpc call into retries
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
@@ -321,16 +341,19 @@ namespace Octopus.Tentacle.Tests.Integration
                                     if (!hasPausedOrStoppedPortForwarder)
                                     {
                                         hasPausedOrStoppedPortForwarder = true;
-                                        service.EnsureTentacleIsConnectedToServer(Logger);
+                                        await service.EnsureTentacleIsConnectedToServer(Logger);
                                         PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
-                                        if (rpcCallStage == RpcCallStage.Connecting) service.EnsurePollingQueueWontSendMessageToDisconnectedTentacles(Logger);
+                                        if (rpcCallStage == RpcCallStage.Connecting)
+                                        {
+                                            await service.EnsurePollingQueueWontSendMessageToDisconnectedTentacles(Logger);
+                                        }
                                     }
                                 }
 
                                 var timer = Stopwatch.StartNew();
                                 try
                                 {
-                                    return service.GetStatus(request, options);
+                                    return await service.GetStatusAsync(request, options);
                                 }
                                 finally
                                 {
@@ -343,8 +366,10 @@ namespace Octopus.Tentacle.Tests.Integration
                                 ensureCancellationOccursDuringAnRpcCall.Wait(CancellationToken);
                             }
                         })
-                        .BeforeCancelScript(() =>
+                        .BeforeCancelScript(async () =>
                         {
+                            await Task.CompletedTask;
+
                             if (!restartedPortForwarderForCancel)
                             {
                                 restartedPortForwarderForCancel = true;
@@ -402,11 +427,16 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [TestCase(TentacleType.Polling, RpcCallStage.Connecting)]
-        [TestCase(TentacleType.Listening, RpcCallStage.Connecting)]
-        [TestCase(TentacleType.Polling, RpcCallStage.InFlight)]
-        [TestCase(TentacleType.Listening, RpcCallStage.InFlight)]
-        public async Task DuringCompleteScript_ScriptExecutionCanBeCancelled(TentacleType tentacleType, RpcCallStage rpcCallStage)
+        [TestCase(TentacleType.Polling, RpcCallStage.Connecting, SyncOrAsyncHalibut.Sync)]
+        [TestCase(TentacleType.Listening, RpcCallStage.Connecting, SyncOrAsyncHalibut.Sync)]
+        [TestCase(TentacleType.Polling, RpcCallStage.InFlight, SyncOrAsyncHalibut.Sync)]
+        [TestCase(TentacleType.Listening, RpcCallStage.InFlight, SyncOrAsyncHalibut.Sync)]
+
+        [TestCase(TentacleType.Polling, RpcCallStage.Connecting, SyncOrAsyncHalibut.Async)]
+        [TestCase(TentacleType.Listening, RpcCallStage.Connecting, SyncOrAsyncHalibut.Async)]
+        [TestCase(TentacleType.Polling, RpcCallStage.InFlight, SyncOrAsyncHalibut.Async)]
+        [TestCase(TentacleType.Listening, RpcCallStage.InFlight, SyncOrAsyncHalibut.Async)]
+        public async Task DuringCompleteScript_ScriptExecutionCanBeCancelled(TentacleType tentacleType, RpcCallStage rpcCallStage, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             // ARRANGE
             var rpcCallHasStarted = new Reference<bool>(false);
@@ -422,14 +452,17 @@ namespace Octopus.Tentacle.Tests.Integration
                     .LogAndCountAllCalls(out _, out _, out var scriptServiceV2CallCounts, out _)
                     .RecordAllExceptions(out _, out _, out var scriptServiceV2Exceptions, out _)
                     .DecorateScriptServiceV2With(d => d
-                        .BeforeCompleteScript((service, _) =>
+                        .BeforeCompleteScript(async (service, _) =>
                         {
                             if (!hasPausedOrStoppedPortForwarder)
                             {
                                 hasPausedOrStoppedPortForwarder = true;
-                                service.EnsureTentacleIsConnectedToServer(Logger);
+                                await service.EnsureTentacleIsConnectedToServer(Logger);
                                 PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
-                                if (rpcCallStage == RpcCallStage.Connecting) service.EnsurePollingQueueWontSendMessageToDisconnectedTentacles(Logger);
+                                if (rpcCallStage == RpcCallStage.Connecting)
+                                {
+                                    await service.EnsurePollingQueueWontSendMessageToDisconnectedTentacles(Logger);
+                                }
                             }
                         })
                         .Build())

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
@@ -33,8 +33,10 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInScriptService(out var scriptServiceExceptions)
                     .CountCallsToScriptService(out var scriptServiceCallCounts)
                     .DecorateScriptServiceWith(new ScriptServiceDecoratorBuilder()
-                        .BeforeStartScript(() =>
+                        .BeforeStartScript(async () =>
                         {
+                            await Task.CompletedTask;
+
                             if (scriptServiceExceptions.StartScriptLatestException == null)
                             {
                                 responseMessageTcpKiller.KillConnectionOnNextResponse();
@@ -89,8 +91,10 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInScriptService(out var scriptServiceExceptions)
                     .CountCallsToScriptService(out var scriptServiceCallCounts)
                     .DecorateScriptServiceWith(new ScriptServiceDecoratorBuilder()
-                        .BeforeGetStatus((inner, request) =>
+                        .BeforeGetStatus(async (inner, request) =>
                         {
+                            await Task.CompletedTask;
+
                             scriptStatusRequest = request;
                             if (scriptServiceExceptions.GetStatusLatestException == null)
                             {
@@ -145,13 +149,17 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInScriptService(out var scriptServiceExceptions)
                     .CountCallsToScriptService(out var scriptServiceCallCounts)
                     .DecorateScriptServiceWith(new ScriptServiceDecoratorBuilder()
-                        .BeforeGetStatus((inner, request) =>
+                        .BeforeGetStatus(async (inner, request) =>
                         {
+                            await Task.CompletedTask;
+
                             cts.Cancel();
                             scriptStatusRequest = request;
                         })
-                        .BeforeCancelScript(() =>
+                        .BeforeCancelScript(async () =>
                         {
+                            await Task.CompletedTask;
+
                             if (scriptServiceExceptions.CancelScriptLatestException == null)
                             {
                                 responseMessageTcpKiller.KillConnectionOnNextResponse();
@@ -170,11 +178,10 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Print("AllDone"))
                 .Build();
 
-            List<ProcessOutput> logs = new List<ProcessOutput>();
-
-            //Assert.CatchAsync(async () => await clientTentacle.TentacleClient.ExecuteScriptAssumingException(startScriptCommand, logs, cts.Token));
+            var logs = new List<ProcessOutput>();
+            
             Assert.ThrowsAsync<HalibutClientException>(async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, logs, cts.Token));
-
+            
             // Let the script finish.
             File.WriteAllText(waitForFile, "");
             var legacyTentacleClient = clientTentacle.LegacyTentacleClientBuilder().Build(CancellationToken);
@@ -203,8 +210,10 @@ namespace Octopus.Tentacle.Tests.Integration
                     .RecordExceptionThrownInScriptService(out var scriptServiceExceptions)
                     .CountCallsToScriptService(out var scriptServiceCallCounts)
                     .DecorateScriptServiceWith(new ScriptServiceDecoratorBuilder()
-                        .BeforeCompleteScript(() =>
+                        .BeforeCompleteScript(async () =>
                         {
+                            await Task.CompletedTask;
+
                             if (scriptServiceExceptions.CompleteScriptLatestException == null)
                             {
                                 responseMessageTcpKiller.KillConnectionOnNextResponse();

--- a/source/Octopus.Tentacle.Tests.Integration/Support/SyncOrAsyncHalibut.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/SyncOrAsyncHalibut.cs
@@ -1,0 +1,88 @@
+﻿using Halibut.Util;
+using System.Threading.Tasks;
+using System;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public enum SyncOrAsyncHalibut
+    {
+        Sync,
+        Async
+    }
+
+    public static class SyncOrAsyncExtensionMethods
+    {
+        public static SyncOrAsyncWithoutResult WhenSync(this SyncOrAsyncHalibut syncOrAsyncHalibut, Action action)
+        {
+            if (syncOrAsyncHalibut == SyncOrAsyncHalibut.Sync)
+            {
+                action();
+            }
+
+            return new(syncOrAsyncHalibut);
+        }
+
+        public static async Task WhenAsync(this SyncOrAsyncWithoutResult syncOrAsyncWithoutResult, Func<Task> action)
+        {
+            if (syncOrAsyncWithoutResult.SyncOrAsyncHalibut == SyncOrAsyncHalibut.Async)
+            {
+                await action();
+            }
+        }
+
+        public static void WhenAsync(this SyncOrAsyncWithoutResult syncOrAsyncWithoutResult, Action action)
+        {
+            if (syncOrAsyncWithoutResult.SyncOrAsyncHalibut == SyncOrAsyncHalibut.Async)
+            {
+                action();
+            }
+        }
+
+        public static SyncOrAsyncWithResult<T> WhenSync<T>(this SyncOrAsyncHalibut syncOrAsyncHalibut, Func<T> action)
+        {
+            if (syncOrAsyncHalibut == SyncOrAsyncHalibut.Sync)
+            {
+                return new SyncOrAsyncWithResult<T>(syncOrAsyncHalibut, action());
+            }
+
+            return new SyncOrAsyncWithResult<T>(syncOrAsyncHalibut, default);
+        }
+
+        public static SyncOrAsyncWithoutResult IgnoreResult<T>(this SyncOrAsyncWithResult<T> syncOrAsyncWithResult)
+        {
+            return new(syncOrAsyncWithResult.SyncOrAsyncHalibut);
+        }
+
+        public static async Task<T> WhenAsync<T>(this SyncOrAsyncWithResult<T> syncOrAsyncWithResult, Func<Task<T>> action)
+        {
+            if (syncOrAsyncWithResult.SyncOrAsyncHalibut == SyncOrAsyncHalibut.Async)
+            {
+                return await action();
+            }
+
+            return syncOrAsyncWithResult.Result!;
+        }
+    }
+
+    public class SyncOrAsyncWithoutResult
+    {
+        public SyncOrAsyncHalibut SyncOrAsyncHalibut { get; }
+
+        public SyncOrAsyncWithoutResult(SyncOrAsyncHalibut syncOrAsyncHalibut)
+        {
+            SyncOrAsyncHalibut = syncOrAsyncHalibut;
+        }
+    }
+
+    public class SyncOrAsyncWithResult<T>
+    {
+        public SyncOrAsyncHalibut SyncOrAsyncHalibut { get; }
+        public T? Result { get; }
+
+        public SyncOrAsyncWithResult(SyncOrAsyncHalibut syncOrAsyncHalibut, T? result)
+        {
+            SyncOrAsyncHalibut = syncOrAsyncHalibut;
+            Result = result;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsCapabilitiesServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsCapabilitiesServiceV2Decorator.cs
@@ -1,8 +1,8 @@
-using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
@@ -13,24 +13,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public long GetCapabilitiesCallCountComplete;
     }
 
-    public class CountingCallsCapabilitiesServiceV2Decorator : IClientCapabilitiesServiceV2
+    public class CountingCallsCapabilitiesServiceV2Decorator : IAsyncClientCapabilitiesServiceV2
     {
         private readonly CapabilitiesServiceV2CallCounts counts;
 
-        private readonly IClientCapabilitiesServiceV2 inner;
+        private readonly IAsyncClientCapabilitiesServiceV2 inner;
 
-        public CountingCallsCapabilitiesServiceV2Decorator(IClientCapabilitiesServiceV2 inner, CapabilitiesServiceV2CallCounts counts)
+        public CountingCallsCapabilitiesServiceV2Decorator(IAsyncClientCapabilitiesServiceV2 inner, CapabilitiesServiceV2CallCounts counts)
         {
             this.inner = inner;
             this.counts = counts;
         }
 
-        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions options)
+        public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.GetCapabilitiesCallCountStarted);
             try
             {
-                return inner.GetCapabilities(options);
+                return await inner.GetCapabilitiesAsync(options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsFileTransferServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsFileTransferServiceDecorator.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Halibut;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
@@ -16,24 +16,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public long DownloadFileCallCountComplete;
     }
 
-    public class CountingCallsFileTransferServiceDecorator : IClientFileTransferService
+    public class CountingCallsFileTransferServiceDecorator : IAsyncClientFileTransferService
     {
         private readonly FileTransferServiceCallCounts counts;
 
-        private readonly IClientFileTransferService inner;
+        private readonly IAsyncClientFileTransferService inner;
 
-        public CountingCallsFileTransferServiceDecorator(IClientFileTransferService inner, FileTransferServiceCallCounts counts)
+        public CountingCallsFileTransferServiceDecorator(IAsyncClientFileTransferService inner, FileTransferServiceCallCounts counts)
         {
             this.inner = inner;
             this.counts = counts;
         }
 
-        public UploadResult UploadFile(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
+        public async Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.UploadFileCallCountStarted);
             try
             {
-                return inner.UploadFile(remotePath, upload, options);
+                return await inner.UploadFileAsync(remotePath, upload, options);
             }
             finally
             {
@@ -41,12 +41,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public DataStream DownloadFile(string remotePath, HalibutProxyRequestOptions options)
+        public async Task<DataStream> DownloadFileAsync(string remotePath, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.DownloadFileCallCountStarted);
             try
             {
-                return inner.DownloadFile(remotePath, options);
+                return await inner.DownloadFileAsync(remotePath, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsScriptServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsScriptServiceDecorator.cs
@@ -1,8 +1,8 @@
-using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
@@ -16,23 +16,23 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public long StartScriptCallCountComplete;
     }
 
-    public class CountingCallsScriptServiceDecorator : IClientScriptService
+    public class CountingCallsScriptServiceDecorator : IAsyncClientScriptService
     {
         private readonly ScriptServiceCallCounts scriptServiceCallCounts;
-        private readonly IClientScriptService inner;
+        private readonly IAsyncClientScriptService inner;
 
-        public CountingCallsScriptServiceDecorator(IClientScriptService inner, ScriptServiceCallCounts scriptServiceCallCounts)
+        public CountingCallsScriptServiceDecorator(IAsyncClientScriptService inner, ScriptServiceCallCounts scriptServiceCallCounts)
         {
             this.inner = inner;
             this.scriptServiceCallCounts = scriptServiceCallCounts;
         }
 
-        public ScriptTicket StartScript(StartScriptCommand command, HalibutProxyRequestOptions options)
+        public async Task<ScriptTicket> StartScriptAsync(StartScriptCommand command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref scriptServiceCallCounts.StartScriptCallCountStarted);
             try
             {
-                return inner.StartScript(command, options);
+                return await inner.StartScriptAsync(command, options);
             }
             finally
             {
@@ -40,22 +40,22 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse GetStatus(ScriptStatusRequest request, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref scriptServiceCallCounts.GetStatusCallCountStarted);
-            return inner.GetStatus(request, options);
+            return await inner.GetStatusAsync(request, options);
         }
 
-        public ScriptStatusResponse CancelScript(CancelScriptCommand command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponse> CancelScriptAsync(CancelScriptCommand command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref scriptServiceCallCounts.CancelScriptCallCountStarted);
-            return inner.CancelScript(command, options);
+            return await inner.CancelScriptAsync(command, options);
         }
 
-        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponse> CompleteScriptAsync(CompleteScriptCommand command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref scriptServiceCallCounts.CompleteScriptCallCountStarted);
-            return inner.CompleteScript(command, options);
+            return await inner.CompleteScriptAsync(command, options);
         }
     }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsScriptServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CountingCallsScriptServiceV2Decorator.cs
@@ -1,6 +1,7 @@
 using System.Threading;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
@@ -18,25 +19,25 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public long CompleteScriptCallCountCompleted;
     }
 
-    public class CountingCallsScriptServiceV2Decorator : IClientScriptServiceV2
+    public class CountingCallsScriptServiceV2Decorator : IAsyncClientScriptServiceV2
     {
         private ScriptServiceV2CallCounts counts;
 
 
-        private IClientScriptServiceV2 inner;
+        private IAsyncClientScriptServiceV2 inner;
 
-        public CountingCallsScriptServiceV2Decorator(IClientScriptServiceV2 inner, ScriptServiceV2CallCounts counts)
+        public CountingCallsScriptServiceV2Decorator(IAsyncClientScriptServiceV2 inner, ScriptServiceV2CallCounts counts)
         {
             this.inner = inner;
             this.counts = counts;
         }
 
-        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.StartScriptCallCountStarted);
             try
             {
-                return inner.StartScript(command, options);
+                return await inner.StartScriptAsync(command, options);
             }
             finally
             {
@@ -44,12 +45,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.GetStatusCallCountStarted);
             try
             {
-                return inner.GetStatus(request, options);
+                return await inner.GetStatusAsync(request, options);
             }
             finally
             {
@@ -57,12 +58,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.CancelScriptCallCountStarted);
             try
             {
-                return inner.CancelScript(command, options);
+                return await inner.CancelScriptAsync(command, options);
             }
             finally
             {
@@ -70,12 +71,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
+        public async Task CompleteScriptAsync(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             Interlocked.Increment(ref counts.CompleteScriptCallCountStarted);
             try
             {
-                inner.CompleteScript(command, options);
+                await inner.CompleteScriptAsync(command, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingCapabilitiesServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingCapabilitiesServiceV2Decorator.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
@@ -11,24 +12,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public Exception? GetCapabilitiesLatestException { get; set; }
     }
 
-    public class ErrorRecordingCapabilitiesServiceV2Decorator : IClientCapabilitiesServiceV2
+    public class ErrorRecordingCapabilitiesServiceV2Decorator : IAsyncClientCapabilitiesServiceV2
     {
         private CapabilitiesServiceV2Exceptions errors;
-        private IClientCapabilitiesServiceV2 inner;
+        private IAsyncClientCapabilitiesServiceV2 inner;
         private ILogger logger;
 
-        public ErrorRecordingCapabilitiesServiceV2Decorator(IClientCapabilitiesServiceV2 inner, CapabilitiesServiceV2Exceptions errors)
+        public ErrorRecordingCapabilitiesServiceV2Decorator(IAsyncClientCapabilitiesServiceV2 inner, CapabilitiesServiceV2Exceptions errors)
         {
             this.inner = inner;
             this.errors = errors;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingCapabilitiesServiceV2Decorator>();
         }
 
-        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions options)
+        public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.GetCapabilities(options);
+                return await inner.GetCapabilitiesAsync(options);
             }
             catch (Exception e)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingFileTransferServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingFileTransferServiceDecorator.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Threading.Tasks;
 using Halibut;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
@@ -13,24 +14,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public Exception? DownloadFileLatestException { get; set; }
     }
 
-    public class ErrorRecordingFileTransferServiceDecorator : IClientFileTransferService
+    public class ErrorRecordingFileTransferServiceDecorator : IAsyncClientFileTransferService
     {
         private FileTransferServiceExceptions errors;
-        private IClientFileTransferService inner;
+        private IAsyncClientFileTransferService inner;
         private ILogger logger;
 
-        public ErrorRecordingFileTransferServiceDecorator(IClientFileTransferService inner, FileTransferServiceExceptions errors)
+        public ErrorRecordingFileTransferServiceDecorator(IAsyncClientFileTransferService inner, FileTransferServiceExceptions errors)
         {
             this.inner = inner;
             this.errors = errors;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingFileTransferServiceDecorator>();
         }
 
-        public UploadResult UploadFile(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
+        public async Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.UploadFile(remotePath, upload, options);
+                return await inner.UploadFileAsync(remotePath, upload, options);
             }
             catch (Exception e)
             {
@@ -40,11 +41,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public DataStream DownloadFile(string remotePath, HalibutProxyRequestOptions options)
+        public async Task<DataStream> DownloadFileAsync(string remotePath, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.DownloadFile(remotePath, options);
+                return await inner.DownloadFileAsync(remotePath, options);
             }
             catch (Exception e)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingScriptServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingScriptServiceDecorator.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
@@ -15,24 +16,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public Exception? CompleteScriptLatestException { get; set; }
     }
 
-    public class ErrorRecordingScriptServiceDecorator : IClientScriptService
+    public class ErrorRecordingScriptServiceDecorator : IAsyncClientScriptService
     {
         private readonly ScriptServiceExceptions errors;
-        private readonly IClientScriptService inner;
+        private readonly IAsyncClientScriptService inner;
         private readonly ILogger logger;
 
-        public ErrorRecordingScriptServiceDecorator(IClientScriptService inner, ScriptServiceExceptions errors)
+        public ErrorRecordingScriptServiceDecorator(IAsyncClientScriptService inner, ScriptServiceExceptions errors)
         {
             this.inner = inner;
             this.errors = errors;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingScriptServiceDecorator>();
         }
 
-        public ScriptTicket StartScript(StartScriptCommand command, HalibutProxyRequestOptions options)
+        public async Task<ScriptTicket> StartScriptAsync(StartScriptCommand command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.StartScript(command, options);
+                return await inner.StartScriptAsync(command, options);
             }
             catch (Exception e)
             {
@@ -42,11 +43,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse GetStatus(ScriptStatusRequest request, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.GetStatus(request, options);
+                return await inner.GetStatusAsync(request, options);
             }
             catch (Exception e)
             {
@@ -56,11 +57,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse CancelScript(CancelScriptCommand command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponse> CancelScriptAsync(CancelScriptCommand command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.CancelScript(command, options);
+                return await inner.CancelScriptAsync(command, options);
             }
             catch (Exception e)
             {
@@ -70,11 +71,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponse> CompleteScriptAsync(CompleteScriptCommand command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.CompleteScript(command, options);
+                return await inner.CompleteScriptAsync(command, options);
             }
             catch (Exception e)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingScriptServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ErrorRecordingScriptServiceV2Decorator.cs
@@ -1,6 +1,7 @@
 using System;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Serilog;
 
@@ -14,24 +15,24 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public Exception? CompleteScriptLatestException { get; set; }
     }
 
-    public class ErrorRecordingScriptServiceV2Decorator : IClientScriptServiceV2
+    public class ErrorRecordingScriptServiceV2Decorator : IAsyncClientScriptServiceV2
     {
         private ScriptServiceV2Exceptions errors;
-        private IClientScriptServiceV2 inner;
+        private IAsyncClientScriptServiceV2 inner;
         private ILogger logger;
 
-        public ErrorRecordingScriptServiceV2Decorator(IClientScriptServiceV2 inner, ScriptServiceV2Exceptions errors)
+        public ErrorRecordingScriptServiceV2Decorator(IAsyncClientScriptServiceV2 inner, ScriptServiceV2Exceptions errors)
         {
             this.inner = inner;
             this.errors = errors;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingScriptServiceV2Decorator>();
         }
 
-        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.StartScript(command, options);
+                return await inner.StartScriptAsync(command, options);
             }
             catch (Exception e)
             {
@@ -41,11 +42,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.GetStatus(request, options);
+                return await inner.GetStatusAsync(request, options);
             }
             catch (Exception e)
             {
@@ -55,11 +56,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             try
             {
-                return inner.CancelScript(command, options);
+                return await inner.CancelScriptAsync(command, options);
             }
             catch (Exception e)
             {
@@ -69,11 +70,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
+        public async Task CompleteScriptAsync(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             try
             {
-                inner.CompleteScript(command, options);
+                await inner.CompleteScriptAsync(command, options);
             }
             catch (Exception e)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToCapabilitiesServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToCapabilitiesServiceDecorator.cs
@@ -1,27 +1,28 @@
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
-    public class LogCallsToCapabilitiesServiceDecorator : IClientCapabilitiesServiceV2
+    public class LogCallsToCapabilitiesServiceDecorator : IAsyncClientCapabilitiesServiceV2
     {
-        private IClientCapabilitiesServiceV2 inner;
+        private IAsyncClientCapabilitiesServiceV2 inner;
         private ILogger logger;
 
-        public LogCallsToCapabilitiesServiceDecorator(IClientCapabilitiesServiceV2 inner)
+        public LogCallsToCapabilitiesServiceDecorator(IAsyncClientCapabilitiesServiceV2 inner)
         {
             this.inner = inner;
             logger = new SerilogLoggerBuilder().Build().ForContext<LogCallsToCapabilitiesServiceDecorator>();
         }
 
-        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions options)
+        public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(HalibutProxyRequestOptions options)
         {
             logger.Information("GetCapabilities call started");
             try
             {
-                return inner.GetCapabilities(options);
+                return await inner.GetCapabilitiesAsync(options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToFileTransferServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToFileTransferServiceDecorator.cs
@@ -1,28 +1,29 @@
+using System.Threading.Tasks;
 using Halibut;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
-    public class LogCallsToFileTransferServiceDecorator : IClientFileTransferService
+    public class LogCallsToFileTransferServiceDecorator : IAsyncClientFileTransferService
     {
-        private IClientFileTransferService inner;
+        private IAsyncClientFileTransferService inner;
         private ILogger logger;
 
-        public LogCallsToFileTransferServiceDecorator(IClientFileTransferService inner)
+        public LogCallsToFileTransferServiceDecorator(IAsyncClientFileTransferService inner)
         {
             this.inner = inner;
             logger = new SerilogLoggerBuilder().Build().ForContext<LogCallsToFileTransferServiceDecorator>();
         }
 
-        public UploadResult UploadFile(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
+        public async Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
         {
             logger.Information("UploadFile call started");
             try
             {
-                return inner.UploadFile(remotePath, upload, options);
+                return await inner.UploadFileAsync(remotePath, upload, options);
             }
             finally
             {
@@ -30,12 +31,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public DataStream DownloadFile(string remotePath, HalibutProxyRequestOptions options)
+        public async Task<DataStream> DownloadFileAsync(string remotePath, HalibutProxyRequestOptions options)
         {
             logger.Information("DownloadFile call started");
             try
             {
-                return inner.DownloadFile(remotePath, options);
+                return await inner.DownloadFileAsync(remotePath, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToScriptServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToScriptServiceDecorator.cs
@@ -1,28 +1,28 @@
-using System;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
-    public class LogCallsToScriptServiceDecorator : IClientScriptService
+    public class LogCallsToScriptServiceDecorator : IAsyncClientScriptService
     {
-        private readonly IClientScriptService inner;
+        private readonly IAsyncClientScriptService inner;
         private readonly ILogger logger;
 
-        public LogCallsToScriptServiceDecorator(IClientScriptService inner)
+        public LogCallsToScriptServiceDecorator(IAsyncClientScriptService inner)
         {
             this.inner = inner;
             logger = new SerilogLoggerBuilder().Build().ForContext<ErrorRecordingScriptServiceDecorator>();
         }
 
-        public ScriptTicket StartScript(StartScriptCommand command, HalibutProxyRequestOptions options)
+        public async Task<ScriptTicket> StartScriptAsync(StartScriptCommand command, HalibutProxyRequestOptions options)
         {
             logger.Information("StartScript call started");
             try
             {
-                return inner.StartScript(command, options);
+                return await inner.StartScriptAsync(command, options);
             }
             finally
             {
@@ -30,12 +30,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse GetStatus(ScriptStatusRequest request, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request, HalibutProxyRequestOptions options)
         {
             logger.Information("GetStatus call started");
             try
             {
-                return inner.GetStatus(request, options);
+                return await inner.GetStatusAsync(request, options);
             }
             finally
             {
@@ -43,12 +43,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse CancelScript(CancelScriptCommand command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponse> CancelScriptAsync(CancelScriptCommand command, HalibutProxyRequestOptions options)
         {
             logger.Information("CancelScript call started");
             try
             {
-                return inner.CancelScript(command, options);
+                return await inner.CancelScriptAsync(command, options);
             }
             finally
             {
@@ -56,12 +56,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponse> CompleteScriptAsync(CompleteScriptCommand command, HalibutProxyRequestOptions options)
         {
             logger.Information("CompleteScript call started");
             try
             {
-                return inner.CompleteScript(command, options);
+                return await inner.CompleteScriptAsync(command, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToScriptServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/LogCallsToScriptServiceV2Decorator.cs
@@ -1,27 +1,28 @@
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
-    public class LogCallsToScriptServiceV2Decorator : IClientScriptServiceV2
+    public class LogCallsToScriptServiceV2Decorator : IAsyncClientScriptServiceV2
     {
-        private IClientScriptServiceV2 inner;
+        private IAsyncClientScriptServiceV2 inner;
         private ILogger logger;
 
-        public LogCallsToScriptServiceV2Decorator(IClientScriptServiceV2 inner)
+        public LogCallsToScriptServiceV2Decorator(IAsyncClientScriptServiceV2 inner)
         {
             this.inner = inner;
             logger = new SerilogLoggerBuilder().Build().ForContext<LogCallsToScriptServiceV2Decorator>();
         }
 
-        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             logger.Information("StartScript call started");
             try
             {
-                return inner.StartScript(command, options);
+                return await inner.StartScriptAsync(command, options);
             }
             finally
             {
@@ -29,12 +30,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
         {
             logger.Information("GetStatus call started");
             try
             {
-                return inner.GetStatus(request, options);
+                return await inner.GetStatusAsync(request, options);
             }
             finally
             {
@@ -42,12 +43,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
+        public async Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             logger.Information("CancelScript call started");
             try
             {
-                return inner.CancelScript(command, options);
+                return await inner.CancelScriptAsync(command, options);
             }
             finally
             {
@@ -55,12 +56,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             }
         }
 
-        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
+        public async Task CompleteScriptAsync(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
         {
             logger.Information("CompleteScript call started");
             try
             {
-                inner.CompleteScript(command, options);
+                await inner.CompleteScriptAsync(command, options);
             }
             finally
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/AsyncToSyncProxy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/AsyncToSyncProxy.cs
@@ -1,0 +1,48 @@
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies
+{
+    internal class AsyncToSyncProxy
+    {
+        public static IClientScriptService ProxyAsyncToSync(IAsyncClientScriptService service)
+        {
+            return new ClientScriptServiceAsyncToSyncProxy(service);
+        }
+
+        public static IClientFileTransferService ProxyAsyncToSync(IAsyncClientFileTransferService service)
+        {
+            return new ClientFileTransferServiceAsyncToSyncProxy(service);
+        }
+
+        public static IClientScriptServiceV2 ProxyAsyncToSync(IAsyncClientScriptServiceV2 service)
+        {
+            return new ClientScriptServiceV2AsyncToSyncProxy(service);
+        }
+
+        public static IClientCapabilitiesServiceV2 ProxyAsyncToSync(IAsyncClientCapabilitiesServiceV2 service)
+        {
+            return new ClientCapabilitiesServiceV2AsyncToSyncProxy(service);
+        }
+
+        public static IAsyncClientScriptService ProxySyncToAsync(IClientScriptService service)
+        {
+            return new ClientScriptServiceSyncToAsyncProxy(service);
+        }
+
+        public static IAsyncClientScriptServiceV2 ProxySyncToAsync(IClientScriptServiceV2 service)
+        {
+            return new ClientScriptServiceV2SyncToAsyncProxy(service);
+        }
+
+        public static IAsyncClientFileTransferService ProxySyncToAsync(IClientFileTransferService service)
+        {
+            return new ClientFileTransferServiceSyncToAsyncProxy(service);
+        }
+
+        public static IAsyncClientCapabilitiesServiceV2 ProxySyncToAsync(IClientCapabilitiesServiceV2 service)
+        {
+            return new ClientCapabilitiesServiceV2SyncToAsyncProxy(service);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientCapabilitiesServiceV2AsyncToSyncProxy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientCapabilitiesServiceV2AsyncToSyncProxy.cs
@@ -1,0 +1,23 @@
+using System;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies
+{
+    internal class ClientCapabilitiesServiceV2AsyncToSyncProxy : IClientCapabilitiesServiceV2
+    {
+        private readonly IAsyncClientCapabilitiesServiceV2 service;
+
+        public ClientCapabilitiesServiceV2AsyncToSyncProxy(IAsyncClientCapabilitiesServiceV2 service)
+        {
+            this.service = service;
+        }
+
+        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return service.GetCapabilitiesAsync(halibutProxyRequestOptions).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientCapabilitiesServiceV2SyncToAsyncProxy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientCapabilitiesServiceV2SyncToAsyncProxy.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies
+{
+    internal class ClientCapabilitiesServiceV2SyncToAsyncProxy : IAsyncClientCapabilitiesServiceV2
+    {
+        private readonly IClientCapabilitiesServiceV2 service;
+
+        public ClientCapabilitiesServiceV2SyncToAsyncProxy(IClientCapabilitiesServiceV2 service)
+        {
+            this.service = service;
+        }
+
+        public Task<CapabilitiesResponseV2> GetCapabilitiesAsync(HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            var result = service.GetCapabilities(halibutProxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientFileTransferServiceAsyncToSyncProxy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientFileTransferServiceAsyncToSyncProxy.cs
@@ -1,0 +1,29 @@
+using System;
+using Halibut;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies
+{
+    internal class ClientFileTransferServiceAsyncToSyncProxy : IClientFileTransferService
+    {
+        private readonly IAsyncClientFileTransferService service;
+
+        public ClientFileTransferServiceAsyncToSyncProxy(IAsyncClientFileTransferService service)
+        {
+            this.service = service;
+        }
+
+        public UploadResult UploadFile(string remotePath, DataStream upload, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            return service.UploadFileAsync(remotePath, upload, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+
+        public DataStream DownloadFile(string remotePath, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            return service.DownloadFileAsync(remotePath, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientFileTransferServiceSyncToAsyncProxy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientFileTransferServiceSyncToAsyncProxy.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using Halibut;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies
+{
+    internal class ClientFileTransferServiceSyncToAsyncProxy : IAsyncClientFileTransferService
+    {
+        private readonly IClientFileTransferService service;
+
+        public ClientFileTransferServiceSyncToAsyncProxy(IClientFileTransferService service)
+        {
+            this.service = service;
+        }
+
+        public Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            var result = service.UploadFile(remotePath, upload, halibutProxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+
+        public Task<DataStream> DownloadFileAsync(string remotePath, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            var result = service.DownloadFile(remotePath, halibutProxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientScriptServiceAsyncToSyncProxy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientScriptServiceAsyncToSyncProxy.cs
@@ -1,0 +1,37 @@
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies
+{
+    internal class ClientScriptServiceAsyncToSyncProxy : IClientScriptService
+    {
+        private readonly IAsyncClientScriptService service;
+
+        public ClientScriptServiceAsyncToSyncProxy(IAsyncClientScriptService service)
+        {
+            this.service = service;
+        }
+
+        public ScriptStatusResponse CancelScript(CancelScriptCommand command, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            return service.CancelScriptAsync(command, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+
+        public ScriptStatusResponse CompleteScript(CompleteScriptCommand command, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            return service.CompleteScriptAsync(command, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+
+        public ScriptStatusResponse GetStatus(ScriptStatusRequest request, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            return service.GetStatusAsync(request, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+
+        public ScriptTicket StartScript(StartScriptCommand command, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            return service.StartScriptAsync(command, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientScriptServiceSyncToAsyncProxy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientScriptServiceSyncToAsyncProxy.cs
@@ -1,0 +1,46 @@
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies
+{
+    internal class ClientScriptServiceSyncToAsyncProxy : IAsyncClientScriptService
+    {
+        private readonly IClientScriptService service;
+
+        public ClientScriptServiceSyncToAsyncProxy(IClientScriptService service)
+        {
+            this.service = service;
+        }
+
+        public Task<ScriptTicket> StartScriptAsync(StartScriptCommand command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            var result = service.StartScript(command, halibutProxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+
+        public Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            var result = service.GetStatus(request, halibutProxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+
+        public Task<ScriptStatusResponse> CancelScriptAsync(CancelScriptCommand command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            var result = service.CancelScript(command, halibutProxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+
+        public Task<ScriptStatusResponse> CompleteScriptAsync(CompleteScriptCommand command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            var result = service.CompleteScript(command, halibutProxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientScriptServiceV2AsyncToSyncProxy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientScriptServiceV2AsyncToSyncProxy.cs
@@ -1,0 +1,37 @@
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies
+{
+    internal class ClientScriptServiceV2AsyncToSyncProxy : IClientScriptServiceV2
+    {
+        private readonly IAsyncClientScriptServiceV2 service;
+
+        public ClientScriptServiceV2AsyncToSyncProxy(IAsyncClientScriptServiceV2 service)
+        {
+            this.service = service;
+        }
+
+        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            return service.CancelScriptAsync(command, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+
+        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            service.CompleteScriptAsync(command, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+
+        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            return service.GetStatusAsync(request, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+
+        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            return service.StartScriptAsync(command, proxyRequestOptions).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientScriptServiceV2SyncToAsyncProxy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/SyncAndAsyncProxies/ClientScriptServiceV2SyncToAsyncProxy.cs
@@ -1,0 +1,46 @@
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies
+{
+    internal class ClientScriptServiceV2SyncToAsyncProxy : IAsyncClientScriptServiceV2
+    {
+        private readonly IClientScriptServiceV2 service;
+
+        public ClientScriptServiceV2SyncToAsyncProxy(IClientScriptServiceV2 service)
+        {
+            this.service = service;
+        }
+
+        public Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            var result = service.CancelScript(command, proxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+
+        public Task CompleteScriptAsync(CompleteScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            service.CompleteScript(command, proxyRequestOptions);
+
+            return Task.CompletedTask;
+        }
+
+        public Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            var result = service.GetStatus(request, proxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+
+        public Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions)
+        {
+            var result = service.StartScript(command, proxyRequestOptions);
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/PendingRequestQueueWorkarounds.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/PendingRequestQueueWorkarounds.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
-using Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
 {
     public static class PendingRequestQueueWorkarounds
     {
-        public static void EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IClientScriptServiceV2 service, ILogger logger)
+        public static async Task EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IAsyncClientScriptServiceV2 service, ILogger logger)
         {
             logger.Log().Information("Call GetStatus to work around an issue where the polling queue will send work to a disconnected tentacle");
-            DoIgnoringException(() => service.GetStatus(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), ProxyRequestOptions()));
+            await DoIgnoringException(async () => await service.GetStatusAsync(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), ProxyRequestOptions()));
             logger.Log().Information("Finished GetStatus work around call");
         }
 
@@ -25,17 +25,17 @@ namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
             return new HalibutProxyRequestOptions(cts.Token);
         }
 
-        public static void EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IClientCapabilitiesServiceV2 service, ILogger logger)
+        public static async Task EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IAsyncClientCapabilitiesServiceV2 service, ILogger logger)
         {
             logger.Log().Information("Call GetCapabilities to work around an issue where the polling queue will send work to a disconnected tentacle");
-            DoIgnoringException(() => service.GetCapabilities(ProxyRequestOptions()));
+            await DoIgnoringException(async () => await service.GetCapabilitiesAsync(ProxyRequestOptions()));
             logger.Log().Information("Finished GetCapabilities work around call");
         }
 
-        public static void EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IClientFileTransferService service, ILogger logger)
+        public static async Task EnsurePollingQueueWontSendMessageToDisconnectedTentacles(this IAsyncClientFileTransferService service, ILogger logger)
         {
             logger.Log().Information("Call DownloadFile to work around an issue where the polling queue will send work to a disconnected tentacle");
-            DoIgnoringException(() => service.DownloadFile("nope", ProxyRequestOptions()));
+            await DoIgnoringException(async () => await service.DownloadFileAsync("nope", ProxyRequestOptions()));
             logger.Log().Information("Finished DownloadFile work around call");
         }
 
@@ -44,11 +44,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
             return logger.ForContext(typeof(PendingRequestQueueWorkarounds));
         }
         
-        private static void DoIgnoringException(Action action)
+        private static async Task DoIgnoringException(Func<Task> action)
         {
             try
             {
-                action();
+                await action();
             }
             catch (Exception)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ResponseMessageTcpKillerWorkarounds.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ResponseMessageTcpKillerWorkarounds.cs
@@ -1,10 +1,11 @@
 ﻿using System.Threading;
+using System.Threading.Tasks;
 using Halibut.ServiceModel;
 using Octopus.Tentacle.Client.ClientServices;
-using Serilog;
 using Octopus.Tentacle.Contracts;
-using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 {
@@ -17,10 +18,17 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
             logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished GetStatus work around call");
         }
 
-        public static void EnsureTentacleIsConnectedToServer(this IClientFileTransferService service, ILogger logger)
+        public static async Task EnsureTentacleIsConnectedToServer(this IAsyncClientScriptServiceV2 service, ILogger logger)
+        {
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Call GetStatus to work around an issue where the tcp killer kills setup of new connections");
+            await service.GetStatusAsync(new ScriptStatusRequestV2(new ScriptTicket("nope"), 0), new HalibutProxyRequestOptions(CancellationToken.None));
+            logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished GetStatus work around call");
+        }
+
+        public static async Task EnsureTentacleIsConnectedToServer(this IAsyncClientFileTransferService service, ILogger logger)
         {
             logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Call DownloadFile to work around an issue where the tcp killer kills setup of new connections");
-            service.DownloadFile("nope", new HalibutProxyRequestOptions(CancellationToken.None));
+            await service.DownloadFileAsync("nope", new HalibutProxyRequestOptions(CancellationToken.None));
             logger.ForContext(typeof(ResponseMessageTcpKillerWorkarounds)).Information("Finished DownloadFile work around call");
         }
     }


### PR DESCRIPTION
# Background

Make the TentacleClient decorators async and add a proxy so that sync calls can use the async decorators.

This is in preparation for making the tests support both sync and async service calls

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.