### PR TITLE
Errors in TentacleClientObserver should not stop script execution or fail TentacleClient operations

### DIFF
--- a/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
+++ b/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
@@ -85,14 +85,7 @@ namespace Octopus.Tentacle.Client.Execution
             {
                 var rpcCallMetrics = rpcCallMetricsBuilder.Build();
                 clientOperationMetricsBuilder.WithRpcCall(rpcCallMetrics);
-                try
-                {
-                    tentacleClientObserver.RpcCallCompleted(rpcCallMetrics);
-                }
-                catch (Exception e)
-                {
-                    logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the RPC call completion.");
-                }
+                tentacleClientObserver.RpcCallCompleted(rpcCallMetrics, logger);
             }
         }
 
@@ -129,15 +122,7 @@ namespace Octopus.Tentacle.Client.Execution
                             {
                                 var rpcCallMetrics = rpcCallMetricsBuilder.Build();
                                 clientOperationMetricsBuilder.WithRpcCall(rpcCallMetrics);
-
-                                try
-                                {
-                                    tentacleClientObserver.RpcCallCompleted(rpcCallMetrics);
-                                }
-                                catch (Exception e)
-                                {
-                                    logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the RPC call completion.");
-                                }
+                                tentacleClientObserver.RpcCallCompleted(rpcCallMetrics, logger);
                             }
                         }, ct);
                     },
@@ -180,15 +165,7 @@ namespace Octopus.Tentacle.Client.Execution
                             {
                                 var rpcCallMetrics = rpcCallMetricsBuilder.Build();
                                 clientOperationMetricsBuilder.WithRpcCall(rpcCallMetrics);
-
-                                try
-                                {
-                                    tentacleClientObserver.RpcCallCompleted(rpcCallMetrics);
-                                }
-                                catch (Exception e)
-                                {
-                                    logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the RPC call completion.");
-                                }
+                                tentacleClientObserver.RpcCallCompleted(rpcCallMetrics, logger);
                             }
                         }, ct);
                     },

--- a/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
+++ b/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
@@ -85,13 +85,21 @@ namespace Octopus.Tentacle.Client.Execution
             {
                 var rpcCallMetrics = rpcCallMetricsBuilder.Build();
                 clientOperationMetricsBuilder.WithRpcCall(rpcCallMetrics);
-                tentacleClientObserver.RpcCallCompleted(rpcCallMetrics);
+                try
+                {
+                    tentacleClientObserver.RpcCallCompleted(rpcCallMetrics);
+                }
+                catch (Exception e)
+                {
+                    logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the RPC call completion.");
+                }
             }
         }
 
         public async Task<T> ExecuteWithNoRetries<T>(
             RpcCall rpcCall,
             Func<CancellationToken, Task<T>> action,
+            ILog logger,
             bool abandonActionOnCancellation,
             ClientOperationMetricsBuilder clientOperationMetricsBuilder,
             CancellationToken cancellationToken)
@@ -121,7 +129,15 @@ namespace Octopus.Tentacle.Client.Execution
                             {
                                 var rpcCallMetrics = rpcCallMetricsBuilder.Build();
                                 clientOperationMetricsBuilder.WithRpcCall(rpcCallMetrics);
-                                tentacleClientObserver.RpcCallCompleted(rpcCallMetrics);
+
+                                try
+                                {
+                                    tentacleClientObserver.RpcCallCompleted(rpcCallMetrics);
+                                }
+                                catch (Exception e)
+                                {
+                                    logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the RPC call completion.");
+                                }
                             }
                         }, ct);
                     },
@@ -135,6 +151,7 @@ namespace Octopus.Tentacle.Client.Execution
         public async Task ExecuteWithNoRetries(
             RpcCall rpcCall,
             Func<CancellationToken, Task> action,
+            ILog logger,
             bool abandonActionOnCancellation,
             ClientOperationMetricsBuilder clientOperationMetricsBuilder,
             CancellationToken cancellationToken)
@@ -163,7 +180,15 @@ namespace Octopus.Tentacle.Client.Execution
                             {
                                 var rpcCallMetrics = rpcCallMetricsBuilder.Build();
                                 clientOperationMetricsBuilder.WithRpcCall(rpcCallMetrics);
-                                tentacleClientObserver.RpcCallCompleted(rpcCallMetrics);
+
+                                try
+                                {
+                                    tentacleClientObserver.RpcCallCompleted(rpcCallMetrics);
+                                }
+                                catch (Exception e)
+                                {
+                                    logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the RPC call completion.");
+                                }
                             }
                         }, ct);
                     },

