### PR TITLE
Add RetryHelper

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/RetryHelper.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/RetryHelper.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading.Tasks;
+using Polly;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public class RetryHelper
+    {
+        public static async Task<TResult> RetryAsync<TResult, TException>(Func<Task<TResult>> command, int retryCount = 10, int retryBackoffDurationMilliseconds = 100)
+            where TException : Exception
+        {
+            return await Policy<TResult>
+                .Handle<TException>()
+                .WaitAndRetryAsync(retryCount, rc => TimeSpan.FromMilliseconds(retryBackoffDurationMilliseconds * rc))
+                .ExecuteAsync(command);
+        }
+    }
+}


### PR DESCRIPTION
# Background

Investigation [into this flakey integration test](https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacle_IntegrationTestNet60onWindows2012r2/9505956?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildTestsSection=true&expandBuildChangesSection=true) has uncovered an area of thread unsafe code in Tentacle, which can occasionally cause test failures on the build server but (thankfully) is unlikely to affect customers in production.

The [ApplicationInstanceStore](https://github.com/OctopusDeploy/OctopusTentacle/blob/8edad0d48bcd67fb408e59be1752bb1cd088e69a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceStore.cs) class is responsible for reading and writing instance configurations when creating/starting/deleting Tentacle instances. These configurations are stored as text files on the file system at a hard-coded path. Many Tentacle commands (e.g. `create-instance`, `delete-instance`, `import-certificate`) result in all instance configuration files found being read into memory. _This class has not been read with thread safety in mind._

The use case of this class in production does not require thread safety - we are usually starting a single instance of Tentacle at a time, and this works without issue. However in our integration test builds we are running multiple tests in parallel, and most of these tests make multiple calls to an out-of-process Tentacle. Each of these newly-started Tentacle processes will attempt to read the instance configurations found, and (usually) create a new instance configuration file.

The theory for our flakey tests is that one test may be in the process of trying to create a new instance configuration file while another test is trying to open and read that file, causing :boom:

While we can make changes to future versions of Tentacle to make this thread safe, these tests often require calling old versions of Tentacle which we cannot update. Therefore, we must try to allow our tests to mitigate the issue as much as possible, even if we can't completely fix it.

This PR adds some retry logic when executing Tentacle binaries from an integration test. If the Tentacle executable call fails, the code will retry 10 times (by default) using a back-off waiting strategy.

# Results

🟢 🤞🏻 

Fixes [sc-59223]

# How to review this PR

Will this change affect the behaviour of other unrelated Tentacle integration tests? Maybe it could cause tests to take longer to fail, as we may retry a failing call multiple times? If so, is that a problem?

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.