### PR TITLE
Adds Windows NetFx and NetCore specific build configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _test
 
 .DS_Store
 .env
+source/create-local*.ps1

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -98,6 +98,8 @@
               "BuildLinux",
               "BuildOsx",
               "BuildWindows",
+              "BuildWindowsNetCore",
+              "BuildWindowsNetFx",
               "CalculateVersion",
               "Clean",
               "CopyToLocalPackages",
@@ -141,6 +143,8 @@
               "BuildLinux",
               "BuildOsx",
               "BuildWindows",
+              "BuildWindowsNetCore",
+              "BuildWindowsNetFx",
               "CalculateVersion",
               "Clean",
               "CopyToLocalPackages",
@@ -169,6 +173,9 @@
               "TestWindowsInstallers"
             ]
           }
+        },
+        "TestFilter": {
+          "type": "string"
         },
         "TestFramework": {
           "type": "string"


### PR DESCRIPTION
# Background

We need to run the NetCore builds inside a container in TeamCity, but windows was building both NetFx and NetCore in the same step, this allows us to run them separately.

# Results

<!-- Describe the result of the change -->

Fixes https://github.com/OctopusDeploy/Issues/issues/... _(optional public issue)_

Fixes https://github.com/OctopusDeploy/ResearchAndDevelopment/issues/... _(optional private issue)_

See [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) (including [this flowchart](https://whimsical.com/r-d-incoming-work-workflow-aug-21-NsDnGQXcwBLwU66a88Zhue) 

## Before

<!-- Consider adding a log excerpt or screen capture. -->

![Before](https://user-images.githubusercontent.com/5088479/120727281-72762180-c51d-11eb-9776-85363dc084e2.png)

## After

<!-- Consider adding a log excerpt or screen capture. -->

![After](https://user-images.githubusercontent.com/5088479/120727258-67bb8c80-c51d-11eb-8d2a-e047095b2d01.png)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.