### PR TITLE
Convert IWorkspaceCleanerTask to Lazy<IWorkspaceCleanerTask>

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
@@ -52,7 +52,7 @@ namespace Octopus.Tentacle.Tests.Commands
                 Substitute.For<IWindowsLocalAdminRightsChecker>(),
                 new AppVersion(GetType().Assembly),
                 Substitute.For<ILogFileOnlyLogger>(),
-                workspaceCleanerTask);
+                new Lazy<IWorkspaceCleanerTask>(() => workspaceCleanerTask));
 
             selector.Current.Returns(new ApplicationInstanceConfiguration("MyTentacle", null, null, null));
         }

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -28,7 +28,7 @@ namespace Octopus.Tentacle.Commands
         readonly Lazy<IProxyInitializer> proxyInitializer;
         readonly IWindowsLocalAdminRightsChecker windowsLocalAdminRightsChecker;
         readonly AppVersion appVersion;
-        readonly IWorkspaceCleanerTask workspaceCleanerTask;
+        readonly Lazy<IWorkspaceCleanerTask> workspaceCleanerTask;
         int wait;
         bool halibutHasStarted;
 
@@ -46,7 +46,7 @@ namespace Octopus.Tentacle.Commands
             IWindowsLocalAdminRightsChecker windowsLocalAdminRightsChecker,
             AppVersion appVersion,
             ILogFileOnlyLogger logFileOnlyLogger,
-            IWorkspaceCleanerTask workspaceCleanerTask) : base(selector, log, logFileOnlyLogger)
+            Lazy<IWorkspaceCleanerTask> workspaceCleanerTask) : base(selector, log, logFileOnlyLogger)
         {
             this.halibut = halibut;
             this.configuration = configuration;
@@ -122,7 +122,7 @@ namespace Octopus.Tentacle.Commands
             halibut.Value.Start();
             halibutHasStarted = true;
 
-            workspaceCleanerTask.Start();
+            workspaceCleanerTask.Value.Start();
 
             Runtime.WaitForUserToExit();
         }
@@ -146,7 +146,7 @@ namespace Octopus.Tentacle.Commands
                 halibut.Value.Stop();
             }
 
-            workspaceCleanerTask.Stop();
+            workspaceCleanerTask.Value.Stop();
         }
     }
 }

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -18,19 +18,23 @@ namespace Octopus.Tentacle.Commands
 {
     public class RunAgentCommand : AbstractStandardCommand
     {
+        // The lazy dependencies allow the class to be created when its dependencies are not initialised yet.
+        // This is needed when calling commands like 'help' or providing feedback on validation (e.g. when no --instance parameter provided)
         readonly Lazy<IHalibutInitializer> halibut;
         readonly Lazy<IWritableTentacleConfiguration> configuration;
         readonly Lazy<IHomeConfiguration> home;
         readonly Lazy<IProxyConfiguration> proxyConfiguration;
+        readonly Lazy<IProxyInitializer> proxyInitializer;
+        readonly Lazy<IWorkspaceCleanerTask> workspaceCleanerTask;
+        
         readonly ISleep sleep;
         readonly ISystemLog log;
         readonly IApplicationInstanceSelector selector;
-        readonly Lazy<IProxyInitializer> proxyInitializer;
         readonly IWindowsLocalAdminRightsChecker windowsLocalAdminRightsChecker;
         readonly AppVersion appVersion;
-        readonly Lazy<IWorkspaceCleanerTask> workspaceCleanerTask;
         int wait;
         bool halibutHasStarted;
+        bool workspaceCleanerHasStarted;
 
         public override bool CanRunAsService => true;
 
@@ -123,7 +127,8 @@ namespace Octopus.Tentacle.Commands
             halibutHasStarted = true;
 
             workspaceCleanerTask.Value.Start();
-
+            workspaceCleanerHasStarted = true;
+            
             Runtime.WaitForUserToExit();
         }
 
@@ -146,7 +151,10 @@ namespace Octopus.Tentacle.Commands
                 halibut.Value.Stop();
             }
 
