### PR TITLE
Rename nuke param for consistency

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -31,7 +31,7 @@ partial class Build
 
     [PublicAPI]
     Target TestIntegration => _ => _
-        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime, Filter));
+        .Executes(() => RunIntegrationTests(TestFramework, TestRuntime, TestFilter));
 
     [PublicAPI]
     Target TestLinuxPackages => _ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -51,7 +51,7 @@ partial class Build : NukeBuild
 
     [Parameter] string TestFramework = "";
     [Parameter] string TestRuntime = "";
-    [Parameter] string Filter = "";
+    [Parameter] string TestFilter = "";
 
     [PackageExecutable(
         packageId: "azuresigntool",


### PR DESCRIPTION
# Background

It's much nicer if our custom Nuke params are named the same between Halibut and Tentacle, so this PR ensures this for the new test filter param i.e. `Filter` -> `TestFilter`

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.