### PR TITLE
In tentacle builder throw when cancellation is requested, rather than fail for seemingly unrelated reasons.

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -139,11 +139,13 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         protected void AddCertificateToTentacle(string tentacleExe, string instanceName, string tentaclePfxPath, TemporaryDirectory tmp, CancellationToken cancellationToken)
         {
             RunTentacleCommand(tentacleExe, new[] { "import-certificate", $"--from-file={tentaclePfxPath}", $"--instance={instanceName}" }, tmp, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         protected void CreateInstance(string tentacleExe, string configFilePath, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)
         {
             RunTentacleCommand(tentacleExe, new[] { "create-instance", "--config", $"\"{configFilePath}\"", $"--instance={instanceName}" }, tmp, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         internal void DeleteInstanceIgnoringFailure(string tentacleExe, string instanceName, TemporaryDirectory tmp, CancellationToken cancellationToken)


### PR DESCRIPTION
# Background

Throw if cancellation is requested that way it is clear the cancellation token was triggered. Currently if the test times out early on  the `tentacle.exe` call to setup the tentacle config silently fails and so doesn't make a config file resulting in weird errors around the config file being missing. That is super hard to relate to, "the cancellation token was triggered".

[SC-56842]

# Example of the problem before this test:
```
utofac.Core.DependencyResolutionException : An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = WritableTentacleConfiguration (ReflectionActivator), Services = [Octopus.Tentacle.Configuration.IWritableTentacleConfiguration], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IWritableKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IWritableKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> The configuration file at C:\Users\agentuser\AppData\Local\Octopus\Temp\b09fa997-6400-4154-a4a9-6ce30fcc8360\TentacleIT-7fd2791d798e453f8fdc707fb6a110a4.cfg could not be located at the specified location. (See inner exception for details.) (See inner exception for details.)
  ----> Autofac.Core.DependencyResolutionException : An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = IWritableKeyValueStore (DelegateActivator), Services = [Octopus.Configuration.IWritableKeyValueStore], Lifetime = Autofac.Core.Lifetime.RootScopeLifetime, Sharing = Shared, Ownership = OwnedByLifetimeScope ---> The configuration file at C:\Users\agentuser\AppData\Local\Octopus\Temp\b09fa997-6400-4154-a4a9-6ce30fcc8360\TentacleIT-7fd2791d798e453f8fdc707fb6a110a4.cfg could not be located at the specified location. (See inner exception for details.)
  ----> Octopus.Tentacle.ControlledFailureException : The configuration file at C:\Users\agentuser\AppData\Local\Octopus\Temp\b09fa997-6400-4154-a4a9-6ce30fcc8360\TentacleIT-7fd2791d798e453f8fdc707fb6a110a4.cfg could not be located at the specified location.

  1) The test timed out.
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.ResolutionExtensions.TryResolveService(IComponentContext context, Service service, IEnumerable`1 parameters, Object& instance)
   at Autofac.ResolutionExtensions.ResolveService(IComponentContext context, Service service, IEnumerable`1 parameters)
   at Autofac.ResolutionExtensions.Resolve[TService](IComponentContext context, IEnumerable`1 parameters)
   at Octopus.Tentacle.Tests.Integration.Support.TentacleBuilder`1.WithWritableTentacleConfiguration(String configFilePath, Action`1 action) in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\Support\TentacleBuilder.cs:line 42
   at Octopus.Tentacle.Tests.Integration.Support.PollingTentacleBuilder.ConfigureTentacleToPollOctopusServer(String configFilePath, Uri subscriptionId) in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\Support\PollingTentacleBuilder.cs:line 46
   at Octopus.Tentacle.Tests.Integration.Support.PollingTentacleBuilder.<Build>d__2.MoveNext() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\Support\PollingTentacleBuilder.cs:line 31
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Octopus.Tentacle.Tests.Integration.Support.ClientAndTentacleBuilder.<Build>d__26.MoveNext() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\Support\ClientAndTentacleBuilder.cs:line 168
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Octopus.Tentacle.Tests.Integration.ClientFileTransfersAreRetriedWhenRetriesAreEnabled.<FailedDownloadsAreRetriedAndIsEventuallySuccessful>d__1.MoveNext() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs:line 59
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
--DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
--ControlledFailureException
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceSelector.EnsureConfigurationExists(String instanceName, String configurationPath) in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle\Configuration\Instances\ApplicationInstanceSelector.cs:line 86
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceSelector.LoadInstance() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle\Configuration\Instances\ApplicationInstanceSelector.cs:line 69
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceSelector.LoadCurrentInstance() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle\Configuration\Instances\ApplicationInstanceSelector.cs:line 57
   at Octopus.Tentacle.Configuration.ConfigurationModule.<>c.<Load>b__3_3(IComponentContext c) in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle\Configuration\ConfigurationModule.cs:line 77
   at Autofac.Builder.RegistrationBuilder.<>c__DisplayClass0_0`1.<ForDelegate>b__0(IComponentContext c, IEnumerable`1 p)
   at Autofac.Core.Activators.Delegate.DelegateActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
1)    at Octopus.Tentacle.Tests.Integration.Support.IntegrationTest.<SetUp>b__10_0() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\Support\IntegrationTest.cs:line 28
2)    at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.ResolveOperation.Execute(IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.ResolutionExtensions.TryResolveService(IComponentContext context, Service service, IEnumerable`1 parameters, Object& instance)
   at Autofac.ResolutionExtensions.ResolveService(IComponentContext context, Service service, IEnumerable`1 parameters)
   at Autofac.ResolutionExtensions.Resolve[TService](IComponentContext context, IEnumerable`1 parameters)
   at Octopus.Tentacle.Tests.Integration.Support.TentacleBuilder`1.WithWritableTentacleConfiguration(String configFilePath, Action`1 action) in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\Support\TentacleBuilder.cs:line 42
   at Octopus.Tentacle.Tests.Integration.Support.PollingTentacleBuilder.ConfigureTentacleToPollOctopusServer(String configFilePath, Uri subscriptionId) in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\Support\PollingTentacleBuilder.cs:line 46
   at Octopus.Tentacle.Tests.Integration.Support.PollingTentacleBuilder.<Build>d__2.MoveNext() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\Support\PollingTentacleBuilder.cs:line 31
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Octopus.Tentacle.Tests.Integration.Support.ClientAndTentacleBuilder.<Build>d__26.MoveNext() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\Support\ClientAndTentacleBuilder.cs:line 168
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Octopus.Tentacle.Tests.Integration.ClientFileTransfersAreRetriedWhenRetriesAreEnabled.<FailedDownloadsAreRetriedAndIsEventuallySuccessful>d__1.MoveNext() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle.Tests.Integration\ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs:line 59
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.BlockUntilCompleted()
   at NUnit.Framework.Internal.MessagePumpStrategy.NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter awaiter)
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
--DependencyResolutionException
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
   at Autofac.Core.Lifetime.LifetimeScope.GetOrCreateAndShare(Guid id, Func`1 creator)
   at Autofac.Core.Resolving.InstanceLookup.Execute()
   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable`1 parameters)
   at Autofac.Core.Activators.Reflection.ConstructorParameterBinding.Instantiate()
   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
--ControlledFailureException
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceSelector.EnsureConfigurationExists(String instanceName, String configurationPath) in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle\Configuration\Instances\ApplicationInstanceSelector.cs:line 86
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceSelector.LoadInstance() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle\Configuration\Instances\ApplicationInstanceSelector.cs:line 69
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceSelector.LoadCurrentInstance() in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle\Configuration\Instances\ApplicationInstanceSelector.cs:line 57
   at Octopus.Tentacle.Configuration.ConfigurationModule.<>c.<Load>b__3_3(IComponentContext c) in C:\BuildAgent\work\639265b01610d682\source\Octopus.Tentacle\Configuration\ConfigurationModule.cs:line 77
   at Autofac.Builder.RegistrationBuilder.<>c__DisplayClass0_0`1.<ForDelegate>b__0(IComponentContext c, IEnumerable`1 p)
   at Autofac.Core.Activators.Delegate.DelegateActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)

```


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.