### PR TITLE
Stop logging retry messages when retries won't actually be performed

### DIFF
--- a/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
+++ b/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
@@ -64,13 +64,21 @@ namespace Octopus.Tentacle.Client.Execution
                             await Task.CompletedTask;
 
                             var remainingDurationInSeconds = (int)(totalRetryDuration - elapsedDuration).TotalSeconds;
-                            logger.Info($"An error occurred communicating with Tentacle. This action will be retried after {sleepDuration.TotalSeconds} seconds. Retry attempt {retryCount}. Retries will be performed for up to {remainingDurationInSeconds} seconds.");
+                            logger.Info($"An error occurred communicating with Tentacle. This action will be retried after {(int)sleepDuration.TotalSeconds} seconds. Retry attempt {retryCount}. Retries will be performed for up to {remainingDurationInSeconds} seconds.");
                             logger.Verbose(lastException);
                         },
-                        onTimeoutAction: async (timeoutDuration, _) =>
+                        onTimeoutAction: async (timeoutDuration, elapsedDuration, retryCount, _) =>
                         {
                             await Task.CompletedTask;
-                            logger.Info($"Could not communicate with Tentacle after {timeoutDuration.TotalSeconds} seconds. No more retries will be attempted.");
+
+                            if (retryCount > 0)
+                            {
+                                logger.Info($"Could not communicate with Tentacle after {(int)elapsedDuration.TotalSeconds} seconds. No more retries will be attempted.");
+                            }
+                            else
+                            {
+                                logger.Info($"Could not communicate with Tentacle after {(int)elapsedDuration.TotalSeconds} seconds.");
+                            }
                         },
                         abandonActionOnCancellation,
                         AbandonAfter,

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
@@ -22,8 +22,11 @@ namespace Octopus.Tentacle.Tests.Integration
     [IntegrationTestTimeout]
     public class ClientFileTransferRetriesTimeout : IntegrationTest
     {
+        readonly TimeSpan retryIfRemainingDurationAtLeastBuffer = TimeSpan.FromSeconds(1);
+        readonly TimeSpan retryBackoffBuffer = TimeSpan.FromSeconds(2);
+
         [Test]
-        [TentacleConfigurations(additionalParameterTypes: new object[] { typeof(StopPortForwarderAfterFirstCallValues)})]
+        [TentacleConfigurations(additionalParameterTypes: new object[] { typeof(StopPortForwarderAfterFirstCallValues) })]
         public async Task WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(TentacleConfigurationTestCase tentacleConfigurationTestCase, bool stopPortForwarderAfterFirstCall)
         {
             PortForwarder portForwarder = null!;
@@ -68,12 +71,14 @@ namespace Octopus.Tentacle.Tests.Integration
 
             portForwarder = clientAndTentacle.PortForwarder;
 
+            var inMemoryLog = new InMemoryLog();
+
             var remotePath = Path.Combine(clientAndTentacle.TemporaryDirectory.DirectoryPath, "UploadFile.txt");
             var dataStream = DataStream.FromString("The Stream");
 
             // Start the script which will wait for a file to exist
             var duration = Stopwatch.StartNew();
-            var executeScriptTask = clientAndTentacle.TentacleClient.UploadFile(remotePath, dataStream, CancellationToken);
+            var executeScriptTask = clientAndTentacle.TentacleClient.UploadFile(remotePath, dataStream, CancellationToken, inMemoryLog);
 
             Func<Task> action = async () => await executeScriptTask;
             await action.Should().ThrowAsync<HalibutClientException>();
@@ -83,7 +88,51 @@ namespace Octopus.Tentacle.Tests.Integration
             fileTransferServiceCallCounts.DownloadFileCallCountStarted.Should().Be(0);
 
             // Ensure we actually waited and retried until the timeout policy kicked in
-            duration.Elapsed.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(14));
+            duration.Elapsed.Should().BeGreaterOrEqualTo(clientAndTentacle.RpcRetrySettings.RetryDuration - retryIfRemainingDurationAtLeastBuffer - retryBackoffBuffer);
+
+            RetryLogMessageAssertions.AssertRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+        }
+
+        [Test]
+        [TentacleConfigurations]
+        public async Task WhenUploadFileFails_AndTakesLongerThanTheRetryDuration_TheCallIsNotRetried_AndTimesOut(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var retryDuration = TimeSpan.FromSeconds(15);
+
+            await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                // Set a short retry duration so we cancel fairly quickly
+                .WithRetryDuration(retryDuration)
+                .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .LogCallsToFileTransferService()
+                    .CountCallsToFileTransferService(out var fileTransferServiceCallCounts)
+                    .DecorateFileTransferServiceWith(d => d
+                        .BeforeUploadFile(async (service, _, _) =>
+                        {
+                            await service.EnsureTentacleIsConnectedToServer(Logger);
+
+                            // Sleep to make the initial RPC call take longer than the allowed retry duration
+                            await Task.Delay(retryDuration + TimeSpan.FromSeconds(1));
+
+                            // Kill the first UploadFile call to force the rpc call into retries
+                            responseMessageTcpKiller.KillConnectionOnNextResponse();
+                        })
+                        .Build())
+                    .Build())
+                .Build(CancellationToken);
+
+            var inMemoryLog = new InMemoryLog();
+            var remotePath = Path.Combine(clientAndTentacle.TemporaryDirectory.DirectoryPath, "UploadFile.txt");
+            var dataStream = DataStream.FromString("The Stream");
+            var executeScriptTask = clientAndTentacle.TentacleClient.UploadFile(remotePath, dataStream, CancellationToken, inMemoryLog);
+            
+            Func<Task> action = async () => await executeScriptTask;
+            await action.Should().ThrowAsync<HalibutClientException>();
+
+            fileTransferServiceCallCounts.UploadFileCallCountStarted.Should().Be(1);
+            fileTransferServiceCallCounts.DownloadFileCallCountStarted.Should().Be(0);
+            
+            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
         }
 
         [Test]
