### PR TITLE
Add support for .Net 6 Windows tentacle upgrader

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -359,12 +359,10 @@ partial class Build
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{OctoVersionInfo.FullSemVer}-net6.0-win-x86.msi", workingDirectory / "Octopus.Tentacle-net6.0-win-x86.msi");
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{OctoVersionInfo.FullSemVer}-net6.0-win-x64.msi", workingDirectory / "Octopus.Tentacle-net6.0-win-x64.msi");
 
-            var octopusTentacleUpgraderDirectory = BuildDirectory / "Octopus.Tentacle.Upgrader" / NetFramework / "win";
-            octopusTentacleUpgraderDirectory.GlobFiles("*").ForEach(sourceFilePath => FileSystemTasks.CopyFileToDirectory(sourceFilePath, workingDirectory));
             FileSystemTasks.CopyFile(BuildDirectory / "Octopus.Tentacle.Upgrader" / NetCore / "win-x86" / "Octopus.Tentacle.Upgrader.exe", workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x86.exe");
             FileSystemTasks.CopyFile(BuildDirectory / "Octopus.Tentacle.Upgrader" / NetCore / "win-x64" / "Octopus.Tentacle.Upgrader.exe", workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x64.exe");
             
-            
+            var octopusTentacleUpgraderDirectory = BuildDirectory / "Octopus.Tentacle.Upgrader" / NetFramework / "win";
             octopusTentacleUpgraderDirectory.GlobFiles("*").ForEach(x => FileSystemTasks.CopyFileToDirectory(x, workingDirectory));
             FileSystemTasks.CopyFile(ArtifactsDirectory / "deb" / debAmd64PackageFilename, workingDirectory / debAmd64PackageFilename);
             FileSystemTasks.CopyFile(ArtifactsDirectory / "deb" / debArm64PackageFilename, workingDirectory / debArm64PackageFilename);

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -360,6 +360,11 @@ partial class Build
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{OctoVersionInfo.FullSemVer}-net6.0-win-x64.msi", workingDirectory / "Octopus.Tentacle-net6.0-win-x64.msi");
 
             var octopusTentacleUpgraderDirectory = BuildDirectory / "Octopus.Tentacle.Upgrader" / NetFramework / "win";
+            octopusTentacleUpgraderDirectory.GlobFiles("*").ForEach(sourceFilePath => FileSystemTasks.CopyFileToDirectory(sourceFilePath, workingDirectory));
+            FileSystemTasks.CopyFile(BuildDirectory / "Octopus.Tentacle.Upgrader" / NetCore / "win-x86" / "Octopus.Tentacle.Upgrader.exe", workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x86.exe");
+            FileSystemTasks.CopyFile(BuildDirectory / "Octopus.Tentacle.Upgrader" / NetCore / "win-x64" / "Octopus.Tentacle.Upgrader.exe", workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x64.exe");
+            
+            
             octopusTentacleUpgraderDirectory.GlobFiles("*").ForEach(x => FileSystemTasks.CopyFileToDirectory(x, workingDirectory));
             FileSystemTasks.CopyFile(ArtifactsDirectory / "deb" / debAmd64PackageFilename, workingDirectory / debAmd64PackageFilename);
             FileSystemTasks.CopyFile(ArtifactsDirectory / "deb" / debArm64PackageFilename, workingDirectory / debArm64PackageFilename);
@@ -386,6 +391,8 @@ partial class Build
             Assert.True((workingDirectory / "Octopus.Tentacle-net6.0-win-x86.msi").FileExists(), "Missing Octopus.Tentacle-net6.0-win-x86.msi");
             Assert.True((workingDirectory / "Octopus.Tentacle-net6.0-win-x64.msi").FileExists(), "Missing Octopus.Tentacle-net6.0-win-x64.msi");
             Assert.True((workingDirectory / "Octopus.Tentacle.Upgrader.exe").FileExists(), "Missing Octopus.Tentacle.Upgrader.exe");
+            Assert.True((workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x86.exe").FileExists(), "Missing Octopus.Tentacle.Upgrader-net6.0-win-x86.exe");
+            Assert.True((workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x64.exe").FileExists(), "Missing Octopus.Tentacle.Upgrader-net6.0-win-x64.exe");
             Assert.True((workingDirectory / debAmd64PackageFilename).FileExists(), $"Missing {debAmd64PackageFilename}");
             Assert.True((workingDirectory / debArm64PackageFilename).FileExists(), $"Missing {debArm64PackageFilename}");
             Assert.True((workingDirectory / debArm32PackageFilename).FileExists(), $"Missing {debArm32PackageFilename}");

--- a/source/Octopus.Tentacle.Upgrader/GlobalSuppressions.cs
+++ b/source/Octopus.Tentacle.Upgrader/GlobalSuppressions.cs
@@ -3,7 +3,10 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "PC001:API not supported on all platforms", Justification = "Upgrader only support windows anyway", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.Program.PerformUpgrade(System.String[])~System.Int32")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "PC001:API not supported on all platforms", Justification = "Upgrader only support windows anyway", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.ServiceBouncer.GetRegistryValue(System.String,System.String)~System.String")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "PC001:API not supported on all platforms", Justification = "Upgrader only support windows anyway", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.SoftwareInstaller.IsPendingServerRestart()~System.Boolean")]
+using System.Diagnostics.CodeAnalysis;
 
+[assembly: SuppressMessage("Usage", "PC001:API not supported on all platforms", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.Program.PerformUpgrade(System.String[])~System.Int32")]
+[assembly: SuppressMessage("Usage", "PC001:API not supported on all platforms", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.ServiceBouncer.GetRegistryValue(System.String,System.String)~System.String")]
+[assembly: SuppressMessage("Usage", "PC001:API not supported on all platforms", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.SoftwareInstaller.IsPendingServerRestart()~System.Boolean")]
+[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.ServiceBouncer.EnsureServiceExecutablePathIsCorrect(System.ServiceProcess.ServiceController)")]
+[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.SoftwareInstaller.IsPendingServerRestart~System.Boolean")]

--- a/source/Octopus.Tentacle.Upgrader/GlobalSuppressions.cs
+++ b/source/Octopus.Tentacle.Upgrader/GlobalSuppressions.cs
@@ -5,8 +5,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Usage", "PC001:API not supported on all platforms", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.Program.PerformUpgrade(System.String[])~System.Int32")]
-[assembly: SuppressMessage("Usage", "PC001:API not supported on all platforms", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.ServiceBouncer.GetRegistryValue(System.String,System.String)~System.String")]
-[assembly: SuppressMessage("Usage", "PC001:API not supported on all platforms", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.SoftwareInstaller.IsPendingServerRestart()~System.Boolean")]
-[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.ServiceBouncer.EnsureServiceExecutablePathIsCorrect(System.ServiceProcess.ServiceController)")]
-[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Upgrader only supports windows", Scope = "member", Target = "~M:Octopus.Tentacle.Upgrader.SoftwareInstaller.IsPendingServerRestart~System.Boolean")]
+[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Upgrader only supports Windows", Scope = "module")]

--- a/source/Octopus.Tentacle.Upgrader/Octopus.Tentacle.Upgrader.csproj
+++ b/source/Octopus.Tentacle.Upgrader/Octopus.Tentacle.Upgrader.csproj
@@ -8,17 +8,32 @@
     <OutputType>Exe</OutputType>
     <PublishDir>../../_build/$(AssemblyName)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
     <RootNamespace>Octopus.Tentacle.Upgrader</RootNamespace>
-    <RuntimeIdentifiers>win</RuntimeIdentifiers>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
-
+    
+  <Choose>
+      <When Condition="'$(TargetFramework)'=='net48'">
+          <PropertyGroup>
+              <RuntimeIdentifier>win</RuntimeIdentifier><!-- This is AnyCPU -->
+          </PropertyGroup>
+      </When>
+      <Otherwise>
+          <PropertyGroup>
+              <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+              <PublishSingleFile>true</PublishSingleFile>
+              <PublishTrimmed>true</PublishTrimmed>
+              <DebugType>embedded</DebugType>
+          </PropertyGroup>
+      </Otherwise>
+  </Choose>
+    
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <Optimize>True</Optimize>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='net48' AND '$(RuntimeIdentifier)'=='win'">
+    
+  <PropertyGroup Condition="('$(TargetFramework)'=='net48' OR '$(TargetFramework)'=='net6.0') AND ('$(RuntimeIdentifier)'=='win' OR '$(RuntimeIdentifier)'=='win-x86' OR '$(RuntimeIdentifier)'=='win-x64')">
     <IsPublishable>true</IsPublishable>
   </PropertyGroup>
 
@@ -35,8 +50,12 @@
 		</Compile>
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='net48'">
 	  <Reference Include="System.ServiceProcess" />
 	</ItemGroup>
+
+    <ItemGroup  Condition="'$(TargetFramework)'=='net6.0'">
+        <PackageReference Include="System.ServiceProcess.ServiceController" Version="7.0.1" />
+    </ItemGroup>
 
 </Project>

--- a/source/Octopus.Tentacle.Upgrader/ServiceBouncer.cs
+++ b/source/Octopus.Tentacle.Upgrader/ServiceBouncer.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.ServiceProcess;
 using System.Threading;
 using Microsoft.Win32;
-#pragma warning disable CA1416
 
 namespace Octopus.Tentacle.Upgrader
 {

--- a/source/Octopus.Tentacle.Upgrader/ServiceBouncer.cs
+++ b/source/Octopus.Tentacle.Upgrader/ServiceBouncer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.ServiceProcess;
 using System.Threading;
 using Microsoft.Win32;
+#pragma warning disable CA1416
 
 namespace Octopus.Tentacle.Upgrader
 {


### PR DESCRIPTION
# Background

The Windows auto-upgrade installer (managed by Octopus Server) requires an `Octopus.Tentacle.Upgrader` file to kick off the auto-upgrade process. It requires .Net Framework to be installed on the user's machine. 

Now that we are rolling out support for .Net 6 standalone tentacles on Windows, we need to include standalone versions of the `Octopus.Tentacle.Upgrader` so that customers don't need to have .Net Framework installed on their Windows machines to allow Octopus server to install and run tentacles.

The `Octopus.Tentacle.CrossPlatformBundle` should now include two new files:
- Octopus.Tentacle.Upgrader-net6.0-win-x86.exe
- Octopus.Tentacle.Upgrader-net6.0-win-x64.exe

[sc-59761]

# Results

It should get rid of the following error when the server tries to upgrade a .Net 6 tentacle:

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/117602873/35cdd76f-4740-4d79-88fb-6946477a4ce9)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.