### PR TITLE
Change the SQL Docker image for the "Test: Windows Docker Image"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3"
 
 services:
   db:
-    image: docker.packages.octopushq.com/octopusdeploy/mssql-server-windows-express:${MSSQL_SERVER_VERSION}
+    # There appears to be an issue with this docker image and the latest version will not start
+    # image: docker.packages.octopushq.com/octopusdeploy/mssql-server-windows-express:${MSSQL_SERVER_VERSION}
+    image: octopusdeploy/mssql-server-windows-express:latest
     environment:
       sa_password: "${SA_PASSWORD}"
       ACCEPT_EULA: "Y"


### PR DESCRIPTION
# Background

Change the SQL Docker image for the "Test: Windows Docker Image"

This original image gets rebuilt quite frequently and appears to be breaking when starting locally. We don't publish tagged versions so I don't think there is a way to use an older image.

Reverting to a much older docker image that Octopus publish gets us back to a working image.

In the long term, we may want to investigate why the original image has stopped working, but this removed an immediate blocker.

## Before

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/df4a0302-930a-4ef4-a3fb-31fb66987cff)

## After 

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/c6344ab2-8db9-48bf-99fe-6f8a5b24ee9b)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.