### PR TITLE
Add optional ExecutionProperties to StartScriptCommandV2

### DIFF
--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV2Builder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV2Builder.cs
@@ -21,6 +21,7 @@ namespace Octopus.Tentacle.CommonTestUtils.Builders
         string taskId = Guid.NewGuid().ToString();
         ScriptTicket scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
         TimeSpan? durationStartScriptCanWaitForScriptToFinish;
+        Dictionary<string, string>? executionProperties;
 
         public StartScriptCommandV2Builder WithScriptBody(string scriptBody)
         {
@@ -105,6 +106,13 @@ namespace Octopus.Tentacle.CommonTestUtils.Builders
             return this;
         }
 
+        public StartScriptCommandV2Builder WithExecutionProperty(string name, string value)
+        {
+            executionProperties ??= new Dictionary<string, string>();
+            executionProperties[name] = value;
+            return this;
+        }
+
         public StartScriptCommandV2 Build()
             => new StartScriptCommandV2(scriptBody.ToString(),
                 isolation,
@@ -114,6 +122,7 @@ namespace Octopus.Tentacle.CommonTestUtils.Builders
                 taskId,
                 scriptTicket,
                 durationStartScriptCanWaitForScriptToFinish,
+                executionProperties,
                 additionalScripts,
                 files.ToArray());
     }

--- a/source/Octopus.Tentacle.Contracts/ScriptServiceV2/StartScriptCommandV2.cs
+++ b/source/Octopus.Tentacle.Contracts/ScriptServiceV2/StartScriptCommandV2.cs
@@ -15,12 +15,14 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV2
             string[] arguments,
             string taskId,
             ScriptTicket scriptTicket,
-            TimeSpan? durationToWaitForScriptToFinish)
+            TimeSpan? durationToWaitForScriptToFinish,
+            Dictionary<string,string>? executionProperties)
         {
             Arguments = arguments;
             TaskId = taskId;
             ScriptTicket = scriptTicket;
             DurationToWaitForScriptToFinish = durationToWaitForScriptToFinish;
+            ExecutionProperties = executionProperties;
             ScriptBody = scriptBody;
             Isolation = isolation;
             ScriptIsolationMutexTimeout = scriptIsolationMutexTimeout;
@@ -35,6 +37,7 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV2
             string taskId,
             ScriptTicket scriptTicket,
             TimeSpan? durationToWaitForScriptToFinish,
+            Dictionary<string,string>? executionProperties,
             params ScriptFile[]? additionalFiles)
             : this(scriptBody,
                 isolation,
@@ -43,7 +46,8 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV2
                 arguments,
                 taskId,
                 scriptTicket,
-                durationToWaitForScriptToFinish)
+                durationToWaitForScriptToFinish,
+                executionProperties)
         {
             if (additionalFiles != null)
                 Files.AddRange(additionalFiles);
@@ -57,6 +61,7 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV2
             string taskId,
             ScriptTicket scriptTicket,
             TimeSpan? durationToWaitForScriptToFinish,
+            Dictionary<string,string>? executionProperties,
             Dictionary<ScriptType, string>? additionalScripts,
             params ScriptFile[]? additionalFiles)
             : this(scriptBody,
@@ -67,6 +72,7 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV2
                 taskId,
                 scriptTicket,
                 durationToWaitForScriptToFinish,
+                executionProperties,
                 additionalFiles)
         {
             if (additionalScripts == null || !additionalScripts.Any())
@@ -90,5 +96,7 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV2
         public Dictionary<ScriptType, string> Scripts { get; } = new();
         public List<ScriptFile> Files { get; } = new();
         public string[] Arguments { get; }
+
+        public Dictionary<string, string>? ExecutionProperties { get; }
     }
 }


### PR DESCRIPTION
# Background

Adds a new optional field to the `StartScriptCommandV2`, the `ExecutionProperties`. The intention is that this is for extra properties to be passed from Server relating to the Tentacles execution of the script.

This is a preliminary PR for the changes relating to the Octopus Kubernetes Agent, where we will need to pass container image (execution container) when the scripts are being executed via Kubernetes Jobs.

# Results

Adds the new optional `Dictionary<string,string> ExecutionProperties { get; }`. This is not currently used for running scripts via the shell.

I have tested this locally and a Server sending the command without this property is successfully executed. As this is an additional, optional property, this should be forwards and backwards compatible.

Shortcut story: [sc-61739]

# How to review this PR

Is the name `ExecutionProperties` an acceptable name? I didn't want to use "arguments" as we already have that for the scripts args.

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.