### PR TITLE
Cleaning up old workspaces

### DIFF
--- a/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptExecutionOrchestrator.cs
@@ -461,9 +461,15 @@ namespace Octopus.Tentacle.Client.Scripts
                             clientOperationMetricsBuilder,
                             CancellationToken.None);
 
-                    await actionTask.WaitTillCompletion(onCancellationAbandonCompleteScriptAfter, scriptExecutionCancellationToken);
+                    var actionTaskCompletionResult = await actionTask.WaitTillCompletion(onCancellationAbandonCompleteScriptAfter, scriptExecutionCancellationToken);
+                    if (actionTaskCompletionResult == TaskCompletionResult.Abandoned)
+                    {
+                        throw new OperationAbandonedException(onCancellationAbandonCompleteScriptAfter);
+                    }
+
+                    await actionTask;
                 }
-                catch (Exception ex) when (ex is HalibutClientException or OperationCanceledException)
+                catch (Exception ex) when (ex is HalibutClientException or OperationCanceledException or OperationAbandonedException)
                 {
                     logger.Warn("Failed to cleanup the script working directory on Tentacle");
                     logger.Verbose(ex);

--- a/source/Octopus.Tentacle.Contracts/ScriptTicket.cs
+++ b/source/Octopus.Tentacle.Contracts/ScriptTicket.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 
 namespace Octopus.Tentacle.Contracts
 {
@@ -18,7 +17,7 @@ namespace Octopus.Tentacle.Contracts
                 return false;
             if (ReferenceEquals(this, other))
                 return true;
-            return string.Equals(TaskId, other.TaskId);
+            return string.Equals(TaskId, other.TaskId, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object? obj)
@@ -33,7 +32,7 @@ namespace Octopus.Tentacle.Contracts
         }
 
         public override int GetHashCode()
-            => TaskId != null ? TaskId.GetHashCode() : 0;
+            => TaskId != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(TaskId) : 0;
 
         public static bool operator ==(ScriptTicket left, ScriptTicket right)
             => Equals(left, right);

--- a/source/Octopus.Tentacle.Contracts/ScriptTicket.cs
+++ b/source/Octopus.Tentacle.Contracts/ScriptTicket.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Octopus.Tentacle.Contracts
 {
@@ -17,7 +18,7 @@ namespace Octopus.Tentacle.Contracts
                 return false;
             if (ReferenceEquals(this, other))
                 return true;
-            return string.Equals(TaskId, other.TaskId, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(TaskId, other.TaskId);
         }
 
         public override bool Equals(object? obj)
@@ -32,7 +33,7 @@ namespace Octopus.Tentacle.Contracts
         }
 
         public override int GetHashCode()
-            => TaskId != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(TaskId) : 0;
+            => TaskId != null ? TaskId.GetHashCode() : 0;
 
         public static bool operator ==(ScriptTicket left, ScriptTicket right)
             => Equals(left, right);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
@@ -21,7 +21,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             using var tmp = new TemporaryDirectory();
             var path = Path.Combine(tmp.DirectoryPath, "file");
-            
+
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
                     .CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -16,23 +16,22 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         internal async Task<RunningTentacle> Build(ILogger log, CancellationToken cancellationToken)
         {
-            var tempDirectory = new TemporaryDirectory();
             var instanceName = InstanceNameGenerator();
-            var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
+            var configFilePath = Path.Combine(HomeDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
             
             var logger = log.ForContext<ListeningTentacleBuilder>();
             logger.Information($"Tentacle.exe location: {tentacleExe}");
 
-            await CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
-            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
+            await CreateInstance(tentacleExe, configFilePath, instanceName, HomeDirectory, cancellationToken);
+            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, HomeDirectory, cancellationToken);
             ConfigureTentacleToListen(configFilePath);
 
             var runningTentacle = await StartTentacle(
                 null,
                 tentacleExe,
                 instanceName,
-                tempDirectory,
+                HomeDirectory,
                 TentacleThumbprint,
                 logger,
                 cancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -22,25 +22,24 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         internal async Task<RunningTentacle> Build(ILogger log, CancellationToken cancellationToken)
         {
-            var tempDirectory = new TemporaryDirectory();
             var instanceName = InstanceNameGenerator();
-            var configFilePath = Path.Combine(tempDirectory.DirectoryPath, instanceName + ".cfg");
+            var configFilePath = Path.Combine(HomeDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
             var subscriptionId = PollingSubscriptionId.Generate();
             
             var logger = log.ForContext<ListeningTentacleBuilder>();
             logger.Information($"Tentacle.exe location: {tentacleExe}");
 
-            await CreateInstance(tentacleExe, configFilePath, instanceName, tempDirectory, cancellationToken);
+            await CreateInstance(tentacleExe, configFilePath, instanceName, HomeDirectory, cancellationToken);
             ConfigureTentacleToPollOctopusServer(configFilePath, subscriptionId);
-            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, tempDirectory, cancellationToken);
+            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, HomeDirectory, cancellationToken);
             
 
             return await StartTentacle(
                 subscriptionId,
                 tentacleExe,
                 instanceName,
-                tempDirectory,
+                HomeDirectory,
                 TentacleThumbprint,
                 logger,
                 cancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
@@ -9,7 +9,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 {
     public class RunningTentacle : IAsyncDisposable
     {
-        private readonly IDisposable temporaryDirectory;
+        private readonly TemporaryDirectory temporaryDirectory;
         private CancellationTokenSource? cancellationTokenSource;
         private Task? runningTentacleTask;
         private readonly Func<CancellationToken, Task<(Task runningTentacleTask, Uri serviceUri)>> startTentacleFunction;
@@ -17,7 +17,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         private ILogger logger;
 
         public RunningTentacle(
-            IDisposable temporaryDirectory,
+            TemporaryDirectory temporaryDirectory,
             Func<CancellationToken, Task<(Task, Uri)>> startTentacleFunction,
             string thumbprint, 
             Func<CancellationToken, Task> deleteInstanceFunction,
@@ -33,6 +33,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         public Uri ServiceUri { get; private set; }
         public string Thumbprint { get; }
+        public string HomeDirectory => temporaryDirectory.DirectoryPath;
 
         public async Task Start(CancellationToken cancellationToken)
         {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilderExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilderExtensionMethods.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Octopus.Tentacle.Maintenance;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public static class TentacleBuilderExtensionMethods
+    {
+        public static ITentacleBuilder WithWorkspaceCleaningSettings(this ITentacleBuilder builder, TimeSpan cleanerDelay, TimeSpan deleteWorkspacesOlderThan)
+        {
+            return builder
+                .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.CleanerDelayEnvironmentVariableName, cleanerDelay)
+                .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.DeleteWorkspacesOlderThanTimeSpanEnvironmentVariableName, deleteWorkspacesOlderThan);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -13,11 +13,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             bool testCapabilitiesServiceVersions = false,
             bool testNoCapabilitiesServiceVersions = false,
             bool testScriptIsolationLevelVersions = false,
+            bool testDefaultTentacleRuntimeOnly = false,
             params object[] additionalParameterTypes)
             : base(
                 typeof(TentacleConfigurationTestCases),
                 nameof(TentacleConfigurationTestCases.GetEnumerator),
-                new object[] {testCommonVersions, testCapabilitiesServiceVersions, testNoCapabilitiesServiceVersions, testScriptIsolationLevelVersions, additionalParameterTypes})
+                new object[] {testCommonVersions, testCapabilitiesServiceVersions, testNoCapabilitiesServiceVersions, testScriptIsolationLevelVersions, testDefaultTentacleRuntimeOnly, additionalParameterTypes})
         {
         }
     }
@@ -29,6 +30,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             bool testCapabilitiesVersions,
             bool testNoCapabilitiesServiceVersions,
             bool testScriptIsolationLevel,
+            bool testDefaultTentacleRuntimeOnly,
             object[] additionalParameterTypes)
         {
             var tentacleTypes = new[] {TentacleType.Listening, TentacleType.Polling};
@@ -81,12 +83,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 versions.Add(TentacleVersions.Current);
             }
 
-#if NETFRAMEWORK
             var runtimes = new List<TentacleRuntime> { DefaultTentacleRuntime.Value };
-#else
-            var runtimes = PlatformDetection.IsRunningOnWindows
-                ? new List<TentacleRuntime> {TentacleRuntime.DotNet6, TentacleRuntime.Framework48}
-                : new List<TentacleRuntime> {DefaultTentacleRuntime.Value};
+#if !NETFRAMEWORK
+            if (!testDefaultTentacleRuntimeOnly && PlatformDetection.IsRunningOnWindows)
+            {
+                runtimes = new List<TentacleRuntime> {TentacleRuntime.DotNet6, TentacleRuntime.Framework48};
+            }
 #endif
 
             var testCases =
@@ -108,7 +110,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             return CombineTestCasesWithAdditionalParameters(testCases, additionalParameterTypes);
         }
 
-        private static IEnumerator CombineTestCasesWithAdditionalParameters(IEnumerable<TentacleConfigurationTestCase> testCases, object[] additionalEnumerables)
+        static IEnumerator CombineTestCasesWithAdditionalParameters(IEnumerable<TentacleConfigurationTestCase> testCases, object[] additionalEnumerables)
         {
             AllCombinations enums = new AllCombinations();
             var additionalEnums = additionalEnumerables.Cast<Type>().ToArray();

--- a/source/Octopus.Tentacle.Tests.Integration/WorkspaceCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/WorkspaceCleanerTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.CommonTestUtils.Builders;
+using Octopus.Tentacle.Maintenance;
+using Octopus.Tentacle.Scripts;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Util;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [IntegrationTestTimeout]
+    public class WorkspaceCleanerTests : IntegrationTest
+    {
+        [Test]
+        [TentacleConfigurations(testDefaultTentacleRuntimeOnly: true)]
+        public async Task WhenScriptServiceIsRunning_ThenWorkspaceIsNotDeleted(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var cleanerDelay = TimeSpan.FromMilliseconds(500);
+            var deleteWorkspacesOlderThan = TimeSpan.FromMilliseconds(500);
+
+            var startScriptCommand = new StartScriptCommandV2Builder().WithScriptBody(b => b.Print("Hello")).Build();
+
+            var workspaceDirectory = string.Empty;
+            await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacle(b =>
+                {
+                    b.WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.CleanerDelayEnvironmentVariableName, cleanerDelay)
+                        .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.DeleteWorkspacesOlderThanTimeSpanEnvironmentVariableName, deleteWorkspacesOlderThan);
+                })
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .DecorateScriptServiceV2With(d =>
+                        d.BeforeCompleteScript(async (_, _) =>
+                            {
+                                Directory.Exists(workspaceDirectory).Should().BeTrue("Workspace should exist before we complete");
+
+                                await Task.Delay(2 * 500, CancellationToken);
+
+                                Directory.Exists(workspaceDirectory).Should().BeTrue("Workspace should not have been cleaned up");
+                            })
+                            .Build())
+                    .Build())
+                .Build(CancellationToken);
+
+            workspaceDirectory = GetWorkspaceDirectoryPath(clientAndTentacle.RunningTentacle.HomeDirectory, startScriptCommand.ScriptTicket.TaskId);
+
+            await clientAndTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, new InMemoryLog());
+            
+            Directory.Exists(workspaceDirectory).Should().BeFalse("Workspace should be naturally cleaned up after completion");
+        }
+        
+        [Test]
+        [TentacleConfigurations(testDefaultTentacleRuntimeOnly: true)]
+        public async Task WhenTentacleClientCrashesAndTentacleNeverGotToldToComplete_ThenWorkspaceIsConsideredRunning_AndWillNotBeDeleted(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var cleanerDelay = TimeSpan.FromMilliseconds(500);
+            var deleteWorkspacesOlderThan = TimeSpan.FromMilliseconds(500);
+
+            var startScriptCommand = new StartScriptCommandV2Builder().WithScriptBody(b => b.Print("Hello")).Build();
+
+            await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacle(b =>
+                {
+                    b.WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.CleanerDelayEnvironmentVariableName, cleanerDelay)
+                        .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.DeleteWorkspacesOlderThanTimeSpanEnvironmentVariableName, deleteWorkspacesOlderThan);
+                })
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .DecorateScriptServiceV2With(d =>
+                        d.BeforeCompleteScript((_, _) => throw new NotImplementedException("Force failure to simulate tentacle client crashing, and ensure we do not completion"))
+                        .Build())
+                    .Build())
+                .Build(CancellationToken);
+            
+            await AssertionExtensions
+                .Should(() => clientAndTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, new InMemoryLog()))
+                .ThrowAsync<NotImplementedException>();
+
+            await Task.Delay(1000, CancellationToken);
+
+            var workspaceDirectory = GetWorkspaceDirectoryPath(clientAndTentacle.RunningTentacle.HomeDirectory, startScriptCommand.ScriptTicket.TaskId);
+
+            Directory.Exists(workspaceDirectory).Should().BeTrue();
+        }
+
+        [Test]
+        [TentacleConfigurations(testDefaultTentacleRuntimeOnly: true)]
+        public async Task WhenTentacleStarts_WithWorkspaceOlderThanThreshold_ThenWorkspaceIsDeleted(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var cleanerDelay = TimeSpan.FromMilliseconds(500);
+            var deleteWorkspacesOlderThan = TimeSpan.FromMilliseconds(500);
+
+            var existingHomeDirectory = new TemporaryDirectory();
+            var existingOrphanedWorkspaceDirectory = GivenExistingOrphanedWorkspaceExists(existingHomeDirectory);
+            File.WriteAllText(ScriptWorkspace.GetLogFilePath(existingOrphanedWorkspaceDirectory), "Existing log file");
+
+            await Task.Delay(1000, CancellationToken);
+
+            await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacle(b =>
+                {
+                    b.WithHomeDirectory(existingHomeDirectory)
+                        .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.CleanerDelayEnvironmentVariableName, cleanerDelay)
+                        .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.DeleteWorkspacesOlderThanTimeSpanEnvironmentVariableName, deleteWorkspacesOlderThan);
+                })
+                .Build(CancellationToken);
+
+            await Wait.For(() => !Directory.Exists(existingOrphanedWorkspaceDirectory), CancellationToken);
+        }
+
+        [Test]
+        [TentacleConfigurations(testDefaultTentacleRuntimeOnly: true)]
+        public async Task WhenTentacleStarts_WithWorkspaceYoungerThanThreshold_ThenWorkspaceIsLeftAlone(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var cleanerDelay = TimeSpan.FromMilliseconds(500);
+            var deleteWorkspacesOlderThan = TimeSpan.FromMinutes(30);
+
+            var existingHomeDirectory = new TemporaryDirectory();
+            var existingOrphanedWorkspaceDirectory = GivenExistingOrphanedWorkspaceExists(existingHomeDirectory);
+            File.WriteAllText(ScriptWorkspace.GetLogFilePath(existingOrphanedWorkspaceDirectory), "Existing log file");
+
+            await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacle(b =>
+                {
+                    b.WithHomeDirectory(existingHomeDirectory)
+                        .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.CleanerDelayEnvironmentVariableName, cleanerDelay)
+                        .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.DeleteWorkspacesOlderThanTimeSpanEnvironmentVariableName, deleteWorkspacesOlderThan);
+                })
+                .Build(CancellationToken);
+
+            await Task.Delay(1000, CancellationToken);
+
+            Directory.Exists(existingOrphanedWorkspaceDirectory).Should().BeTrue();
+        }
+
+        [Test]
+        [TentacleConfigurations(testDefaultTentacleRuntimeOnly: true)]
+        public async Task WhenTentacleIsRunning_WithWorkspaceThatBecomesOlderThanThreshold_ThenWorkspaceIsDeleted(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var cleanerDelay = TimeSpan.FromMilliseconds(500);
+            var deleteWorkspacesOlderThan = TimeSpan.FromMilliseconds(500);
+
+            var existingHomeDirectory = new TemporaryDirectory();
+
+            await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacle(b =>
+                {
+                    b.WithHomeDirectory(existingHomeDirectory)
+                        .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.CleanerDelayEnvironmentVariableName, cleanerDelay)
+                        .WithRunTentacleEnvironmentVariable(WorkspaceCleanerConfiguration.DeleteWorkspacesOlderThanTimeSpanEnvironmentVariableName, deleteWorkspacesOlderThan);
+                })
+                .Build(CancellationToken);
+
+            await Task.Delay(1000, CancellationToken);
+
+            var existingOrphanedWorkspaceDirectory = GivenExistingOrphanedWorkspaceExists(existingHomeDirectory);
+            File.WriteAllText(ScriptWorkspace.GetLogFilePath(existingOrphanedWorkspaceDirectory), "Existing log file");
+
+            await Task.Delay(1000, CancellationToken);
+
+            await Wait.For(() => !Directory.Exists(existingOrphanedWorkspaceDirectory), CancellationToken);
+        }
+        
+        static string GetWorkspaceDirectoryPath(string homeDirectory, string scriptTicket)
+        {
+            var workspaceDirectory = Path.Combine(
+                homeDirectory,
+                ScriptWorkspaceFactory.WorkDirectory,
+                scriptTicket);
+            return workspaceDirectory;
+        }
+
+        static string GivenExistingOrphanedWorkspaceExists(TemporaryDirectory existingHomeDirectory)
+        {
+            var existingOrphanedWorkspaceDirectory = GetWorkspaceDirectoryPath(existingHomeDirectory.DirectoryPath, "35024668-3FED-46B7-94E5-FA288292ABF9");
+            Directory.CreateDirectory(existingOrphanedWorkspaceDirectory);
+            return existingOrphanedWorkspaceDirectory;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
@@ -8,10 +8,12 @@ using Octopus.Tentacle.Commands;
 using Octopus.Tentacle.Communications;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Startup;
 using Octopus.Tentacle.Util;
 using Octopus.Time;
+using Octopus.Tentacle.Maintenance;
 
 namespace Octopus.Tentacle.Tests.Commands
 {
@@ -23,6 +25,7 @@ namespace Octopus.Tentacle.Tests.Commands
         ISleep sleep = null!;
         IHomeConfiguration home = null!;
         IApplicationInstanceSelector selector = null!;
+        IWorkspaceCleanerTask workspaceCleanerTask = null!;
 
         [SetUp]
         public override void SetUp()
@@ -35,6 +38,7 @@ namespace Octopus.Tentacle.Tests.Commands
             tentacleConfiguration.TentacleCertificate.Returns(certificate);
             home = Substitute.For<IHomeConfiguration>();
             sleep = Substitute.For<ISleep>();
+            workspaceCleanerTask = Substitute.For<IWorkspaceCleanerTask>();
 
             Command = new RunAgentCommand(
                 new Lazy<IHalibutInitializer>(() => halibut),
@@ -47,16 +51,30 @@ namespace Octopus.Tentacle.Tests.Commands
                 new Lazy<IProxyInitializer>(() => Substitute.For<IProxyInitializer>()),
                 Substitute.For<IWindowsLocalAdminRightsChecker>(),
                 new AppVersion(GetType().Assembly),
-                Substitute.For<ILogFileOnlyLogger>());
+                Substitute.For<ILogFileOnlyLogger>(),
+                workspaceCleanerTask);
 
             selector.Current.Returns(new ApplicationInstanceConfiguration("MyTentacle", null, null, null));
         }
 
         [Test]
