### PR TITLE
Add support for testing net6.0 client (TentacleClient) with net48 service (Tentacle)

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/EnumExtensions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/EnumExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public static class EnumExtensions
+    {
+        public static string GetDescription(this Enum enumValue)
+        {
+            var attr = enumValue
+                .GetType()
+                .GetField(enumValue.ToString())!
+                .GetCustomAttributes(typeof(DescriptionAttribute), false)
+                .Cast<DescriptionAttribute>()
+                .FirstOrDefault();
+
+            if (attr == null)
+                throw new Exception($"Enum value '{enumValue}' doesn't have Description attribute");
+
+            return attr.Description;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
@@ -14,6 +14,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
     {
         private readonly TentacleType tentacleType;
         private Version? tentacleVersion;
+        private TentacleRuntime tentacleRuntime = TentacleRuntime.Default;
         private AsyncHalibutFeature asyncHalibutFeature = AsyncHalibutFeature.Disabled;
 
         public LegacyClientAndTentacleBuilder(TentacleType tentacleType)
@@ -24,6 +25,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
         public LegacyClientAndTentacleBuilder WithTentacleVersion(Version? tentacleVersion)
         {
             this.tentacleVersion = tentacleVersion;
+            return this;
+        }
+
+        public LegacyClientAndTentacleBuilder WithTentacleRuntime(TentacleRuntime tentacleRuntime)
+        {
+            this.tentacleRuntime = tentacleRuntime;
             return this;
         }
 
@@ -62,8 +69,10 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
             // Tentacle
             var temporaryDirectory = new TemporaryDirectory();
             var tentacleExe = tentacleVersion == null ?
-                TentacleExeFinder.FindTentacleExe() :
-                await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, logger, cancellationToken);
+                TentacleExeFinder.FindTentacleExe(this.tentacleRuntime) :
+                await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, tentacleRuntime, logger, cancellationToken);
+            
+            logger.Information($"Tentacle.exe location: {tentacleExe}");
 
             if (tentacleType == TentacleType.Polling)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Tests.Integration.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
@@ -20,6 +21,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var instanceName = InstanceNameGenerator();
             var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
+            
+            var logger = new SerilogLoggerBuilder().Build().ForContext<ListeningTentacleBuilder>();
+            logger.Information($"Tentacle.exe location: {tentacleExe}");
 
             await CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
             await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Client.Model;
 using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
@@ -26,6 +27,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
             var subscriptionId = PollingSubscriptionId.Generate();
+            
+            var logger = new SerilogLoggerBuilder().Build().ForContext<ListeningTentacleBuilder>();
+            logger.Information($"Tentacle.exe location: {tentacleExe}");
 
             await CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
             ConfigureTentacleToPollOctopusServer(configFilePath, subscriptionId);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/WarmTentacleCache.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/WarmTentacleCache.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using NUnit.Framework;
 using Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers;
-using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Util;
 using Serilog;
 
@@ -28,40 +26,32 @@ namespace Octopus.Tentacle.Tests.Integration.Support.SetupFixtures
                 tasks.Add(Task.Run(async () =>
                 {
                     using var l = await concurrentDownloadLimiter.LockAsync(cts.Token);
-                    await GetTentacle(logger, tentacleVersion);
+                    await GetTentacleVersion(logger, tentacleVersion);
                 }));
             }
 
             Task.WhenAll(tasks).GetAwaiter().GetResult();
         }
 
-        private async Task GetTentacle(ILogger logger, Version tentacleVersion)
+        private async Task GetTentacleVersion(ILogger logger, Version tentacleVersion)
         {
             if (PlatformDetection.IsRunningOnWindows && RuntimeDetection.IsDotNet60)
             {
-                using (var net60TempDir = new TemporaryDirectory())
-                {
-                    logger.Information($"Will fetch tentacle {tentacleVersion} ({TentacleRuntime.DotNet6.GetStringValue()}) if it is not already in cache");
-                    await TentacleFetcher.GetTentacleVersion(net60TempDir.DirectoryPath, tentacleVersion, TentacleRuntime.DotNet6, logger, cts.Token);
-                    logger.Information($"Tentacle {tentacleVersion} ({TentacleRuntime.DotNet6.GetStringValue()}) is now in cache");
-                }
-
-                using (var net48TempDir = new TemporaryDirectory())
-                {
-                    logger.Information($"Will fetch tentacle {tentacleVersion} ({TentacleRuntime.Framework48.GetStringValue()}) if it is not already in cache");
-                    await TentacleFetcher.GetTentacleVersion(net48TempDir.DirectoryPath, tentacleVersion, TentacleRuntime.Framework48, logger, cts.Token);
-                    logger.Information($"Tentacle {tentacleVersion} ({TentacleRuntime.Framework48.GetStringValue()}) is now in cache");
-                }
+                await GetTentacleVersionWithRuntime(logger, tentacleVersion, TentacleRuntime.DotNet6);
+                await GetTentacleVersionWithRuntime(logger, tentacleVersion, TentacleRuntime.Framework48);
             }
             else
             {
-                using (var temporaryDirectory = new TemporaryDirectory())
-                {
-                    logger.Information($"Will fetch tentacle {tentacleVersion} if it is not already in cache");
-                    await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, TentacleRuntime.Default, logger, cts.Token);
-                    logger.Information($"Tentacle {tentacleVersion} is now in cache");
-                }
+                await GetTentacleVersionWithRuntime(logger, tentacleVersion, TentacleRuntime.Default);
             }
+        }
+
+        private async Task GetTentacleVersionWithRuntime(ILogger logger, Version tentacleVersion, TentacleRuntime tentacleRuntime)
+        {
+            using var tempDir = new TemporaryDirectory();
+            logger.Information($"Will fetch tentacle {tentacleVersion} ({tentacleRuntime.GetDescription()}) if it is not already in cache");
+            await TentacleFetcher.GetTentacleVersion(tempDir.DirectoryPath, tentacleVersion, tentacleRuntime, logger, cts.Token);
+            logger.Information($"Tentacle {tentacleVersion} ({tentacleRuntime.GetDescription()}) is now in cache");
         }
 
         public void OneTimeTearDown(ILogger logger)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/WarmTentacleCache.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/WarmTentacleCache.cs
