### PR TITLE
Fixing tests for 2012

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/TestEnvironmentHelper.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TestEnvironmentHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System.Security.Principal;
 using System;
-using System.Linq;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
@@ -8,8 +7,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     public static class TestEnvironmentHelper
     {
 #pragma warning disable CA1416
-        public static string CurrentFullUserName => PlatformDetection.IsRunningOnWindows ? WindowsIdentity.GetCurrent().Name : Environment.UserName;
-        public static string CurrentUserName => PlatformDetection.IsRunningOnWindows ? WindowsIdentity.GetCurrent().Name.Split('\\').Last() : Environment.UserName;
+        public static string CurrentUserName => PlatformDetection.IsRunningOnWindows ? WindowsIdentity.GetCurrent().Name : Environment.UserName;
 #pragma warning restore CA1416
+
+        // These "Environment" versions are required for testing older operating systems on TeamCity, as "CurrentUserName" gives different values to what is actually set in the environment...
+        public static string EnvironmentUserName => Environment.GetEnvironmentVariable("username") ?? throw new Exception("Environment variable 'username' not set");
+        public static string EnvironmentDomain => Environment.GetEnvironmentVariable("userdomain") ?? throw new Exception("Environment variable 'userdomain' not set");
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TestEnvironmentHelper.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TestEnvironmentHelper.cs
@@ -11,7 +11,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 #pragma warning restore CA1416
 
         // These "Environment" versions are required for testing older operating systems on TeamCity, as "CurrentUserName" gives different values to what is actually set in the environment...
-        public static string EnvironmentUserName => Environment.GetEnvironmentVariable("username") ?? throw new Exception("Environment variable 'username' not set");
-        public static string EnvironmentDomain => Environment.GetEnvironmentVariable("userdomain") ?? throw new Exception("Environment variable 'userdomain' not set");
+        public static string EnvironmentUserName => Environment.GetEnvironmentVariable("username") ?? Environment.UserName;
+        public static string EnvironmentDomain => Environment.GetEnvironmentVariable("userdomain") ?? string.Empty;
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TestEnvironmentHelper.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TestEnvironmentHelper.cs
@@ -1,0 +1,15 @@
+﻿using System.Security.Principal;
+using System;
+using System.Linq;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public static class TestEnvironmentHelper
+    {
+#pragma warning disable CA1416
+        public static string CurrentFullUserName => PlatformDetection.IsRunningOnWindows ? WindowsIdentity.GetCurrent().Name : Environment.UserName;
+        public static string CurrentUserName => PlatformDetection.IsRunningOnWindows ? WindowsIdentity.GetCurrent().Name.Split('\\').Last() : Environment.UserName;
+#pragma warning restore CA1416
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
@@ -144,7 +144,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
             runningScript.Execute();
             runningScript.ExitCode.Should().Be(0, "the script should have run to completion");
             scriptLog.StdErr.Length.Should().Be(0, "the script shouldn't have written to stderr");
-            scriptLog.StdOut.ToString().Should().ContainEquivalentOf(TestEnvironmentHelper.CurrentUserName);
+            scriptLog.StdOut.ToString().Should().ContainEquivalentOf(TestEnvironmentHelper.EnvironmentUserName);
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
@@ -144,7 +144,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
             runningScript.Execute();
             runningScript.ExitCode.Should().Be(0, "the script should have run to completion");
             scriptLog.StdErr.Length.Should().Be(0, "the script shouldn't have written to stderr");
-            scriptLog.StdOut.ToString().Should().ContainEquivalentOf($@"{Environment.UserName}");
+            scriptLog.StdOut.ToString().Should().ContainEquivalentOf(TestEnvironmentHelper.CurrentUserName);
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
@@ -52,7 +52,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                     cts.Token);
 
                 exitCode.Should().Be(99, "our custom exit code should be reflected");
-                debugMessages.ToString().Should().ContainEquivalentOf($"Starting {command} in working directory '' using '{SilentProcessRunner.EncodingDetector.GetOEMEncoding().EncodingName}' encoding running as '{TestEnvironmentHelper.CurrentFullUserName}'");
+                debugMessages.ToString().Should().ContainEquivalentOf($"Starting {command} in working directory '' using '{SilentProcessRunner.EncodingDetector.GetOEMEncoding().EncodingName}' encoding running as '{TestEnvironmentHelper.CurrentUserName}'");
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
                 infoMessages.ToString().Should().BeEmpty("no messages should be written to stdout");
             }
@@ -78,7 +78,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                 debugMessages.ToString()
                     .Should()
                     .ContainEquivalentOf(command, "the command should be logged")