--- a/source/Octopus.Tentacle.Client/Observability/NonThrowingTentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.Client/Observability/NonThrowingTentacleClientObserver.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Contracts.Observability;
+
+namespace Octopus.Tentacle.Client.Observability
+{
+    public class NonThrowingTentacleClientObserverDecorator : ITentacleClientObserver
+    {
+        private readonly ITentacleClientObserver inner;
+
+        public NonThrowingTentacleClientObserverDecorator(ITentacleClientObserver inner)
+        {
+            this.inner = inner;
+        }
+
+        public void RpcCallCompleted(RpcCallMetrics rpcCallMetrics, ILog logger)
+        {
+            try
+            {
+                inner.RpcCallCompleted(rpcCallMetrics, logger);
+            }
+            catch (Exception e)
+            {
+                logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the RPC call completion.");
+            }
+        }
+
+        public void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
+        {
+            try
+            {
+                inner.UploadFileCompleted(clientOperationMetrics, logger);
+            }
+            catch (Exception e)
+            {
+                logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the Upload File completion.");
+            }
+        }
+
+        public void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
+        {
+            try
+            {
+                inner.DownloadFileCompleted(clientOperationMetrics, logger);
+            }
+            catch (Exception e)
+            {
+                logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the Download File completion.");
+            }
+        }
+
+        public void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
+        {
+            try
+            {
+                inner.ExecuteScriptCompleted(clientOperationMetrics, logger);
+            }
+            catch (Exception e)
+            {
+                logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the Execute Script completion.");
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Observability/TentacleClientObserverExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Client/Observability/TentacleClientObserverExtensionMethods.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Octopus.Tentacle.Contracts.Observability;
+
+namespace Octopus.Tentacle.Client.Observability
+{
+    public static class TentacleClientObserverExtensionMethods
+    {
+        public static ITentacleClientObserver DecorateWithNonThrowingTentacleClientObserver(this ITentacleClientObserver tentacleClientObserver)
+        {
+            return new NonThrowingTentacleClientObserverDecorator(tentacleClientObserver);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionOrchestrator.cs
@@ -115,6 +115,7 @@ namespace Octopus.Tentacle.Client.Scripts
                         scriptStatusResponse = await rpcCallExecutor.ExecuteWithNoRetries(
                             RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.StartScript)),
                             StartScriptAction,
+                            logger,
                             abandonActionOnCancellation: true,
                             clientOperationMetricsBuilder,
                             scriptExecutionCancellationToken).ConfigureAwait(false);
@@ -157,6 +158,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
                         return result;
                     },
+                    logger,
                     abandonActionOnCancellation: false,
                     clientOperationMetricsBuilder,
                     scriptExecutionCancellationToken).ConfigureAwait(false);
@@ -206,6 +208,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 tentacleCapabilities = await rpcCallExecutor.ExecuteWithNoRetries(
                     RpcCall.Create<ICapabilitiesServiceV2>(nameof(ICapabilitiesServiceV2.GetCapabilities)),
                     GetCapabilitiesFunc,
+                    logger,
                     abandonActionOnCancellation: true,
                     clientOperationMetricsBuilder,
                     cancellationToken).ConfigureAwait(false);
@@ -331,6 +334,7 @@ namespace Octopus.Tentacle.Client.Scripts
                         return await rpcCallExecutor.ExecuteWithNoRetries(
                             RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.GetStatus)),
                             GetStatusAction,
+                            logger,
                             abandonActionOnCancellation: true,
                             clientOperationMetricsBuilder,
                             cancellationToken).ConfigureAwait(false);
@@ -356,6 +360,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
                         return result;
                     },
+                    logger,
                     abandonActionOnCancellation: false,
                     clientOperationMetricsBuilder,
                     cancellationToken).ConfigureAwait(false);
@@ -399,6 +404,7 @@ namespace Octopus.Tentacle.Client.Scripts
                     return await rpcCallExecutor.ExecuteWithNoRetries(
                         RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.CancelScript)),
                         CancelScriptAction,
+                        logger,
                         abandonActionOnCancellation: false,
                         clientOperationMetricsBuilder,
                         cancellationToken).ConfigureAwait(false);
@@ -418,6 +424,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
                         return result;
                     },
+                    logger,
                     abandonActionOnCancellation: false,
                     clientOperationMetricsBuilder,
                     cancellationToken).ConfigureAwait(false);