@@ -12,14 +12,14 @@ namespace Octopus.Tentacle.Tests.Integration.Support.SetupFixtures
 {
     public class WarmTentacleCache : ISetupFixture
         {
-            private CancellationTokenSource cts = new CancellationTokenSource();
+            private CancellationTokenSource cts = new();
             
             public void OneTimeSetUp(ILogger logger)
             {
                 logger.Fatal("Downloading all tentacles now");
                 
                 var tasks = new List<Task>();
-                var concurrentDownloads = TentacleExeFinder.IsRunningInTeamCity() ? 4 : 1;
+                var concurrentDownloads = TeamCityDetection.IsRunningInTeamCity() ? 4 : 1;
                 var concurrentDownloadLimiter = new SemaphoreSlim(concurrentDownloads, concurrentDownloads);
                 
                 foreach (var tentacleVersion in TentacleVersions.AllTestedVersionsToDownload)
@@ -29,15 +29,33 @@ namespace Octopus.Tentacle.Tests.Integration.Support.SetupFixtures
                     {
                         using var l = await concurrentDownloadLimiter.LockAsync(cts.Token);
                         using var temporaryDirectory = new TemporaryDirectory();
-                        logger.Information($"Will fetch tentacle {tentacleVersion} if it is not already in cache");
-                        await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, logger, cts.Token);
-                        logger.Information($"Tentacle {tentacleVersion} is now in cache");
+                        await GetTentacle(logger, temporaryDirectory, tentacleVersion);
                     }));
                 }
                 
                 Task.WhenAll(tasks).GetAwaiter().GetResult();
             }
-            
+
+            private async Task GetTentacle(ILogger logger, TemporaryDirectory temporaryDirectory, Version tentacleVersion)
+            {
+                if (PlatformDetection.IsRunningOnWindows && RuntimeDetection.IsDotNet60)
+                {
+                    logger.Information($"Will fetch tentacle {tentacleVersion} ({TentacleRuntime.DotNet6.GetStringValue()}) if it is not already in cache");
+                    await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, TentacleRuntime.DotNet6, logger, cts.Token);
+                    logger.Information($"Tentacle {tentacleVersion} ({TentacleRuntime.DotNet6.GetStringValue()}) is now in cache");
+                    
+                    logger.Information($"Will fetch tentacle {tentacleVersion} ({TentacleRuntime.Framework48.GetStringValue()}) if it is not already in cache");
+                    await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, TentacleRuntime.Framework48, logger, cts.Token);
+                    logger.Information($"Tentacle {tentacleVersion} ({TentacleRuntime.Framework48.GetStringValue()}) is now in cache");
+                }
+                else
+                {
+                    logger.Information($"Will fetch tentacle {tentacleVersion} if it is not already in cache");
+                    await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, TentacleRuntime.Default, logger, cts.Token);
+                    logger.Information($"Tentacle {tentacleVersion} is now in cache");
+                }
+            }
+
             public void OneTimeTearDown(ILogger logger)
             {
                 cts.Cancel();

--- a/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/WarmTentacleCache.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/WarmTentacleCache.cs
@@ -11,56 +11,63 @@ using Serilog;
 namespace Octopus.Tentacle.Tests.Integration.Support.SetupFixtures
 {
     public class WarmTentacleCache : ISetupFixture
+    {
+        private CancellationTokenSource cts = new();
+
+        public void OneTimeSetUp(ILogger logger)
         {
-            private CancellationTokenSource cts = new();
-            
-            public void OneTimeSetUp(ILogger logger)
+            logger.Fatal("Downloading all tentacles now");
+
+            var tasks = new List<Task>();
+            var concurrentDownloads = TeamCityDetection.IsRunningInTeamCity() ? 4 : 1;
+            var concurrentDownloadLimiter = new SemaphoreSlim(concurrentDownloads, concurrentDownloads);
+
+            foreach (var tentacleVersion in TentacleVersions.AllTestedVersionsToDownload)
             {
-                logger.Fatal("Downloading all tentacles now");
-                
-                var tasks = new List<Task>();
-                var concurrentDownloads = TeamCityDetection.IsRunningInTeamCity() ? 4 : 1;
-                var concurrentDownloadLimiter = new SemaphoreSlim(concurrentDownloads, concurrentDownloads);
-                
-                foreach (var tentacleVersion in TentacleVersions.AllTestedVersionsToDownload)
+                if (tentacleVersion == TentacleVersions.Current) continue;
+                tasks.Add(Task.Run(async () =>
                 {
-                    if(tentacleVersion == TentacleVersions.Current) continue;
-                    tasks.Add(Task.Run(async () =>
-                    {
-                        using var l = await concurrentDownloadLimiter.LockAsync(cts.Token);
-                        using var temporaryDirectory = new TemporaryDirectory();
-                        await GetTentacle(logger, temporaryDirectory, tentacleVersion);
-                    }));
-                }
-                
-                Task.WhenAll(tasks).GetAwaiter().GetResult();
+                    using var l = await concurrentDownloadLimiter.LockAsync(cts.Token);
+                    await GetTentacle(logger, tentacleVersion);
+                }));
             }
 
-            private async Task GetTentacle(ILogger logger, TemporaryDirectory temporaryDirectory, Version tentacleVersion)
+            Task.WhenAll(tasks).GetAwaiter().GetResult();
+        }
+
+        private async Task GetTentacle(ILogger logger, Version tentacleVersion)
+        {
+            if (PlatformDetection.IsRunningOnWindows && RuntimeDetection.IsDotNet60)
             {
-                if (PlatformDetection.IsRunningOnWindows && RuntimeDetection.IsDotNet60)
+                using (var net60TempDir = new TemporaryDirectory())
                 {
                     logger.Information($"Will fetch tentacle {tentacleVersion} ({TentacleRuntime.DotNet6.GetStringValue()}) if it is not already in cache");
-                    await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, TentacleRuntime.DotNet6, logger, cts.Token);
+                    await TentacleFetcher.GetTentacleVersion(net60TempDir.DirectoryPath, tentacleVersion, TentacleRuntime.DotNet6, logger, cts.Token);
                     logger.Information($"Tentacle {tentacleVersion} ({TentacleRuntime.DotNet6.GetStringValue()}) is now in cache");
-                    
+                }
+
+                using (var net48TempDir = new TemporaryDirectory())
+                {
                     logger.Information($"Will fetch tentacle {tentacleVersion} ({TentacleRuntime.Framework48.GetStringValue()}) if it is not already in cache");
-                    await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, TentacleRuntime.Framework48, logger, cts.Token);
+                    await TentacleFetcher.GetTentacleVersion(net48TempDir.DirectoryPath, tentacleVersion, TentacleRuntime.Framework48, logger, cts.Token);
                     logger.Information($"Tentacle {tentacleVersion} ({TentacleRuntime.Framework48.GetStringValue()}) is now in cache");
                 }
-                else
+            }
+            else
+            {
+                using (var temporaryDirectory = new TemporaryDirectory())
                 {
                     logger.Information($"Will fetch tentacle {tentacleVersion} if it is not already in cache");
                     await TentacleFetcher.GetTentacleVersion(temporaryDirectory.DirectoryPath, tentacleVersion, TentacleRuntime.Default, logger, cts.Token);
                     logger.Information($"Tentacle {tentacleVersion} is now in cache");
                 }
             }
-
-            public void OneTimeTearDown(ILogger logger)
-            {
-                cts.Cancel();
-                cts.Dispose();
-            }
         }
