### PR TITLE
Removing TentacleRuntime.Default, replacing it with a calculated value

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -25,7 +25,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         IScriptObserverBackoffStrategy scriptObserverBackoffStrategy = new DefaultScriptObserverBackoffStrategy();
         public readonly TentacleType TentacleType;
         Version? tentacleVersion;
-        private TentacleRuntime tentacleRuntime = TentacleRuntime.Default;
+        private TentacleRuntime tentacleRuntime = DefaultTentacleRuntime.Value;
         readonly List<Func<PortForwarderBuilder, PortForwarderBuilder>> portForwarderModifiers = new ();
         readonly List<Action<ServiceEndPoint>> serviceEndpointModifiers = new();
         private IPendingRequestQueueFactory? queueFactory = null;

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
@@ -14,7 +14,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
     {
         private readonly TentacleType tentacleType;
         private Version? tentacleVersion;
-        private TentacleRuntime tentacleRuntime = TentacleRuntime.Default;
+        private TentacleRuntime tentacleRuntime = DefaultTentacleRuntime.Value;
         private AsyncHalibutFeature asyncHalibutFeature = AsyncHalibutFeature.Disabled;
 
         public LegacyClientAndTentacleBuilder(TentacleType tentacleType)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/WarmTentacleCache.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/WarmTentacleCache.cs
@@ -42,7 +42,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.SetupFixtures
             }
             else
             {
-                await GetTentacleVersionWithRuntime(logger, tentacleVersion, TentacleRuntime.Default);
+                await GetTentacleVersionWithRuntime(logger, tentacleVersion, DefaultTentacleRuntime.Value);
             }
         }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
@@ -47,11 +47,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             string version = Version?.ToString() ?? "Latest";
             builder.Append($"{version},");
             builder.Append($"{SyncOrAsyncHalibut}");
-
-            if (TentacleRuntime != TentacleRuntime.Default)
-            {
-                builder.Append($",{TentacleRuntime.GetDescription()}");
-            }
+            builder.Append($",{TentacleRuntime.GetDescription()}");
 
             return builder.ToString();
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -82,11 +82,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             }
 
 #if NETFRAMEWORK
-            var runtimes = new List<TentacleRuntime> { TentacleRuntime.Default };
+            var runtimes = new List<TentacleRuntime> { DefaultTentacleRuntime.Value };
 #else
             var runtimes = PlatformDetection.IsRunningOnWindows
                 ? new List<TentacleRuntime> {TentacleRuntime.DotNet6, TentacleRuntime.Framework48}
-                : new List<TentacleRuntime> {TentacleRuntime.Default};
+                : new List<TentacleRuntime> {DefaultTentacleRuntime.Value};
 #endif
 
             var testCases =

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleExeFinder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleExeFinder.cs
@@ -8,7 +8,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         public static string FindTentacleExe()
         {
-            return FindTentacleExe(TentacleRuntime.Default);
+            return FindTentacleExe(DefaultTentacleRuntime.Value);
         }
 
         public static string FindTentacleExe(TentacleRuntime version)
@@ -25,22 +25,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 const string net48ArtifactDir = "tentaclereal-net48";
                 const string net60ArtifactDir = "tentaclereal-net6.0";
-
-                string GetDefaultArtifactDir()
-                {
-#if NETFRAMEWORK
-                    return net48ArtifactDir;
-#else
-                    return net60ArtifactDir;
-#endif
-                }
-
+                
                 string artifactDir =
                     version switch
                     {
                         TentacleRuntime.Framework48 => net48ArtifactDir,
                         TentacleRuntime.DotNet6 => net60ArtifactDir,
-                        TentacleRuntime.Default => GetDefaultArtifactDir(),
                         _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
                     };
 
@@ -53,7 +43,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 {
                     TentacleRuntime.Framework48 => "net48",
                     TentacleRuntime.DotNet6 => "net6.0",
-                    TentacleRuntime.Default => assemblyDir.Name,
                     _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
                 };
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/NugetTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/NugetTentacleFetcher.cs
@@ -68,13 +68,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
                 {
                     TentacleRuntime.DotNet6 => net60ArtifactName,
                     TentacleRuntime.Framework48 => net48ArtifactName,
-                    TentacleRuntime.Default =>
-#if NETFRAMEWORK
-                        net48ArtifactName,
-#endif
-#if !NETFRAMEWORK
-                        net60ArtifactName,
-#endif
                     _ => throw new ArgumentOutOfRangeException(nameof(runtime), runtime, null)
                 };
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleBinaryCache.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleBinaryCache.cs
@@ -70,7 +70,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             // If non-default, use what was passed in
             return runtime switch
             {
-                TentacleRuntime.Default => RuntimeDetection.GetCurrentRuntime(),
                 TentacleRuntime.DotNet6 => TentacleRuntime.DotNet6.GetDescription(),
                 TentacleRuntime.Framework48 => TentacleRuntime.Framework48.GetDescription(),
                 _ => throw new ArgumentOutOfRangeException(nameof(runtime), runtime, null)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
@@ -4,11 +4,18 @@ using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
+    public static class DefaultTentacleRuntime
+    {
+        public const TentacleRuntime Value =
+#if NETFRAMEWORK
+            TentacleRuntime.Framework48;
+#else
+            TentacleRuntime.DotNet6;
+#endif
+    }
+
     public enum TentacleRuntime
     {
-        [Description("Default")]
-        Default,
-        
         [Description(RuntimeDetection.DotNet6)]
         DotNet6,
         


### PR DESCRIPTION
[sc-60184]

# Background

We recently [added support for testing net6.0 client with net48 service](https://github.com/OctopusDeploy/OctopusTentacle/pull/576).

This seemed to drastically increase the number of tests run in TeamCity.
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/29f7a95c-7bdd-4732-b82a-ac29afe4bf13)


# Results

Related to OctopusDeploy/Issues#8266

## Before
TeamCity would run the tests on different test chains, for different platforms, and aggregate them together. 

As seen here, before we introduced the net6.0/net48 test cases, it ran each of these on 7 different build chains:
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/ebeed321-975a-46ca-b50e-d454f74ed1ef)

`TentacleConfigurationsAttribute` was then altered to try different runtimes:
```
#if NETFRAMEWORK
            var runtimes = new List<TentacleRuntime> { TentacleRuntime.Default };
#else
            var runtimes = PlatformDetection.IsRunningOnWindows
                ? new List<TentacleRuntime> {TentacleRuntime.DotNet6, TentacleRuntime.Framework48}
                : new List<TentacleRuntime> {TentacleRuntime.Default};
#endif
```

So if we were a Windows net6.0 build chain, we would now have twice as many test cases.

As seen below, this appeared to be what was happening:
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/197a7965-9e1e-4f16-b257-38555fd02584)


But when we use the 'Default' runtime, the test case does not show what the runtime is.

So when TeamCity groups by name, it looks like there are far more test cases now. Whereas really, it's just not grouping them together.

## After
So to make this report more accurately in TeamCity, we made the test case always report the framework in it's name.

While looking into this, it made us wonder if 'Default' was a legitimate `TentacleRuntime`. 

So instead, we decided to remove `Default` as a `TentacleRuntime`, and replace it with a field based on the current runtime. This also helped to simplify the code that would switch on the runtime.

As seen here, the values are now aggregated.
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/e1c9e758-f85c-4275-823a-e9dab40b5573)


# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.