@@ -449,6 +456,7 @@ namespace Octopus.Tentacle.Client.Scripts
                                     .WhenDisabled(() => clientScriptServiceV2.SyncService.CompleteScript(request, new HalibutProxyRequestOptions(ct, CancellationToken.None)))
                                     .WhenEnabled(async () => await clientScriptServiceV2.AsyncService.CompleteScriptAsync(request, new HalibutProxyRequestOptions(ct, CancellationToken.None)));
                             },
+                            logger,
                             abandonActionOnCancellation: false,
                             clientOperationMetricsBuilder,
                             CancellationToken.None);
@@ -494,6 +502,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
                         return result;
                     },
+                    logger,
                     abandonActionOnCancellation: false,
                     clientOperationMetricsBuilder,
                     CancellationToken.None).ConfigureAwait(false);

--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -169,6 +169,7 @@ namespace Octopus.Tentacle.Client
                     return await rpcCallExecutor.ExecuteWithNoRetries(
                         RpcCall.Create<IFileTransferService>(nameof(IFileTransferService.UploadFile)),
                         UploadFileAction,
+                        logger,
                         abandonActionOnCancellation: false,
                         operationMetricsBuilder,
                         cancellationToken).ConfigureAwait(false);
@@ -182,7 +183,15 @@ namespace Octopus.Tentacle.Client
             finally
             {
                 var operationMetrics = operationMetricsBuilder.Build();
-                tentacleClientObserver.UploadFileCompleted(operationMetrics);
+
+                try
+                {
+                    tentacleClientObserver.UploadFileCompleted(operationMetrics);
+                }
+                catch (Exception e)
+                {
+                    logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the Upload File completion.");
+                }
             }
         }
 
@@ -221,6 +230,7 @@ namespace Octopus.Tentacle.Client
                     return await rpcCallExecutor.ExecuteWithNoRetries(
                         RpcCall.Create<IFileTransferService>(nameof(IFileTransferService.DownloadFile)),
                         DownloadFileAction,
+                        logger,
                         abandonActionOnCancellation: false,
                         operationMetricsBuilder,
                         cancellationToken).ConfigureAwait(false);
@@ -234,7 +244,15 @@ namespace Octopus.Tentacle.Client
             finally
             {
                 var operationMetrics = operationMetricsBuilder.Build();
-                tentacleClientObserver.DownloadFileCompleted(operationMetrics);
+
+                try
+                {
+                    tentacleClientObserver.DownloadFileCompleted(operationMetrics);
+                }
+                catch (Exception e)
+                {
+                    logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the Download File completion.");
+                }
             }
         }
 
@@ -275,7 +293,15 @@ namespace Octopus.Tentacle.Client
             finally
             {
                 var operationMetrics = operationMetricsBuilder.Build();
-                tentacleClientObserver.ExecuteScriptCompleted(operationMetrics);
+
+                try
+                {
+                    tentacleClientObserver.ExecuteScriptCompleted(operationMetrics);
+                }
+                catch (Exception e)
+                {
+                    logger.Warn(e, "An error occurred while notifying the Tentacle Client Observer of the Execute Script completion.");
+                }
             }
         }
 

--- a/source/Octopus.Tentacle.CommonTestUtils/TestTentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/TestTentacleClientObserver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts.Observability;
 
 namespace Octopus.Tentacle.CommonTestUtils
@@ -16,22 +17,22 @@ namespace Octopus.Tentacle.CommonTestUtils
         public IReadOnlyList<ClientOperationMetrics> DownloadFileMetrics => downloadFileMetrics;
         public IReadOnlyList<ClientOperationMetrics> ExecuteScriptMetrics => executeScriptMetrics;
 
-        public void RpcCallCompleted(RpcCallMetrics rpcCallMetrics)
+        public void RpcCallCompleted(RpcCallMetrics rpcCallMetrics, ILog logger)
         {
             this.rpcCallMetrics.Add(rpcCallMetrics);
         }
 
-        public void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics)
+        public void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
         {
             uploadFileMetrics.Add(clientOperationMetrics);
         }
 
-        public void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics)
+        public void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
         {
             downloadFileMetrics.Add(clientOperationMetrics);
         }
 
-        public void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics)
+        public void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
         {
             executeScriptMetrics.Add(clientOperationMetrics);
         }