@@ -133,10 +182,12 @@ namespace Octopus.Tentacle.Tests.Integration
             portForwarder = clientAndTentacle.PortForwarder;
 
             using var tempFile = new RandomTemporaryFileBuilder().Build();
+            
+            var inMemoryLog = new InMemoryLog();
 
             // Start the script which will wait for a file to exist
             var duration = Stopwatch.StartNew();
-            var executeScriptTask = clientAndTentacle.TentacleClient.DownloadFile(tempFile.File.FullName, CancellationToken);
+            var executeScriptTask = clientAndTentacle.TentacleClient.DownloadFile(tempFile.File.FullName, CancellationToken, inMemoryLog);
 
             Func<Task<DataStream>> action = async () => await executeScriptTask;
             await action.Should().ThrowAsync<HalibutClientException>();
@@ -146,7 +197,50 @@ namespace Octopus.Tentacle.Tests.Integration
             fileTransferServiceCallCounts.UploadFileCallCountStarted.Should().Be(0);
 
             // Ensure we actually waited and retried until the timeout policy kicked in
-            duration.Elapsed.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(14));
+            duration.Elapsed.Should().BeGreaterOrEqualTo(clientAndTentacle.RpcRetrySettings.RetryDuration - retryIfRemainingDurationAtLeastBuffer - retryBackoffBuffer);
+
+            RetryLogMessageAssertions.AssertRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+        }
+
+        [Test]
+        [TentacleConfigurations]
+        public async Task WhenDownloadFileFails_AndTakesLongerThanTheRetryDuration_TheCallIsNotRetried_AndTimesOut(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var retryDuration = TimeSpan.FromSeconds(15);
+
+            await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                // Set a short retry duration so we cancel fairly quickly
+                .WithRetryDuration(retryDuration)
+                .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .LogCallsToFileTransferService()
+                    .CountCallsToFileTransferService(out var fileTransferServiceCallCounts)
+                    .DecorateFileTransferServiceWith(d => d
+                        .BeforeDownloadFile(async (service, _) =>
+                        {
+                            await service.EnsureTentacleIsConnectedToServer(Logger);
+
+                            // Sleep to make the initial RPC call take longer than the allowed retry duration
+                            await Task.Delay(retryDuration + TimeSpan.FromSeconds(1));
+
+                            // Kill the first DownloadFile call to force the rpc call into retries
+                            responseMessageTcpKiller.KillConnectionOnNextResponse();
+                        })
+                        .Build())
+                    .Build())
+                .Build(CancellationToken);
+
+            using var tempFile = new RandomTemporaryFileBuilder().Build();
+            var inMemoryLog = new InMemoryLog();
+            var executeScriptTask = clientAndTentacle.TentacleClient.DownloadFile(tempFile.File.FullName, CancellationToken, inMemoryLog);
+
+            Func<Task<DataStream>> action = async () => await executeScriptTask;
+            await action.Should().ThrowAsync<HalibutClientException>();
+
+            fileTransferServiceCallCounts.DownloadFileCallCountStarted.Should().Be(1);
+            fileTransferServiceCallCounts.UploadFileCallCountStarted.Should().Be(0);
+
+            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
         }
 
         class StopPortForwarderAfterFirstCallValues : IEnumerable

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Halibut;
 using NUnit.Framework;
 using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
 using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
@@ -90,7 +91,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Ensure we actually waited and retried until the timeout policy kicked in
             duration.Elapsed.Should().BeGreaterOrEqualTo(clientAndTentacle.RpcRetrySettings.RetryDuration - retryIfRemainingDurationAtLeastBuffer - retryBackoffBuffer);
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndRetryFailure();
         }
 
         [Test]
@@ -132,7 +133,7 @@ namespace Octopus.Tentacle.Tests.Integration
             fileTransferServiceCallCounts.UploadFileCallCountStarted.Should().Be(1);
             fileTransferServiceCallCounts.DownloadFileCallCountStarted.Should().Be(0);
             
-            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryFailureAndNoRetryAttempts();
         }
 
         [Test]
@@ -199,7 +200,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Ensure we actually waited and retried until the timeout policy kicked in
             duration.Elapsed.Should().BeGreaterOrEqualTo(clientAndTentacle.RpcRetrySettings.RetryDuration - retryIfRemainingDurationAtLeastBuffer - retryBackoffBuffer);
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndRetryFailure();
         }
 
         [Test]
@@ -240,7 +241,7 @@ namespace Octopus.Tentacle.Tests.Integration
             fileTransferServiceCallCounts.DownloadFileCallCountStarted.Should().Be(1);
             fileTransferServiceCallCounts.UploadFileCallCountStarted.Should().Be(0);
 