-    
+
+        public void OneTimeTearDown(ILogger logger)
+        {
+            cts.Cancel();
+            cts.Dispose();
+        }
+    }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
@@ -8,7 +8,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         public TentacleType TentacleType { get; }
         public SyncOrAsyncHalibut SyncOrAsyncHalibut { get; }
-        public TentacleRuntime TentacleRuntime { get; set; }
+        public TentacleRuntime TentacleRuntime { get; }
         public Version? Version { get; }
 
         public TentacleConfigurationTestCase(
@@ -50,7 +50,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
             if (TentacleRuntime != TentacleRuntime.Default)
             {
-                builder.Append($", {TentacleRuntime.GetStringValue()}");
+                builder.Append($",{TentacleRuntime.GetDescription()}");
             }
 
             return builder.ToString();

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
@@ -8,15 +8,18 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         public TentacleType TentacleType { get; }
         public SyncOrAsyncHalibut SyncOrAsyncHalibut { get; }
+        public TentacleRuntime TentacleRuntime { get; set; }
         public Version? Version { get; }
 
         public TentacleConfigurationTestCase(
             TentacleType tentacleType,
             SyncOrAsyncHalibut syncOrAsyncHalibut,
+            TentacleRuntime tentacleRuntime,
             Version? version)
         {
             TentacleType = tentacleType;
             SyncOrAsyncHalibut = syncOrAsyncHalibut;
+            TentacleRuntime = tentacleRuntime;
             Version = version;
         }
         
@@ -24,14 +27,16 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         {
             return new ClientAndTentacleBuilder(TentacleType)
                 .WithAsyncHalibutFeature(SyncOrAsyncHalibut.ToAsyncHalibutFeature())
-                .WithTentacleVersion(Version);
+                .WithTentacleVersion(Version)
+                .WithTentacleRuntime(TentacleRuntime);
         }
 
         internal LegacyClientAndTentacleBuilder CreateLegacyBuilder()
         {
             return new LegacyClientAndTentacleBuilder(TentacleType)
                 .WithAsyncHalibutFeature(SyncOrAsyncHalibut.ToAsyncHalibutFeature())
-                .WithTentacleVersion(Version);
+                .WithTentacleVersion(Version)
+                .WithTentacleRuntime(TentacleRuntime);
         }
 
         public override string ToString()
@@ -42,6 +47,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             string version = Version?.ToString() ?? "Latest";
             builder.Append($"{version},");
             builder.Append($"{SyncOrAsyncHalibut}");
+
+            if (TentacleRuntime != TentacleRuntime.Default)
+            {
+                builder.Append($", {TentacleRuntime.GetStringValue()}");
+            }
 
             return builder.ToString();
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -2,12 +2,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
-    public class TentacleConfigurationsAttribute : TestCaseSourceAttribute
+    public class TentacleConfigurationsAttribute : TentacleTestCaseSourceAttribute
     {
         public TentacleConfigurationsAttribute(
             bool testCommonVersions = false,

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
@@ -81,20 +82,31 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 versions.Add(TentacleVersions.Current);
             }
 
+#if NETFRAMEWORK
+            List<TentacleRuntime> runtimes = new List<TentacleRuntime> { TentacleRuntime.Default };
+#endif
+#if !NETFRAMEWORK
+            List<TentacleRuntime> runtimes = PlatformDetection.IsRunningOnWindows
+                ? new List<TentacleRuntime> {TentacleRuntime.DotNet6, TentacleRuntime.Framework48}
+                : new List<TentacleRuntime> {TentacleRuntime.Default};
+#endif
+
             var testCases =
                 from tentacleType in tentacleTypes
                 from halibutType in halibutTypes
+                from runtime in runtimes
                 from version in versions.Distinct()
                 select new TentacleConfigurationTestCase(
                     tentacleType,
                     halibutType,
+                    runtime,
                     version);
 
             if (additionalParameterTypes.Length == 0)
             {
                 return testCases.GetEnumerator();
             }
-            
+
             return CombineTestCasesWithAdditionalParameters(testCases, additionalParameterTypes);
         }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -82,10 +82,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             }
 
 #if NETFRAMEWORK
-            List<TentacleRuntime> runtimes = new List<TentacleRuntime> { TentacleRuntime.Default };
-#endif
-#if !NETFRAMEWORK
-            List<TentacleRuntime> runtimes = PlatformDetection.IsRunningOnWindows
+            var runtimes = new List<TentacleRuntime> { TentacleRuntime.Default };
+#else
+            var runtimes = PlatformDetection.IsRunningOnWindows
                 ? new List<TentacleRuntime> {TentacleRuntime.DotNet6, TentacleRuntime.Framework48}
                 : new List<TentacleRuntime> {TentacleRuntime.Default};
 #endif

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -27,7 +27,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         public static IEnumerator GetEnumerator(
             bool testCommonVersions,
-            bool testCapabilitiesInterestingVersions,
+            bool testCapabilitiesVersions,
             bool testNoCapabilitiesServiceVersions,
             bool testScriptIsolationLevel,
             object[] additionalParameterTypes)
@@ -47,7 +47,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 });
             }
 
