### PR TITLE
Ignore development scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _test
 
 .DS_Store
 .env
+scripts/development/


### PR DESCRIPTION
I have some development scripts for registering a tentacle locally but I don't want these checked in (as they have API keys in them), so I want to ignore them