-            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryFailureAndNoRetryAttempts();
         }
 
         class StopPortForwarderAfterFirstCallValues : IEnumerable

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
@@ -6,6 +6,7 @@ using Halibut;
 using NUnit.Framework;
 using Octopus.Tentacle.CommonTestUtils;
 using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
 using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
 using Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers;
@@ -51,7 +52,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var actuallySent = (await clientTentacle.TentacleClient.DownloadFile(remotePath, CancellationToken)).GetUtf8String();
             actuallySent.Should().Be("Hello");
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndNoRetryFailures();
         }
 
         [Test]
@@ -90,7 +91,7 @@ namespace Octopus.Tentacle.Tests.Integration
             fileTransferServiceCallCounts.DownloadFileCallCountStarted.Should().Be(2);
             actuallySent.Should().Be("Hello");
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndNoRetryFailures();
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
@@ -204,7 +204,7 @@ namespace Octopus.Tentacle.Tests.Integration
             metric.Exception.Should().BeNull();
             metric.WasCancelled.Should().BeFalse();
 
-            metric.End.Should().BeAfter(metric.Start);
+            metric.End.Should().BeOnOrAfter(metric.Start);
             metric.Duration.Should().Be(metric.End - metric.Start);
         }
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -12,6 +12,7 @@ using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
 using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
@@ -46,7 +47,11 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromHours(1))
                 .Build();
 
-            var execScriptTask = Task.Run(async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken), CancellationToken);
+            var inMemoryLog = new InMemoryLog();
+
+            var execScriptTask = Task.Run(
+                async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog), 
+                CancellationToken);
 
             // Wait for the script to start.
             await Wait.For(() => File.Exists(scriptHasStartFile), CancellationToken);
@@ -66,6 +71,8 @@ namespace Octopus.Tentacle.Tests.Integration
             allLogs.Should().Contain("hello");
 
             scriptServiceV2CallCounts.StartScriptCallCountStarted.Should().BeGreaterThan(1);
+
+            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
         }
 
         [Test]
@@ -101,7 +108,11 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Print("AllDone"))
                 .Build();
 
-            var execScriptTask = Task.Run(async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken), CancellationToken);
+            var inMemoryLog = new InMemoryLog();
+
+            var execScriptTask = Task.Run(
+                async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog), 
+                CancellationToken);
 
             await Wait.For(() => scriptServiceV2Exceptions.GetStatusLatestException != null, CancellationToken);
 
@@ -116,6 +127,8 @@ namespace Octopus.Tentacle.Tests.Integration
             var allLogs = logs.JoinLogs();
             allLogs.Should().Contain("hello");
             scriptServiceV2Exceptions.GetStatusLatestException.Should().NotBeNull();
+
+            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
         }
 
         [Test]
@@ -154,7 +167,8 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithScriptBody(new ScriptBuilder().Print("hello").Sleep(TimeSpan.FromSeconds(1)))
                 .Build();
 
-            var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+            var inMemoryLog = new InMemoryLog();
+            var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog);
 
             finalResponse.State.Should().Be(ProcessState.Complete);
             finalResponse.ExitCode.Should().Be(0);
@@ -162,6 +176,8 @@ namespace Octopus.Tentacle.Tests.Integration
             var allLogs = logs.JoinLogs();
             allLogs.Should().Contain("hello");
             completeScriptWasCalled.Should().BeTrue("The tests expects that the client actually called this");
+
+            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndNoRetryFailureLogged(inMemoryLog);
         }
 
         [Test]
@@ -208,6 +224,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             Exception? actualException = null;
             var logs = new List<ProcessOutput>();
+            var inMemoryLog = new InMemoryLog();
 
             try
             {
@@ -217,7 +234,7 @@ namespace Octopus.Tentacle.Tests.Integration
                         logs.AddRange(onScriptStatusResponseReceived.Logs);
                     },
                     _ => Task.CompletedTask,
-                    new SerilogLoggerBuilder().Build().ForContext<TentacleClient>().ToILog(),
+                    new SerilogLoggerBuilder().Build().ForContext<TentacleClient>().ToILog().Chain(inMemoryLog),
                     cts.Token);
             }
             catch (Exception ex)
@@ -231,6 +248,8 @@ namespace Octopus.Tentacle.Tests.Integration
             allLogs.Should().Contain("hello");
             allLogs.Should().NotContain("AllDone");
             scriptServiceV2Exceptions.CancelScriptLatestException.Should().NotBeNull();
+
+            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
         }
 
         [Test]
@@ -273,11 +292,13 @@ namespace Octopus.Tentacle.Tests.Integration
                     asyncScriptServiceV2 = clientTentacle.Server.ServerHalibutRuntime.CreateAsyncClient<IScriptServiceV2, IAsyncClientScriptServiceV2>(clientTentacle.ServiceEndPoint);
                 });
 
+            var inMemoryLog = new InMemoryLog();
+
             var startScriptCommand = new StartScriptCommandV2Builder()
                 .WithScriptBody(new ScriptBuilder().Print("hello"))
                 .Build();
 
-            var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+            var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog);
 
             finalResponse.State.Should().Be(ProcessState.Complete);
             finalResponse.ExitCode.Should().Be(0);
@@ -286,6 +307,8 @@ namespace Octopus.Tentacle.Tests.Integration
             allLogs.Should().Contain("hello");
             capabilitiesServiceV2Exceptions.GetCapabilitiesLatestException.Should().NotBeNull();
             capabilitiesServiceV2CallCounts.GetCapabilitiesCallCountStarted.Should().Be(2);