-                    .And.ContainEquivalentOf(TestEnvironmentHelper.CurrentFullUserName, "the current user details should be logged");
+                    .And.ContainEquivalentOf(TestEnvironmentHelper.CurrentUserName, "the current user details should be logged");
                 infoMessages.ToString().Should().ContainEquivalentOf("hello");
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
             }
@@ -181,7 +181,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
 
                 exitCode.Should().Be(0, "the process should have run to completion");
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
-                infoMessages.ToString().Should().ContainEquivalentOf($@"{TestEnvironmentHelper.CurrentUserName}");
+                infoMessages.ToString().Should().ContainEquivalentOf($@"{TestEnvironmentHelper.EnvironmentUserName}");
             }
         }
 
@@ -205,7 +205,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                 exitCode.Should().Be(0, "the process should have run to completion");
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
 
-                infoMessages.ToString().Should().ContainEquivalentOf(TestEnvironmentHelper.CurrentFullUserName);
+                infoMessages.ToString().Should().ContainEquivalentOf($@"{TestEnvironmentHelper.EnvironmentDomain}\{TestEnvironmentHelper.EnvironmentUserName}");
             }
         }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
@@ -52,7 +52,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                     cts.Token);
 
                 exitCode.Should().Be(99, "our custom exit code should be reflected");
-                debugMessages.ToString().Should().ContainEquivalentOf($"Starting {command} in working directory '' using '{SilentProcessRunner.EncodingDetector.GetOEMEncoding().EncodingName}' encoding running as '{CurrentUserName}'");
+                debugMessages.ToString().Should().ContainEquivalentOf($"Starting {command} in working directory '' using '{SilentProcessRunner.EncodingDetector.GetOEMEncoding().EncodingName}' encoding running as '{TestEnvironmentHelper.CurrentFullUserName}'");
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
                 infoMessages.ToString().Should().BeEmpty("no messages should be written to stdout");
             }
@@ -78,7 +78,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                 debugMessages.ToString()
                     .Should()
                     .ContainEquivalentOf(command, "the command should be logged")
-                    .And.ContainEquivalentOf(CurrentUserName, "the current user details should be logged");
+                    .And.ContainEquivalentOf(TestEnvironmentHelper.CurrentFullUserName, "the current user details should be logged");
                 infoMessages.ToString().Should().ContainEquivalentOf("hello");
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
             }
@@ -181,7 +181,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
 
                 exitCode.Should().Be(0, "the process should have run to completion");
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
-                infoMessages.ToString().Should().ContainEquivalentOf($@"{Environment.UserName}");
+                infoMessages.ToString().Should().ContainEquivalentOf($@"{TestEnvironmentHelper.CurrentUserName}");
             }
         }
 
@@ -204,7 +204,8 @@ namespace Octopus.Tentacle.Tests.Integration.Util
 
                 exitCode.Should().Be(0, "the process should have run to completion");
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
-                infoMessages.ToString().Should().ContainEquivalentOf($@"{Environment.UserDomainName}\{Environment.UserName}");
+
+                infoMessages.ToString().Should().ContainEquivalentOf(TestEnvironmentHelper.CurrentFullUserName);
             }
         }
 
@@ -255,13 +256,5 @@ namespace Octopus.Tentacle.Tests.Integration.Util
 
             return exitCode;
         }
-        
-        public static string CurrentUserName => PlatformDetection.IsRunningOnWindows
-            ?
-#pragma warning disable CA1416
-            WindowsIdentity.GetCurrent().Name
-#pragma warning restore CA1416
-            :
-            Environment.UserName;
     }
 }


### PR DESCRIPTION
[sc-59228]
[sc-59220]

# Background

To support Windows 2012 and Windows 2012R2, we have a build chain that tests Tentacle against this OS. But there are some tests that fail reliably.

# Results

## Before

There were consistent [test failures for 2012] (https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacle_IntegrationTestNet48onWindows2012/9512172?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true&expandBuildTestsSection=true):
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/e7982482-ca5b-4fa4-af3d-d54884147dd9)

and [in 2012R2](https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacle_IntegrationTestNet48onWindows2012r2/9512177?hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildProblemsSection=true):
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/11624534-bf65-4c3b-9bb0-b632be77e0f3)


The causes for these were due to 2 fundamental issues:
- A test concurrency issue that was causing a `The account already exists`
- A username inconsistency issue that was causing the user to be `SYSTEM` where it was actually something like `WIN-VTD8GECL0HO$`

## After

Thankfully, the concurrency issue was fixed in [another PR](https://github.com/OctopusDeploy/OctopusTentacle/pull/590) (yay 😁)

The username logic was fixed in this PR. It looks like this was a known issue, with a known fix. So we simply centralised the fix, and applied it to the failing tests.

# How to review this PR


Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.