### PR TITLE
Minor output wording adjustments

### DIFF
--- a/source/Octopus.Tentacle.Tests/Configuration/ApplicationInstanceSelectorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Configuration/ApplicationInstanceSelectorFixture.cs
@@ -170,8 +170,6 @@ namespace Octopus.Tentacle.Tests.Configuration
         void SetupMissingStoredInstances(string? instanceName = null)
         {
             applicationInstanceStore.LoadInstanceDetails(instanceName).Throws(new ControlledFailureException(""));
-            applicationInstanceStore.TryLoadInstanceDetails(instanceName, out Arg.Any<ApplicationInstanceRecord>()!)
-                .Returns(x => false);
         }
 
         string SetupAvailableStoredInstance(string instanceName)
@@ -179,12 +177,6 @@ namespace Octopus.Tentacle.Tests.Configuration
             var configPath = Guid.NewGuid().ToString();
             var record = new ApplicationInstanceRecord(instanceName, configPath);
             applicationInstanceStore.LoadInstanceDetails(instanceName).Returns(record);
-            applicationInstanceStore.TryLoadInstanceDetails(instanceName, out Arg.Any<ApplicationInstanceRecord>()!)
-                .Returns(x =>
-                {
-                    x[1] = record;
-                    return true;
-                });
             octopusFileSystem.FileExists(configPath).Returns(true);
             return configPath;
         }

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommand.cs
@@ -51,7 +51,7 @@ namespace Octopus.Tentacle.Commands
                 throw new ControlledFailureException("Please specify an environment name, e.g., --environment=Development");
 
             if (roles.Count == 0 || string.IsNullOrWhiteSpace(roles.First()))
-                throw new ControlledFailureException("Please specify an role name, e.g., --role=web-server");
+                throw new ControlledFailureException("Please specify a role name, e.g., --role=web-server");
         }
 
         protected override void EnhanceOperation(IRegisterMachineOperation registerOperation)

--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceSelector.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceSelector.cs
@@ -124,7 +124,7 @@ namespace Octopus.Tentacle.Configuration.Instances
                     // This will throw a ControlledFailureException if it can't find the instance so it won't be null
                     var indexDefaultInstance = applicationInstanceStore.LoadInstanceDetails(null);
                     
-                    return (indexDefaultInstance!.InstanceName, indexDefaultInstance!.ConfigurationFilePath);
+                    return (indexDefaultInstance.InstanceName, indexDefaultInstance.ConfigurationFilePath);
                 }
             }
         }

--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceSelector.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceSelector.cs
@@ -123,7 +123,7 @@ namespace Octopus.Tentacle.Configuration.Instances
 
                     if (!applicationInstanceStore.TryLoadInstanceDetails(null, out var indexDefaultInstance))
                     {
-                        throw new ControlledFailureException("There are no instances of OctopusServer configured on this machine. " +
+                        throw new ControlledFailureException("There are no instances of OctopusTentacle configured on this machine. " +
                             "Please run the setup wizard, configure an instance using the command-line interface or specify a configuration file");
                     }
 

--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceSelector.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceSelector.cs
@@ -121,12 +121,9 @@ namespace Octopus.Tentacle.Configuration.Instances
                     if (fileSystem.FileExists(rootPath))
                         return (null, rootPath);
 
-                    if (!applicationInstanceStore.TryLoadInstanceDetails(null, out var indexDefaultInstance))
-                    {
-                        throw new ControlledFailureException("There are no instances of OctopusTentacle configured on this machine. " +
-                            "Please run the setup wizard, configure an instance using the command-line interface or specify a configuration file");
-                    }
-
+                    // This will throw a ControlledFailureException if it can't find the instance so it won't be null
+                    var indexDefaultInstance = applicationInstanceStore.LoadInstanceDetails(null);
+                    
                     return (indexDefaultInstance!.InstanceName, indexDefaultInstance!.ConfigurationFilePath);
                 }
             }

--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceStore.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceStore.cs
@@ -33,20 +33,6 @@ namespace Octopus.Tentacle.Configuration.Instances
                 machineConfigurationHomeDirectory = "/etc/octopus";
         }
 