+
+            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -72,7 +72,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             scriptServiceV2CallCounts.StartScriptCallCountStarted.Should().BeGreaterThan(1);
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndNoRetryFailures();
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace Octopus.Tentacle.Tests.Integration
             allLogs.Should().Contain("hello");
             scriptServiceV2Exceptions.GetStatusLatestException.Should().NotBeNull();
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndNoRetryFailures();
         }
 
         [Test]
@@ -177,7 +177,7 @@ namespace Octopus.Tentacle.Tests.Integration
             allLogs.Should().Contain("hello");
             completeScriptWasCalled.Should().BeTrue("The tests expects that the client actually called this");
 
-            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndNoRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldNotHaveLoggedRetryAttemptsOrRetryFailures();
         }
 
         [Test]
@@ -249,7 +249,7 @@ namespace Octopus.Tentacle.Tests.Integration
             allLogs.Should().NotContain("AllDone");
             scriptServiceV2Exceptions.CancelScriptLatestException.Should().NotBeNull();
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndNoRetryFailures();
         }
 
         [Test]
@@ -308,7 +308,7 @@ namespace Octopus.Tentacle.Tests.Integration
             capabilitiesServiceV2Exceptions.GetCapabilitiesLatestException.Should().NotBeNull();
             capabilitiesServiceV2CallCounts.GetCapabilitiesCallCountStarted.Should().Be(2);
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedButNoRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndNoRetryFailures();
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -10,6 +10,7 @@ using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
 using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
@@ -105,7 +106,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Ensure we actually waited and retried until the timeout policy kicked in
             duration.Elapsed.Should().BeGreaterOrEqualTo(clientAndTentacle.RpcRetrySettings.RetryDuration - retryIfRemainingDurationAtLeastBuffer - retryBackoffBuffer);
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndRetryFailure();
         }
 
         [Test]
@@ -162,7 +163,7 @@ namespace Octopus.Tentacle.Tests.Integration
             capabilitiesServiceCallCounts.GetCapabilitiesCallCountStarted.Should().Be(1);
             scriptServiceV2CallCounts.StartScriptCallCountStarted.Should().Be(0, "Test should not have not proceeded past GetCapabilities");
 
-            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryFailureAndNoRetryAttempts();
         }
 
         [Test]
@@ -232,7 +233,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Ensure we actually waited and retried until the timeout policy kicked in
             duration.Elapsed.Should().BeGreaterOrEqualTo(clientAndTentacle.RpcRetrySettings.RetryDuration - retryIfRemainingDurationAtLeastBuffer - retryBackoffBuffer);
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndRetryFailure();
         }
 
         [Test]
@@ -278,7 +279,7 @@ namespace Octopus.Tentacle.Tests.Integration
             scriptServiceCallCounts.CancelScriptCallCountStarted.Should().Be(0);
             scriptServiceCallCounts.CompleteScriptCallCountStarted.Should().Be(0);
 
-            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryFailureAndNoRetryAttempts();
         }
 
         [Test]
@@ -350,7 +351,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Ensure we actually waited and retried until the timeout policy kicked in
             duration.Elapsed.Should().BeGreaterOrEqualTo(clientAndTentacle.RpcRetrySettings.RetryDuration - retryIfRemainingDurationAtLeastBuffer - retryBackoffBuffer);
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndRetryFailure();
         }
 
         [Test]
@@ -398,7 +399,7 @@ namespace Octopus.Tentacle.Tests.Integration
             scriptServiceCallCounts.CancelScriptCallCountStarted.Should().Be(0);
             scriptServiceCallCounts.CompleteScriptCallCountStarted.Should().Be(0);
 
-            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryFailureAndNoRetryAttempts();
         }
 
         [Test]
@@ -483,7 +484,7 @@ namespace Octopus.Tentacle.Tests.Integration
             // Ensure we actually waited and retried until the timeout policy kicked in
             duration.Elapsed.Should().BeGreaterOrEqualTo(clientAndTentacle.RpcRetrySettings.RetryDuration - retryIfRemainingDurationAtLeastBuffer - retryBackoffBuffer);
 
-            RetryLogMessageAssertions.AssertRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryAttemptsAndRetryFailure();
         }
 
         [Test]
@@ -544,7 +545,7 @@ namespace Octopus.Tentacle.Tests.Integration
             scriptServiceCallCounts.CancelScriptCallCountStarted.Should().Be(1);
             scriptServiceCallCounts.CompleteScriptCallCountStarted.Should().Be(0);
 
-            RetryLogMessageAssertions.AssertNoRetryAttemptsLoggedAndRetryFailureLogged(inMemoryLog);
+            inMemoryLog.ShouldHaveLoggedRetryFailureAndNoRetryAttempts();
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <AssemblyName>Octopus.Tentacle.Tests.Integration</AssemblyName>
@@ -32,7 +32,7 @@
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Assent" Version="1.8.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="Octopus.TestPortForwarder" Version="6.0.1069" />
+        <PackageReference Include="Octopus.TestPortForwarder" Version="6.0.1415" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Halibut;
 using Halibut.Util;
 using Octopus.Tentacle.Client;
