### PR TITLE
Fixing script ticket casing equality

### DIFF
--- a/source/Octopus.Tentacle.Contracts/ScriptTicket.cs
+++ b/source/Octopus.Tentacle.Contracts/ScriptTicket.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Contracts
                 return false;
             if (ReferenceEquals(this, other))
                 return true;
-            return string.Equals(TaskId, other.TaskId);
+            return string.Equals(TaskId, other.TaskId, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object? obj)
@@ -33,7 +33,7 @@ namespace Octopus.Tentacle.Contracts
         }
 
         public override int GetHashCode()
-            => TaskId != null ? TaskId.GetHashCode() : 0;
+            => TaskId != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(TaskId) : 0;
 
         public static bool operator ==(ScriptTicket left, ScriptTicket right)
             => Equals(left, right);

--- a/source/Octopus.Tentacle.Tests/Contracts/ScriptTicketFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Contracts/ScriptTicketFixture.cs
@@ -1,0 +1,32 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Tests.Contracts
+{
+    [TestFixture]
+    public class ScriptTicketFixture
+    {
+        [Test]
+        public void GetHashCodeShouldIgnoreCasing()
+        {
+            var originalScriptTicket = new ScriptTicket("MixedCasing");
+            var upperCaseScriptTicket = new ScriptTicket(originalScriptTicket.TaskId.ToUpper());
+            var lowerCaseScriptTicket = new ScriptTicket(originalScriptTicket.TaskId.ToLower());
+
+            upperCaseScriptTicket.GetHashCode().Should().Be(originalScriptTicket.GetHashCode());
+            lowerCaseScriptTicket.GetHashCode().Should().Be(originalScriptTicket.GetHashCode());
+        }
+
+        [Test]
+        public void EqualityShouldIgnoreCasing()
+        {
+            var originalScriptTicket = new ScriptTicket("MixedCasing");
+            var upperCaseScriptTicket = new ScriptTicket(originalScriptTicket.TaskId.ToUpper());
+            var lowerCaseScriptTicket = new ScriptTicket(originalScriptTicket.TaskId.ToLower());
+
+            upperCaseScriptTicket.Should().Be(originalScriptTicket);
+            lowerCaseScriptTicket.Should().Be(originalScriptTicket);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Contracts/ScriptTicketFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Contracts/ScriptTicketFixture.cs
@@ -25,8 +25,17 @@ namespace Octopus.Tentacle.Tests.Contracts
             var upperCaseScriptTicket = new ScriptTicket(originalScriptTicket.TaskId.ToUpper());
             var lowerCaseScriptTicket = new ScriptTicket(originalScriptTicket.TaskId.ToLower());
 
-            upperCaseScriptTicket.Should().Be(originalScriptTicket);
-            lowerCaseScriptTicket.Should().Be(originalScriptTicket);
+            originalScriptTicket.Equals(upperCaseScriptTicket).Should().BeTrue();
+            originalScriptTicket.Equals(lowerCaseScriptTicket).Should().BeTrue();
+
+            originalScriptTicket.Equals((object)upperCaseScriptTicket).Should().BeTrue();
+            originalScriptTicket.Equals((object)lowerCaseScriptTicket).Should().BeTrue();
+
+            (originalScriptTicket == upperCaseScriptTicket).Should().BeTrue();
+            (originalScriptTicket == lowerCaseScriptTicket).Should().BeTrue();
+
+            (originalScriptTicket != upperCaseScriptTicket).Should().BeFalse();
+            (originalScriptTicket != lowerCaseScriptTicket).Should().BeFalse();
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests/Contracts/ScriptTicketFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Contracts/ScriptTicketFixture.cs
@@ -19,6 +19,15 @@ namespace Octopus.Tentacle.Tests.Contracts
         }
 
         [Test]
+        public void WhenScriptTicketsAreDifferentThenHashCodeShouldNotBeSame()
+        {
+            var scriptTicket1 = new ScriptTicket("one");
+            var scriptTicket2 = new ScriptTicket("two");
+
+            scriptTicket1.GetHashCode().Should().NotBe(scriptTicket2.GetHashCode());
+        }
+
+        [Test]
         public void EqualityShouldIgnoreCasing()
         {
             var originalScriptTicket = new ScriptTicket("MixedCasing");
@@ -36,6 +45,21 @@ namespace Octopus.Tentacle.Tests.Contracts
 
             (originalScriptTicket != upperCaseScriptTicket).Should().BeFalse();
             (originalScriptTicket != lowerCaseScriptTicket).Should().BeFalse();
+        }
+
+        [Test]
+        public void WhenScriptTicketsAreDifferentThenShouldNotBeEqual()
+        {
+            var scriptTicket1 = new ScriptTicket("one");
+            var scriptTicket2 = new ScriptTicket("two");
+
+            scriptTicket1.Equals(scriptTicket2).Should().BeFalse();
+
+            scriptTicket1.Equals((object)scriptTicket2).Should().BeFalse();
+
+            (scriptTicket1 == scriptTicket2).Should().BeFalse();
+
+            (scriptTicket1 != scriptTicket2).Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
[sc-60772]

# Background

When comparing the [ScriptService](https://github.com/OctopusDeploy/OctopusTentacle/blob/c8c61358a053365e30b6df33d0248252db6bc856/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs#L11) and [ScriptServiceV2](https://github.com/OctopusDeploy/OctopusTentacle/blob/c8c61358a053365e30b6df33d0248252db6bc856/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs), it was noticed that `ScriptService` was doing lookups on the `TaskId` of the `ScriptTicket` ignoring case. But `ScriptServiceV2` was doing lookups on the `ScriptTicket` itself (therefore using `GetHashCode`, which respects casing). These were inconsistent. 

# Results

## Before

If someone made a request of the V2 API using a `ScriptTicket` with different casing, it would not return the correct result.

## After

Now, we ignore casing for `GetHashCode` and `Equals` for a `ScriptTicket`, as different casing still means the same `ScriptTicket`. 

As a result, V2 requests now behave correctly.

We looked through Octopus Server and Tentacle, and could not find anywhere that this change would cause a problem.

# How to review this PR


Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.