-        public bool TryLoadInstanceDetails(string? instanceName, out ApplicationInstanceRecord? instanceRecord)
-        {
-            instanceRecord = null;
-            try
-            {
-                instanceRecord = LoadInstanceDetails(instanceName);
-                return true;
-            }
-            catch (ControlledFailureException)
-            {
-                return false;
-            }
-        }
-
         public ApplicationInstanceRecord LoadInstanceDetails(string? instanceName)
         {
             ApplicationInstanceRecord? persistedRecord;

--- a/source/Octopus.Tentacle/Configuration/Instances/IApplicationInstanceStore.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/IApplicationInstanceStore.cs
@@ -10,7 +10,6 @@ namespace Octopus.Tentacle.Configuration.Instances
     /// </summary>
     public interface IApplicationInstanceStore
     {
-        bool TryLoadInstanceDetails(string? instanceName, out ApplicationInstanceRecord? instanceRecord);
         ApplicationInstanceRecord LoadInstanceDetails(string? instanceName);
         void RegisterInstance(ApplicationInstanceRecord instanceRecord);
         void DeleteInstance(string instanceName);


### PR DESCRIPTION
Tentacle CLI gives the same error message for a range of failure modes, and references the OctopusServer instead of Tentacle.

The `ApplicationInstanceSelector` code was copied directly from `Octopus.Shared` when it was merged into the different codebases, and the reference to `OctopusServer` should have been removed then. 

Additionally, we used an unnecessary try-catch when handling control flow exceptions that was stripping out useful error messages so I've removed it.

# Background
When you are configuring Tentacle via the command line, have multiple instances configured, and forget to specify which instance, you get a cryptic response:
> PS C:\Program Files\Octopus Deploy\Tentacle> .\Tentacle.exe service --stop
There are no instances of OctopusServer configured on this machine. Please run the setup wizard, configure an instance using the command-line interface or specify a configuration file

This message doesn't explain _why_ the failure occurred, and it refers to the wrong application. 

The [incorrect application reference](https://github.com/OctopusDeploy/OctopusTentacle/blame/efb1821c0bbb2f5c084b80e5ae9877e7ae9eb210/source/Octopus.Shared/Configuration/Instances/ApplicationInstanceSelector.cs) came from when we split out the `Octopus.Shared` library into projects in each application. 

Even with the application correctly showing `OctopusTentacle`, the error message still isn't helpful as it's incorrect in the case of multiple instances of Tentacle. There is much more logic that produces useful, actionable user-facing messages from the public `LoadInstanceDetails` function. In the case of multiple installed instances, the right user-facing message is in a `ControlledFailureException` thrown inside `GetDefaultRegistryRecord` In the current implementation, by using `TryLoadInstanceDetails` we throw all those messages away, but still throw the same exception type.

# Results

The `TryLoad ...` function just wrapped calling `LoadInstanceDetails` in a try-catch under the hood. In the `ApplicationInstanceSelector`, I replaced `TryLoad...` with `LoadInstance...` to achieve the same logic but with better exception messages. This preserves the existing behaviour because the `ApplicationInstanceSelector` was throwing the same type of exception anyway, when `TryLoadInstanceDetails` fails.

I deleted `TryLoadInstanceDetails` as it was only used in the `ApplicationInstanceSelector` and we don't want anyone else to use it without realising it strips out useful error messages. 

## Before

```
Tentacle register-with --server=http://localhost:8066/ --apiKey=API-X --environment=Dev --role=app-server
There are no instances of OctopusServer configured on this machine. Please run the setup wizard, configure an instance using the command-line interface or specify a configuration file

Process finished with exit code 1.
```

## After

```
Tentacle register-with --server=http://localhost:8066/ --apiKey=API-X --environment=Dev --role=app-server
There is more than one instance of Tentacle configured on this machine. 
Please pass --instance=INSTANCENAME when invoking this command to target a specific instance. 
Available instances: sast-net6-tentacle-upgrade-script-Tentacle0, sast-net6-tentacle-upgrade-script-Tentacle1.

Process finished with exit code 1.
```

# How to review this PR
I ran this by a few people - @samdanaei @david-staniec-octopus @sburmanoctopus - and we agreed it was a sensible change and unlikely to affect anything, because we're still using the same exception type across boundaries, it just has a better exception message now. Additionally, this PR is not changing behaviour across project boundaries.

Quality :heavy_check_mark:

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.