### PR TITLE
Reduce thread usage with a async command runner

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
@@ -47,7 +47,7 @@ namespace Octopus.Tentacle.Tests.Integration
             Version? version, 
             SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(version)
                 .Build(CancellationToken);
@@ -77,7 +77,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var capabilitiesResponses = new List<CapabilitiesResponseV2>();
             var resumePortForwarder = false;
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPortForwarder(out var portForwarder)
                 .WithTentacleVersion(version)

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
@@ -28,7 +28,7 @@ namespace Octopus.Tentacle.Tests.Integration
             [Values]SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             PortForwarder portForwarder = null!;
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
@@ -95,7 +95,7 @@ namespace Octopus.Tentacle.Tests.Integration
             [Values]SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             PortForwarder portForwarder = null!;
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreNotRetriedWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreNotRetriedWhenRetriesAreDisabled.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
         public async Task FailedUploadsAreNotRetriedAndFail(TentacleType tentacleType, Version? version, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(version)
                 .WithRetriesDisabled()
@@ -59,7 +59,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
         public async Task FailedDownloadsAreNotRetriedAndFail(TentacleType tentacleType, Version? version, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(version)
                 .WithRetriesDisabled()

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
         public async Task FailedUploadsAreRetriedAndIsEventuallySuccessful(TentacleType tentacleType, Version? version, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(version)
                 .WithPortForwarderDataLogging()
@@ -56,7 +56,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
         public async Task FailedDownloadsAreRetriedAndIsEventuallySuccessful(TentacleType tentacleType, Version? version, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(version)
                 .WithPortForwarderDataLogging()

--- a/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
@@ -26,7 +26,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
             var exception = new HalibutClientException("Error");
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
@@ -94,7 +94,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
@@ -123,7 +123,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
             var exception = new HalibutClientException("Error");
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
@@ -154,7 +154,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)
@@ -184,7 +184,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Arrange
             var tentacleClientObserver = new TestTentacleClientObserver();
             var exception = new HalibutClientException("Error");
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleClientObserver(tentacleClientObserver)

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
@@ -22,7 +22,7 @@ namespace Octopus.Tentacle.Tests.Integration
             using var tmp = new TemporaryDirectory();
             var path = Path.Combine(tmp.DirectoryPath, "file");
             
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
@@ -46,7 +46,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var hasPausedOrStoppedPortForwarder = false;
             var ensureCancellationOccursDuringAnRpcCall = new SemaphoreSlim(0, 1);
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPendingRequestQueueFactory(new CancellationObservingPendingRequestQueueFactory(syncOrAsyncHalibut)) // Partially works around disconnected polling tentacles take work from the queue
                 .WithServiceEndpointModifier(point => point.TryAndConnectForALongTime())
@@ -145,7 +145,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var hasPausedOrStoppedPortForwarder = false;
             SemaphoreSlim ensureCancellationOccursDuringAnRpcCall = new SemaphoreSlim(0, 1);
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPendingRequestQueueFactory(new CancellationObservingPendingRequestQueueFactory(syncOrAsyncHalibut)) // Partially works around disconnected polling tentacles take work from the queue
                 .WithServiceEndpointModifier(point => point.TryAndConnectForALongTime())
@@ -266,7 +266,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var hasPausedOrStoppedPortForwarder = false;
             SemaphoreSlim ensureCancellationOccursDuringAnRpcCall = new SemaphoreSlim(0, 1);
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPendingRequestQueueFactory(new CancellationObservingPendingRequestQueueFactory(syncOrAsyncHalibut)) // Partially works around disconnected polling tentacles take work from the queue
                 .WithServiceEndpointModifier(point => point.TryAndConnectForALongTime())
@@ -380,7 +380,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var rpcCallHasStarted = new Reference<bool>(false);
             var hasPausedOrStoppedPortForwarder = false;
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPendingRequestQueueFactory(new CancellationObservingPendingRequestQueueFactory(syncOrAsyncHalibut)) // Partially works around disconnected polling tentacles take work from the queue
                 .WithServiceEndpointModifier(point => point.TryAndConnectForALongTime())

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
@@ -50,7 +50,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var hasPausedOrStoppedPortForwarder = false;
             var ensureCancellationOccursDuringAnRpcCall = new SemaphoreSlim(0, 1);
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPendingRequestQueueFactory(new CancellationObservingPendingRequestQueueFactory(syncOrAsyncHalibut)) // Partially works around disconnected polling tentacles take work from the queue
                 .WithServiceEndpointModifier(point =>
@@ -171,7 +171,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var hasPausedOrStoppedPortForwarder = false;
             var ensureCancellationOccursDuringAnRpcCall = new SemaphoreSlim(0, 1);
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPendingRequestQueueFactory(new CancellationObservingPendingRequestQueueFactory(syncOrAsyncHalibut)) // Partially works around disconnected polling tentacles take work from the queue
                 .WithServiceEndpointModifier(point =>
@@ -322,7 +322,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var hasPausedOrStoppedPortForwarder = false;
             var ensureCancellationOccursDuringAnRpcCall = new SemaphoreSlim(0, 1);
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPendingRequestQueueFactory(new CancellationObservingPendingRequestQueueFactory(syncOrAsyncHalibut)) // Partially works around disconnected polling tentacles take work from the queue
                 .WithServiceEndpointModifier(point =>
@@ -455,7 +455,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var rpcCallHasStarted = new Reference<bool>(false);
             var hasPausedOrStoppedPortForwarder = false;
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPendingRequestQueueFactory(new CancellationObservingPendingRequestQueueFactory(syncOrAsyncHalibut)) // Partially works around disconnected polling tentacles take work from the queue
                 .WithRetryDuration(TimeSpan.FromHours(1))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -27,7 +27,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task WhenANetworkFailureOccurs_DuringStartScript_TheClientIsAbleToSuccessfullyCompleteTheScript(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPortForwarder()
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
@@ -73,7 +73,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task WhenANetworkFailureOccurs_DuringGetStatus_TheClientIsAbleToSuccessfullyCompleteTheScript(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPortForwarderDataLogging()
                 .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)
@@ -126,7 +126,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             bool completeScriptWasCalled = false;
             PortForwarder? portForwarder = null;
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPortForwarderDataLogging()
                 .WithServiceEndpointModifier(serviceEndpoint =>
@@ -175,7 +175,7 @@ namespace Octopus.Tentacle.Tests.Integration
             using var tmp = new TemporaryDirectory();
             var scriptIsRunningFlag = Path.Combine(tmp.DirectoryPath, "scriptisrunning");
 
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPortForwarderDataLogging()
                 .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)
@@ -244,7 +244,7 @@ namespace Octopus.Tentacle.Tests.Integration
             IClientScriptServiceV2? scriptServiceV2 = null;
             IAsyncClientScriptServiceV2? asyncScriptServiceV2 = null;
 
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPortForwarderDataLogging()
                 .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
@@ -44,7 +44,7 @@ namespace Octopus.Tentacle.Tests.Integration
             ScriptIsolationLevel levelOfSecondScript,
             SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
@@ -149,7 +149,7 @@ namespace Octopus.Tentacle.Tests.Integration
             ScriptsInParallelTestCases scriptsInParallelTestCases,
             SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .Build(CancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -30,7 +30,7 @@ namespace Octopus.Tentacle.Tests.Integration
             IClientScriptServiceV2? scriptServiceV2 = null;
             IAsyncClientScriptServiceV2? asyncScriptServiceV2 = null;
 
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
@@ -100,7 +100,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenRpcRetriesTimeOut_DuringStartScript_TheRpcCallIsCancelled([Values] TentacleType tentacleType, [Values] RpcCallStage rpcCallStage, [Values] SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
@@ -166,7 +166,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenRpcRetriesTimeOut_DuringGetStatus_TheRpcCallIsCancelled([Values] TentacleType tentacleType, [Values] RpcCallStage rpcCallStage, [Values] SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))
@@ -234,7 +234,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task WhenRpcRetriesTimeOut_DuringCancelScript_TheRpcCallIsCancelled([Values] TentacleType tentacleType, [Values] RpcCallStage rpcCallStage, [Values] SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 // Set a short retry duration so we cancel fairly quickly
                 .WithRetryDuration(TimeSpan.FromSeconds(15))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
         public async Task ArgumentsArePassedToTheScript(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .Build(CancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
         public async Task ScriptFilesAreSent(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .Build(CancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
@@ -24,7 +24,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task WhenANetworkFailureOccurs_DuringStartScript_WithATentacleThatOnlySupportsV1ScriptService_TheCallIsNotRetried(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(TentacleVersions.v6_3_451_NoCapabilitiesService)
                 .WithPortForwarderDataLogging()
@@ -83,7 +83,7 @@ namespace Octopus.Tentacle.Tests.Integration
         public async Task WhenANetworkFailureOccurs_DuringGetStatus_WithATentacleThatOnlySupportsV1ScriptService_TheCallIsNotRetried(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             ScriptStatusRequest? scriptStatusRequest = null;
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithTentacleVersion(TentacleVersions.v6_3_451_NoCapabilitiesService)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithPortForwarderDataLogging()
@@ -151,7 +151,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             ScriptStatusRequest? scriptStatusRequest = null;
             CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(TentacleVersions.v6_3_451_NoCapabilitiesService)
                 .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)
@@ -222,7 +222,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task WhenANetworkFailureOccurs_DuringCompleteScript_WithATentacleThatOnlySupportsV1ScriptService_TheCallIsNotRetried(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(TentacleVersions.v6_3_451_NoCapabilitiesService)
                 .WithPortForwarderDataLogging()

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV2IsNotRetriedWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV2IsNotRetriedWhenRetriesAreDisabled.cs
@@ -29,7 +29,7 @@ namespace Octopus.Tentacle.Tests.Integration
             IClientScriptServiceV2? scriptServiceV2 = null;
             IAsyncClientScriptServiceV2? asyncScriptServiceV2 = null;
 
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithRetriesDisabled()
                 .WithPortForwarderDataLogging()
@@ -85,7 +85,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task WhenANetworkFailureOccurs_DuringStartScript_TheCallIsNotRetried(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithRetriesDisabled()
                 .WithPortForwarderDataLogging()
@@ -135,7 +135,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task WhenANetworkFailureOccurs_DuringGetStatus_TheCallIsNotRetried(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithRetriesDisabled()
                 .WithPortForwarderDataLogging()
@@ -192,7 +192,7 @@ namespace Octopus.Tentacle.Tests.Integration
         public async Task WhenANetworkFailureOccurs_DuringCancelScript_TheCallIsNotRetried(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
             CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithRetriesDisabled()
                 .WithPortForwarderDataLogging()
@@ -252,7 +252,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task WhenANetworkFailureOccurs_DuringCompleteScript_TheCallIsNotRetried(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithRetriesDisabled()
                 .WithPortForwarderDataLogging()

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWorksWithMultipleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWorksWithMultipleVersions.cs
@@ -17,7 +17,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
         public async Task CanRunScript(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .Build(CancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
@@ -17,7 +17,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesAndCommonVersionsToTest))]
         public async Task TheScriptObserverBackoffShouldBeRespected(TentacleType tentacleType, Version? tentacleVersion, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleVersion(tentacleVersion)
                 .WithScriptObserverBackoffStrategy(new FuncScriptObserverBackoffStrategy(iters => TimeSpan.FromSeconds(20)))

--- a/source/Octopus.Tentacle.Tests.Integration/FileTransferServiceTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/FileTransferServiceTests.cs
@@ -21,7 +21,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             using var fileToUpload = new RandomTemporaryFileBuilder().Build();
 
-            using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .Build(CancellationToken);
             
@@ -69,7 +69,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             using var fileToDownload = new RandomTemporaryFileBuilder().Build();
 
-            using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -25,6 +25,7 @@
     </PropertyGroup>
 
   <ItemGroup>
+        <PackageReference Include="CliWrap" Version="3.6.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <ProjectReference Include="..\Octopus.Tentacle.CommonTestUtils\Octopus.Tentacle.CommonTestUtils.csproj" />
         <PackageReference Include="NSubstitute" Version="4.4.0" />

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceTests.cs
@@ -31,7 +31,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 sleep 3
                 echo This is the end of the script";
 
-            using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .Build(CancellationToken);
 
@@ -62,7 +62,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 exit 1
                 echo This is the end of the script";
 
-            using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .Build(CancellationToken);
 
@@ -89,7 +89,7 @@ namespace Octopus.Tentacle.Tests.Integration
                               ping 127.0.0.1 -c 100
                               echo This is the end of the script";
 
-            using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
+            await using var clientAndTentacle = await new LegacyClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
@@ -21,7 +21,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task CanRunScript(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder().CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts).Build())
                 .Build(CancellationToken);
@@ -54,7 +54,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task DelayInStartScriptSavesNetworkCalls(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder().CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts).Build())
                 .Build(CancellationToken);
@@ -86,7 +86,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task WhenTentacleRestartsWhileRunningAScript_TheExitCodeShouldBe_UnknownResultExitCode(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder().CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts).Build())
                 .Build(CancellationToken);
@@ -132,7 +132,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TestCaseSource(typeof(TentacleTypesToTest))]
         public async Task WhenALongRunningScriptIsCancelled_TheScriptShouldStop(TentacleType tentacleType, SyncOrAsyncHalibut syncOrAsyncHalibut)
         {
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder().CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts).Build())
                 .Build(CancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Halibut;
 using Halibut.Util;
 using Octopus.Tentacle.Client;
@@ -7,7 +8,7 @@ using Octopus.TestPortForwarder;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
-    public class ClientAndTentacle: IDisposable
+    public class ClientAndTentacle: IAsyncDisposable
     {
         private readonly IHalibutRuntime halibutRuntime;
         public ServiceEndPoint ServiceEndPoint { get; }
@@ -40,11 +41,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             this.ServiceEndPoint = serviceEndPoint;
         }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
             Server.Dispose();
             PortForwarder?.Dispose();
-            RunningTentacle.Dispose();
+            await RunningTentacle.DisposeAsync();
             TentacleClient.Dispose();
             TemporaryDirectory.Dispose();
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacle.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Octopus.TestPortForwarder;
 
 namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
 {
-    internal class LegacyClientAndTentacle : IDisposable
+    internal class LegacyClientAndTentacle : IAsyncDisposable
     {
         private readonly TemporaryDirectory temporaryDirectory;
         public Server Server { get; }
@@ -25,11 +26,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
             TentacleClient = tentacleClient;
         }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
             Server.Dispose();
             PortForwarder.Dispose();
-            RunningTentacle.Dispose();
+            await RunningTentacle.DisposeAsync();
             temporaryDirectory.Dispose();
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -21,8 +21,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
 
-            CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
-            AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
+            await CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
+            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
             ConfigureTentacleToListen(configFilePath);
 
             var runningTentacle = await StartTentacle(

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -27,9 +27,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
             var subscriptionId = PollingSubscriptionId.Generate();
 
-            CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
+            await CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
             ConfigureTentacleToPollOctopusServer(configFilePath, subscriptionId);
-            AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
+            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
             
 
             return await StartTentacle(

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -192,19 +192,26 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 commandOutput(s);
             }
 
-            var commandResult = await Cli.Wrap(
-                tentacleExe)
-                .WithArguments(args)
-                .WithWorkingDirectory(tmp.DirectoryPath)
-                .WithStandardOutputPipe(PipeTarget.ToDelegate(ProcessLogs))
-                .WithStandardErrorPipe(PipeTarget.ToDelegate(ProcessLogs))
-                .ExecuteAsync(cancellationToken);
-
-            if (cancellationToken.IsCancellationRequested) return;
-
-            if (commandResult.ExitCode != 0)
+            try
             {
-                throw new Exception("Tentacle returns non zero exit code: " + commandResult.ExitCode);
+                var commandResult = await Cli.Wrap(
+                        tentacleExe)
+                    .WithArguments(args)
+                    .WithWorkingDirectory(tmp.DirectoryPath)
+                    .WithStandardOutputPipe(PipeTarget.ToDelegate(ProcessLogs))
+                    .WithStandardErrorPipe(PipeTarget.ToDelegate(ProcessLogs))
+                    .ExecuteAsync(cancellationToken);
+
+                if (cancellationToken.IsCancellationRequested) return;
+
+                if (commandResult.ExitCode != 0)
+                {
+                    throw new Exception("Tentacle returns non zero exit code: " + commandResult.ExitCode);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return;
             }
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
@@ -23,7 +23,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Arrange
             var tentacleClientObserver = new BrokenTentacleClientObserver(errorOnExecuteScriptCompleted: true);
 
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
@@ -51,7 +51,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Arrange
             var tentacleClientObserver = new BrokenTentacleClientObserver(errorOnRpcCallCompleted: true);
 
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
@@ -79,7 +79,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Arrange
             var tentacleClientObserver = new BrokenTentacleClientObserver(errorOnUploadFileCompleted: true);
 
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .Build(CancellationToken);
@@ -97,7 +97,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Arrange
             var tentacleClientObserver = new BrokenTentacleClientObserver(errorOnDownloadFileCompleted: true);
 
-            using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
+            await using var clientTentacle = await new ClientAndTentacleBuilder(tentacleType)
                 .WithAsyncHalibutFeature(syncOrAsyncHalibut.ToAsyncHalibutFeature())
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .Build(CancellationToken);


### PR DESCRIPTION
# Background

In the hopes this might help reduce failures like this:
```
00:00:00.0523229 [ClientFileTransfersAreRetriedWhenRetriesAreEnabled] [FailedDownloadsAreRetriedAndIsEventuallySuccessful(Polling,6.3.417,Sync)] Test started
00:00:54.6654409 [PortForwarder] [FailedDownloadsAreRetriedAndIsEventuallySuccessful(Polling,6.3.417,Sync)] Listening on "127.0.0.1:50205"
```
In which it took `54s` to go from the test starting the the port forwarder (which is the first thing to do anything before tentacle is started) to start listening.
[SC-56842]
# Results

## Before
```
> pstacks

________________________________________________
 ~~~~ 83e0
    1 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
    1 System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, CancellationToken)
    1 System.Threading.Tasks.Task.InternalWait(Int32, CancellationToken)
    1 System.Threading.Tasks.Task.Wait(Int32, CancellationToken)
    1 JetBrains.ReSharper.TestRunner.Implementation.UnitTestRemoteAgent.ConnectAndWaitForShutdown(IApplicationOptions)
    1 JetBrains.ReSharper.TestRunner.Application.Run()
    1 System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object, Object[], Object[])
    1 System.Reflection.RuntimeMethodInfo.Invoke(Object, BindingFlags, Binder, Object[], CultureInfo)
    1 JetBrains.ReSharper.TestRunner.Extensions.LoadContextExtensions.RunInContext(ILoadContext, Expression<Action<__Canon>>, Object[])
    1 JetBrains.ReSharper.TestRunner.Bootstrapper<System.__Canon>.RunAppInSeparateLoadContext(ILifetimeScope)
    1 JetBrains.ReSharper.TestRunner.Bootstrapper<System.__Canon>.Run()
    1 JetBrains.ReSharper.TestRunner.Bootstrapper<System.__Canon>.Run(IApplicationOptions)
    1 JetBrains.ReSharper.TestRunner.EntryPoint.Run(String[])
    1 JetBrains.ReSharper.TestRunner.Program.Main(String[])


________________________________________________
           ~~~~ 101f4
              1 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
              1 System.Threading.ManualResetEventSlim.Wait(Int32)
              1 NUnit.Framework.Api.NUnitTestAssemblyRunner.WaitForCompletion(Int32)
              1 NUnit.Framework.Api.NUnitTestAssemblyRunner.Run(ITestListener, ITestFilter)
              1 NUnit.Framework.Api.FrameworkController.RunTests(ICallbackEventHandler, String)
              1 NUnit.Framework.Api.FrameworkController+RunTestsAction..ctor(FrameworkController, String, Object)
              1 System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags, Binder, Object[], CultureInfo)
              1 System.RuntimeType.CreateInstanceImpl(BindingFlags, Binder, Object[], CultureInfo, Object[], StackCrawlMark ByRef)
              1 System.Activator.CreateInstance(Type, BindingFlags, Binder, Object[], CultureInfo, Object[])
              1 System.Activator.CreateInstance(String, String, Boolean, BindingFlags, Binder, Object[], CultureInfo, Object[], Evidence, StackCrawlMark ByRef)
              1 System.Activator.CreateInstance(String, String, Boolean, BindingFlags, Binder, Object[], CultureInfo, Object[], Evidence)
              1 System.AppDomain.CreateInstance(String, String, Boolean, BindingFlags, Binder, Object[], CultureInfo, Object[], Evidence)
              1 System.AppDomain.CreateInstanceAndUnwrap(String, String, Boolean, BindingFlags, Binder, Object[], CultureInfo, Object[], Evidence)
              1 NUnit.Engine.Drivers.NUnit3FrameworkDriver.CreateObject(String, Object[])
              1 NUnit.Engine.Drivers.NUnit3FrameworkDriver.Run(ITestEventListener, String)
              1 NUnit.Engine.Runners.DirectTestRunner.RunTests(ITestEventListener, TestFilter)
              1 NUnit.Engine.Runners.MasterTestRunner.RunTests(ITestEventListener, TestFilter)
              1 NUnit.Engine.Runners.MasterTestRunner.Run(ITestEventListener, TestFilter)
              1 JetBrains.ReSharper.TestRunner.Adapters.NUnit3.NUnitRunner+<>c__DisplayClass5_0.<RunTests>b__0(NUnitTestAssemblyTask)
              1 JetBrains.ReSharper.TestRunner.Adapters.NUnit3.NUnitRunner.RunTests(TestRunRequest, ITestDiscoverySink, ITestExecutionSink)
              1 System.Runtime.Remoting.Messaging.StackBuilderSink.SyncProcessMessage(IMessage)
              1 System.Runtime.Remoting.Messaging.ServerObjectTerminatorSink.SyncProcessMessage(IMessage)
              1 System.Runtime.Remoting.Messaging.ServerContextTerminatorSink.SyncProcessMessage(IMessage)
              1 System.Runtime.Remoting.Channels.CrossContextChannel.SyncProcessMessageCallback(Object[])
              1 System.Runtime.Remoting.Channels.CrossContextChannel.SyncProcessMessage(IMessage)
              1 System.Runtime.Remoting.Channels.ChannelServices.SyncDispatchMessage(IMessage)
              1 System.Runtime.Remoting.Channels.CrossAppDomainSink.DoDispatch(Byte[], SmuggledMethodCallMessage, SmuggledMethodReturnMessage ByRef)
              1 System.Runtime.Remoting.Channels.CrossAppDomainSink.DoTransitionDispatchCallback(Object[])
              1 System.Runtime.Remoting.Channels.CrossAppDomainSink.DoTransitionDispatch(Byte[], SmuggledMethodCallMessage, SmuggledMethodReturnMessage ByRef)
              1 System.Runtime.Remoting.Channels.CrossAppDomainSink.SyncProcessMessage(IMessage)
              1 System.Runtime.Remoting.Proxies.RemotingProxy.CallProcessMessage(IMessageSink, IMessage, ArrayWithSize, Thread, Context, Boolean)
              1 System.Runtime.Remoting.Proxies.RemotingProxy.InternalInvoke(IMethodCallMessage, Boolean, Int32)
              1 System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData ByRef, Int32)
              1 JetBrains.ReSharper.TestRunner.Implementation.UnitTestRemoteAgent.Execute(TestRunRequest)
              1 JetBrains.ReSharper.TestRunner.Implementation.ClientEndpoint+<>c__DisplayClass4_1.<TryRegisterHandler>b__1()
           ~~~~ 46a4,e4c0,11d38,4234
              4 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
              4 System.Threading.ManualResetEventSlim.Wait(TimeSpan, CancellationToken)
              4 Halibut.ServiceModel.PendingRequestQueue+PendingRequest.WaitUntilComplete(CancellationToken)
              4 Halibut.ServiceModel.PendingRequestQueue.QueueAndWait(RequestMessage, CancellationToken)
              4 Halibut.ServiceModel.PendingRequestQueue+<QueueAndWaitAsync>d__10.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(<QueueAndWaitAsync>d__10 ByRef)
              4 Halibut.ServiceModel.PendingRequestQueue.QueueAndWaitAsync(RequestMessage, CancellationToken)
              4 Halibut.HalibutRuntime+<SendOutgoingPollingRequest>d__63.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(<SendOutgoingPollingRequest>d__63 ByRef)
              4 Halibut.HalibutRuntime.SendOutgoingPollingRequest(RequestMessage, CancellationToken)
              4 Halibut.HalibutRuntime+<SendOutgoingRequestSynchronouslyAsync>d__59.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(<SendOutgoingRequestSynchronouslyAsync>d__59 ByRef)
              4 Halibut.HalibutRuntime.SendOutgoingRequestSynchronouslyAsync(RequestMessage, MethodInfo, CancellationToken)
              4 Halibut.HalibutRuntime.SendOutgoingRequest(RequestMessage, MethodInfo, CancellationToken)
              4 Halibut.ServiceModel.HalibutProxy.DispatchRequest(RequestMessage, MethodInfo, CancellationToken)
              4 Halibut.ServiceModel.HalibutProxy.Invoke(IMessage)
              4 System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData ByRef, Int32)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies.ClientFileTransferServiceSyncToAsyncProxy.UploadFileAsync(String, DataStream, HalibutProxyRequestOptions)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.FileTransferServiceDecoratorBuilder+<>c+<<-ctor>b__12_0>d.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(__Canon ByRef)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.FileTransferServiceDecoratorBuilder+<>c.ctor>b__12_0(IAsyncClientFileTransferService, String, DataStream, HalibutProxyRequestOptions)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.FileTransferServiceDecoratorBuilder+FuncDecoratingFileTransferService+<UploadFileAsync>d__4.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(__Canon ByRef)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.FileTransferServiceDecoratorBuilder+FuncDecoratingFileTransferService.UploadFileAsync(String, DataStream, HalibutProxyRequestOptions)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.ErrorRecordingFileTransferServiceDecorator+<UploadFileAsync>d__4.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(__Canon ByRef)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.ErrorRecordingFileTransferServiceDecorator.UploadFileAsync(String, DataStream, HalibutProxyRequestOptions)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.CountingCallsFileTransferServiceDecorator+<UploadFileAsync>d__3.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(__Canon ByRef)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.CountingCallsFileTransferServiceDecorator.UploadFileAsync(String, DataStream, HalibutProxyRequestOptions)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.LogCallsToFileTransferServiceDecorator+<UploadFileAsync>d__3.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(__Canon ByRef)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.LogCallsToFileTransferServiceDecorator.UploadFileAsync(String, DataStream, HalibutProxyRequestOptions)
              4 Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.SyncAndAsyncProxies.ClientFileTransferServiceAsyncToSyncProxy.UploadFile(String, DataStream, HalibutProxyRequestOptions)
              4 Octopus.Tentacle.Client.TentacleClient+<>c__DisplayClass16_1.<UploadFile>b__1()
              4 Octopus.Tentacle.Client.Utils.AsyncHalibutFeatureExtensionMethods.WhenDisabled(AsyncHalibutFeature, Func<__Canon>)
              4 Octopus.Tentacle.Client.TentacleClient+<>c__DisplayClass16_0+<<UploadFile>g__UploadFileAction|0>d.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(__Canon ByRef)
              4 Octopus.Tentacle.Client.TentacleClient+<>c__DisplayClass16_0.<UploadFile>g__UploadFileAction|0(CancellationToken)
              4 Octopus.Tentacle.Client.Execution.RpcCallExecutor+<>c__DisplayClass7_1<System.__Canon>+<<ExecuteWithRetries>b__3>d.MoveNext()
              4 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(__Canon ByRef)
              4 Octopus.Tentacle.Client.Execution.RpcCallExecutor+<>c__DisplayClass7_1<System.__Canon>.<ExecuteWithRetries>b__3()
         5 System.Threading.Tasks.Task<System.__Canon>.InnerInvoke()
      ~~~~ 19e8,b168,d568,3f4c...
        16 System.Threading.WaitHandle.InternalWaitOne(SafeHandle, Int64, Boolean, Boolean)
        16 System.Threading.WaitHandle.WaitOne(Int32, Boolean)
        16 System.Diagnostics.Process.WaitForExit(Int32)
        16 Octopus.Tentacle.Util.SilentProcessRunner.ExecuteCommand(String, String, String, Action<String>, Action<String>, Action<String>, CancellationToken)
        16 Octopus.Tentacle.Tests.Integration.Support.TentacleBuilder<System.__Canon>.RunTentacleCommandOutOfProcess(String, String[], TemporaryDirectory, Action<String>, CancellationToken)
        16 Octopus.Tentacle.Tests.Integration.Support.TentacleBuilder<System.__Canon>+<>c__DisplayClass9_0.<RunTentacle>b__0()
      ~~~~ 7c54,b1c4,88c4,c75c...
        32 IL_STUB_PInvoke(SafeFileHandle, Byte*, Int32, Int32 ByRef, IntPtr)
        32 System.IO.FileStream.ReadFileNative(SafeFileHandle, Byte[], Int32, Int32, NativeOverlapped*, Int32 ByRef)
        32 System.IO.FileStream.ReadCore(Byte[], Int32, Int32)
        32 System.IO.FileStream.Read(Byte[], Int32, Int32)
        32 System.IO.Stream+<>c.<BeginReadInternal>b__39_0(Object)
        32 System.Threading.Tasks.Task<System.Int32>.InnerInvoke()
   53 System.Threading.Tasks.Task.Execute()
   53 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
   53 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object, Boolean)
   53 System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task ByRef)
   53 System.Threading.Tasks.Task.ExecuteEntry(Boolean)
   53 System.Threading.ThreadPoolWorkQueue.Dispatch()


________________________________________________
      ~~~~ 10544
         1 JetBrains.Threading.ByteBufferAsyncProcessor.ThreadProc()
         1 JetBrains.Threading.ByteBufferAsyncProcessor.ThreadProcCatchAbort()
      ~~~~ 74f0
         1 IL_STUB_PInvoke(IntPtr, Byte*, Int32, SocketFlags)
         1 System.Net.Sockets.Socket.Receive(Byte[], Int32, Int32, SocketFlags, SocketError ByRef)
         1 JetBrains.Rd.Impl.SocketWire+Base.ReceiveFromSocket(Byte[], Int32, Int32)
         1 JetBrains.Rd.Impl.BufferWindow.Read(BufferWindow ByRef, Receiver, Int32)
         1 JetBrains.Rd.Impl.SocketWire+Base.ReceiveFromPkgBuffer(Byte[], Int32, Int32)
         1 JetBrains.Rd.Impl.BufferWindow.Read(BufferWindow ByRef, Receiver, Int32)
         1 JetBrains.Rd.Impl.SocketWire+Base.ReadMsg()
         1 JetBrains.Rd.Impl.SocketWire+Base.ReceiverProc(Socket)
         1 JetBrains.Rd.Impl.SocketWire+Base+<>c__DisplayClass19_0.ctor>b__1(Socket)
         1 JetBrains.Collections.Viewable.SignalBase<System.__Canon>.Fire(__Canon)
         1 JetBrains.Collections.Viewable.ViewableProperty<System.__Canon>.set_Value(__Canon)
         1 JetBrains.Rd.Impl.SocketWire+Client+<>c__DisplayClass1_0.ctor>b__0()
      ~~~~ ba64
         1 System.Threading.SemaphoreSlim.WaitUntilCountOrTimeout(Int32, UInt32, CancellationToken)
         1 System.Threading.SemaphoreSlim.Wait(Int32, CancellationToken)
         1 System.Collections.Concurrent.BlockingCollection<System.__Canon>.TryTakeWithNoTimeValidation(__Canon ByRef, Int32, CancellationToken, CancellationTokenSource)
         1 System.Collections.Concurrent.BlockingCollection<System.__Canon>+<GetConsumingEnumerable>d__68.MoveNext()
         1 JetBrains.ReSharper.TestRunner.Implementation.SingleThreadTaskScheduler.RunOnCurrentThread()
      ~~~~ d4f0
         1 IL_STUB_PInvoke(IntPtr, Byte[], Int32 ByRef)
         1 System.Net.SafeCloseSocket+InnerSafeCloseSocket.Accept(SafeCloseSocket, Byte[], Int32 ByRef)
         1 System.Net.Sockets.Socket.Accept()
         1 System.Net.Sockets.TcpListener.AcceptSocket()
         1 NUnit.Engine.Communication.Transports.Tcp.TcpServer.WaitForClientConnections()
      ~~~~ 760
         1 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
         1 System.Threading.ManualResetEventSlim.Wait(Int32)
         1 NUnit.Framework.Internal.Execution.EventQueue.Dequeue(Boolean)
         1 NUnit.Framework.Internal.Execution.EventPump.PumpThreadProc()
      ~~~~ 6d58,130a4,a234,73e4...
        16 IL_STUB_PInvoke(IntPtr, Byte[], Int32 ByRef)
        16 System.Net.SafeCloseSocket+InnerSafeCloseSocket.Accept(SafeCloseSocket, Byte[], Int32 ByRef)
        16 System.Net.Sockets.Socket.Accept()
        16 System.Net.Sockets.TcpListener.AcceptTcpClient()
        16 Halibut.Transport.SecureListener.Accept()
           ~~~~ 7220
              1 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
              1 System.Threading.ManualResetEventSlim.Wait(Int32)
              1 NUnit.Framework.Internal.Execution.WorkItemQueue.Dequeue()
           ~~~~ 7e9c,ba34,bc84,b290...
             16 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
             16 System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, CancellationToken)
             16 System.Threading.Tasks.Task.InternalWait(Int32, CancellationToken)
             16 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task)
             16 System.Runtime.CompilerServices.TaskAwaiter<System.Threading.Tasks.VoidTaskResult>.GetResult()
             16 NUnit.Framework.Internal.TaskAwaitAdapter+GenericAdapter<System.Threading.Tasks.VoidTaskResult>.BlockUntilCompleted()
             16 NUnit.Framework.Internal.MessagePumpStrategy+NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter)
             16 NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func<Object>)
             16 NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext)
             16 NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext)
             16 NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand+<>c__DisplayClass1_0.<Execute>b__0()
             16 NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext, Action)
             16 NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.Execute(TestExecutionContext)
             16 NUnit.Framework.Internal.Commands.BeforeTestCommand.Execute(TestExecutionContext)
             16 NUnit.Framework.Internal.Execution.SimpleWorkItem+<>c__DisplayClass4_0.<PerformWork>b__0()
             16 NUnit.Framework.Internal.ContextUtils+<>c__DisplayClass1_0<System.__Canon>.<DoIsolated>b__0(Object)
             16 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
             16 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object, Boolean)
             16 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object)
             16 NUnit.Framework.Internal.ContextUtils.DoIsolated(ContextCallback, Object)
             16 NUnit.Framework.Internal.ContextUtils.DoIsolated(Func<__Canon>)
             16 NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork()
             16 NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
             16 NUnit.Framework.Internal.Execution.WorkItem.Execute()
        17 NUnit.Framework.Internal.Execution.TestWorker.TestWorkerThreadProc()
   38 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
   38 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object, Boolean)
   38 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object)
   38 System.Threading.ThreadHelper.ThreadStart()


________________________________________________
 ~~~~ d650
    1 IL_STUB_PInvoke(IntPtr, Byte*, Int32, SocketFlags)
    1 System.Net.Sockets.Socket.Receive(Byte[], Int32, Int32, SocketFlags, SocketError ByRef)
    1 System.Net.Sockets.NetworkStream.Read(Byte[], Int32, Int32)
    1 System.Net.FixedSizeReader.ReadPacket(Byte[], Int32, Int32)
    1 System.Net.Security._SslStream.StartFrameHeader(Byte[], Int32, Int32, AsyncProtocolRequest)
    1 System.Net.Security._SslStream.StartReading(Byte[], Int32, Int32, AsyncProtocolRequest)
    1 System.Net.Security._SslStream.ProcessRead(Byte[], Int32, Int32, AsyncProtocolRequest)
    1 System.Net.Security.SslStream.Read(Byte[], Int32, Int32)
    1 System.IO.Stream.ReadByte()
    1 Halibut.Transport.SecureListener+<ReadInitialRequest>d__32.MoveNext()
    1 System.Runtime.CompilerServices.AsyncTaskMethodBuilder<System.__Canon>.AsyncTaskMethodBuilder`1(<ReadInitialRequest>d__32 ByRef)
    1 Halibut.Transport.SecureListener.ReadInitialRequest(Stream)
    1 Halibut.Transport.SecureListener+<ExecuteRequest>d__22.MoveNext()
    1 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
    1 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object, Boolean)
    1 System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run()
    1 System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(Action, Boolean, Task ByRef)
    1 System.Threading.Tasks.Task.FinishContinuations()
    1 System.Threading.Tasks.Task<System.Threading.Tasks.VoidTaskResult>.TrySetResult(VoidTaskResult)
    1 System.Threading.Tasks.TaskFactory<System.Threading.Tasks.VoidTaskResult>.FromAsyncCoreLogic(IAsyncResult, Func<IAsyncResult,VoidTaskResult>, Action<IAsyncResult>, Task<VoidTaskResult>, Boolean)
    1 System.Threading.Tasks.TaskFactory<System.Threading.Tasks.VoidTaskResult>.FromAsyncCoreLogic(IAsyncResult, Func<IAsyncResult,VoidTaskResult>, Action<IAsyncResult>, Task<VoidTaskResult>, Boolean)
    1 System.Threading.Tasks.TaskFactory<System.Threading.Tasks.VoidTaskResult>+<>c__DisplayClass35_0.<FromAsyncImpl>b__0(IAsyncResult)
    1 System.Net.LazyAsyncResult.Complete(IntPtr)
    1 System.Net.LazyAsyncResult.ProtectedInvokeCallback(Object, IntPtr)
    1 System.Net.Security.SslState.FinishHandshake(Exception, AsyncProtocolRequest)
    1 System.Net.Security.SslState.FinishHandshake(Exception, AsyncProtocolRequest)
    1 System.Net.Security.SslState.CheckCompletionBeforeNextReceive(ProtocolToken, AsyncProtocolRequest)
    1 System.Net.Security.SslState.WriteCallback(IAsyncResult)
    1 System.Net.LazyAsyncResult.Complete(IntPtr)
    1 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
    1 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object, Boolean)
    1 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object)
    1 System.Net.ContextAwareResult.Complete(IntPtr)
    1 System.Net.LazyAsyncResult.ProtectedInvokeCallback(Object, IntPtr)
    1 System.Net.Sockets.BaseOverlappedAsyncResult.CompletionPortCallback(UInt32, UInt32, NativeOverlapped*)
    1 System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32, UInt32, NativeOverlapped*)


==> 93 threads with 4 roots

```
## After

```
pstacks

________________________________________________
 ~~~~ 793c
    1 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
    1 System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, CancellationToken)
    1 System.Threading.Tasks.Task.InternalWait(Int32, CancellationToken)
    1 System.Threading.Tasks.Task.Wait(Int32, CancellationToken)
    1 JetBrains.ReSharper.TestRunner.Implementation.UnitTestRemoteAgent.ConnectAndWaitForShutdown(IApplicationOptions)
    1 JetBrains.ReSharper.TestRunner.Application.Run()
    1 System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object, Object[], Object[])
    1 System.Reflection.RuntimeMethodInfo.Invoke(Object, BindingFlags, Binder, Object[], CultureInfo)
    1 JetBrains.ReSharper.TestRunner.Extensions.LoadContextExtensions.RunInContext(ILoadContext, Expression<Action<__Canon>>, Object[])
    1 JetBrains.ReSharper.TestRunner.Bootstrapper<System.__Canon>.RunAppInSeparateLoadContext(ILifetimeScope)
    1 JetBrains.ReSharper.TestRunner.Bootstrapper<System.__Canon>.Run()
    1 JetBrains.ReSharper.TestRunner.Bootstrapper<System.__Canon>.Run(IApplicationOptions)
    1 JetBrains.ReSharper.TestRunner.EntryPoint.Run(String[])
    1 JetBrains.ReSharper.TestRunner.Program.Main(String[])


________________________________________________
      ~~~~ 1182c
         1 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
         1 System.Threading.ManualResetEventSlim.Wait(Int32)
         1 NUnit.Framework.Api.NUnitTestAssemblyRunner.WaitForCompletion(Int32)
         1 NUnit.Framework.Api.NUnitTestAssemblyRunner.Run(ITestListener, ITestFilter)
         1 NUnit.Framework.Api.FrameworkController.RunTests(ICallbackEventHandler, String)
         1 NUnit.Framework.Api.FrameworkController+RunTestsAction..ctor(FrameworkController, String, Object)
         1 System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags, Binder, Object[], CultureInfo)
         1 System.RuntimeType.CreateInstanceImpl(BindingFlags, Binder, Object[], CultureInfo, Object[], StackCrawlMark ByRef)
         1 System.Activator.CreateInstance(Type, BindingFlags, Binder, Object[], CultureInfo, Object[])
         1 System.Activator.CreateInstance(String, String, Boolean, BindingFlags, Binder, Object[], CultureInfo, Object[], Evidence, StackCrawlMark ByRef)
         1 System.Activator.CreateInstance(String, String, Boolean, BindingFlags, Binder, Object[], CultureInfo, Object[], Evidence)
         1 System.AppDomain.CreateInstance(String, String, Boolean, BindingFlags, Binder, Object[], CultureInfo, Object[], Evidence)
         1 System.AppDomain.CreateInstanceAndUnwrap(String, String, Boolean, BindingFlags, Binder, Object[], CultureInfo, Object[], Evidence)
         1 NUnit.Engine.Drivers.NUnit3FrameworkDriver.CreateObject(String, Object[])
         1 NUnit.Engine.Drivers.NUnit3FrameworkDriver.Run(ITestEventListener, String)
         1 NUnit.Engine.Runners.DirectTestRunner.RunTests(ITestEventListener, TestFilter)
         1 NUnit.Engine.Runners.MasterTestRunner.RunTests(ITestEventListener, TestFilter)
         1 NUnit.Engine.Runners.MasterTestRunner.Run(ITestEventListener, TestFilter)
         1 JetBrains.ReSharper.TestRunner.Adapters.NUnit3.NUnitRunner+<>c__DisplayClass5_0.<RunTests>b__0(NUnitTestAssemblyTask)
         1 JetBrains.ReSharper.TestRunner.Adapters.NUnit3.NUnitRunner.RunTests(TestRunRequest, ITestDiscoverySink, ITestExecutionSink)
         1 System.Runtime.Remoting.Messaging.StackBuilderSink.SyncProcessMessage(IMessage)
         1 System.Runtime.Remoting.Messaging.ServerObjectTerminatorSink.SyncProcessMessage(IMessage)
         1 System.Runtime.Remoting.Messaging.ServerContextTerminatorSink.SyncProcessMessage(IMessage)
         1 System.Runtime.Remoting.Channels.CrossContextChannel.SyncProcessMessageCallback(Object[])
         1 System.Runtime.Remoting.Channels.CrossContextChannel.SyncProcessMessage(IMessage)
         1 System.Runtime.Remoting.Channels.ChannelServices.SyncDispatchMessage(IMessage)
         1 System.Runtime.Remoting.Channels.CrossAppDomainSink.DoDispatch(Byte[], SmuggledMethodCallMessage, SmuggledMethodReturnMessage ByRef)
         1 System.Runtime.Remoting.Channels.CrossAppDomainSink.DoTransitionDispatchCallback(Object[])
         1 System.Runtime.Remoting.Channels.CrossAppDomainSink.DoTransitionDispatch(Byte[], SmuggledMethodCallMessage, SmuggledMethodReturnMessage ByRef)
         1 System.Runtime.Remoting.Channels.CrossAppDomainSink.SyncProcessMessage(IMessage)
         1 System.Runtime.Remoting.Proxies.RemotingProxy.CallProcessMessage(IMessageSink, IMessage, ArrayWithSize, Thread, Context, Boolean)
         1 System.Runtime.Remoting.Proxies.RemotingProxy.InternalInvoke(IMethodCallMessage, Boolean, Int32)
         1 System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData ByRef, Int32)
         1 JetBrains.ReSharper.TestRunner.Implementation.UnitTestRemoteAgent.Execute(TestRunRequest)
         1 JetBrains.ReSharper.TestRunner.Implementation.ClientEndpoint+<>c__DisplayClass4_1.<TryRegisterHandler>b__1()
         1 System.Threading.Tasks.Task<System.__Canon>.InnerInvoke()
      ~~~~ 4664,7634,1230c,12c94...
        32 IL_STUB_PInvoke(SafeFileHandle, Byte*, Int32, Int32 ByRef, IntPtr)
        32 System.IO.FileStream.ReadFileNative(SafeFileHandle, Byte[], Int32, Int32, NativeOverlapped*, Int32 ByRef)
        32 System.IO.FileStream.ReadCore(Byte[], Int32, Int32)
        32 System.IO.FileStream.Read(Byte[], Int32, Int32)
        32 System.IO.Stream+<>c.<BeginReadInternal>b__39_0(Object)
        32 System.Threading.Tasks.Task<System.Int32>.InnerInvoke()
   33 System.Threading.Tasks.Task.Execute()
   33 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
   33 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object, Boolean)
   33 System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task ByRef)
   33 System.Threading.Tasks.Task.ExecuteEntry(Boolean)
   33 System.Threading.ThreadPoolWorkQueue.Dispatch()


________________________________________________
      ~~~~ d234
         1 JetBrains.Threading.ByteBufferAsyncProcessor.ThreadProc()
         1 JetBrains.Threading.ByteBufferAsyncProcessor.ThreadProcCatchAbort()
      ~~~~ 2c0
         1 IL_STUB_PInvoke(IntPtr, Byte*, Int32, SocketFlags)
         1 System.Net.Sockets.Socket.Receive(Byte[], Int32, Int32, SocketFlags, SocketError ByRef)
         1 JetBrains.Rd.Impl.SocketWire+Base.ReceiveFromSocket(Byte[], Int32, Int32)
         1 JetBrains.Rd.Impl.BufferWindow.Read(BufferWindow ByRef, Receiver, Int32)
         1 JetBrains.Rd.Impl.SocketWire+Base.ReceiveFromPkgBuffer(Byte[], Int32, Int32)
         1 JetBrains.Rd.Impl.BufferWindow.Read(BufferWindow ByRef, Receiver, Int32)
         1 JetBrains.Rd.Impl.SocketWire+Base.ReadMsg()
         1 JetBrains.Rd.Impl.SocketWire+Base.ReceiverProc(Socket)
         1 JetBrains.Rd.Impl.SocketWire+Base+<>c__DisplayClass19_0.ctor>b__1(Socket)
         1 JetBrains.Collections.Viewable.SignalBase<System.__Canon>.Fire(__Canon)
         1 JetBrains.Collections.Viewable.ViewableProperty<System.__Canon>.set_Value(__Canon)
         1 JetBrains.Rd.Impl.SocketWire+Client+<>c__DisplayClass1_0.ctor>b__0()
      ~~~~ b368
         1 System.Threading.SemaphoreSlim.WaitUntilCountOrTimeout(Int32, UInt32, CancellationToken)
         1 System.Threading.SemaphoreSlim.Wait(Int32, CancellationToken)
         1 System.Collections.Concurrent.BlockingCollection<System.__Canon>.TryTakeWithNoTimeValidation(__Canon ByRef, Int32, CancellationToken, CancellationTokenSource)
         1 System.Collections.Concurrent.BlockingCollection<System.__Canon>+<GetConsumingEnumerable>d__68.MoveNext()
         1 JetBrains.ReSharper.TestRunner.Implementation.SingleThreadTaskScheduler.RunOnCurrentThread()
      ~~~~ 78b4
         1 IL_STUB_PInvoke(IntPtr, Byte[], Int32 ByRef)
         1 System.Net.SafeCloseSocket+InnerSafeCloseSocket.Accept(SafeCloseSocket, Byte[], Int32 ByRef)
         1 System.Net.Sockets.Socket.Accept()
         1 System.Net.Sockets.TcpListener.AcceptSocket()
         1 NUnit.Engine.Communication.Transports.Tcp.TcpServer.WaitForClientConnections()
      ~~~~ cf4c
         1 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
         1 System.Threading.ManualResetEventSlim.Wait(Int32)
         1 NUnit.Framework.Internal.Execution.EventQueue.Dequeue(Boolean)
         1 NUnit.Framework.Internal.Execution.EventPump.PumpThreadProc()
      ~~~~ 1088c,ae78,8ed8,9984...
        16 IL_STUB_PInvoke(IntPtr, Byte[], Int32 ByRef)
        16 System.Net.SafeCloseSocket+InnerSafeCloseSocket.Accept(SafeCloseSocket, Byte[], Int32 ByRef)
        16 System.Net.Sockets.Socket.Accept()
        16 System.Net.Sockets.TcpListener.AcceptTcpClient()
        16 Halibut.Transport.SecureListener.Accept()
           ~~~~ 6504
              1 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
              1 System.Threading.ManualResetEventSlim.Wait(Int32)
              1 NUnit.Framework.Internal.Execution.WorkItemQueue.Dequeue()
           ~~~~ 2384,3864,5ba4,9c08...
             16 System.Threading.ManualResetEventSlim.Wait(Int32, CancellationToken)
             16 System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, CancellationToken)
             16 System.Threading.Tasks.Task.InternalWait(Int32, CancellationToken)
             16 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task)
             16 System.Runtime.CompilerServices.TaskAwaiter<System.Threading.Tasks.VoidTaskResult>.GetResult()
             16 NUnit.Framework.Internal.TaskAwaitAdapter+GenericAdapter<System.Threading.Tasks.VoidTaskResult>.BlockUntilCompleted()
             16 NUnit.Framework.Internal.MessagePumpStrategy+NoMessagePumpStrategy.WaitForCompletion(AwaitAdapter)
             16 NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func<Object>)
             16 NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext)
             16 NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext)
             16 NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand+<>c__DisplayClass1_0.<Execute>b__0()
             16 NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext, Action)
             16 NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.Execute(TestExecutionContext)
             16 NUnit.Framework.Internal.Commands.BeforeTestCommand.Execute(TestExecutionContext)
             16 NUnit.Framework.Internal.Execution.SimpleWorkItem+<>c__DisplayClass4_0.<PerformWork>b__0()
             16 NUnit.Framework.Internal.ContextUtils+<>c__DisplayClass1_0<System.__Canon>.<DoIsolated>b__0(Object)
             16 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
             16 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object, Boolean)
             16 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object)
             16 NUnit.Framework.Internal.ContextUtils.DoIsolated(ContextCallback, Object)
             16 NUnit.Framework.Internal.ContextUtils.DoIsolated(Func<__Canon>)
             16 NUnit.Framework.Internal.Execution.SimpleWorkItem.PerformWork()
             16 NUnit.Framework.Internal.Execution.WorkItem.RunOnCurrentThread()
             16 NUnit.Framework.Internal.Execution.WorkItem.Execute()
        17 NUnit.Framework.Internal.Execution.TestWorker.TestWorkerThreadProc()
   38 System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
   38 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object, Boolean)
   38 System.Threading.ExecutionContext.Run(ExecutionContext, ContextCallback, Object)
   38 System.Threading.ThreadHelper.ThreadStart()


==> 72 threads with 3 roots
```
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.