### PR TITLE
Copy Client & Contracts to local packages with unique timestamped version

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -68,10 +68,10 @@ partial class Build
                         .EnableTty()
                         .SetImage(testConfiguration.DockerImage)
                         .SetEnv(
-                            $"VERSION={OctoVersionInfo.FullSemVer}",
+                            $"VERSION={FullSemVer}",
                             "INPUT_PATH=/input",
                             "OUTPUT_PATH=/output",
-                            $"BUILD_NUMBER={OctoVersionInfo.FullSemVer}")
+                            $"BUILD_NUMBER={FullSemVer}")
                         .SetVolume(
                             $"{testScriptsBindMountPoint}:/test-scripts:ro",
                             $"{ArtifactsDirectory}:/artifacts:ro")


### PR DESCRIPTION
If you are making changes to the Clients and Contracts libraries and want to use them locally in Server, to make this easier we add a unique timestamp and target to all Local builds.

Also adds a new Target to build and copy these two packages to the LocalPackages directory