### PR TITLE
Fix Solution for VS Users and Nuke

### DIFF
--- a/source/Tentacle.sln
+++ b/source/Tentacle.sln
@@ -138,7 +138,15 @@ Global
 		{8F604C33-4137-4C00-A9B3-847FD403811D}.Release-net6.0-win-x86|Any CPU.Build.0 = Release|Any CPU
 		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net48-win|Any CPU.ActiveCfg = Release|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-linux-arm|Any CPU.ActiveCfg = Release|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-linux-arm64|Any CPU.ActiveCfg = Release|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-linux-musl-x64|Any CPU.ActiveCfg = Release|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-linux-x64|Any CPU.ActiveCfg = Release|Any CPU
 		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Release|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-osx-x64|Any CPU.ActiveCfg = Release|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-win-x64|Any CPU.ActiveCfg = Release|Any CPU
+		{5C47E1B4-F87A-4212-8C62-18AC2ECE789E}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Release|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{407551C4-B4DF-4665-96B1-BFF6A6A74D36}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
[sc-62554]

# Background

Every time a Visual Studio user would open the Tentacle solution, VS would alter it.

If the unsuspecting VS user was not paying attention, this change would often make its way into a PR, and the build server would no longer compile. Often leaving the poor VS developer confused about what they did wrong.

# Results

We applied to same fix as [this PR](https://github.com/OctopusDeploy/Halibut/pull/512) for Halibut.

# How to review this PR


Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.