### PR TITLE
Update git ignore to include .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ tools
 
 _artifacts
 _build
+
+.DS_Store


### PR DESCRIPTION
# Background

After pulling this repo and loading it in Rider, I noticed that `.DS_Store` files are showing up. Usually we just add `.DS_Store` to the git ignore to stop them from showing up as they are just a MacOS hidden file that we can safely ignore.

More info here: https://en.wikipedia.org/wiki/.DS_Store

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.