-        public void RunsBackgroundServices()
+        public void WhenCommandIsStartedThenBackgroundServicesAreStarted()
         {
             Start();
+
             halibut.Received().Start();
+            workspaceCleanerTask.Received().Start();
+        }
+
+        [Test]
+        public void WhenCommandIsStoppedThenBackgroundServicesAreStopped()
+        {
+            Start();
+
+            Stop();
+
+            halibut.Received().Stop();
+            workspaceCleanerTask.Received().Stop();
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
@@ -420,13 +420,11 @@ namespace Octopus.Tentacle.Tests.Integration
             runningScriptState.Completed.Should().BeNull();
             runningScriptState.ExitCode.Should().BeNull();
             runningScriptState.RanToCompletion.Should().BeNull();
-            runningScriptState.ScriptTicket.Should().BeEquivalentTo(startScriptCommand.ScriptTicket);
             runningScriptState.Created.Should().BeOnOrAfter(testStarted).And.BeOnOrBefore(testFinished);
 
             finishedScriptState.Completed.Should().BeOnOrAfter(testStarted.AddSeconds(5)).And.BeOnOrBefore(testFinished);
             finishedScriptState.ExitCode.Should().Be(0);
             finishedScriptState.RanToCompletion.Should().BeTrue();
-            finishedScriptState.ScriptTicket.Should().BeEquivalentTo(startScriptCommand.ScriptTicket);
             finishedScriptState.Created.Should().Be(runningScriptState.Created);
             finishedScriptState.Started.Should().BeOnOrAfter(testStarted).And.BeOnOrBefore(testFinished);
         }
