### PR TITLE
Fix integration test builds on previous versions of Windows

### DIFF
--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
@@ -41,7 +41,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders
 touch '{file}'
 ");
             windowsScript.AppendLine($@"
-New-Item '{file}'
+New-Item -type file '{file}'
 ");
             return this;
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/RandomTemporaryFileBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/RandomTemporaryFileBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Octopus.Tentacle.Tests.Integration.Util
 {
@@ -38,7 +39,14 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         {
             if (File.Exists)
             {
-                File.Delete();
+                try
+                {
+                    _ = Task.Run(() => File.Delete());
+                }
+                catch
+                {
+                    // We really don't care
+                }
             }
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/RandomTemporaryFileBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/RandomTemporaryFileBuilder.cs
@@ -45,7 +45,9 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                 }
                 catch
                 {
-                    // We really don't care
+                    // We sometimes have tests failing due to this file being locked during teardown.
+                    // As this is class purely for testing, and we regularly recycle our build agents,
+                    // we are happy with a 'best effort' approach here.
                 }
             }
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
@@ -43,7 +43,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
                 var size = dataFromTentacle.Length;
                 // It seems messages around 45 and below are control messages
                 // So anything bigger must be the interesting one.
-                if (pauseConnection && size > 45)
+                if (pauseConnection && size > 85)
                 {
                     pauseConnection = false;
                     logger.Information("Pause connection");
@@ -51,7 +51,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
                     pauseConnectionCallBack?.Invoke();
                 }
 
-                if (killConnection && size > 45)
+                if (killConnection && size > 85)
                 {
                     killConnection = false;
                     logger.Information("Killing connection");

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
@@ -40,10 +40,18 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
         {
             return new DataTransferObserverBuilder().WithWritingDataObserver((tcpPump, dataFromTentacle) =>
             {
-                var size = dataFromTentacle.Length;
-                // It seems messages around 45 and below are control messages
+                // It seems messages around 45 and below are control messages - except for
+                // Windows Server 2012, where the max size seems to be ~85.
                 // So anything bigger must be the interesting one.
-                if (pauseConnection && size > 85)
+                //
+                // We increased this value from 45 -> 85 to account for Windows Server 2012,
+                // and all the integration test builds seem happy with it.
+                // May need to be adjusted in the future to account for different OSs,
+                // runtimes, lunar cycles, and/or any other random heuristic.
+                const int assumedControlMessageMaxSize = 85;
+                
+                var size = dataFromTentacle.Length;
+                if (pauseConnection && size > assumedControlMessageMaxSize)
                 {
                     pauseConnection = false;
                     logger.Information("Pause connection");
@@ -51,7 +59,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
                     pauseConnectionCallBack?.Invoke();
                 }
 
-                if (killConnection && size > 85)
+                if (killConnection && size > assumedControlMessageMaxSize)
                 {
                     killConnection = false;
                     logger.Information("Killing connection");


### PR DESCRIPTION
# Background

We would like to have full confidence in the reliability of Tentacle on older versions of Windows i.e. Windows Server 2012, 2012 R2, and 2016. As such, this PR makes some small changes to our integration test setup to ensure we get reliable test run results.

There are detailed comments below each code change in the PR, to explain why the particular change is being made.

# Results

Fixes [sc-58883]

## Before
![20230906-200043_2v8NzMdjoO](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/d4935577-aca3-46ce-9cca-243e8dae9bac)


## After
![20230906-195539_firefox_DPAwqCTyWy](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/6fbe80ae-69e9-4677-9419-906970311086)

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.