### PR TITLE
Add Integration Test build target for net 6.0 client <-> net48 service

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -31,11 +31,7 @@ partial class Build
 
     [PublicAPI]
     Target TestIntegration => _ => _
-        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime, "TestCategory!=\"Net60ClientNet48Service\""));
-
-    [PublicAPI]
-    Target TestIntegrationNet60ClientNet48Service => _ => _
-        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime,"TestCategory=\"Net60ClientNet48Service\""));
+        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime, Filter));
 
     [PublicAPI]
     Target TestLinuxPackages => _ => _

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -31,7 +31,11 @@ partial class Build
 
     [PublicAPI]
     Target TestIntegration => _ => _
-        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime));
+        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime, "TestCategory!=\"Net60ClientNet48Tentacle\""));
+
+    [PublicAPI]
+    Target TestIntegrationNet60ClientNet48Service => _ => _
+        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime,"TestCategory=\"Net60ClientNet48Tentacle\""));
 
     [PublicAPI]
     Target TestLinuxPackages => _ => _
@@ -289,7 +293,7 @@ partial class Build
         }
     }
 
-    void RunIntegrationTests(string testFramework, string testRuntime)
+    void RunIntegrationTests(string testFramework, string testRuntime, string filter)
     {
         Log.Information("Running test for Framework: {TestFramework} and Runtime: {TestRuntime}", testFramework, testRuntime);
 
@@ -311,6 +315,7 @@ partial class Build
                 DotNetTasks.DotNetTest(settings => settings
                     .SetProjectFile(projectPath)
                     .SetFramework(testFramework)
+                    .SetFilter(filter)
                     .SetLoggers("console;verbosity=normal", "teamcity"))
             );
         }

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -31,11 +31,11 @@ partial class Build
 
     [PublicAPI]
     Target TestIntegration => _ => _
-        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime, "TestCategory!=\"Net60ClientNet48Tentacle\""));
+        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime, "TestCategory!=\"Net60ClientNet48Service\""));
 
     [PublicAPI]
     Target TestIntegrationNet60ClientNet48Service => _ => _
-        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime,"TestCategory=\"Net60ClientNet48Tentacle\""));
+        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime,"TestCategory=\"Net60ClientNet48Service\""));
 
     [PublicAPI]
     Target TestLinuxPackages => _ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -51,6 +51,7 @@ partial class Build : NukeBuild
 
     [Parameter] string TestFramework = "";
     [Parameter] string TestRuntime = "";
+    [Parameter] string Filter = "";
 
     [PackageExecutable(
         packageId: "azuresigntool",

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
@@ -43,7 +43,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         private readonly NUnitTestCaseBuilder _builder = new();
         
-        public const string Net60ClientNet48Tentacle = nameof(Net60ClientNet48Tentacle);
+        public const string Net60ClientNet48Service = nameof(Net60ClientNet48Service);
 
         /// <summary>
         /// Construct with a Type and name
@@ -163,7 +163,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                         #if !NETFRAMEWORK
                         if (item is TentacleConfigurationTestCase {TentacleRuntime: TentacleRuntime.Framework48} testCase)
                         {
-                            parms.Properties.Add(PropertyNames.Category, Net60ClientNet48Tentacle);
+                            parms.Properties.Add(PropertyNames.Category, Net60ClientNet48Service);
                         }
                         #endif
 


### PR DESCRIPTION
# Background

[Recent changes to test more combinations of server and client versions](https://github.com/OctopusDeploy/OctopusTentacle/pull/576) (i.e. net6.0 client <-> net48 service) have made our Windows (net6.0) Integration test builds take longer than we'd like.

This PR adds another build target called `TestIntegrationNet60ClientNet48Service`, which in combination with changes to the build chain in TeamCity, will allow us to split our integration test builds into separate test runs, allowing quicker and clearer feedback from the builds system.

# Results

* Existing Windows integration test builds (current, 2016, 2012 R2, 2012) take roughly the same time they have been
* New (!) Windows integration test builds for current, 2016, 2012 R2, 2012 versions i.e. `Integration Test: net6.0 on Windows (net48 service)`

## Before / After


![20230914-174557_firefox_pkE6CK1OJc](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/47ae05ba-dc64-48fe-977c-4e29feccbef6)

![20230914-174953_firefox_9iTnGNQqL7](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/b2743c7b-9b67-4d73-812d-b4ee953ba42c)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.