### PR TITLE
Adding extra testing for both net48 and net6.0 installers

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -123,7 +123,7 @@
               "TestLinuxPackages",
               "TestOsx",
               "TestWindows",
-              "TestWindowsInstallerPermissions"
+              "TestWindowsInstallers"
             ]
           }
         },
@@ -166,7 +166,7 @@
               "TestLinuxPackages",
               "TestOsx",
               "TestWindows",
-              "TestWindowsInstallerPermissions"
+              "TestWindowsInstallers"
             ]
           }
         },

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -149,7 +149,7 @@ partial class Build
         {
             ThenTentacleShouldHaveBeenInstalled(destination);
             ThenTentacleShouldBeRunnable(destination);
-            ThenBuildInUserShouldNotHaveWritePermissions(destination);
+            ThenBuiltInUserShouldNotHaveWritePermissions(destination);
         }
         finally
         {
@@ -165,7 +165,7 @@ partial class Build
         {
             throw new Exception($"Tentacle was not installed at {expectedTentacleExe}");
         }
-        Log.Information($"Tentacle was Installed at {expectedTentacleExe}");
+        Log.Information($"Tentacle was successfully installed at {expectedTentacleExe}");
     }
 
     void ThenTentacleShouldBeRunnable(string destination)
@@ -206,7 +206,7 @@ partial class Build
         Log.Information($"Tentacle successfully ran using '{tentacleProcess.StartInfo.Arguments}' argument");
     }
 
-    void ThenBuildInUserShouldNotHaveWritePermissions(string destination)
+    void ThenBuiltInUserShouldNotHaveWritePermissions(string destination)
     {
         var builtInUsersHaveWriteAccess = DoesSidHaveRightsToDirectory(destination, WellKnownSidType.BuiltinUsersSid, FileSystemRights.AppendData, FileSystemRights.CreateFiles);
         if (builtInUsersHaveWriteAccess)

--- a/installer/Octopus.Tentacle.Installer/Product.wxs
+++ b/installer/Octopus.Tentacle.Installer/Product.wxs
@@ -14,7 +14,7 @@
     - Product/Version      : Change this every major build
     - Product/UpgradeCode  : Never change this
   -->
-  <Product Id="*" Name="Octopus Deploy Tentacle" Language="1033" Version="7.0.178" Manufacturer="Octopus Deploy Pty. Ltd." UpgradeCode="1B32E04F-49C2-4907-8879-A556986F7F16">
+  <Product Id="*" Name="Octopus Deploy Tentacle" Language="1033" Version="7.0.201" Manufacturer="Octopus Deploy Pty. Ltd." UpgradeCode="1B32E04F-49C2-4907-8879-A556986F7F16">
     <Package InstallerVersion="200" Compressed="yes" Description="Octopus Deploy Tentacle" Platform="$(var.Platform)" InstallScope="perMachine" />
     <Media Id="1" Cabinet="Files.cab" EmbedCab="yes" />
     <Property Id="MSIFASTINSTALL" Value="3" />


### PR DESCRIPTION
[sc-58906]

# Background

We want to ensure our existing (net48) and new (net6.0) installers work with some automated tests.

# Results

Related to OctopusDeploy/Issues#8266

## Before
We have one existing automated test for our installers. It does actually cover both installers already. But all it tested was that the install location directory excluded a certain permission.

## After
We now also test that `Tentacle.exe` was installed, and that it can be run (just a simple command, `help`).

**Locally**
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/0ea8852e-a109-4961-a0d9-7e46dfff4df5)

**TeamCity**
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/0ae032f6-a86b-4424-a347-a4ffb8a56887)

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.