@@ -442,7 +440,7 @@ namespace Octopus.Tentacle.Tests.Integration
         private ScriptStateStore SetupScriptStateStore(ScriptTicket ticket)
         {
             var workspace = workspaceFactory.GetWorkspace(ticket);
-            var stateWorkspace = stateStoreFactory.Create(ticket, workspace);
+            var stateWorkspace = stateStoreFactory.Create(workspace);
             return stateWorkspace;
         }
 

--- a/source/Octopus.Tentacle/Communications/IServiceRegistration.cs
+++ b/source/Octopus.Tentacle/Communications/IServiceRegistration.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Octopus.Tentacle.Communications
+{
+    public interface IServiceRegistration
+    {
+        T GetService<T>();
+    }
+}

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -16,7 +16,8 @@ namespace Octopus.Tentacle.Communications
 
             builder.RegisterType<ProxyConfigParser>().As<IProxyConfigParser>();
             builder.RegisterType<HalibutInitializer>().As<IHalibutInitializer>();
-            builder.RegisterType<AutofacServiceFactory>().As<IServiceFactory>();
+            builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
+
             builder.Register(c =>
             {
                 var configuration = c.Resolve<ITentacleConfiguration>();

--- a/source/Octopus.Tentacle/Configuration/EnvironmentVariableMappings/EnvironmentVariableReader.cs
+++ b/source/Octopus.Tentacle/Configuration/EnvironmentVariableMappings/EnvironmentVariableReader.cs
@@ -4,7 +4,14 @@ namespace Octopus.Tentacle.Configuration.EnvironmentVariableMappings
 {
     public class EnvironmentVariableReader : IEnvironmentVariableReader
     {
-        public string? Get(string variableName)
-            => Environment.GetEnvironmentVariable(variableName);
+        public string? Get(string variableName) => Environment.GetEnvironmentVariable(variableName);
+
+        public TimeSpan GetOrDefault(string variableName, TimeSpan defaultValue)
+        {
+            var environmentVariableValue = Get(variableName);
+            if (TimeSpan.TryParse(environmentVariableValue, out var timeSpan)) return timeSpan;
+
+            return defaultValue;
+        }
     }
 }

--- a/source/Octopus.Tentacle/Configuration/EnvironmentVariableMappings/IEnvironmentVariableReader.cs
+++ b/source/Octopus.Tentacle/Configuration/EnvironmentVariableMappings/IEnvironmentVariableReader.cs
@@ -5,5 +5,6 @@ namespace Octopus.Tentacle.Configuration.EnvironmentVariableMappings
     public interface IEnvironmentVariableReader
     {
         string? Get(string variableName);
+        TimeSpan GetOrDefault(string variableName, TimeSpan defaultValue);
     }
 }

--- a/source/Octopus.Tentacle/Maintenance/MaintenanceModule.cs
+++ b/source/Octopus.Tentacle/Maintenance/MaintenanceModule.cs
@@ -1,0 +1,16 @@
+﻿using Autofac;
+
+namespace Octopus.Tentacle.Maintenance
+{
+    public class MaintenanceModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            base.Load(builder);
+
+            builder.RegisterType<WorkspaceCleanerConfiguration>().SingleInstance();
+            builder.RegisterType<WorkspaceCleaner>().SingleInstance();
+            builder.RegisterType<WorkspaceCleanerTask>().As<IWorkspaceCleanerTask>().SingleInstance();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Maintenance/WorkspaceCleaner.cs
+++ b/source/Octopus.Tentacle/Maintenance/WorkspaceCleaner.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Communications;
+using Octopus.Tentacle.Scripts;
+using Octopus.Tentacle.Services.Scripts;
+using Octopus.Time;
+
+namespace Octopus.Tentacle.Maintenance
+{
+    public class WorkspaceCleaner
+    {
+        readonly WorkspaceCleanerConfiguration configuration;
+        readonly IScriptWorkspaceFactory scriptWorkspaceFactory;
+        readonly IClock clock;
+        readonly ISystemLog log;
+
+        readonly ScriptService scriptService;
+        readonly ScriptServiceV2 scriptServiceV2;
+
+        public WorkspaceCleaner(
+            WorkspaceCleanerConfiguration configuration,
+            IScriptWorkspaceFactory scriptWorkspaceFactory,
+            IServiceRegistration serviceRegistration,
+            IClock clock,
+            ISystemLog log)
+        {
+            this.configuration = configuration;
+            this.scriptWorkspaceFactory = scriptWorkspaceFactory;
+            this.clock = clock;
+            this.log = log;
+
+            scriptService = serviceRegistration.GetService<ScriptService>();
+            scriptServiceV2 = serviceRegistration.GetService<ScriptServiceV2>();
+        }
+
+        public async Task Clean(CancellationToken cancellationToken)
+        {
+            var deleteWorkspacesOlderThanDateTimeUtc = clock.GetUtcTime().DateTime.Subtract(configuration.DeleteWorkspacesOlderThanTimeSpan);
+            log.Verbose($"Cleaning orphaned workspaces older than {deleteWorkspacesOlderThanDateTimeUtc:g}");
+
+            var deletedCount = 0;
+            var workspaces = scriptWorkspaceFactory.GetUncompletedWorkspaces();
+            foreach (var workspace in workspaces)
+            {
+                try
+                {
+                    if (scriptService.IsRunningScript(workspace.ScriptTicket)) continue;
+                    if (scriptServiceV2.IsRunningScript(workspace.ScriptTicket)) continue;
+
+                    var workspaceLogFilePath = workspace.LogFilePath;
+                    if (!File.Exists(workspaceLogFilePath)) continue;
+
+                    var outputLogFileLastWriteTimeUtc = File.GetLastWriteTimeUtc(workspaceLogFilePath);
+                    if (outputLogFileLastWriteTimeUtc >= deleteWorkspacesOlderThanDateTimeUtc) continue;
+
+                    await workspace.Delete(cancellationToken);
+                    deletedCount++;
+                }
+                catch (Exception e)
+                {
+                    log.Error(e, $"Could not delete orphaned workspace {workspace.WorkingDirectory}.");
+                }
+            }
+
+            if (deletedCount > 0)
+            {
+                log.Info($"Deleted {deletedCount} orphaned workspace{(deletedCount != 1 ? "s" : "")}.");
+            }
+            else
+            {
+                log.Verbose("No orphaned workspaces found.");
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerConfiguration.cs
+++ b/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerConfiguration.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Octopus.Tentacle.Configuration.EnvironmentVariableMappings;
+
+namespace Octopus.Tentacle.Maintenance
+{
+    public class WorkspaceCleanerConfiguration
+    {
+        public const string DeleteWorkspacesOlderThanTimeSpanEnvironmentVariableName = "TENTACLE_WORKSPACE_CLEANER_DELETE_OLDER_THAN";
+        public const string CleanerDelayEnvironmentVariableName = "TENTACLE_WORKSPACE_CLEANER_DELAY";
+
+        public TimeSpan CleaningDelay { get; }
+        public TimeSpan DeleteWorkspacesOlderThanTimeSpan { get; }
+
+        public WorkspaceCleanerConfiguration(IEnvironmentVariableReader environmentVariableReader)
+        {
+            CleaningDelay = environmentVariableReader.GetOrDefault(CleanerDelayEnvironmentVariableName, TimeSpan.FromHours(2));
+            DeleteWorkspacesOlderThanTimeSpan = environmentVariableReader.GetOrDefault(DeleteWorkspacesOlderThanTimeSpanEnvironmentVariableName, TimeSpan.FromDays(1));
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerTask.cs
+++ b/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerTask.cs
@@ -43,6 +43,12 @@ namespace Octopus.Tentacle.Maintenance
         {
             lock (taskLock)
             {
+                if (cleanerTask is not null)
+                {
+                    log.Error("Workspace cleaner task already running.");
+                    return;
+                }
+
                 cleanerTask = Task.Run(RunTask);
             }
         }

--- a/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerTask.cs
+++ b/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerTask.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Diagnostics;
+
+namespace Octopus.Tentacle.Maintenance
+{
+    public interface IWorkspaceCleanerTask
+    {
+        void Start();
+        void Stop();
+    }
+
+    class WorkspaceCleanerTask : IWorkspaceCleanerTask, IDisposable
+    {
+        readonly WorkspaceCleanerConfiguration configuration;
+        readonly WorkspaceCleaner workspaceCleaner;
+        readonly ISystemLog log;
+
+        readonly CancellationTokenSource cancellationTokenSource = new ();
+        readonly object taskLock = new();
+
+        Task? cleanerTask;
+
+        public WorkspaceCleanerTask(
+            WorkspaceCleanerConfiguration configuration,
+            WorkspaceCleaner workspaceCleaner, 
+            ISystemLog log)
+        {
+            this.configuration = configuration;
+            this.workspaceCleaner = workspaceCleaner;
+            this.log = log;
+        }
+
+        public void Dispose()
+        {
+            Stop();
+
+            cancellationTokenSource.Dispose();
+        }
+
+        public void Start()
+        {
+            lock (taskLock)
+            {
+                cleanerTask = Task.Run(RunTask);
+            }
+        }
+
+        public void Stop()
+        {
+            lock (taskLock)
+            {
+                if (cleanerTask is null) return;
+
+                try
+                {
+                    cancellationTokenSource.Cancel();
+
+                    cleanerTask.Wait();
+                }
+                catch (Exception e)
+                {
+                    log.Error(e, "Could not stop workspace cleaner");
+                }
+                finally
+                {
+                    cleanerTask = null;
+                }
+            }
+        }
+
+        async Task RunTask()
+        {
+            var cancellationToken = cancellationTokenSource.Token;
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await workspaceCleaner.Clean(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // This is just the application closing. Ignore.
+                }
+                catch (Exception e)
+                {
+                    log.Error(e, "Error running workspace cleaner");
+                }
+
+                try
+                {
+                    // Do the delay separately, otherwise a failure in `Clean` could result in this code spinning wheels.
+                    await Task.Delay(configuration.CleaningDelay, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // This is just the application closing. Ignore.
+                }
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -7,6 +7,7 @@ using Octopus.Tentacle.Commands.OptionSets;
 using Octopus.Tentacle.Communications;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Maintenance;
 using Octopus.Tentacle.Properties;
 using Octopus.Tentacle.Services;
 using Octopus.Tentacle.Startup;
@@ -54,6 +55,7 @@ namespace Octopus.Tentacle
             builder.RegisterModule(new TentacleCommunicationsModule());
             builder.RegisterModule(new ServicesModule());
             builder.RegisterModule(new VersioningModule(GetType().Assembly));
+            builder.RegisterModule(new MaintenanceModule());
 
             builder.RegisterCommand<CreateInstanceCommand>("create-instance", "Registers a new instance of the Tentacle service");
             builder.RegisterCommand<DeleteInstanceCommand>("delete-instance", "Deletes an instance of the Tentacle service");

--- a/source/Octopus.Tentacle/Scripts/BashScriptWorkspace.cs
+++ b/source/Octopus.Tentacle/Scripts/BashScriptWorkspace.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Util;
 
@@ -8,10 +9,11 @@ namespace Octopus.Tentacle.Scripts
     public class BashScriptWorkspace : ScriptWorkspace
     {
         public BashScriptWorkspace(
+            ScriptTicket scriptTicket,
             string workingDirectory,
             IOctopusFileSystem fileSystem,
             SensitiveValueMasker sensitiveValueMasker) :
-            base(workingDirectory, fileSystem, sensitiveValueMasker)
+            base(scriptTicket, workingDirectory, fileSystem, sensitiveValueMasker)
         {
         }
 

--- a/source/Octopus.Tentacle/Scripts/IScriptStateStoreFactory.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptStateStoreFactory.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using Octopus.Tentacle.Contracts;
 
 namespace Octopus.Tentacle.Scripts
 {
     public interface IScriptStateStoreFactory
     {
-        ScriptStateStore Create(ScriptTicket ticket, IScriptWorkspace workspace);
+        ScriptStateStore Create(IScriptWorkspace workspace);
     }
 }

--- a/source/Octopus.Tentacle/Scripts/IScriptWorkspace.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptWorkspace.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Contracts;
 
 namespace Octopus.Tentacle.Scripts
 {
     public interface IScriptWorkspace
     {
+        ScriptTicket ScriptTicket { get; }
         string WorkingDirectory { get; }
         string BootstrapScriptFilePath { get; }
         string[]? ScriptArguments { get; set; }
@@ -14,6 +17,8 @@ namespace Octopus.Tentacle.Scripts
         void BootstrapScript(string scriptBody);
         string ResolvePath(string fileName);
         void Delete();
+        Task Delete(CancellationToken cancellationToken);
         IScriptLog CreateLog();
+        string LogFilePath { get; }
     }
 }

--- a/source/Octopus.Tentacle/Scripts/IScriptWorkspaceFactory.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptWorkspaceFactory.cs
@@ -7,6 +7,7 @@ namespace Octopus.Tentacle.Scripts
     public interface IScriptWorkspaceFactory
     {
         IScriptWorkspace GetWorkspace(ScriptTicket ticket);
+
         IScriptWorkspace PrepareWorkspace(
             ScriptTicket ticket,
             string scriptBody,
@@ -16,5 +17,7 @@ namespace Octopus.Tentacle.Scripts
             string? scriptMutexName,
             string[]? scriptArguments,
             List<ScriptFile> files);
+
+        List<IScriptWorkspace> GetUncompletedWorkspaces();
     }
 }

--- a/source/Octopus.Tentacle/Scripts/ScriptState.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptState.cs
@@ -7,7 +7,7 @@ namespace Octopus.Tentacle.Scripts
     public class ScriptState
     {
         [JsonConstructor]
-        public ScriptState(ScriptTicket scriptTicket,
+        public ScriptState(
             DateTimeOffset created,
             DateTimeOffset? started,
             DateTimeOffset? completed,
@@ -16,7 +16,6 @@ namespace Octopus.Tentacle.Scripts
             bool? ranToCompletion)
         {
             Created = created;
-            ScriptTicket = scriptTicket;
             Started = started;
             Completed = completed;
             State = state;
@@ -24,13 +23,11 @@ namespace Octopus.Tentacle.Scripts
             RanToCompletion = ranToCompletion;
         }
 
-        public ScriptState(ScriptTicket scriptTicket, DateTimeOffset created)
+        public ScriptState(DateTimeOffset created)
         {
-            ScriptTicket = scriptTicket;
             Created = created;
         }
-
-        public ScriptTicket ScriptTicket { get; }
+        
         public DateTimeOffset Created { get; }
         public DateTimeOffset? Started { get; private set; }
         public DateTimeOffset? Completed { get; private set; }

--- a/source/Octopus.Tentacle/Scripts/ScriptStateStore.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptStateStore.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Threading;
 using Newtonsoft.Json;
-using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Scripts
@@ -11,12 +10,10 @@ namespace Octopus.Tentacle.Scripts
     {
         readonly SemaphoreSlim scriptStateLock = new(1, 1);
         readonly IScriptWorkspace workspace;
-        readonly ScriptTicket scriptTicket;
         readonly IOctopusFileSystem fileSystem;
 
-        public ScriptStateStore(ScriptTicket scriptTicket, IScriptWorkspace workspace, IOctopusFileSystem fileSystem)
+        public ScriptStateStore(IScriptWorkspace workspace, IOctopusFileSystem fileSystem)
         {
-            this.scriptTicket = scriptTicket;
             this.workspace = workspace;
             this.fileSystem = fileSystem;
         }
@@ -32,7 +29,7 @@ namespace Octopus.Tentacle.Scripts
                 throw new InvalidOperationException($"ScriptState already exists at {StateFilePath}");
             }
 
-            var state = new ScriptState(scriptTicket, DateTimeOffset.UtcNow);
+            var state = new ScriptState(DateTimeOffset.UtcNow);
             var serialized = SerializeState(state);
             using var writer = GetStreamWriter(StateFilePath, FileMode.CreateNew);
             writer.Write(serialized);

--- a/source/Octopus.Tentacle/Scripts/ScriptStateStoreFactory.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptStateStoreFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Scripts
@@ -13,9 +12,9 @@ namespace Octopus.Tentacle.Scripts
             this.fileSystem = fileSystem;
         }
 
-        public ScriptStateStore Create(ScriptTicket ticket, IScriptWorkspace workspace)
+        public ScriptStateStore Create(IScriptWorkspace workspace)
         {
-            return new ScriptStateStore(ticket, workspace, fileSystem);
+            return new ScriptStateStore(workspace, fileSystem);
         }
     }
 }

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
@@ -92,7 +92,15 @@ namespace Octopus.Tentacle.Services.Scripts
 
         public bool IsRunningScript(ScriptTicket ticket)
         {
-            return running.ContainsKey(ticket.TaskId);
+            if (running.TryGetValue(ticket.TaskId, out var script))
+            {
+                if (script.State != ProcessState.Complete)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
@@ -89,5 +89,10 @@ namespace Octopus.Tentacle.Services.Scripts
             var logs = scriptLog.GetOutput(lastLogSequence, out var next);
             return new ScriptStatusResponse(ticket, state, exitCode, logs, next);
         }
+
+        public bool IsRunningScript(ScriptTicket ticket)
+        {
+            return running.ContainsKey(ticket.TaskId);
+        }
     }
 }

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
@@ -152,7 +152,15 @@ namespace Octopus.Tentacle.Services.Scripts
 
         public bool IsRunningScript(ScriptTicket ticket)
         {
-            return runningScripts.ContainsKey(ticket);
+            if (runningScripts.TryGetValue(ticket, out var script))
+            {
+                if (script.Process?.State != ProcessState.Complete)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         class RunningScriptWrapper

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
@@ -35,10 +35,10 @@ namespace Octopus.Tentacle.Services.Scripts
         {
             var runningScript = runningScripts.GetOrAdd(
                 command.ScriptTicket,
-                s =>
+                _ =>
                 {
                     var workspace = workspaceFactory.GetWorkspace(command.ScriptTicket);
-                    var scriptState = scriptStateStoreFactory.Create(s, workspace);
+                    var scriptState = scriptStateStoreFactory.Create(workspace);
                     return new RunningScriptWrapper(scriptState);
                 });
 
@@ -133,7 +133,7 @@ namespace Octopus.Tentacle.Services.Scripts
             }
 
             // If we don't have a RunningProcess we check the ScriptStateStore to see if we have persisted a script result
-            var scriptStateStore = scriptStateStoreFactory.Create(ticket, workspace);
+            var scriptStateStore = scriptStateStoreFactory.Create(workspace);
             if (scriptStateStore.Exists())
             {
                 var scriptState = scriptStateStore.Load();
@@ -148,6 +148,11 @@ namespace Octopus.Tentacle.Services.Scripts
             }
 
             return new ScriptStatusResponseV2(ticket, ProcessState.Complete, ScriptExitCodes.UnknownScriptExitCode, logs, next);
+        }
+
+        public bool IsRunningScript(ScriptTicket ticket)
+        {
+            return runningScripts.ContainsKey(ticket);
         }
 
         class RunningScriptWrapper

--- a/source/Octopus.Tentacle/Util/IOctopusFileSystem.cs
+++ b/source/Octopus.Tentacle/Util/IOctopusFileSystem.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Octopus.Tentacle.Util
 {
@@ -11,6 +13,7 @@ namespace Octopus.Tentacle.Util
         bool DirectoryExists(string path);
         void DeleteFile(string path, DeletionOptions? options = null);
         void DeleteDirectory(string path, DeletionOptions? options = null);
+        Task DeleteDirectory(string path, CancellationToken cancellationToken, DeletionOptions? options = null);
         IEnumerable<string> EnumerateFiles(string parentDirectoryPath, params string[] searchPatterns);
         long GetFileSize(string path);
         string ReadFile(string path);

--- a/source/Tentacle.sln.DotSettings
+++ b/source/Tentacle.sln.DotSettings
@@ -7,6 +7,8 @@
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=C193BA12_002DCA2F_002D40AC_002DAEB8_002D21B5D24BCA6E_002Ff_003Atext_002Esettings_002Ejson_002Fs_003A_002E_002E_003Ftext_002Esettings_002Ejson/@EntryIndexedValue">ExplicitlyExcluded</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=Octopus_0020Deploy/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="Octopus Deploy"&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;CSRemoveCodeRedundancies&gt;True&lt;/CSRemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSUseVar&gt;&lt;BehavourStyle&gt;CAN_CHANGE_TO_IMPLICIT&lt;/BehavourStyle&gt;&lt;LocalVariableStyle&gt;ALWAYS_IMPLICIT&lt;/LocalVariableStyle&gt;&lt;ForeachVariableStyle&gt;ALWAYS_IMPLICIT&lt;/ForeachVariableStyle&gt;&lt;/CSUseVar&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;CssAlphabetizeProperties&gt;True&lt;/CssAlphabetizeProperties&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSEnforceVarKeywordUsageSettings&gt;True&lt;/CSEnforceVarKeywordUsageSettings&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;/Profile&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">Octopus Deploy</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_BINARY_EXPRESSIONS_CHAIN/@EntryValue">False</s:Boolean>
 	
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
@@ -209,4 +211,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=octopusdeploy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=octopushq/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upgrader/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Versioning/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Versioning/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Workspaces/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
# Background

Tentacles do not clean up old workspaces if something stops them from doing it naturally. This can lead to a build up of files and directories over time.

# Results

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/619

## Before
We had no way of cleaning up old workspaces if Octopus Server could not send the `CompleteScript` command.

## After
We now have a separate background task that periodically looks for old workspaces and deletes them.

Running the task makes sense to only do when we are running the agent. So we only start it during the `RunAgentCommand`.

Services are kept within their own separate scope inside `AutofacServiceFactory`. But we needed to access them in our clean up to find what is currently running. Since we want to minimize change to `ScriptService`, we instead exposed the two script services via a new interface (`IServiceRegistration`)

`ScriptTicket` was never used in `ScriptState`. This was removed during an initial version of this PR. Although that change it's not required anymore, it was left in as the change made sense.

### Testing
**Pointing at an old instance which had 4 orphaned workspaces, it cleaned them all up:**
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/d95b154e-fdc2-47ff-aec0-3cf6d116866f)
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/411223cd-2d30-41e9-93f0-b83b1a237bb7)

**Forcing a failure mid way so that we created an orphaned workspace, the task left it alone:**
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/e050ffbd-6207-4848-8837-01b24e18c13a)
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/3dd21921-63fb-43e8-9c81-e110b4e9afdb)

**While running, the new folder was left alone:**
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/5bef5cdb-5b97-40f6-bc15-97a819713699)

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.