--- a/source/Octopus.Tentacle.Contracts/Observability/ITentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.Contracts/Observability/ITentacleClientObserver.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using Octopus.Diagnostics;
 
 namespace Octopus.Tentacle.Contracts.Observability
 {
     public interface ITentacleClientObserver
     {
-        void RpcCallCompleted(RpcCallMetrics rpcCallMetrics);
-        void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics);
-        void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics);
-        void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics);
+        void RpcCallCompleted(RpcCallMetrics rpcCallMetrics, ILog logger);
+        void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger);
+        void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger);
+        void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger);
     }
 }

--- a/source/Octopus.Tentacle.Contracts/Observability/NoTentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.Contracts/Observability/NoTentacleClientObserver.cs
@@ -1,20 +1,22 @@
-﻿namespace Octopus.Tentacle.Contracts.Observability
+﻿using Octopus.Diagnostics;
+
+namespace Octopus.Tentacle.Contracts.Observability
 {
     public class NoTentacleClientObserver : ITentacleClientObserver
     {
-        public void RpcCallCompleted(RpcCallMetrics rpcCallMetrics)
+        public void RpcCallCompleted(RpcCallMetrics rpcCallMetrics, ILog logger)
         {
         }
 
-        public void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics)
+        public void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
         {
         }
 
-        public void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics)
+        public void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
         {
         }
 
-        public void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics)
+        public void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
         {
         }
     }

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -29,6 +29,7 @@
   </Choose>
   <ItemGroup>
     <PackageReference Include="Halibut" Version="6.0.1069" />
+    <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut;
+using NUnit.Framework;
+using Octopus.Tentacle.CommonTestUtils.Builders;
+using Octopus.Tentacle.Contracts.Observability;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [IntegrationTestTimeout]
+    public class TentacleClientObserver : IntegrationTest
+    {
+        [Test]
+        [TestCaseSource(typeof(TentacleTypesToTest))]
+        public async Task AnErrorDuringTheCallbackTo_ExecuteScriptCompleted_ShouldNotThrowOrStopScriptExecution(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
+        {
+            // Arrange
+            var tentacleClientObserver = new BrokenTentacleClientObserver(errorOnExecuteScriptCompleted: true);
+
+            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
+                .WithTentacleClientObserver(tentacleClientObserver)
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .LogAllCalls()
+                    .CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts)
+                    .Build())
+                .Build(CancellationToken);
+            
+            var startScriptCommand = new StartScriptCommandV2Builder()
+                .WithScriptBody(b => b.Print("Hello"))
+                .Build();
+
+            // Act
+            await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+
+            // Assert
+            // We should have completed the script and not failed due to the error thrown by the TentacleClientObserver
+            scriptServiceV2CallCounts.CompleteScriptCallCountStarted.Should().Be(1);
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TentacleTypesToTest))]
+        public async Task AnErrorDuringTheCallbackTo_RpcCallComplete_ShouldNotThrowOrStopScriptExecution(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
+        {
+            // Arrange
+            var tentacleClientObserver = new BrokenTentacleClientObserver(errorOnRpcCallCompleted: true);
+
+            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
+                .WithTentacleClientObserver(tentacleClientObserver)
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .LogAllCalls()
+                    .CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts)
+                    .Build())
+                .Build(CancellationToken);
+            
+            var startScriptCommand = new StartScriptCommandV2Builder()
+                .WithScriptBody(b => b.Print("Hello"))
+                .Build();
+
+            // Act
+            await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+
+            // Assert
+            // We should have completed the script and not failed due to the error thrown by the TentacleClientObserver
+            scriptServiceV2CallCounts.CompleteScriptCallCountStarted.Should().Be(1);
+        }
+        
+        [Test]
+        [TestCaseSource(typeof(TentacleTypesToTest))]
+        public async Task AnErrorDuringTheCallbackTo_UploadFileCompleted_ShouldNotThrowAnExecution(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
+        {
+            // Arrange
+            var tentacleClientObserver = new BrokenTentacleClientObserver(errorOnUploadFileCompleted: true);
+
+            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
+                .WithTentacleClientObserver(tentacleClientObserver)
+                .Build(CancellationToken);
+
+            var remotePath = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "UploadFile.txt");
+            
+            // Act + Assert
+            await clientTentacle.TentacleClient.UploadFile(remotePath, DataStream.FromString("Hello"), CancellationToken);
+        }
+
+        [Test]
+        [TestCaseSource(typeof(TentacleTypesToTest))]
+        public async Task AnErrorDuringTheCallbackTo_DownloadFileCompleted_ShouldNotThrowAnExecution(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
+        {
+            // Arrange
+            var tentacleClientObserver = new BrokenTentacleClientObserver(errorOnDownloadFileCompleted: true);
+
+            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+                .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
+                .WithTentacleClientObserver(tentacleClientObserver)
+                .Build(CancellationToken);
+
+            var remotePath = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "DownloadFile.txt");
+            await clientTentacle.TentacleClient.UploadFile(remotePath, DataStream.FromString("Hello"), CancellationToken);
+
+            // Act + Assert
+            await clientTentacle.TentacleClient.DownloadFile(remotePath, CancellationToken);
+        }
+
+        class BrokenTentacleClientObserver : ITentacleClientObserver
+        {
+            private readonly bool errorOnRpcCallCompleted;
+            private readonly bool errorOnUploadFileCompleted;
+            private readonly bool errorOnDownloadFileCompleted;
+            private readonly bool errorOnExecuteScriptCompleted;
+
+            public BrokenTentacleClientObserver(
+                bool errorOnRpcCallCompleted = false,
+                bool errorOnUploadFileCompleted = false,
+                bool errorOnDownloadFileCompleted = false,
+                bool errorOnExecuteScriptCompleted = false)
+            {
+                this.errorOnRpcCallCompleted = errorOnRpcCallCompleted;
+                this.errorOnUploadFileCompleted = errorOnUploadFileCompleted;
+                this.errorOnDownloadFileCompleted = errorOnDownloadFileCompleted;
+                this.errorOnExecuteScriptCompleted = errorOnExecuteScriptCompleted;
+            }
+
+            public void RpcCallCompleted(RpcCallMetrics metrics)
+            {
+                if (errorOnRpcCallCompleted)
+                {
+                    throw new Exception($"RpcCallCompleted {Guid.NewGuid()}");
+                }
+            }
+
+            public void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics)
+            {
+                if (errorOnUploadFileCompleted)
+                {
+                    throw new Exception($"UploadFileCompleted {Guid.NewGuid()}");
+                }
+            }
+
+            public void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics)
+            {
+                if (errorOnDownloadFileCompleted)
+                {
+                    throw new Exception($"DownloadFileCompleted {Guid.NewGuid()}");
+                }
+            }
+
+            public void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics)
+            {
+                if (errorOnExecuteScriptCompleted)
+                {
+                    throw new Exception($"ExecuteScriptCompleted {Guid.NewGuid()}");
+                }
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut;
 using NUnit.Framework;
+using Octopus.Diagnostics;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts.Observability;
 using Octopus.Tentacle.Tests.Integration.Support;
@@ -127,7 +128,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 this.errorOnExecuteScriptCompleted = errorOnExecuteScriptCompleted;
             }
 
