### PR TITLE
Abstract script execution to new IScriptExecutor

### DIFF
--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandBuilder.cs
@@ -14,7 +14,7 @@ namespace Octopus.Tentacle.CommonTestUtils.Builders
         StringBuilder scriptBody = new StringBuilder(string.Empty);
         ScriptIsolationLevel isolation = ScriptIsolationLevel.FullIsolation;
         TimeSpan scriptIsolationMutexTimeout = ScriptIsolationMutex.NoTimeout;
-        string scriptIsolationMutexName = nameof(RunningScript);
+        string scriptIsolationMutexName = nameof(RunningShellScript);
         string? taskId;
 
         public StartScriptCommandBuilder WithScriptBody(string scriptBody)

--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV2Builder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV2Builder.cs
@@ -17,7 +17,7 @@ namespace Octopus.Tentacle.CommonTestUtils.Builders
         StringBuilder scriptBody = new StringBuilder(string.Empty);
         ScriptIsolationLevel isolation = ScriptIsolationLevel.NoIsolation;
         TimeSpan scriptIsolationMutexTimeout = ScriptIsolationMutex.NoTimeout;
-        string scriptIsolationMutexName = nameof(RunningScript);
+        string scriptIsolationMutexName = nameof(RunningShellScript);
         string taskId = Guid.NewGuid().ToString();
         ScriptTicket scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
         TimeSpan? durationStartScriptCanWaitForScriptToFinish;

--- a/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
@@ -26,7 +26,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         string taskId;
         IScriptWorkspace workspace;
         TestScriptLog scriptLog;
-        RunningScript runningScript;
+        RunningShellScript runningScript;
         TestUserPrincipal user;
 
         [SetUp]