-            workspaceCleanerTask.Value.Stop();
+            if (workspaceCleanerHasStarted)
+            {
+                workspaceCleanerTask.Value.Stop();
+            }
         }
     }
 }


### PR DESCRIPTION
# Background

From @sburmanoctopus: 

> The newly introduced `WorkspaceCleanerTask`, through its dependency tree, eventually takes a dependency on the `IKeyValueStore`.
> 
> This object validates some of the configuration. So when it does that, it might not be valid (e.g. in E2E tests), and throws an exception.
> 
> This, in turn, causes the `WorkspaceCleanerTask` to also throw a dependency resolution exception.
> 
> Looking at the `RunAgentCommand` (which is what creates the cleaner task), it seems like this isn't the first time this problem has happened.
> 
> And the go-to move we have done several times in this class already is to add the dependency using a Lazy.
> 
> This allows the class to be created when its dependencies are not legit yet. Which is what we need when calling commands like 'help'.
> 

Additionally, this PR allows a version bump to happen to a 7.1.x version in Octopus Server. Tests may be added with a separate PR. See [sc-61789].



# Results

<!-- Describe the result of the change -->

## Before

```
> .\Tentacle.exe agent --help
===============================================================================
An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = RunAgentCommand (ReflectionActivator), Services = [Octopus.Tentacle.Startup.ICommand], Lifetime = Autofac.Core.Lifetime.CurrentScopeLifetime, Sharing = None, Ownership = OwnedByLifetimeScope ---> An error occurred during the activation of a particular registration. See the inner exception for details. Registration: Activator = WorkspaceCleanerTask (ReflectionActivator), Services = [Octopus.Tentacle.Maintenance.IWorkspaceCleanerTask]

...

--Inner Exception--
There is more than one instance of Tentacle configured on this machine. Please pass --instance=INSTANCENAME when invoking this command to target a specific instance. Available instances: e2e-8DBC4407FC18339, e2e-8DBC5B9D575A5A7, e2e-8DBC6508681DD80, e2e-8DBC652D0477A30, e2e-8DBC6568588DC41, e2e-8DBC65CF4042424, e2e-8DBC6666255D89B, e2e-8DBC97B01EFF415, e2e-8DBC97BD98567CE, e2e-8DBC9AD048274A0, e2e-8DBC9AF1FFB9477, sast-net6-tentacle-upgrade-script-Tentacle0, Tentacle0001.
Octopus.Tentacle.ControlledFailureException
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceStore.GetDefaultRegistryRecord() in ApplicationInstanceStore.cs:line 172
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceStore.LoadInstanceDetails(String instanceName) in ApplicationInstanceStore.cs:line 54
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceSelector.LocateApplicationPrimaryConfiguration() in ApplicationInstanceSelector.cs:line 125
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceSelector.LoadInstance() in ApplicationInstanceSelector.cs:line 67
   at Octopus.Tentacle.Configuration.Instances.ApplicationInstanceSelector.LoadCurrentInstance() in ApplicationInstanceSelector.cs:line 57
   at Octopus.Tentacle.Configuration.ConfigurationModule.<>c.<Load>b__3_2(IComponentContext c) in ConfigurationModule.cs:line 69
   at Autofac.Builder.RegistrationBuilder.<>c__DisplayClass0_0`1.<ForDelegate>b__0(IComponentContext c, IEnumerable`1 p)   at Autofac.Core.Activators.Delegate.DelegateActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)
   at Autofac.Core.Resolving.InstanceLookup.Activate(IEnumerable`1 parameters)
```

## After

```
>  .\Tentacle.exe agent --help
Usage: Tentacle agent [<options>]

Where [<options>] is any of:

      --instance=VALUE       Name of the instance to use
      --config=VALUE         Configuration file to use
      --wait=VALUE           Delay (ms) before starting
      --console              Don't attempt to run as a service, even if the
                               user is non-interactive

Or one of the common options:

      --help                 Show detailed help for this command
```
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.