### PR TITLE
Fix flaky test CancelsTheExecutingActionIfItIsARetryAfterTheTimeout

### DIFF
--- a/source/Octopus.Tentacle.Tests/Client/RpcCallRetryHandlerFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Client/RpcCallRetryHandlerFixture.cs
@@ -424,7 +424,7 @@ namespace Octopus.Tentacle.Tests.Client
             }
             catch (HalibutClientException) { }
 
-            stopWatch.Elapsed.Should().BeGreaterOrEqualTo(TimeSpan.FromSeconds(8)).And.BeLessThan(TimeSpan.FromSeconds(20));
+            stopWatch.Elapsed.Should().BeGreaterOrEqualTo(GetMinTimeoutDuration(handler)).And.BeLessThan(TimeSpan.FromSeconds(20));
             callCount.Should().Be(2);
         }
 
@@ -469,9 +469,7 @@ namespace Octopus.Tentacle.Tests.Client
             }
             catch (HalibutClientException) { }
 
-            stopWatch.Elapsed.Should()
-                .BeGreaterOrEqualTo(handler.RetryTimeout - handler.RetryIfRemainingDurationAtLeast - retryBackoffBuffer)
-                .And.BeLessThan(TimeSpan.FromSeconds(20));
+            stopWatch.Elapsed.Should().BeGreaterOrEqualTo(GetMinTimeoutDuration(handler)).And.BeLessThan(TimeSpan.FromSeconds(20));
             callCount.Should().Be(2);
         }
 
@@ -786,6 +784,10 @@ namespace Octopus.Tentacle.Tests.Client
             var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutInSeconds));
             var cancellationToken = cancellationTokenSource.Token;
             return cancellationToken;
+        }
+        private TimeSpan GetMinTimeoutDuration(RpcCallRetryHandler handler)
+        {
+            return handler.RetryTimeout - handler.RetryIfRemainingDurationAtLeast - retryBackoffBuffer;
         }
     }
 }


### PR DESCRIPTION
# Background

Fix https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacleNet48_SensibleDefaultsChainFullChain/9675007?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.