+using Octopus.Tentacle.Client.Retries;
 using Octopus.Tentacle.Tests.Integration.Support.Legacy;
 using Octopus.TestPortForwarder;
 
@@ -17,20 +18,21 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public RunningTentacle RunningTentacle { get; }
         public TentacleClient TentacleClient { get; }
         public TemporaryDirectory TemporaryDirectory { get; }
+        public RpcRetrySettings RpcRetrySettings { get; }
 
         public LegacyTentacleClientBuilder LegacyTentacleClientBuilder(AsyncHalibutFeature asyncHalibutFeature)
         {
             return new LegacyTentacleClientBuilder(halibutRuntime, ServiceEndPoint, asyncHalibutFeature);
         }
 
-        public ClientAndTentacle(
-            IHalibutRuntime halibutRuntime,
+        public ClientAndTentacle(IHalibutRuntime halibutRuntime,
             ServiceEndPoint serviceEndPoint,
             Server server,
             PortForwarder? portForwarder,
             RunningTentacle runningTentacle,
             TentacleClient tentacleClient,
-            TemporaryDirectory temporaryDirectory)
+            TemporaryDirectory temporaryDirectory, 
+            RpcRetrySettings rpcRetrySettings)
         {
             this.halibutRuntime = halibutRuntime;
             Server = server;
@@ -38,6 +40,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             RunningTentacle = runningTentacle;
             TentacleClient = tentacleClient;
             TemporaryDirectory = temporaryDirectory;
+            RpcRetrySettings = rpcRetrySettings;
             this.ServiceEndPoint = serviceEndPoint;
         }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -209,15 +209,17 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
             TentacleClient.CacheServiceWasNotFoundResponseMessages(server.ServerHalibutRuntime);
 
+            var retrySettings = new RpcRetrySettings(retriesEnabled, retryDuration);
+
             var tentacleClient = new TentacleClient(
                 tentacleEndPoint,
                 server.ServerHalibutRuntime,
                 scriptObserverBackoffStrategy,
                 tentacleClientObserver,
-                new RpcRetrySettings(retriesEnabled, retryDuration),
+                retrySettings,
                 tentacleServiceDecorator);
 
-            return new ClientAndTentacle(server.ServerHalibutRuntime, tentacleEndPoint, server, portForwarder, runningTentacle, tentacleClient, temporaryDirectory);
+            return new ClientAndTentacle(server.ServerHalibutRuntime, tentacleEndPoint, server, portForwarder, runningTentacle, tentacleClient, temporaryDirectory, retrySettings);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/InMemoryLogAssertionExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/InMemoryLogAssertionExtensionMethods.cs
@@ -1,24 +1,15 @@
 ﻿using System.Text.RegularExpressions;
 using FluentAssertions;
 