-            public void RpcCallCompleted(RpcCallMetrics metrics)
+            public void RpcCallCompleted(RpcCallMetrics metrics, ILog logger)
             {
                 if (errorOnRpcCallCompleted)
                 {
@@ -135,7 +136,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 }
             }
 
-            public void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics)
+            public void UploadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
             {
                 if (errorOnUploadFileCompleted)
                 {
@@ -143,7 +144,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 }
             }
 
-            public void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics)
+            public void DownloadFileCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
             {
                 if (errorOnDownloadFileCompleted)
                 {
@@ -151,7 +152,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 }
             }
 
-            public void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics)
+            public void ExecuteScriptCompleted(ClientOperationMetrics clientOperationMetrics, ILog logger)
             {
                 if (errorOnExecuteScriptCompleted)
                 {

--- a/source/Octopus.Tentacle.Tests/Client/RpcCallExecutorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Client/RpcCallExecutorFixture.cs
@@ -318,6 +318,7 @@ namespace Octopus.Tentacle.Tests.Client
             return await sut.ExecuteWithNoRetries(
                 new RpcCall(RpcService, RpcCallName),
                 action,
+                Substitute.For<ILog>(),
                 abandonActionOnCancellation: false,
                 clientOperationMetricsBuilder,
                 cancellationToken);
@@ -339,6 +340,7 @@ namespace Octopus.Tentacle.Tests.Client
                     await action(ct);
                     return true;
                 },
+                Substitute.For<ILog>(),
                 abandonActionOnCancellation: false,
                 clientOperationMetricsBuilder,
                 cancellationToken);


### PR DESCRIPTION
# Background

If an error occurs in the ITentacleClientObserver passed to the TentacleClient operations, it can cause Script Execution to stop and fail or throw an exception at the end of script execution / upload / download file, which is not desired.

This PR adds a decorator which will try..catch.. to ensure they do not impact the TentacleClient operations and logs a warning in the ILog so they are visible in the task log.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.