@@ -58,7 +58,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
             Console.WriteLine($"Working directory: {workspace.WorkingDirectory}");
             scriptLog = new TestScriptLog();
             cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            runningScript = new RunningScript(shell,
+            runningScript = new RunningShellScript(shell,
                 workspace,
                 scriptLog,
                 taskId,
@@ -157,7 +157,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                     ? (new PowerShell(), "Start-Sleep -seconds")
                     : (new Bash() as IShell, "sleep");
 
-                var script = new RunningScript(shell,
+                var script = new RunningShellScript(shell,
                     workspace,
                     scriptLog,
                     taskId,

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
@@ -37,11 +37,22 @@ namespace Octopus.Tentacle.Tests.Integration
             var octopusPhysicalFileSystem = new OctopusPhysicalFileSystem(Substitute.For<ISystemLog>());
             workspaceFactory = new ScriptWorkspaceFactory(octopusPhysicalFileSystem, homeConfiguration, new SensitiveValueMasker());
             stateStoreFactory = new ScriptStateStoreFactory(octopusPhysicalFileSystem);
+
+            var shellScriptExecutor = new ShellScriptExecutor(
+                PlatformDetection.IsRunningOnWindows ? new PowerShell() : new Bash(),
+                Substitute.For<ISystemLog>()
+            );
+
+            var factory = new ScriptExecutorFactory(
+                new Lazy<ShellScriptExecutor>(() => new ShellScriptExecutor(
+                    PlatformDetection.IsRunningOnWindows ? new PowerShell() : new Bash(),
+                    Substitute.For<ISystemLog>()
+                )));
+
             service = new ScriptServiceV2(
-                PlatformDetection.IsRunningOnWindows ? (IShell)new PowerShell() : new Bash(),
+                factory,
                 workspaceFactory,
-                stateStoreFactory,
-                Substitute.For<ISystemLog>());
+                stateStoreFactory);
         }
 
         [Test]

--- a/source/Octopus.Tentacle/Scripts/IRunningScript.cs
+++ b/source/Octopus.Tentacle/Scripts/IRunningScript.cs
@@ -1,0 +1,11 @@
+﻿using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Scripts
+{
+    public interface IRunningScript
+    {
+        int ExitCode { get; }
+        ProcessState State { get; }
+        IScriptLog ScriptLog { get; }
+    }
+}

--- a/source/Octopus.Tentacle/Scripts/IScriptExecutor.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptExecutor.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Octopus.Tentacle.Scripts
+{
+    public interface IScriptExecutor
+    {
+        IRunningScript ExecuteOnThread(StartScriptCommandV2 command, IScriptWorkspace workspace, ScriptStateStore? scriptStateStore, CancellationTokenSource cancellationTokenSource);
+    }
+}

--- a/source/Octopus.Tentacle/Scripts/IScriptExecutorFactory.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptExecutorFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Octopus.Tentacle.Scripts
+{
+    public interface IScriptExecutorFactory
+    {
+        IScriptExecutor GetExecutor();
+    }
+}

--- a/source/Octopus.Tentacle/Scripts/RunningScript.cs
+++ b/source/Octopus.Tentacle/Scripts/RunningScript.cs
@@ -6,7 +6,7 @@ using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Scripts
 {
-    public class RunningScript
+    public class RunningScript : IRunningScript
     {
         readonly IScriptWorkspace workspace;
         readonly IScriptStateStore? stateStore;

--- a/source/Octopus.Tentacle/Scripts/RunningShellScript.cs
+++ b/source/Octopus.Tentacle/Scripts/RunningShellScript.cs
@@ -6,7 +6,7 @@ using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Scripts
 {
-    public class RunningScript : IRunningScript
+    public class RunningShellScript : IRunningScript
     {
         readonly IScriptWorkspace workspace;
         readonly IScriptStateStore? stateStore;
@@ -15,7 +15,7 @@ namespace Octopus.Tentacle.Scripts
         readonly CancellationToken token;
         readonly ILog log;
 
-        public RunningScript(IShell shell,
+        public RunningShellScript(IShell shell,
             IScriptWorkspace workspace,
             IScriptStateStore? stateStore,
             IScriptLog scriptLog,
@@ -33,7 +33,7 @@ namespace Octopus.Tentacle.Scripts
             this.State = ProcessState.Pending;
         }
 
-        public RunningScript(IShell shell,
+        public RunningShellScript(IShell shell,
             IScriptWorkspace workspace,
             IScriptLog scriptLog,
             string taskId,
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Scripts
                     {
                         using (ScriptIsolationMutex.Acquire(workspace.IsolationLevel,
                                    workspace.ScriptMutexAcquireTimeout,
-                                   workspace.ScriptMutexName ?? nameof(RunningScript),
+                                   workspace.ScriptMutexName ?? nameof(RunningShellScript),
                                    message => writer.WriteOutput(ProcessOutputSource.StdOut, message),
                                    taskId,
                                    token,

--- a/source/Octopus.Tentacle/Scripts/ScriptExecutorFactory.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptExecutorFactory.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Octopus.Tentacle.Scripts
+{
+    public class ScriptExecutorFactory : IScriptExecutorFactory
+    {
+        readonly Lazy<ShellScriptExecutor> shellScriptExecutor;
+
+        public ScriptExecutorFactory(Lazy<ShellScriptExecutor> shellScriptExecutor)
+        {
+            this.shellScriptExecutor = shellScriptExecutor;
+        }
+
+        public IScriptExecutor GetExecutor()
+        {
+            return shellScriptExecutor.Value;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Scripts/ShellScriptExecutor.cs
+++ b/source/Octopus.Tentacle/Scripts/ShellScriptExecutor.cs
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Scripts
 
         public IRunningScript ExecuteOnThread(StartScriptCommandV2 command, IScriptWorkspace workspace, ScriptStateStore? scriptStateStore, CancellationTokenSource cancellationTokenSource)
         {
-            var runningScript = new RunningScript(shell, workspace,  scriptStateStore, workspace.CreateLog(), command.TaskId, cancellationTokenSource.Token, log);
+            var runningScript = new RunningShellScript(shell, workspace,  scriptStateStore, workspace.CreateLog(), command.TaskId, cancellationTokenSource.Token, log);
 
             var thread = new Thread(runningScript.Execute) { Name = $"Executing {shellName} script for " + command.ScriptTicket.TaskId };
             thread.Start();

--- a/source/Octopus.Tentacle/Scripts/ShellScriptExecutor.cs
+++ b/source/Octopus.Tentacle/Scripts/ShellScriptExecutor.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Octopus.Tentacle.Scripts
+{
+    public class ShellScriptExecutor : IScriptExecutor
+    {
+        readonly IShell shell;
+        readonly ISystemLog log;
+        readonly string shellName;
+
+        public ShellScriptExecutor(IShell shell, ISystemLog log)
+        {
+            this.shell = shell;
+            shellName = shell.GetType().Name;
+            this.log = log;
+        }
+
+        public IRunningScript ExecuteOnThread(StartScriptCommandV2 command, IScriptWorkspace workspace, ScriptStateStore? scriptStateStore, CancellationTokenSource cancellationTokenSource)
+        {
+            var runningScript = new RunningScript(shell, workspace,  scriptStateStore, workspace.CreateLog(), command.TaskId, cancellationTokenSource.Token, log);
+
+            var thread = new Thread(runningScript.Execute) { Name = $"Executing {shellName} script for " + command.ScriptTicket.TaskId };
+            thread.Start();
+
+            return runningScript;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Services.Scripts
         readonly IShell shell;
         readonly IScriptWorkspaceFactory workspaceFactory;
         readonly ISystemLog log;
-        readonly ConcurrentDictionary<string, RunningScript> running = new(StringComparer.OrdinalIgnoreCase);
+        readonly ConcurrentDictionary<string, RunningShellScript> running = new(StringComparer.OrdinalIgnoreCase);
         readonly ConcurrentDictionary<string, CancellationTokenSource> cancellationTokens = new(StringComparer.OrdinalIgnoreCase);
 
         public ScriptService(
@@ -72,15 +72,15 @@ namespace Octopus.Tentacle.Services.Scripts
             return response;
         }
 
-        RunningScript LaunchShell(ScriptTicket ticket, string serverTaskId, IScriptWorkspace workspace, CancellationTokenSource cancel)
+        RunningShellScript LaunchShell(ScriptTicket ticket, string serverTaskId, IScriptWorkspace workspace, CancellationTokenSource cancel)
         {
-            var runningScript = new RunningScript(shell, workspace, workspace.CreateLog(), serverTaskId, cancel.Token, log);
+            var runningScript = new RunningShellScript(shell, workspace, workspace.CreateLog(), serverTaskId, cancel.Token, log);
             var thread = new Thread(runningScript.Execute) { Name = "Executing PowerShell script for " + ticket.TaskId };
             thread.Start();
             return runningScript;
         }
 
-        ScriptStatusResponse GetResponse(ScriptTicket ticket, RunningScript? script, long lastLogSequence)
+        ScriptStatusResponse GetResponse(ScriptTicket ticket, RunningShellScript? script, long lastLogSequence)
         {
             var exitCode = script != null ? script.ExitCode : 0;
             var state = script != null ? script.State : ProcessState.Complete;

--- a/source/Octopus.Tentacle/Services/ServicesModule.cs
+++ b/source/Octopus.Tentacle/Services/ServicesModule.cs
@@ -18,6 +18,10 @@ namespace Octopus.Tentacle.Services
 
             builder.RegisterType<NuGetPackageInstaller>().As<IPackageInstaller>();
 
+            // Register the script executor logic
+            builder.RegisterType<ScriptExecutorFactory>().As<IScriptExecutorFactory>();
+            builder.RegisterType<ShellScriptExecutor>().AsSelf().As<IScriptExecutor>();
+
             // Register our Halibut services
             var serviceTypes = ThisAssembly.GetTypes().Where(t => t.GetCustomAttributes(typeof(ServiceAttribute), true).Length > 0).ToArray();
             var assemblyServices = new KnownServiceSource(serviceTypes);


### PR DESCRIPTION
# Background

For the upcoming Octopus Kubernetes Agent, we want to change Tentacle to execute script workloads as Kubernetes Jobs, rather than scripts.

Our design is to change how the script itself is executed, not the contract with Server (not withstanding the change in #625). This PR abstract the point at which the script is executed, allowing for the jobs execution to be used when appropriate

# Results

Adds 3 new interfaces and some derived implementations

- `IScriptExecutor` -> Represents a distinct way to execute a script
- `IScriptExecutorFactory` -> A factory that constructs/returns an `IScriptExecutor`
- `IRunningScript` -> Represents a running script

I have also renamed `RunningScript` to `RunningShellScript` to distinguish this from future Kubernetes running scripts

Shortcut story: [sc-61762]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.