-namespace Octopus.Tentacle.Tests.Integration.Support
+namespace Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods
 {
-    internal static class RetryLogMessageAssertions
+    internal static class InMemoryLogAssertionExtensionMethods
     {
-        static readonly Regex retryingMessageRegex = new ("An error occurred communicating with Tentacle. This action will be retried after \\d* seconds. Retry attempt \\d*. Retries will be performed for up to \\d* seconds.\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
-        static readonly Regex timeoutAfterRetriesMessageRegex = new ("Could not communicate with Tentacle after \\d* seconds. No more retries will be attempted.\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
-        static readonly Regex timeoutAfterNoRetriesMessageRegex = new ("Could not communicate with Tentacle after \\d* seconds.\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
+        static readonly Regex retryingMessageRegex = new("An error occurred communicating with Tentacle. This action will be retried after \\d* seconds. Retry attempt \\d*. Retries will be performed for up to \\d* seconds.\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
+        static readonly Regex timeoutAfterRetriesMessageRegex = new("Could not communicate with Tentacle after \\d* seconds. No more retries will be attempted.\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
+        static readonly Regex timeoutAfterNoRetriesMessageRegex = new("Could not communicate with Tentacle after \\d* seconds.\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
 
-        public static void AssertRetryAttemptsLoggedButNoRetryFailureLogged(InMemoryLog logs)
-        {
-            AssertRetriedLogMessages(logs);
-            
-            // Negative assertions
-            AssertNoTimeoutAfterRetriedLogMessages(logs);
-            AssertNoTimeoutAfterNoRetriedLogMessages(logs);
-        }
-
-        public static  void AssertRetryAttemptsLoggedAndRetryFailureLogged(InMemoryLog logs)
+        public static void ShouldHaveLoggedRetryAttemptsAndRetryFailure(this InMemoryLog logs)
         {
             AssertRetriedLogMessages(logs);
             AssertTimeoutAfterRetriedLogMessages(logs);
@@ -27,21 +18,30 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             AssertNoTimeoutAfterNoRetriedLogMessages(logs);
         }
 
-        public static  void AssertNoRetryAttemptsLoggedAndRetryFailureLogged(InMemoryLog logs)
+        public static void ShouldNotHaveLoggedRetryAttemptsOrRetryFailures(this InMemoryLog logs)
+        {
+            // Negative assertions
+            AssertNoRetriedLogMessages(logs);
+            AssertNoTimeoutAfterRetriedLogMessages(logs);
+            AssertNoTimeoutAfterNoRetriedLogMessages(logs);
+        }
+
+        public static void ShouldHaveLoggedRetryAttemptsAndNoRetryFailures(this InMemoryLog logs)
+        {
+            AssertRetriedLogMessages(logs);
+
+            // Negative assertions
+            AssertNoTimeoutAfterRetriedLogMessages(logs);
+            AssertNoTimeoutAfterNoRetriedLogMessages(logs);
+        }
+
+        public static void ShouldHaveLoggedRetryFailureAndNoRetryAttempts(this InMemoryLog logs)
         {
             AssertTimeoutAfterNoRetriedLogMessages(logs);
 
             // Negative assertions
             AssertNoRetriedLogMessages(logs);
             AssertNoTimeoutAfterRetriedLogMessages(logs);
-        }
-
-        public static  void AssertNoRetryAttemptsLoggedAndNoRetryFailureLogged(InMemoryLog logs)
-        {
-            // Negative assertions
-            AssertNoRetriedLogMessages(logs);
-            AssertNoTimeoutAfterRetriedLogMessages(logs);
-            AssertNoTimeoutAfterNoRetriedLogMessages(logs);
         }
 
         private static void AssertRetriedLogMessages(InMemoryLog logs)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/LogExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/LogExtensionMethods.cs
@@ -1,0 +1,39 @@
+using System;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Diagnostics;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods
+{
+    public static class LogExtensionMethods
+    {
+        public static Log Chain(this Log log, Log? otherLog)
+        {
+            if (otherLog == null)
+            {
+                return log;
+            }
+
+            return new LogChain(log, otherLog);
+        }
+
+        class LogChain : Log
+        {
+            private readonly Log log1;
+            private readonly Log log2;
+
+            public LogChain(Log log1, Log log2)
+            {
+                this.log1 = log1;
+                this.log2 = log2;
+            }
+
+            public override string CorrelationId => log1.CorrelationId;
+
+            public override void Write(LogCategory category, Exception? error, string messageText)
+            {
+                log1.Write(category, error, messageText);
+                log2.Write(category, error, messageText);
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/IntegrationTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading;
 using NUnit.Framework;
 using Octopus.Tentacle.Tests.Integration.Util;
@@ -11,7 +10,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     public abstract class IntegrationTest
     {
         CancellationTokenSource? cancellationTokenSource;
-        private CancellationTokenRegistration? cancellationTokenRegistration;
         public CancellationToken CancellationToken { get; private set; }
         public ILogger Logger { get; private set; } = null!;
 
@@ -20,44 +18,19 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         {
             Logger = new SerilogLoggerBuilder().Build().ForContext(GetType());
             Logger.Information("Test started");
-            cancellationTokenSource = new CancellationTokenSource(IntegrationTestTimeout.TestTimeoutInMilliseconds() - (int)TimeSpan.FromSeconds(5).TotalMilliseconds);
+            cancellationTokenSource = new CancellationTokenSource();
             CancellationToken = cancellationTokenSource.Token;
-            cancellationTokenRegistration = CancellationToken.Register(() =>
-            {
-                Logger.Error("The test timed out.");
-                Assert.Fail("The test timed out.");
-            });
         }
-
+        
         [TearDown]
         public void TearDown()
         {
-            Logger.Information("Tearing down");
-            
-            cancellationTokenRegistration?.Dispose();
+            Logger.Information("Staring Test Tearing Down");
+            Logger.Information("Cancelling CancellationTokenSource");
+            cancellationTokenSource?.Cancel();
+            Logger.Information("Disposing CancellationTokenSource");
             cancellationTokenSource?.Dispose();
-            
-        }
-    }
-
-    public class IntegrationTestTimeout : TimeoutAttribute
-    {
-        public IntegrationTestTimeout(int timeoutInSeconds) : base((int)TimeSpan.FromSeconds(timeoutInSeconds).TotalMilliseconds)
-        {
-        }
-
-        public IntegrationTestTimeout() : base(TestTimeoutInMilliseconds())
-        {
-        }
-
-        public static int TestTimeoutInMilliseconds()
-        {
-            if (Debugger.IsAttached)
-            {
-                return (int)TimeSpan.FromHours(1).TotalMilliseconds;
-            }
-
-            return (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
+            Logger.Information("Finished Test Tearing Down");
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/IntegrationTestTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/IntegrationTestTimeout.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Diagnostics;
+using NUnit.Framework;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public class IntegrationTestTimeout : TimeoutAttribute
+    {
+        public IntegrationTestTimeout(int timeoutInSeconds) : base((int)TimeSpan.FromSeconds(timeoutInSeconds).TotalMilliseconds)
+        {
+        }
+
+        public IntegrationTestTimeout() : base(TestTimeoutInMilliseconds())
+        {
+        }
+
+        public static int TestTimeoutInMilliseconds()
+        {
+            if (Debugger.IsAttached)
+            {
+                return (int)TimeSpan.FromHours(1).TotalMilliseconds;
+            }
+
+            return (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/RetryLogMessageAssertions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/RetryLogMessageAssertions.cs
@@ -1,0 +1,86 @@
+﻿using System.Text.RegularExpressions;
+using FluentAssertions;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    internal static class RetryLogMessageAssertions
+    {
+        static readonly Regex retryingMessageRegex = new ("An error occurred communicating with Tentacle. This action will be retried after \\d* seconds. Retry attempt \\d*. Retries will be performed for up to \\d* seconds.\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
+        static readonly Regex timeoutAfterRetriesMessageRegex = new ("Could not communicate with Tentacle after \\d* seconds. No more retries will be attempted.\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
+        static readonly Regex timeoutAfterNoRetriesMessageRegex = new ("Could not communicate with Tentacle after \\d* seconds.\\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
+
+        public static void AssertRetryAttemptsLoggedButNoRetryFailureLogged(InMemoryLog logs)
+        {
+            AssertRetriedLogMessages(logs);
+            
+            // Negative assertions
+            AssertNoTimeoutAfterRetriedLogMessages(logs);
+            AssertNoTimeoutAfterNoRetriedLogMessages(logs);
+        }
+
+        public static  void AssertRetryAttemptsLoggedAndRetryFailureLogged(InMemoryLog logs)
+        {
+            AssertRetriedLogMessages(logs);
+            AssertTimeoutAfterRetriedLogMessages(logs);
+
+            // Negative assertions
+            AssertNoTimeoutAfterNoRetriedLogMessages(logs);
+        }
+
+        public static  void AssertNoRetryAttemptsLoggedAndRetryFailureLogged(InMemoryLog logs)
+        {
+            AssertTimeoutAfterNoRetriedLogMessages(logs);
+
+            // Negative assertions
+            AssertNoRetriedLogMessages(logs);
+            AssertNoTimeoutAfterRetriedLogMessages(logs);
+        }
+
+        public static  void AssertNoRetryAttemptsLoggedAndNoRetryFailureLogged(InMemoryLog logs)
+        {
+            // Negative assertions
+            AssertNoRetriedLogMessages(logs);
+            AssertNoTimeoutAfterRetriedLogMessages(logs);
+            AssertNoTimeoutAfterNoRetriedLogMessages(logs);
+        }
+
+        private static void AssertRetriedLogMessages(InMemoryLog logs)
+        {
+            logs.GetLog().Should().MatchRegex(retryingMessageRegex);
+
+            var matches = retryingMessageRegex.Matches(logs.GetLog());
+            matches.Count.Should().BeGreaterThanOrEqualTo(1);
+        }
+
+        private static void AssertNoRetriedLogMessages(InMemoryLog logs)
+        {
+            logs.GetLog().Should().NotMatchRegex(retryingMessageRegex);
+        }
+
+        private static void AssertTimeoutAfterRetriedLogMessages(InMemoryLog logs)
+        {
+            logs.GetLog().Should().MatchRegex(timeoutAfterRetriesMessageRegex);
+
+            var matches = timeoutAfterRetriesMessageRegex.Matches(logs.GetLog());
+            matches.Count.Should().Be(1);
+        }
+
+        private static void AssertNoTimeoutAfterRetriedLogMessages(InMemoryLog logs)
+        {
+            logs.GetLog().Should().NotMatchRegex(timeoutAfterRetriesMessageRegex);
+        }
+
+        private static void AssertTimeoutAfterNoRetriedLogMessages(InMemoryLog logs)
+        {
+            logs.GetLog().Should().MatchRegex(timeoutAfterNoRetriesMessageRegex);
+
+            var matches = timeoutAfterNoRetriesMessageRegex.Matches(logs.GetLog());
+            matches.Count.Should().Be(1);
+        }
+
+        private static void AssertNoTimeoutAfterNoRetriedLogMessages(InMemoryLog logs)
+        {
+            logs.GetLog().Should().NotMatchRegex(timeoutAfterNoRetriesMessageRegex);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/BumpThreadPoolForAllTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/BumpThreadPoolForAllTests.cs
@@ -9,8 +9,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support.SetupFixtures
         public void OneTimeSetUp(ILogger logger)
         {
             logger.Information("Bumping thread pool");
-            var minWorkerPoolThreads = 5000;
-            var minCompletionPortThreads = 5000;
+            var minWorkerPoolThreads = 1000;
+            ThreadPool.GetMinThreads(out _, out var minCompletionPortThreads);
             ThreadPool.GetMaxThreads(out var maxWorkerThreads, out var maxCompletionPortThreads);
             ThreadPool.SetMaxThreads(Math.Max(minWorkerPoolThreads, maxWorkerThreads), Math.Max(minCompletionPortThreads, maxCompletionPortThreads));
             ThreadPool.SetMinThreads(minWorkerPoolThreads, minCompletionPortThreads);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TestSerilogILoggerILog.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TestSerilogILoggerILog.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Threading;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Diagnostics;
-using Octopus.Tentacle.Tests.Integration.Util;
 using Serilog;
 using Log = Octopus.Tentacle.Diagnostics.Log;
 

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SerilogLoggerBuilder.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Text;
 using Halibut.Diagnostics;
 using NUnit.Framework;
-using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Util;
 using Serilog;
 using Serilog.Core;
@@ -15,7 +14,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
 {
     public class SerilogLoggerBuilder
     {
-        public static readonly ConcurrentDictionary<string, Stopwatch> TestTimers = new ConcurrentDictionary<string, Stopwatch>();
+        public static readonly ConcurrentDictionary<string, Stopwatch> TestTimers = new();
 
         StringBuilder? stringBuilder;
 
@@ -83,8 +82,9 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                 }
                 _formatter.Format(logEvent, output);
                 // This is the change, call this instead of: TestContext.Progress
-                var elapsed = SerilogLoggerBuilder.TestTimers[TestContext.CurrentContext.Test.ID].Elapsed.ToString();
-                var s = elapsed + " " + output.ToString();
+                var elapsed = TestTimers[TestContext.CurrentContext.Test.ID].Elapsed.ToString();
+                var s = elapsed + " " + output;
+
                 if (stringBuilder != null)
                 {
                     lock (stringBuilder)
@@ -92,6 +92,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                         stringBuilder.Append(s);
                     }
                 }
+
                 if (TeamCityDetection.IsRunningInTeamCity() || IsForcingContextWrite.Value)
                 {
                     TestContext.Write(s);

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TentacleClientTestExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TentacleClientTestExtensionMethods.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Tentacle.Client;

--- a/source/Octopus.Tentacle.Tests/Client/DefaultScriptObserverBackoffStrategyTests.cs
+++ b/source/Octopus.Tentacle.Tests/Client/DefaultScriptObserverBackoffStrategyTests.cs
@@ -7,15 +7,9 @@ using Octopus.Tentacle.Client.Scripts;
 namespace Octopus.Tentacle.Tests.Client
 {
     [TestFixture]
+    [Parallelizable(ParallelScope.All)]
     public class DefaultScriptObserverBackoffStrategyTests
     {
-        readonly DefaultScriptObserverBackoffStrategy defaultScriptObserverBackoffStrategy;
-
-        public DefaultScriptObserverBackoffStrategyTests()
-        {
-            defaultScriptObserverBackoffStrategy = new DefaultScriptObserverBackoffStrategy();
-        }
-
         [Test]
         public void BacksOffCorrectly()
         {
@@ -52,6 +46,7 @@ namespace Octopus.Tentacle.Tests.Client
 
             // Act
             var results = new List<double>();
+            var defaultScriptObserverBackoffStrategy = new DefaultScriptObserverBackoffStrategy();
 
             for (var i = 0; i < testIteration; i++)
             {

--- a/source/Octopus.Tentacle.Tests/Client/PollingTentacleScriptObserverBackoffStrategyTests.cs
+++ b/source/Octopus.Tentacle.Tests/Client/PollingTentacleScriptObserverBackoffStrategyTests.cs
@@ -1,20 +1,15 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Tentacle.Client.Scripts;
 
-namespace Octopus.IntegrationTests.Server.Orchestration.Targets.Tentacle
+namespace Octopus.Tentacle.Tests.Client
 {
     [TestFixture]
+    [Parallelizable(ParallelScope.All)]
     public class PollingTentacleScriptObserverBackoffStrategyTests
     {
-        readonly PollingTentacleScriptObserverBackoffStrategy pollingTentacleScriptObserverBackoffStrategy;
-
-        public PollingTentacleScriptObserverBackoffStrategyTests()
-        {
-            pollingTentacleScriptObserverBackoffStrategy = new PollingTentacleScriptObserverBackoffStrategy();
-        }
-
         [Test]
         public void BacksOffCorrectly()
         {
@@ -41,6 +36,7 @@ namespace Octopus.IntegrationTests.Server.Orchestration.Targets.Tentacle
 
             // Act
             var results = new List<double>();
+            var pollingTentacleScriptObserverBackoffStrategy = new PollingTentacleScriptObserverBackoffStrategy();
 
             for (var i = 0; i < testIteration; i++)
             {

--- a/source/Octopus.Tentacle.Tests/Client/RpcCallExecutorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Client/RpcCallExecutorFixture.cs
@@ -16,6 +16,7 @@ using Octopus.Tentacle.Contracts.ScriptServiceV2;
 namespace Octopus.Tentacle.Tests.Client
 {
     [TestFixture]
+    [Parallelizable(ParallelScope.All)]
     public class RpcCallExecutorFixture
     {
         private const string RpcCallName = nameof(IScriptServiceV2.GetStatus);
@@ -113,7 +114,7 @@ namespace Octopus.Tentacle.Tests.Client
             var rpcCallObserver = new TestTentacleClientObserver();
             var exception = new HalibutClientException("An error has occurred.");
             //Timeout for long enough that we get a few attempts.
-            var retryDuration = TimeSpan.FromSeconds(3);
+            var retryDuration = TimeSpan.FromSeconds(8);
             var clientOperationMetricsBuilder = new ClientOperationMetricsBuilder(DateTimeOffset.UtcNow);
 
             // Act

--- a/source/Octopus.Tentacle/Diagnostics/Log.cs
+++ b/source/Octopus.Tentacle/Diagnostics/Log.cs
@@ -9,7 +9,7 @@ namespace Octopus.Tentacle.Diagnostics
 {
     public abstract class Log : ILog, IDisposable
     {
-        public static ConcurrentBag<ILogAppender> Appenders { get; } = new ConcurrentBag<ILogAppender>();
+        public static ConcurrentBag<ILogAppender> Appenders { get; } = new();
         static IEnumerable<ILogAppender> GetThreadSafeAppenderCollection() => Appenders.ToArray();
 
         protected Log(string[]? sensitiveValues = null)


### PR DESCRIPTION
# Background

Don't log that we will retry when there is no time left and reties won't be performed.
Don't log that retries have timed out if we never performed them as there was no time e.g. the initial request took longer than the retry duration.

## Before

Would log that a retry was going to be performed when there was no time left.

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/9a289cce-3287-47ff-80cb-229322544970)

Would log that retries were attempted even if none were performed. 

## After

Will not log we are about to retry when there is no time left.
Will not log that retries timed out if no retries were attempted.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.