### PR TITLE
Bump Halibut to v6.0.1457

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="6.0.1415" />
+    <PackageReference Include="Halibut" Version="6.0.1457" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR bumps Halibut to get [some more detail in our logs](https://github.com/OctopusDeploy/Halibut/pull/503), which will be useful for monitoring the Async Halibut rollout.
