### PR TITLE
Add ScriptServiceV3Alpha implementation

### DIFF
--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV3AlphaBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV3AlphaBuilder.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+using Octopus.Tentacle.Scripts;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.CommonTestUtils.Builders
+{
+    public class StartScriptCommandV3AlphaBuilder
+    {
+        readonly List<ScriptFile> files = new List<ScriptFile>();
+        readonly List<string> arguments = new List<string>();
+        readonly Dictionary<ScriptType, string> additionalScripts = new Dictionary<ScriptType, string>();
+        StringBuilder scriptBody = new StringBuilder(string.Empty);
+        ScriptIsolationLevel isolation = ScriptIsolationLevel.NoIsolation;
+        TimeSpan scriptIsolationMutexTimeout = ScriptIsolationMutex.NoTimeout;
+        string scriptIsolationMutexName = nameof(RunningScript);
+        string taskId = Guid.NewGuid().ToString();
+        ScriptTicket scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
+        TimeSpan? durationStartScriptCanWaitForScriptToFinish;
+        IScriptExecutionContext executionContext = new LocalShellScriptExecutionContext();
+
+        public StartScriptCommandV3AlphaBuilder WithScriptBody(string scriptBody)
+        {
+            this.scriptBody = new StringBuilder(scriptBody);
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithScriptBodyForCurrentOs(string windowsScript, string bashScript)
+        {
+            this.scriptBody = new StringBuilder(PlatformDetection.IsRunningOnWindows ? windowsScript : bashScript);
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithScriptBody(ScriptBuilder scriptBuilder)
+        {
+            scriptBody = new StringBuilder(scriptBuilder.BuildForCurrentOs());
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithScriptBody(Action<ScriptBuilder> builderFunc)
+        {
+            var scriptBuilder = new ScriptBuilder();
+            builderFunc(scriptBuilder);
+            return WithScriptBody(scriptBuilder);
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithAdditionalScriptTypes(ScriptType scriptType, string scriptBody)
+        {
+            additionalScripts.Add(scriptType, scriptBody);
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithIsolation(ScriptIsolationLevel isolation)
+        {
+            this.isolation = isolation;
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithFiles(params ScriptFile[] files)
+        {
+            if (files != null)
+                this.files.AddRange(files);
+
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithArguments(params string[] arguments)
+        {
+            if (arguments != null)
+                this.arguments.AddRange(arguments);
+
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithMutexTimeout(TimeSpan scriptIsolationMutexTimeout)
+        {
+            this.scriptIsolationMutexTimeout = scriptIsolationMutexTimeout;
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithMutexName(string name)
+        {
+            scriptIsolationMutexName = name;
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithTaskId(string taskId)
+        {
+            this.taskId = taskId;
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithScriptTicket(ScriptTicket scriptTicket)
+        {
+            this.scriptTicket = scriptTicket;
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan? duration)
+        {
+            this.durationStartScriptCanWaitForScriptToFinish = duration;
+            return this;
+        }
+
+        public StartScriptCommandV3AlphaBuilder WithExecutionContext(IScriptExecutionContext executionContext)
+        {
+            this.executionContext = executionContext;
+            return this;
+        }
+
+        public StartScriptCommandV3Alpha Build()
+            => new StartScriptCommandV3Alpha(scriptBody.ToString(),
+                isolation,
+                scriptIsolationMutexTimeout,
+                scriptIsolationMutexName,
+                arguments.ToArray(),
+                taskId,
+                scriptTicket,
+                durationStartScriptCanWaitForScriptToFinish,
+                executionContext,
+                additionalScripts,
+                files.ToArray());
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -93,7 +92,10 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var started = Stopwatch.StartNew();
 
-            var tasks = scripts.Select(script => service.StartScriptAsync(script.Command, CancellationToken.None));
+            var tasks = scripts.Select(async script =>
+            {
+                script.Response = await service.StartScriptAsync(script.Command, CancellationToken.None);
+            });
 
             await Task.WhenAll(tasks);
 

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
@@ -1,0 +1,538 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.CommonTestUtils.Builders;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Scripts;
+using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [TestFixture]
+    public class ScriptServiceV3AlphaFixture
+    {
+        IAsyncScriptServiceV3Alpha service = null!;
+        ScriptWorkspaceFactory workspaceFactory = null!;
+        ScriptStateStoreFactory stateStoreFactory = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var homeConfiguration = Substitute.For<IHomeConfiguration>();
+            homeConfiguration.HomeDirectory.Returns(Environment.CurrentDirectory);
+
+            var octopusPhysicalFileSystem = new OctopusPhysicalFileSystem(Substitute.For<ISystemLog>());
+            workspaceFactory = new ScriptWorkspaceFactory(octopusPhysicalFileSystem, homeConfiguration, new SensitiveValueMasker());
+            stateStoreFactory = new ScriptStateStoreFactory(octopusPhysicalFileSystem);
+            service = new ScriptServiceV3Alpha(
+                PlatformDetection.IsRunningOnWindows ? new PowerShell() : new Bash(),
+                workspaceFactory,
+                stateStoreFactory,
+                Substitute.For<ISystemLog>());
+        }
+
+        [Test]
+        public async Task ShouldExecuteAScriptSuccessfully()
+        {
+            var windowsScript = "& ping.exe localhost -n 1";
+            var bashScript = "ping localhost -c 1";
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBodyForCurrentOs(windowsScript, bashScript)
+                .Build();
+
+            var startScriptResponse = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+            var (logs, finalResponse) = await RunUntilScriptCompletes(startScriptCommand, startScriptResponse);
+
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().Be(0);
+            logs.Count.Should().BeGreaterThan(1);
+        }
+
+        [Test]
+        public async Task ShouldReturnANonZeroExitCodeForAFailingScript()
+        {
+            const string windowsScript = "& ping.exe nope -n 1";
+            const string bashScript = "ping nope -c 1";
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBodyForCurrentOs(windowsScript, bashScript)
+                .Build();
+
+            var startScriptResponse = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+            var (logs, finalResponse) = await RunUntilScriptCompletes(startScriptCommand, startScriptResponse);
+
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().NotBe(0);
+            logs.Count.Should().BeGreaterThan(1);
+        }
+
+        [Test]
+        public async Task ShouldExecuteMultipleScriptsConcurrently()
+        {
+            const string bashScript = "sleep 10";
+            const string windowsScript = "Start-Sleep -Seconds 10";
+
+            var scripts = Enumerable.Range(0, 5).Select(x =>
+                new StartScriptCommandAndResponse(command: new StartScriptCommandV3AlphaBuilder()
+                    .WithScriptBodyForCurrentOs(windowsScript, bashScript)
+                    .Build())).ToList();
+
+            var started = Stopwatch.StartNew();
+
+            var tasks = scripts.Select(script => service.StartScriptAsync(script.Command, CancellationToken.None));
+
+            await Task.WhenAll(tasks);
+
+            var startDuration = started.Elapsed;
+            startDuration.Should().BeLessThan(TimeSpan.FromSeconds(5));
+
+            await Task.Delay(TimeSpan.FromSeconds(10), CancellationToken.None);
+
+            foreach (var script in scripts)
+            {
+                var (logs, finalResponse) = await RunUntilScriptCompletes(script.Command, script.Response);
+
+                finalResponse.State.Should().Be(ProcessState.Complete);
+                finalResponse.ExitCode.Should().Be(0);
+                logs.Count.Should().BeGreaterThan(1);
+            }
+
+            started.Stop();
+            started.Elapsed.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(20));
+        }
+
+        [Test]
+        public async Task ShouldStartExecuteAScriptQuickly()
+        {
+            var script = "echo \"finished\"";
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBody(script)
+                .Build();
+
+            var durationUntilScriptStartedRunning = Stopwatch.StartNew();
+            var response = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+
+            while (response.State != ProcessState.Complete)
+            {
+                response = await service.GetStatusAsync(new ScriptStatusRequestV3Alpha(startScriptCommand.ScriptTicket, response.NextLogSequence), CancellationToken.None);
+
+                if (response.State == ProcessState.Running && durationUntilScriptStartedRunning.IsRunning)
+                {
+                    durationUntilScriptStartedRunning.Stop();
+                }
+
+                if (response.State != ProcessState.Complete)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100));
+                }
+            }
+
+            await service.CompleteScriptAsync(new CompleteScriptCommandV3Alpha(startScriptCommand.ScriptTicket), CancellationToken.None);
+
+            durationUntilScriptStartedRunning.Elapsed.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(10));
+        }
+
+        [Test]
+        public async Task ShouldExecuteALongRunningScriptSuccessfully()
+        {
+            var bashScript = "sleep 10";
+            var windowsScript = "Start-Sleep -Seconds 10";
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBodyForCurrentOs(windowsScript, bashScript)
+                .Build();
+
+            var startScriptResponse = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+            var (_, finalResponse) = await RunUntilScriptCompletes(startScriptCommand, startScriptResponse);
+
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().Be(0);
+        }
+
+        [Test]
+        public async Task StartScriptShouldWaitForAShortScriptToFinish()
+        {
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBody("echo \"finished\"")
+                .WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromSeconds(5))
+                .Build();
+
+            var startScriptResponse = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+
+            startScriptResponse.State.Should().Be(ProcessState.Complete);
+            startScriptResponse.ExitCode.Should().Be(0);
+            startScriptResponse.Logs.Count.Should().BeGreaterThan(1);
+
+            await service.CompleteScriptAsync(new CompleteScriptCommandV3Alpha(startScriptCommand.ScriptTicket), CancellationToken.None);
+        }
+
+        [Test]
+        public async Task StartScriptShouldNotWaitForALongScriptToFinish()
+        {
+            var bashScript = "sleep 10";
+            var windowsScript = "Start-Sleep -Seconds 10";
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBodyForCurrentOs(windowsScript, bashScript)
+                .WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromSeconds(5))
+                .Build();
+
+            var startScriptResponse = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+            await RunUntilScriptCompletes(startScriptCommand, startScriptResponse);
+
+            startScriptResponse.State.Should().Be(ProcessState.Running);
+            startScriptResponse.ExitCode.Should().Be(0);
+            startScriptResponse.Logs.Count.Should().BeGreaterThan(1);
+        }
+
+        [Test]
+        public async Task StartScriptShouldNotStartTheScriptForTheSameScriptTicketMoreThanOnce_SequentialRequests()
+        {
+            // Arrange
+            var scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
+            var script1 = GetStartScriptCommandForScriptThatCreatesAFile(scriptTicket);
+            var script2 = GetStartScriptCommandForScriptThatCreatesAFile(scriptTicket);
+
+            // Act
+            await service.StartScriptAsync(script1.StartScriptCommand, CancellationToken.None);
+
+            var startScriptResponse = await service.StartScriptAsync(script2.StartScriptCommand, CancellationToken.None);
+            var (_, finalResponse) = await RunUntilScriptCompletes(script2.StartScriptCommand, startScriptResponse);
+
+            // Assert
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().Be(0);
+
+            File.Exists(script1.FileScriptWillCreate.FullName).Should().BeTrue();
+            File.Exists(script2.FileScriptWillCreate.FullName).Should().BeFalse();
+        }
+
+        [Test]
+        public async Task StartScriptShouldNotStartTheScriptForTheSameScriptTicketMoreThanOnce_ConcurrentRequests()
+        {
+            // Arrange
+            var scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
+
+            var scripts = new List<(StartScriptCommandV3Alpha StartScriptCommand, FileInfo FileScriptWillCreate)>();
+
+            for (var i = 0; i < 1000; i++)
+            {
+                scripts.Add(GetStartScriptCommandForScriptThatCreatesAFile(scriptTicket, scriptDelayInSeconds: 10));
+            }
+            // Act
+            var tasks = scripts.Select(x => service.StartScriptAsync(x.StartScriptCommand, CancellationToken.None));
+
+            await Task.WhenAll(tasks);
+
+            var (_, finalResponse) = await RunUntilScriptCompletes(
+                scripts[0].StartScriptCommand,
+                new ScriptStatusResponseV3Alpha(scripts[0].StartScriptCommand.ScriptTicket, ProcessState.Pending, 0, new List<ProcessOutput>(), 0));
+
+            // Assert
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().Be(0);
+
+            var filesCreated = 0;
+
+            scripts.ForEach(x =>
+            {
+                if (File.Exists(x.FileScriptWillCreate.FullName))
+                {
+                    ++filesCreated;
+                }
+            });
+        }
+
+        [Test]
+        public async Task CancelScriptShouldCancelAnExecutingScript()
+        {
+            var bashScript = "sleep 60";
+            var windowsScript = "Start-Sleep -Seconds 60";
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBodyForCurrentOs(windowsScript, bashScript)
+                .Build();
+
+            var cancellationTimer = new Stopwatch();
+            var response = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+            var logs = new List<ProcessOutput>(response.Logs);
+
+            while (response.State != ProcessState.Complete)
+            {
+                response = await service.GetStatusAsync(new ScriptStatusRequestV3Alpha(startScriptCommand.ScriptTicket, response.NextLogSequence), CancellationToken.None);
+                logs.AddRange(response.Logs);
+
+                if (response.State == ProcessState.Running && !cancellationTimer.IsRunning)
+                {
+                    cancellationTimer.Start();
+                    response = await service.CancelScriptAsync(new CancelScriptCommandV3Alpha(startScriptCommand.ScriptTicket, response.NextLogSequence), CancellationToken.None);
+                    logs.AddRange(response.Logs);
+                }
+
+                if (response.State != ProcessState.Complete)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100));
+                }
+            }
+
+            cancellationTimer.Stop();
+
+            await service.CompleteScriptAsync(new CompleteScriptCommandV3Alpha(startScriptCommand.ScriptTicket), CancellationToken.None);
+
+            WriteLogsToConsole(logs);
+
+            response.State.Should().Be(ProcessState.Complete);
+            response.ExitCode.Should().NotBe(0, "The exit code varies based on the OS and flakiness with killing the running script");
+            cancellationTimer.Elapsed.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(5));
+        }
+
+        [Test]
+        public async Task CompleteScriptShouldCleanupTheWorkspace()
+        {
+            var script = "echo \"finished\"";
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBody(script)
+                .Build();
+
+            var workspaceDirectory = workspaceFactory.GetWorkingDirectoryPath(startScriptCommand.ScriptTicket);
+            Directory.Exists(workspaceDirectory).Should().BeFalse();
+
+            var startScriptResponse = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+            Directory.Exists(workspaceDirectory).Should().BeTrue();
+
+            await RunUntilScriptCompletes(startScriptCommand, startScriptResponse);
+            Directory.Exists(workspaceDirectory).Should().BeFalse();
+        }
+
+        [Test]
+        public async Task GetStatusShouldReturnAnExitCodeOf45ForAnUnknownScriptTicket()
+        {
+            var response = await service.GetStatusAsync(new ScriptStatusRequestV3Alpha(new ScriptTicket("nope"), 0), CancellationToken.None);
+
+            response.ExitCode.Should().Be(-45);
+        }
+
+        [Test]
+        public async Task CancelScriptShouldReturnAnExitCodeOf45ForAnUnknownScriptTicket()
+        {
+            var response =await service.CancelScriptAsync(new CancelScriptCommandV3Alpha(new ScriptTicket("nope"), 0), CancellationToken.None);
+
+            response.ExitCode.Should().Be(-45);
+        }
+
+        [Test]
+        public async Task CompleteScriptShouldNotErrorForAnUnknownScriptTicket()
+        {
+            await service.CompleteScriptAsync(new CompleteScriptCommandV3Alpha(new ScriptTicket("nope")), CancellationToken.None);
+        }
+
+        [Test]
+        public async Task GetStatusShouldReturnAnExitCodeOf46ForAScriptWithAnUnknownResult()
+        {
+            var request = new ScriptStatusRequestV3Alpha(new ScriptTicket($"did-not-finish-{Guid.NewGuid()}"), 0);
+            var ticket = request.ScriptTicket;
+            SetupScriptState(ticket);
+
+            var response = await service.GetStatusAsync(request, CancellationToken.None);
+
+            response.ExitCode.Should().Be(-46);
+
+            CleanupWorkspace(ticket);
+        }
+
+        [Test]
+        public async Task CancelScriptShouldReturnAnExitCodeOf46ForAScriptWithAnUnknownResult()
+        {
+            var request = new CancelScriptCommandV3Alpha(new ScriptTicket($"did-not-finish-{Guid.NewGuid()}"), 0);
+            var ticket = request.ScriptTicket;
+            SetupScriptState(ticket);
+
+            var response = await service.CancelScriptAsync(request, CancellationToken.None);
+
+            response.ExitCode.Should().Be(-46);
+
+            CleanupWorkspace(ticket);
+        }
+
+        [Test]
+        public async Task CompleteScriptShouldNotErrorForAScriptWithAnUnknownResult()
+        {
+            var request = new CompleteScriptCommandV3Alpha(new ScriptTicket($"did-not-finish-{Guid.NewGuid()}"));
+            var ticket = request.ScriptTicket;
+            SetupScriptState(ticket);
+
+            await service.CompleteScriptAsync(request, CancellationToken.None);
+        }
+
+        [Test]
+        public async Task ShouldStoreTheStateOfTheScriptInTheScriptStateStore()
+        {
+            var testStarted = DateTimeOffset.UtcNow;
+
+            var bashScript = "sleep 10";
+            var windowsScript = "Start-Sleep -Seconds 10";
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBodyForCurrentOs(windowsScript, bashScript)
+                .Build();
+
+            var scriptStateStore = SetupScriptStateStore(startScriptCommand.ScriptTicket);
+
+            var startScriptResponse = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+
+            var runningScriptState = scriptStateStore.Load();
+
+            var (logs, finalResponse) = await RunUntilScriptFinishes(startScriptCommand, startScriptResponse);
+
+            var testFinished = DateTimeOffset.UtcNow;
+            var finishedScriptState = scriptStateStore.Load();
+
+            await service.CompleteScriptAsync(new CompleteScriptCommandV3Alpha(startScriptCommand.ScriptTicket), CancellationToken.None);
+            WriteLogsToConsole(logs);
+
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().Be(0);
+
+            runningScriptState.Completed.Should().BeNull();
+            runningScriptState.ExitCode.Should().BeNull();
+            runningScriptState.RanToCompletion.Should().BeNull();
+            runningScriptState.Created.Should().BeOnOrAfter(testStarted).And.BeOnOrBefore(testFinished);
+
+            finishedScriptState.Completed.Should().BeOnOrAfter(testStarted.AddSeconds(5)).And.BeOnOrBefore(testFinished);
+            finishedScriptState.ExitCode.Should().Be(0);
+            finishedScriptState.RanToCompletion.Should().BeTrue();
+            finishedScriptState.Created.Should().Be(runningScriptState.Created);
+            finishedScriptState.Started.Should().BeOnOrAfter(testStarted).And.BeOnOrBefore(testFinished);
+        }
+
+        [Test]
+        public async Task ScriptTicketCasingShouldNotAffectCommands()
+        {
+            // Arrange
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBody("echo \"finished\"")
+                .Build();
+
+            var response = await service.StartScriptAsync(startScriptCommand, CancellationToken.None);
+
+            var upperCaseScriptTicket = new ScriptTicket(startScriptCommand.ScriptTicket.TaskId.ToUpper());
+            var lowerCaseScriptTicket = new ScriptTicket(startScriptCommand.ScriptTicket.TaskId.ToLower());
+
+            // Act
+            var upperCaseResponse = await service.GetStatusAsync(new ScriptStatusRequestV3Alpha(upperCaseScriptTicket, response.NextLogSequence), CancellationToken.None);
+            var lowerCaseResponse = await service.GetStatusAsync(new ScriptStatusRequestV3Alpha(lowerCaseScriptTicket, response.NextLogSequence), CancellationToken.None);
+            await service.CompleteScriptAsync(new CompleteScriptCommandV3Alpha(startScriptCommand.ScriptTicket), CancellationToken.None);
+
+            // Assert
+            upperCaseResponse.ExitCode.Should().Be(0);
+            lowerCaseResponse.ExitCode.Should().Be(0);
+        }
+
+        // TODO - Test the stateStore is updated.
+
+        private void SetupScriptState(ScriptTicket ticket)
+        {
+            var stateWorkspace = SetupScriptStateStore(ticket);
+            stateWorkspace.Create();
+        }
+
+        private ScriptStateStore SetupScriptStateStore(ScriptTicket ticket)
+        {
+            var workspace = workspaceFactory.GetWorkspace(ticket);
+            var stateWorkspace = stateStoreFactory.Create(workspace);
+            return stateWorkspace;
+        }
+
+        private void CleanupWorkspace(ScriptTicket ticket)
+        {
+            var workspace = workspaceFactory.GetWorkspace(ticket);
+            workspace.Delete();
+        }
+
+        (StartScriptCommandV3Alpha StartScriptCommand, FileInfo FileScriptWillCreate) GetStartScriptCommandForScriptThatCreatesAFile(ScriptTicket scriptTicket, int? scriptDelayInSeconds = null)
+        {
+            var filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            var bashScript = @$"echo ""Started 1"" > ""{filePath}""";
+            var windowsScript = @$"echo ""Started 1"" > ""{filePath}""";
+
+            if (scriptDelayInSeconds != null)
+            {
+                bashScript += $"{Environment.NewLine} sleep {scriptDelayInSeconds}";
+                windowsScript += $"{Environment.NewLine} Start-Sleep -Seconds {scriptDelayInSeconds}";
+            }
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBodyForCurrentOs(windowsScript, bashScript)
+                .WithScriptTicket(scriptTicket)
+                .Build();
+
+            return (startScriptCommand, new FileInfo(filePath));
+        }
+
+        async Task<(List<ProcessOutput>, ScriptStatusResponseV3Alpha)> RunUntilScriptCompletes(StartScriptCommandV3Alpha startScriptCommand, ScriptStatusResponseV3Alpha response)
+        {
+            var (logs, lastResponse) = await RunUntilScriptFinishes(startScriptCommand, response);
+
+            await service.CompleteScriptAsync(new CompleteScriptCommandV3Alpha(startScriptCommand.ScriptTicket), CancellationToken.None);
+
+            WriteLogsToConsole(logs);
+
+            return (logs, lastResponse);
+        }
+
+        async Task<(List<ProcessOutput> logs, ScriptStatusResponseV3Alpha response)> RunUntilScriptFinishes(StartScriptCommandV3Alpha startScriptCommand, ScriptStatusResponseV3Alpha response)
+        {
+            var logs = new List<ProcessOutput>(response.Logs);
+
+            while (response.State != ProcessState.Complete)
+            {
+                response = await service.GetStatusAsync(new ScriptStatusRequestV3Alpha(startScriptCommand.ScriptTicket, response.NextLogSequence), CancellationToken.None);
+
+                logs.AddRange(response.Logs);
+
+                if (response.State != ProcessState.Complete)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100));
+                }
+            }
+
+            return (logs, response);
+        }
+
+        void WriteLogsToConsole(List<ProcessOutput> logs)
+        {
+            foreach (var log in logs)
+            {
+                TestContext.Out.WriteLine("{0:yyyy-MM-dd HH:mm:ss K}: {1}", log.Occurred.ToLocalTime(), log.Text);
+            }
+        }
+
+        class StartScriptCommandAndResponse
+        {
+            public StartScriptCommandAndResponse(StartScriptCommandV3Alpha command)
+            {
+                Command = command;
+            }
+
+            public StartScriptCommandV3Alpha Command { get; }
+            public ScriptStatusResponseV3Alpha? Response { get; set; }
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Maintenance/WorkspaceCleaner.cs
+++ b/source/Octopus.Tentacle/Maintenance/WorkspaceCleaner.cs
@@ -6,6 +6,7 @@ using Octopus.Diagnostics;
 using Octopus.Tentacle.Communications;
 using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Services.Scripts;
+using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
 using Octopus.Time;
 
 namespace Octopus.Tentacle.Maintenance
@@ -19,6 +20,7 @@ namespace Octopus.Tentacle.Maintenance
 
         readonly ScriptService scriptService;
         readonly ScriptServiceV2 scriptServiceV2;
+        readonly ScriptServiceV3Alpha scriptServiceV3Alpha;
 
         public WorkspaceCleaner(
             WorkspaceCleanerConfiguration configuration,
@@ -34,6 +36,7 @@ namespace Octopus.Tentacle.Maintenance
 
             scriptService = serviceRegistration.GetService<ScriptService>();
             scriptServiceV2 = serviceRegistration.GetService<ScriptServiceV2>();
+            scriptServiceV3Alpha = serviceRegistration.GetService<ScriptServiceV3Alpha>();
         }
 
         public async Task Clean(CancellationToken cancellationToken)
@@ -51,9 +54,10 @@ namespace Octopus.Tentacle.Maintenance
                 {
                     if (scriptService.IsRunningScript(workspace.ScriptTicket)) continue;
                     if (scriptServiceV2.IsRunningScript(workspace.ScriptTicket)) continue;
+                    if(scriptServiceV3Alpha.IsRunningScript(workspace.ScriptTicket)) continue;
 
                     var workspaceLogFilePath = workspace.LogFilePath;
-                    
+
                     var outputLogFileLastWriteTimeUtc = File.GetLastWriteTimeUtc(workspaceLogFilePath);
                     if (outputLogFileLastWriteTimeUtc >= deleteWorkspacesOlderThanDateTimeUtc)
                     {

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha/IAsyncScriptServiceV3Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha/IAsyncScriptServiceV3Alpha.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+
+namespace Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha
+{
+    public interface IAsyncScriptServiceV3Alpha
+    {
+        Task<ScriptStatusResponseV3Alpha> StartScriptAsync(StartScriptCommandV3Alpha command, CancellationToken cancellationToken);
+        Task<ScriptStatusResponseV3Alpha> GetStatusAsync(ScriptStatusRequestV3Alpha request, CancellationToken cancellationToken);
+        Task<ScriptStatusResponseV3Alpha> CancelScriptAsync(CancelScriptCommandV3Alpha command, CancellationToken cancellationToken);
+        Task CompleteScriptAsync(CompleteScriptCommandV3Alpha command, CancellationToken cancellationToken);
+    }
+}

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha/IAsyncScriptServiceV3Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha/IAsyncScriptServiceV3Alpha.cs
@@ -4,6 +4,10 @@ using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 
 namespace Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha
 {
+    /// <remarks>
+    /// This interface should mirror <see cref="IScriptServiceV3Alpha"/>.
+    /// All return types must be <see cref="Task"/>/<see cref="Task{T}"/> and all methods must be suffixed with 'Async' with their last parameter must be a <see cref="CancellationToken"/>.
+    /// </remarks>
     public interface IAsyncScriptServiceV3Alpha
     {
         Task<ScriptStatusResponseV3Alpha> StartScriptAsync(StartScriptCommandV3Alpha command, CancellationToken cancellationToken);

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha/ScriptServiceV3Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha/ScriptServiceV3Alpha.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+using Octopus.Tentacle.Scripts;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha
+{
+    [Service(typeof(IScriptServiceV3Alpha))]
+    public class ScriptServiceV3Alpha : IAsyncScriptServiceV3Alpha
+    {
+        readonly IShell shell;
+        readonly IScriptWorkspaceFactory workspaceFactory;
+        readonly IScriptStateStoreFactory scriptStateStoreFactory;
+        readonly ISystemLog log;
+        readonly ConcurrentDictionary<ScriptTicket, RunningScriptWrapper> runningScripts = new();
+
+        public ScriptServiceV3Alpha(
+            IShell shell,
+            IScriptWorkspaceFactory workspaceFactory,
+            IScriptStateStoreFactory scriptStateStoreFactory,
+            ISystemLog log)
+        {
+            this.shell = shell;
+            this.workspaceFactory = workspaceFactory;
+            this.scriptStateStoreFactory = scriptStateStoreFactory;
+            this.log = log;
+        }
+
+        public async Task<ScriptStatusResponseV3Alpha> StartScriptAsync(StartScriptCommandV3Alpha command, CancellationToken cancellationToken)
+        {
+            var runningScript = runningScripts.GetOrAdd(
+                command.ScriptTicket,
+                _ =>
+                {
+                    var workspace = workspaceFactory.GetWorkspace(command.ScriptTicket);
+                    var scriptState = scriptStateStoreFactory.Create(workspace);
+                    return new RunningScriptWrapper(scriptState);
+                });
+
+            using (await runningScript.StartScriptMutex.LockAsync(cancellationToken))
+            {
+                IScriptWorkspace workspace;
+
+                // If the state already exists then this runningScript is already running/has already run and we should not run it again
+                if (runningScript.ScriptStateStore.Exists())
+                {
+                    var state = runningScript.ScriptStateStore.Load();
+
+                    if (state.HasStarted() || runningScript.Process != null)
+                    {
+                        return await GetResponse(command.ScriptTicket, 0, runningScript.Process);
+                    }
+
+                    workspace = workspaceFactory.GetWorkspace(command.ScriptTicket);
+                }
+                else
+                {
+                    workspace = workspaceFactory.PrepareWorkspace(command.ScriptTicket,
+                        command.ScriptBody,
+                        command.Scripts,
+                        command.Isolation,
+                        command.ScriptIsolationMutexTimeout,
+                        command.IsolationMutexName,
+                        command.Arguments,
+                        command.Files);
+
+                    runningScript.ScriptStateStore.Create();
+                }
+
+                var process = LaunchShell(command.ScriptTicket, command.TaskId, workspace, runningScript.ScriptStateStore, runningScript.CancellationToken);
+
+                runningScript.Process = process;
+
+                if (command.DurationToWaitForScriptToFinish != null)
+                {
+                    var waited = Stopwatch.StartNew();
+                    while (process.State != ProcessState.Complete && waited.Elapsed < command.DurationToWaitForScriptToFinish.Value)
+                    {
+                        Thread.Sleep(TimeSpan.FromMilliseconds(10));
+                    }
+                }
+
+                return await GetResponse(command.ScriptTicket, 0, runningScript.Process);
+            }
+        }
+
+        public async Task<ScriptStatusResponseV3Alpha> GetStatusAsync(ScriptStatusRequestV3Alpha request, CancellationToken cancellationToken)
+        {
+            runningScripts.TryGetValue(request.ScriptTicket, out var runningScript);
+            return await GetResponse(request.ScriptTicket, request.LastLogSequence, runningScript?.Process);
+        }
+
+        public async Task<ScriptStatusResponseV3Alpha> CancelScriptAsync(CancelScriptCommandV3Alpha command, CancellationToken cancellationToken)
+        {
+            if (runningScripts.TryGetValue(command.ScriptTicket, out var runningScript))
+            {
+                runningScript.Cancel();
+            }
+
+            return await GetResponse(command.ScriptTicket, command.LastLogSequence, runningScript?.Process);
+        }
+
+        public async Task CompleteScriptAsync(CompleteScriptCommandV3Alpha command, CancellationToken cancellationToken)
+        {
+            if (runningScripts.TryRemove(command.ScriptTicket, out var runningScript))
+            {
+                runningScript.Dispose();
+            }
+
+            var workspace = workspaceFactory.GetWorkspace(command.ScriptTicket);
+            await workspace.Delete(cancellationToken);
+        }
+
+        RunningScript LaunchShell(ScriptTicket ticket, string serverTaskId, IScriptWorkspace workspace, IScriptStateStore stateStore, CancellationToken cancellationToken)
+        {
+            var runningScript = new RunningScript(shell, workspace, stateStore, workspace.CreateLog(), serverTaskId, cancellationToken, log);
+            var thread = new Thread(runningScript.Execute) { Name = "Executing PowerShell runningScript for " + ticket.TaskId };
+            thread.Start();
+            return runningScript;
+        }
+
+        async Task<ScriptStatusResponseV3Alpha> GetResponse(ScriptTicket ticket, long lastLogSequence, RunningScript? runningScript)
+        {
+            await Task.CompletedTask;
+
+            var workspace = workspaceFactory.GetWorkspace(ticket);
+            var scriptLog = runningScript?.ScriptLog ?? workspace.CreateLog();
+            var logs = scriptLog.GetOutput(lastLogSequence, out var next);
+
+            if (runningScript != null)
+            {
+                return new ScriptStatusResponseV3Alpha(ticket, runningScript.State, runningScript.ExitCode, logs, next);
+            }
+
+            // If we don't have a RunningProcess we check the ScriptStateStore to see if we have persisted a script result
+            var scriptStateStore = scriptStateStoreFactory.Create(workspace);
+            if (scriptStateStore.Exists())
+            {
+                var scriptState = scriptStateStore.Load();
+
+                if (!scriptState.HasCompleted())
+                {
+                    scriptState.Complete(ScriptExitCodes.UnknownResultExitCode, false);
+                    scriptStateStore.Save(scriptState);
+                }
+
+                return new ScriptStatusResponseV3Alpha(ticket, scriptState.State, scriptState.ExitCode ?? ScriptExitCodes.UnknownResultExitCode, logs, next);
+            }
+
+            return new ScriptStatusResponseV3Alpha(ticket, ProcessState.Complete, ScriptExitCodes.UnknownScriptExitCode, logs, next);
+        }
+
+        public bool IsRunningScript(ScriptTicket ticket)
+        {
+            if (runningScripts.TryGetValue(ticket, out var script))
+            {
+                if (script.Process?.State != ProcessState.Complete)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        class RunningScriptWrapper : IDisposable
+        {
+            readonly CancellationTokenSource cancellationTokenSource = new ();
+
+            public RunningScriptWrapper(ScriptStateStore scriptStateStore)
+            {
+                ScriptStateStore = scriptStateStore;
+
+                CancellationToken = cancellationTokenSource.Token;
+            }
+
+            public RunningScript? Process { get; set; }
+            public ScriptStateStore ScriptStateStore { get; }
+            public SemaphoreSlim StartScriptMutex { get; } = new(1, 1);
+
+            public CancellationToken CancellationToken { get; }
+
+            public void Cancel()
+            {
+                cancellationTokenSource.Cancel();
+            }
+
+            public void Dispose()
+            {
+                cancellationTokenSource.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Background

Following on from #635, this PR adds the implementation of `ScriptServiceV3Alpha`. This is a direct copy of the `ScriptServiceV2` class, with modifications to support the async methods.

# Results

I added the `IAsyncScriptServiceV3Alpha` in the same assembly as the implementation as it's not part of the "public" contract, just an internal contract.

I hooked up the new service into the `WorkspaceCleaner`.

I duplicated the `ScriptServiceV2Fixture` and `StartScriptCommandV2Builder` to verify that the new V3 implementation works identically to the existing V2 implementation

Note: It does mean any changes to `ScriptServiceV2` will need to be propagated to `V3Alpha`

Shortcut story: [sc-62810]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change. 