### PR TITLE
Copy Harden-InstallationDirectory script to all possible Windows installer directories

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -126,10 +126,15 @@ partial class Build : NukeBuild
             versionInfoFile.Dispose();
             productWxsFile.Dispose();
             
-            var winFolder = (BuildDirectory / "Tentacle" / NetFramework / "win");
             var hardenInstallationDirectoryScript = RootDirectory / "scripts" / "Harden-InstallationDirectory.ps1";
-            CopyFileToDirectory(hardenInstallationDirectoryScript, winFolder, FileExistsPolicy.Overwrite);
-
+            var directoriesToCopyHardenScriptInto = new []
+            {
+                (BuildDirectory / "Tentacle" / NetFramework / "win"),
+                (BuildDirectory / "Tentacle" / NetCore / "win-x86"),
+                (BuildDirectory / "Tentacle" / NetCore / "win-x64")
+            };
+            directoriesToCopyHardenScriptInto.ForEach(dir => CopyFileToDirectory(hardenInstallationDirectoryScript, dir, FileExistsPolicy.Overwrite));
+            
             // Sign any unsigned libraries that Octopus Deploy authors so that they play nicely with security scanning tools.
             // Refer: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1551655877004400
             // Decision re: no signing everything: https://octopusdeploy.slack.com/archives/C0K9DNQG5/p1557938890227100


### PR DESCRIPTION
# Background

At the moment, the `Harden-InstallationDirectory.ps1` script only gets copied to the .Net Framework installation directory, but it also needs to be available on .Net Core installer directories, now that .Net Core tentacles are supported.

# Results

Fixes [sc-61274]

## Before

The  `Harden-InstallationDirectory.ps1` script is copied over only to: 
- `_build\Tentacle\net48\win`

### Effect on Server Upgrader:

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/117602873/ab9adf46-b614-4982-a621-8f564f1acabe)


## After

The  `Harden-InstallationDirectory.ps1` script is copied over to: 
- `_build\Tentacle\net48\win`
- `_build\Tentacle\net6.0\win-x86`
- `_build\Tentacle\net6.0\win-x64`

### Effect on Server Upgrader:

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/117602873/e856e182-64c7-4d8c-bf0b-ec4ce438c7f1)


# How to review this PR

Should we have tests covering this?

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.