-            if (testCapabilitiesInterestingVersions)
+            if (testCapabilitiesVersions)
             {
                 versions.AddRange(new[]
                 {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/ITentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/ITentacleFetcher.cs
@@ -14,6 +14,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
         /// <param name="version">The version to download.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The full path to the tentacle executable.</returns>
-        public Task<string> GetTentacleVersion(string tmp, Version version, CancellationToken cancellationToken);
+        public Task<string> GetTentacleVersion(string tmp, Version version, TentacleRuntime runtime, CancellationToken cancellationToken);
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
 
         static string LinuxDownloadUrlForVersion(string versionString) => $"https://download.octopusdeploy.com/linux-tentacle/tentacle-{versionString}-linux_x64.tar.gz";
 
-        public async Task<string> GetTentacleVersion(string downloadPath, Version version, CancellationToken cancellationToken)
+        public async Task<string> GetTentacleVersion(string downloadPath, Version version, TentacleRuntime _, CancellationToken cancellationToken)
         {
             var directoryPath = Path.Combine(downloadPath, version.ToString());
             if (!Directory.Exists(directoryPath))

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleBinaryCache.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleBinaryCache.cs
@@ -24,45 +24,55 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
 
         private static readonly string cacheDirRunExtension = Guid.NewGuid().ToString("N");
 
-        private static readonly ConcurrentDictionary<Version, SemaphoreSlim> versionLock = new();
+        private static readonly ConcurrentDictionary<(Version, TentacleRuntime), SemaphoreSlim> versionLock = new();
 
-        public async Task<string> GetTentacleVersion(string tmp, Version version, CancellationToken cancellationToken)
+        // TODO: Fun times with Runtimes
+        public async Task<string> GetTentacleVersion(string tmp, Version version, TentacleRuntime runtime, CancellationToken cancellationToken)
         {
-            using var _ = await versionLock.GetOrAdd(version, s => new SemaphoreSlim(1, 1)).LockAsync();
+            using var _ = await versionLock.GetOrAdd((version, runtime), s => new SemaphoreSlim(1, 1)).LockAsync();
+            
+            var runtimeString = runtime.GetStringValue();
 
-            var tentacleVersionCacheDir = TentacleVersionCacheDir(version.ToString());
+            var tentacleVersionCacheDir = TentacleVersionCacheDir(version.ToString(), runtime);
 
             if (Directory.Exists(tentacleVersionCacheDir)) return Path.Combine(tentacleVersionCacheDir, TentacleExeFinder.AddExeExtension("Tentacle"));
 
             var sw = Stopwatch.StartNew();
 
-            logger.Information("Will download tentacle: {Version}", version);
-            var tentacleExe = await tentacleFetcher.GetTentacleVersion(tmp, version, cancellationToken);
+            logger.Information("Will download tentacle: {Version} ({Runtime})", version, runtimeString);
+            var tentacleExe = await tentacleFetcher.GetTentacleVersion(tmp, version, runtime, cancellationToken);
             var parentDir = new DirectoryInfo(tentacleExe).Parent;
 
             AddTentacleIntoCache(parentDir, tentacleVersionCacheDir);
 
-            logger.Information("Downloaded tentacle: {Version} in {Time}", version, sw.Elapsed);
+            logger.Information("Downloaded tentacle: {Version} ({Runtime}) in {Time}", version, runtimeString, sw.Elapsed);
 
             if (Directory.Exists(tentacleVersionCacheDir)) return Path.Combine(tentacleVersionCacheDir, TentacleExeFinder.AddExeExtension("Tentacle"));
 
             return tentacleExe;
         }
 
-        private static string TentacleVersionCacheDir(string version)
+        private static string TentacleVersionCacheDir(string version, TentacleRuntime runtime)
         {
             var cachDirName = "TentacleBinaryCache";
-            if (TentacleExeFinder.IsRunningInTeamCity())
+            if (TeamCityDetection.IsRunningInTeamCity())
             {
                 cachDirName += cachDirName + cacheDirRunExtension;
             }
 
             var pathBase = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
-            var cacheDir = Path.Combine(pathBase, cachDirName, NugetTentacleFetcher.TentacleBinaryFrameworkForCurrentOs());
+            var cacheDir = Path.Combine(pathBase, cachDirName, GetActualRuntimeStringValue(runtime));
             Directory.CreateDirectory(cacheDir);
 
             var tentacleVersionCacheDir = Path.Combine(cacheDir, version);
             return tentacleVersionCacheDir;
+        }
+
+        private static string GetActualRuntimeStringValue(TentacleRuntime runtime)
+        {
+            // If default, find actual runtime and use that string value
+            // If non-default, use what was passed in
+            return null;
         }
 
         private static void AddTentacleIntoCache(DirectoryInfo? parentDir, string tentacleVersionCacheDir)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleBinaryCache.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleBinaryCache.cs
@@ -26,28 +26,24 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
 
         private static readonly ConcurrentDictionary<(Version, TentacleRuntime), SemaphoreSlim> versionLock = new();
 
-        // TODO: Fun times with Runtimes
         public async Task<string> GetTentacleVersion(string tmp, Version version, TentacleRuntime runtime, CancellationToken cancellationToken)
         {
             using var _ = await versionLock.GetOrAdd((version, runtime), s => new SemaphoreSlim(1, 1)).LockAsync();
             
-            var runtimeString = runtime.GetStringValue();
-
             var tentacleVersionCacheDir = TentacleVersionCacheDir(version.ToString(), runtime);
 
-            if (Directory.Exists(tentacleVersionCacheDir)) return Path.Combine(tentacleVersionCacheDir, TentacleExeFinder.AddExeExtension("Tentacle"));
-
+            if (Directory.Exists(tentacleVersionCacheDir)) return TentacleExeFinder.GetExecutablePath(tentacleVersionCacheDir);
             var sw = Stopwatch.StartNew();
 
-            logger.Information("Will download tentacle: {Version} ({Runtime})", version, runtimeString);
+            logger.Information("Will download tentacle: {Version} ({Runtime})", version, runtime.GetDescription());
             var tentacleExe = await tentacleFetcher.GetTentacleVersion(tmp, version, runtime, cancellationToken);
             var parentDir = new DirectoryInfo(tentacleExe).Parent;
 
             AddTentacleIntoCache(parentDir, tentacleVersionCacheDir);
 
-            logger.Information("Downloaded tentacle: {Version} ({Runtime}) in {Time}", version, runtimeString, sw.Elapsed);
+            logger.Information("Downloaded tentacle: {Version} ({Runtime}) in {Time}", version, runtime.GetDescription(), sw.Elapsed);
 
-            if (Directory.Exists(tentacleVersionCacheDir)) return Path.Combine(tentacleVersionCacheDir, TentacleExeFinder.AddExeExtension("Tentacle"));
+            if (Directory.Exists(tentacleVersionCacheDir)) return TentacleExeFinder.GetExecutablePath(tentacleVersionCacheDir);
 
             return tentacleExe;
         }
@@ -61,22 +57,22 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             }
 
             var pathBase = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify);
-            var cacheDir = Path.Combine(pathBase, cachDirName, GetActualRuntimeStringValue(runtime));
+            var cacheDir = Path.Combine(pathBase, cachDirName, GetRuntimeStringValue(runtime));
             Directory.CreateDirectory(cacheDir);
 
             var tentacleVersionCacheDir = Path.Combine(cacheDir, version);
             return tentacleVersionCacheDir;
         }
 
-        private static string GetActualRuntimeStringValue(TentacleRuntime runtime)
+        private static string GetRuntimeStringValue(TentacleRuntime runtime)
         {
             // If default, find actual runtime and use that string value
             // If non-default, use what was passed in
             return runtime switch
             {
                 TentacleRuntime.Default => RuntimeDetection.GetCurrentRuntime(),
-                TentacleRuntime.DotNet6 => TentacleRuntime.DotNet6.GetStringValue(),
-                TentacleRuntime.Framework48 => TentacleRuntime.Framework48.GetStringValue(),
+                TentacleRuntime.DotNet6 => TentacleRuntime.DotNet6.GetDescription(),
+                TentacleRuntime.Framework48 => TentacleRuntime.Framework48.GetDescription(),
                 _ => throw new ArgumentOutOfRangeException(nameof(runtime), runtime, null)
             };
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleBinaryCache.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleBinaryCache.cs
@@ -72,7 +72,13 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
         {
             // If default, find actual runtime and use that string value
             // If non-default, use what was passed in
-            return null;
+            return runtime switch
+            {
+                TentacleRuntime.Default => RuntimeDetection.GetCurrentRuntime(),
+                TentacleRuntime.DotNet6 => TentacleRuntime.DotNet6.GetStringValue(),
+                TentacleRuntime.Framework48 => TentacleRuntime.Framework48.GetStringValue(),
+                _ => throw new ArgumentOutOfRangeException(nameof(runtime), runtime, null)
+            };
         }
 
         private static void AddTentacleIntoCache(DirectoryInfo? parentDir, string tentacleVersionCacheDir)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleFetcher.cs
@@ -8,13 +8,13 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
 {
     public static class TentacleFetcher
     {
-        public static async Task<string> GetTentacleVersion(string downloadPath, Version version, ILogger logger, CancellationToken cancellationToken)
+        public static async Task<string> GetTentacleVersion(string downloadPath, Version version, TentacleRuntime runtime, ILogger logger, CancellationToken cancellationToken)
         {
             if (!TentacleVersions.AllTestedVersionsToDownload.Any(v => v.Equals(version)))
             {
                 throw new Exception($"Version {version} must be added to {nameof(TentacleVersions)}.{nameof(TentacleVersions.AllTestedVersionsToDownload)}");
             }
-            return await new TentacleFetcherFactory().Create(logger).GetTentacleVersion(downloadPath, version, cancellationToken);
+            return await new TentacleFetcherFactory().Create(logger).GetTentacleVersion(downloadPath, version, runtime, cancellationToken);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/VersionDependentTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/VersionDependentTentacleFetcher.cs
@@ -15,20 +15,20 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             this.logger = logger;
         }
 
-        public async Task<string> GetTentacleVersion(string tmp, Version version, CancellationToken cancellationToken)
+        public async Task<string> GetTentacleVersion(string tmp, Version version, TentacleRuntime runtime, CancellationToken cancellationToken)
         {
             if (PlatformDetection.IsRunningOnNix)
             {
-                return await new LinuxTentacleFetcher(logger).GetTentacleVersion(tmp, version, cancellationToken);
+                return await new LinuxTentacleFetcher(logger).GetTentacleVersion(tmp, version, runtime, cancellationToken);
             }
 
             if (version >= new Version("5.0.0") && version < new Version("6.0.0") && PlatformDetection.IsRunningOnWindows)
             {
-                return await new WindowsOnlyNugetBinsTentacleFetcher(logger).GetTentacleVersion(tmp, version, cancellationToken);
+                return await new WindowsOnlyNugetBinsTentacleFetcher(logger).GetTentacleVersion(tmp, version, runtime, cancellationToken);
             }
             
             // Nuget cross platform packages only go as far back as 6.0.174
-            return await new NugetTentacleFetcher(logger).GetTentacleVersion(tmp, version, cancellationToken);
+            return await new NugetTentacleFetcher(logger).GetTentacleVersion(tmp, version, runtime, cancellationToken);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/WindowsOnlyNugetBinsTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/WindowsOnlyNugetBinsTentacleFetcher.cs
@@ -36,7 +36,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             var dotNetVersionPath = Directory.EnumerateDirectories(buildDir.FullName).FirstOrDefault();
             var tentacleFolder = Directory.EnumerateDirectories(dotNetVersionPath).FirstOrDefault();
 
-            return TentacleExeFinder.AddExeExtension(Path.Combine(tentacleFolder, "Tentacle"));
+            return TentacleExeFinder.GetExecutablePath(tentacleFolder);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/WindowsOnlyNugetBinsTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/WindowsOnlyNugetBinsTentacleFetcher.cs
@@ -19,7 +19,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             this.logger = logger;
         }
 
-        public async Task<string> GetTentacleVersion(string downloadPath, Version version, CancellationToken cancellationToken)
+        public async Task<string> GetTentacleVersion(string downloadPath, Version version, TentacleRuntime _, CancellationToken cancellationToken)
         {
             var downloadFilePath = Path.Combine(downloadPath, Guid.NewGuid().ToString("N"));
 
@@ -33,10 +33,10 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
 
             var buildDir = new DirectoryInfo(Path.Combine(extractionDirectory, "build"));
 
-            var dotnetversionpath = Directory.EnumerateDirectories(buildDir.FullName).FirstOrDefault();
-            var tentacelFolder = Directory.EnumerateDirectories(dotnetversionpath).FirstOrDefault();
+            var dotNetVersionPath = Directory.EnumerateDirectories(buildDir.FullName).FirstOrDefault();
+            var tentacleFolder = Directory.EnumerateDirectories(dotNetVersionPath).FirstOrDefault();
 
-            return TentacleExeFinder.AddExeExtension(Path.Combine(tentacelFolder, "Tentacle"));
+            return TentacleExeFinder.AddExeExtension(Path.Combine(tentacleFolder, "Tentacle"));
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 using System.Linq;
+using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
     public enum TentacleRuntime
     {
+        [StringValue("Default")]
         Default,
         
-        [StringValue("net6.0")]
+        [StringValue(RuntimeDetection.DotNet6)]
         DotNet6,
         
-        [StringValue("net48")]
+        [StringValue(RuntimeDetection.Framework48)]
         Framework48
     }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public enum TentacleRuntime
+    {
+        Default,
+        
+        [StringValue("net6.0")]
+        DotNet6,
+        
+        [StringValue("net48")]
+        Framework48
+    }
+
+    
+    public class StringValueAttribute : Attribute
+    {
+        public string Value { get; }
+
+        public StringValueAttribute(string value)
+        {
+            Value = value;
+        }
+    }
+
+    public static class EnumExtensions
+    {
+        public static string GetStringValue(this Enum enumValue)
+        {
+            var attr = enumValue
+                .GetType()
+                .GetField(enumValue.ToString())!
+                .GetCustomAttributes(typeof(StringValueAttribute), false)
+                .Cast<StringValueAttribute>()
+                .FirstOrDefault();
+
+            if (attr == null)
+                throw new Exception($"Enum value '{enumValue}' doesn't have StringValueAttribute");
+
+            return attr.Value;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
@@ -1,47 +1,18 @@
 ﻿using System;
-using System.Linq;
+using System.ComponentModel;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
     public enum TentacleRuntime
     {
-        [StringValue("Default")]
+        [Description("Default")]
         Default,
         
-        [StringValue(RuntimeDetection.DotNet6)]
+        [Description(RuntimeDetection.DotNet6)]
         DotNet6,
         
-        [StringValue(RuntimeDetection.Framework48)]
+        [Description(RuntimeDetection.Framework48)]
         Framework48
-    }
-
-    
-    public class StringValueAttribute : Attribute
-    {
-        public string Value { get; }
-
-        public StringValueAttribute(string value)
-        {
-            Value = value;
-        }
-    }
-
-    public static class EnumExtensions
-    {
-        public static string GetStringValue(this Enum enumValue)
-        {
-            var attr = enumValue
-                .GetType()
-                .GetField(enumValue.ToString())!
-                .GetCustomAttributes(typeof(StringValueAttribute), false)
-                .Cast<StringValueAttribute>()
-                .FirstOrDefault();
-
-            if (attr == null)
-                throw new Exception($"Enum value '{enumValue}' doesn't have StringValueAttribute");
-
-            return attr.Value;
-        }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
@@ -1,0 +1,378 @@
+﻿// ***********************************************************************
+// Copyright (c) 2008-2015 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using System.Security;
+using System.Threading;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Builders;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    /// <summary>
+    /// Indicates the source to be used to provide test fixture instances for a test class.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class TentacleTestCaseSourceAttribute : NUnitAttribute, ITestBuilder, IImplyFixture
+    {
+        private readonly NUnitTestCaseBuilder _builder = new();
+        
+        public const string Net60ClientNet48Tentacle = nameof(Net60ClientNet48Tentacle);
+
+        /// <summary>
+        /// Construct with a Type and name
+        /// </summary>
+        /// <param name="sourceType">The Type that will provide data</param>
+        /// <param name="sourceName">The name of a static method, property or field that will provide data.</param>
+        /// <param name="methodParams">A set of parameters passed to the method, works only if the Source Name is a method.
+        ///                     If the source name is a field or property has no effect.</param>
+        public TentacleTestCaseSourceAttribute(Type sourceType, string sourceName, object?[]? methodParams)
+        {
+            this.MethodParams = methodParams;
+            this.SourceType = sourceType;
+            this.SourceName = sourceName;
+        }
+        
+        /// <summary>
+        /// A set of parameters passed to the method, works only if the Source Name is a method.
+        /// If the source name is a field or property has no effect.
+        /// </summary>
+        public object?[]? MethodParams { get; }
+        /// <summary>
+        /// The name of a the method, property or field to be used as a source
+        /// </summary>
+        public string? SourceName { get; }
+
+        /// <summary>
+        /// A Type to be used as a source
+        /// </summary>
+        public Type? SourceType { get; }
+
+
+        /// <summary>
+        /// Builds any number of tests from the specified method and context.
+        /// </summary>
+        /// <param name="method">The IMethod for which tests are to be constructed.</param>
+        /// <param name="suite">The suite to which the tests will be added.</param>
+        public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test? suite)
+        {
+            int count = 0;
+
+            foreach (TestCaseParameters parms in GetTestCasesFor(method))
+            {
+                count++;
+                yield return _builder.BuildTestMethod(method, suite, parms);
+            }
+
+            // If count > 0, error messages will be shown for each case
+            // but if it's 0, we need to add an extra "test" to show the message.
+            if (count == 0 && method.GetParameters().Length == 0)
+            {
+                var parms = new TestCaseParameters();
+                parms.RunState = RunState.NotRunnable;
+                parms.Properties.Set(PropertyNames.SkipReason, "TentacleTestCaseSourceAttribute may not be used on a method without parameters");
+
+                yield return _builder.BuildTestMethod(method, suite, parms);
+            }
+        }
+
+        [SecuritySafeCritical]
+        private IEnumerable<ITestCaseData> GetTestCasesFor(IMethodInfo method)
+        {
+            List<ITestCaseData> data = new List<ITestCaseData>();
+
+            try
+            {
+                IEnumerable? source = ContextUtils.DoIsolated(() => GetTestCaseSource(method));
+
+                if (source != null)
+                {
+                    foreach (object? item in source)
+                    {
+                        // First handle two easy cases:
+                        // 1. Source is null. This is really an error but if we
+                        //    throw an exception we simply get an invalid fixture
+                        //    without good info as to what caused it. Passing a
+                        //    single null argument will cause an error to be
+                        //    reported at the test level, in most cases.
+                        // 2. User provided an ITestCaseData and we just use it.
+                        ITestCaseData? parms = item == null
+                            ? new TestCaseParameters(new object?[] { null })
+                            : item as ITestCaseData;
+
+                        if (parms == null)
+                        {
+                            object?[]? args = null;
+
+                            // 3. An array was passed, it may be an object[]
+                            //    or possibly some other kind of array, which
+                            //    TestCaseSource can accept.
+                            var array = item as Array;
+                            if (array != null)
+                            {
+                                // If array has the same number of elements as parameters
+                                // and it does not fit exactly into single existing parameter
+                                // we believe that this array contains arguments, not is a bare
+                                // argument itself.
+                                var parameters = method.GetParameters();
+                                var argsNeeded = parameters.Length;
+                                if (argsNeeded > 0 && argsNeeded == array.Length && parameters[0].ParameterType != array.GetType())
+                                {
+                                    args = new object?[array.Length];
+                                    for (var i = 0; i < array.Length; i++)
+                                        args[i] = array.GetValue(i);
+                                }
+                            }
+
+                            if (args == null)
+                            {
+                                args = new object?[] { item };
+                            }
+
+                            parms = new TestCaseParameters(args);
+                        }
+
+                        // If the test is trying to test .net6.0 TentacleClient against .net48 Tentacle,
+                        // then add the 'Net60ClientNet48Tentacle' category so we can potentially run these tests in a different test run
+                        #if !NETFRAMEWORK
+                        if (item is TentacleConfigurationTestCase {TentacleRuntime: TentacleRuntime.Framework48} testCase)
+                        {
+                            parms.Properties.Add(PropertyNames.Category, Net60ClientNet48Tentacle);
+                        }
+                        #endif
+
+                        data.Add(parms);
+                    }
+                }
+                else
+                {
+                    data.Clear();
+                    data.Add(new TestCaseParameters(new Exception("The test case source could not be found.")));
+                }
+            }
+            catch (Exception ex)
+            {
+                data.Clear();
+                data.Add(new TestCaseParameters(ex));
+            }
+
+            return data;
+        }
+
+        IEnumerable? GetTestCaseSource(IMethodInfo method)
+        {
+            Type sourceType = SourceType ?? method.TypeInfo.Type;
+
+            // Handle Type implementing IEnumerable separately
+            if (SourceName == null)
+                return Reflect.Construct(sourceType, null) as IEnumerable;
+
+            MemberInfo[] members = sourceType.GetMemberIncludingFromBase(SourceName,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+            if (members.Length == 1)
+            {
+                MemberInfo member = members[0];
+
+                var field = member as FieldInfo;
+                if (field != null)
+                    return field.IsStatic
+                        ? (MethodParams == null ? (IEnumerable)field.GetValue(null)
+                                                : ReturnErrorAsParameter(ParamGivenToField))
+                        : ReturnErrorAsParameter(SourceMustBeStatic);
+
+                var property = member as PropertyInfo;
+                if (property != null)
+                    return property.GetGetMethod(true).IsStatic
+                        ? (MethodParams == null ? (IEnumerable)property.GetValue(null, null)
+                                                : ReturnErrorAsParameter(ParamGivenToProperty))
+                        : ReturnErrorAsParameter(SourceMustBeStatic);
+
+                var m = member as MethodInfo;
+                if (m != null)
+                    return m.IsStatic
+                        ? (MethodParams == null || m.GetParameters().Length == MethodParams.Length
+                            ? (IEnumerable)m.Invoke(null, MethodParams)
+                            : ReturnErrorAsParameter(NumberOfArgsDoesNotMatch))
+                        : ReturnErrorAsParameter(SourceMustBeStatic);
+            }
+
+            return null;
+        }
+
+        static IEnumerable ReturnErrorAsParameter(string errorMessage)
+        {
+            var parms = new TestCaseParameters();
+            parms.RunState = RunState.NotRunnable;
+            parms.Properties.Set(PropertyNames.SkipReason, errorMessage);
+            return new TestCaseParameters[] { parms };
+        }
+
+        const string SourceMustBeStatic =
+            "The sourceName specified on a TestCaseSourceAttribute must refer to a static field, property or method.";
+        const string ParamGivenToField = "You have specified a data source field but also given a set of parameters. Fields cannot take parameters, " +
+                                                 "please revise the 3rd parameter passed to the TestCaseSourceAttribute and either remove " +
+                                                 "it or specify a method.";
+        const string ParamGivenToProperty = "You have specified a data source property but also given a set of parameters. " +
+                                                    "Properties cannot take parameters, please revise the 3rd parameter passed to the " +
+                                                    "TestCaseSource attribute and either remove it or specify a method.";
+        const string NumberOfArgsDoesNotMatch = "You have given the wrong number of arguments to the method in the TestCaseSourceAttribute" +
+                                                        ", please check the number of parameters passed in the object is correct in the 3rd parameter for the " +
+                                                        "TestCaseSourceAttribute and this matches the number of parameters in the target method and try again.";
+    }
+
+    // ***********************************************************************
+    // Copyright (c) 2020 Charlie Poole, Rob Prouse
+    //
+    // Permission is hereby granted, free of charge, to any person obtaining
+    // a copy of this software and associated documentation files (the
+    // "Software"), to deal in the Software without restriction, including
+    // without limitation the rights to use, copy, modify, merge, publish,
+    // distribute, sublicense, and/or sell copies of the Software, and to
+    // permit persons to whom the Software is furnished to do so, subject to
+    // the following conditions:
+    //
+    // The above copyright notice and this permission notice shall be
+    // included in all copies or substantial portions of the Software.
+    //
+    // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    // ***********************************************************************
+    static class ContextUtils
+    {
+        public static T DoIsolated<T>(Func<T> func)
+        {
+            var returnValue = default(T);
+            DoIsolated(_ => returnValue = func.Invoke(), state: null);
+            return returnValue;
+        }
+
+        [SecuritySafeCritical]
+        public static void DoIsolated(ContextCallback callback, object state)
+        {
+            var previousState = SandboxedThreadState.Capture();
+            try
+            {
+                var executionContext = ExecutionContext.Capture()
+                    ?? throw new InvalidOperationException("Execution context flow must not be suppressed.");
+
+                using ((object)executionContext as IDisposable)
+                {
+                    ExecutionContext.Run(executionContext, callback, state);
+                }
+            }
+            finally
+            {
+                previousState.Restore();
+            }
+        }
+    }
+
+    // ***********************************************************************
+    // Copyright (c) 2018 Charlie Poole, Rob Prouse
+    //
+    // Permission is hereby granted, free of charge, to any person obtaining
+    // a copy of this software and associated documentation files (the
+    // "Software"), to deal in the Software without restriction, including
+    // without limitation the rights to use, copy, modify, merge, publish,
+    // distribute, sublicense, and/or sell copies of the Software, and to
+    // permit persons to whom the Software is furnished to do so, subject to
+    // the following conditions:
+    //
+    // The above copyright notice and this permission notice shall be
+    // included in all copies or substantial portions of the Software.
+    //
+    // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    // ***********************************************************************
+
+    /// <summary>
+    /// Holds thread state which is captured and restored in order to sandbox user code.
+    /// </summary>
+    internal sealed class SandboxedThreadState
+    {
+        public CultureInfo Culture { get; }
+        public CultureInfo UICulture { get; }
+
+        /// <summary>
+        /// Thread principal.
+        /// This will be null on platforms that don't support <see cref="Thread.CurrentPrincipal"/>.
+        /// </summary>
+        public System.Security.Principal.IPrincipal Principal { get; }
+        private readonly SynchronizationContext _synchronizationContext;
+
+        private SandboxedThreadState(
+            CultureInfo culture,
+            CultureInfo uiCulture,
+            System.Security.Principal.IPrincipal principal,
+            SynchronizationContext synchronizationContext)
+        {
+            Culture = culture;
+            UICulture = uiCulture;
+            Principal = principal;
+            _synchronizationContext = synchronizationContext;
+        }
+
+        /// <summary>
+        /// Captures a snapshot of the tracked state of the current thread to be restored later.
+        /// </summary>
+        public static SandboxedThreadState Capture()
+        {
+            return new SandboxedThreadState(
+                CultureInfo.CurrentCulture,
+                CultureInfo.CurrentUICulture,
+                ThreadUtility.GetCurrentThreadPrincipal(),
+                SynchronizationContext.Current);
+        }
+
+        /// <summary>
+        /// Restores the tracked state of the current thread to the previously captured state.
+        /// </summary>
+        [SecurityCritical]
+        public void Restore()
+        {
+            Thread.CurrentThread.CurrentCulture = Culture;
+            Thread.CurrentThread.CurrentUICulture = UICulture;
+            ThreadUtility.SetCurrentThreadPrincipal(Principal);
+
+            SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
+        }
+    }
+}
+

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Halibut.Diagnostics;
 using NUnit.Framework;
 using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Util;
 using Serilog;
 using Serilog.Core;
 using Serilog.Formatting.Display;
@@ -28,7 +29,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         {
             // In teamcity we need to know what test the log is for, since we can find hung builds and only have a single file containing all log messages.
             var testName = "";
-            if (TentacleExeFinder.IsRunningInTeamCity())
+            if (TeamCityDetection.IsRunningInTeamCity())
             {
                 testName = "[{TestName}] ";
             }
@@ -91,7 +92,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                         stringBuilder.Append(s);
                     }
                 }
-                if (TentacleExeFinder.IsRunningInTeamCity() || IsForcingContextWrite.Value)
+                if (TeamCityDetection.IsRunningInTeamCity() || IsForcingContextWrite.Value)
                 {
                     TestContext.Write(s);
                 }

--- a/source/Octopus.Tentacle/Util/RuntimeDetection.cs
+++ b/source/Octopus.Tentacle/Util/RuntimeDetection.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Octopus.Tentacle.Util
+{
+    public static class RuntimeDetection
+    {
+        public const string DotNet6 = "net6.0";
+        public const string Framework48 = "net48";
+        
+        public static string GetCurrentRuntime()
+        {
+            // This wont work for future versions of dotnet
+            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET 6.0"))
+            {
+                return DotNet6;
+            }
+
+            // This is the last net framework
+            return Framework48;
+        }
+
+        public static bool IsDotNet60 => GetCurrentRuntime() == DotNet6;
+        public static bool IsFramework48 => GetCurrentRuntime() == Framework48;
+    }
+}

--- a/source/Octopus.Tentacle/Util/TeamCityDetection.cs
+++ b/source/Octopus.Tentacle/Util/TeamCityDetection.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Octopus.Tentacle.Util
+{
+    public class TeamCityDetection
+    {
+        private static Lazy<bool> IsRunningInTeamCityLazy = new Lazy<bool>(() =>
+        {
+            // Under linux we don't have the team city environment variables
+            if (typeof(TeamCityDetection).Assembly.Location.Contains("TeamCity"))
+            {
+                return true;
+            }
+
+            // Under windows we do.
+            var teamcityenvvars = new String[] {"TEAMCITY_VERSION", "TEAMCITY_BUILD_ID"};
+            foreach (var s in teamcityenvvars)
+            {
+                var environmentVariableValue = Environment.GetEnvironmentVariable(s);
+                if (!string.IsNullOrEmpty(environmentVariableValue)) return true;
+            }
+
+            return false;
+        });
+        
+        public static bool IsRunningInTeamCity()
+        {
+            return IsRunningInTeamCityLazy.Value;
+        }
+    }
+}


### PR DESCRIPTION
# Background

We would like to automatically test a net6 client (i.e. Octopus Server using TentacleClient) communicating with a net48 service (i.e. Tentacle running on .NET Framework). This PR adds support for this by adding a `TentacleRuntime` enum, which is then used by the test system to automatically generate extra test cases from existing tests for this scenario.

The extra test cases will only be generated if:
- Tests are being run on **Windows**, and...
- Tests are being run using the **.NET 6.0** runtime

Test runs on other platforms (Linux, Mac) or other runtimes (.NET Framework 4.8) should be unaffected.

These extra test cases will also be tagged with the test category `Net60ClientNet48Tentacle`, which will allow us to split them into another test run if desired.

<!-- Why does this PR exist? -->

# Results

<!-- Describe the result of the change -->

Fixes [sc-56679]

## Before
![20230904-114127_rider64_DpqRBDPO2k](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/3555db17-572d-4e40-81ea-fc2c7a36a2ba)


## After
![20230907-161441_rider64_Gy4a3Go4Do](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/8d3d427d-e11b-4340-886f-cb4617733afa)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.