### PR TITLE
Cleanup the halibut exception decorators

### DIFF
--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionCapabilitiesServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionCapabilitiesServiceV2Decorator.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Decorators
+{
+    class HalibutExceptionCapabilitiesServiceV2Decorator : HalibutExceptionTentacleServiceDecorator, IClientCapabilitiesServiceV2
+    {
+        readonly IClientCapabilitiesServiceV2 inner;
+
+        public HalibutExceptionCapabilitiesServiceV2Decorator(IClientCapabilitiesServiceV2 inner)
+        {
+            this.inner = inner;
+        }
+
+        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return HandleCancellationException(() => inner.GetCapabilities(halibutProxyRequestOptions));
+        }
+    }
+
+    class HalibutExceptionAsyncCapabilitiesServiceV2Decorator : HalibutExceptionTentacleServiceDecorator, IAsyncClientCapabilitiesServiceV2
+    {
+        readonly IAsyncClientCapabilitiesServiceV2 inner;
+
+        public HalibutExceptionAsyncCapabilitiesServiceV2Decorator(IAsyncClientCapabilitiesServiceV2 inner)
+        {
+            this.inner = inner;
+        }
+
+        public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return await HandleCancellationException(async () => await inner.GetCapabilitiesAsync(halibutProxyRequestOptions));
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionExtensions.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Halibut;
+
+namespace Octopus.Tentacle.Client.Decorators
+{
+    public static class HalibutExceptionExtensions
+    {
+        public static bool IsHalibutOperationCancellationException(this Exception exception)
+        {
+            return exception is HalibutClientException && exception.Message.Contains("The operation was canceled");
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionScriptServiceV2Decorator.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionScriptServiceV2Decorator.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Octopus.Tentacle.Client.Decorators
+{
+    class HalibutExceptionScriptServiceV2Decorator : HalibutExceptionTentacleServiceDecorator, IClientScriptServiceV2
+    {
+        readonly IClientScriptServiceV2 inner;
+
+        public HalibutExceptionScriptServiceV2Decorator(IClientScriptServiceV2 inner)
+        {
+            this.inner = inner;
+        }
+
+        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return HandleCancellationException(() => inner.StartScript(command, halibutProxyRequestOptions));
+        }
+
+        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return HandleCancellationException(() => inner.GetStatus(request, halibutProxyRequestOptions));
+        }
+
+        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return HandleCancellationException(() => inner.CancelScript(command, halibutProxyRequestOptions));
+        }
+
+        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            HandleCancellationException(() => inner.CompleteScript(command, halibutProxyRequestOptions));
+        }
+    }
+
+    class HalibutExceptionAsyncScriptServiceV2Decorator : HalibutExceptionTentacleServiceDecorator, IAsyncClientScriptServiceV2
+    {
+        readonly IAsyncClientScriptServiceV2 inner;
+
+        public HalibutExceptionAsyncScriptServiceV2Decorator(IAsyncClientScriptServiceV2 inner)
+        {
+            this.inner = inner;
+        }
+
+        public async Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return await HandleCancellationException(async () => await inner.StartScriptAsync(command, halibutProxyRequestOptions));
+        }
+
+        public async Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return await HandleCancellationException(async () => await inner.GetStatusAsync(request, halibutProxyRequestOptions));
+        }
+
+        public async Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return await HandleCancellationException(async () => await inner.CancelScriptAsync(command, halibutProxyRequestOptions));
+        }
+
+        public async Task CompleteScriptAsync(CompleteScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            await HandleCancellationException(async () => await inner.CompleteScriptAsync(command, halibutProxyRequestOptions));
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
@@ -6,7 +6,6 @@ namespace Octopus.Tentacle.Client.Decorators
     public abstract class HalibutExceptionTentacleServiceDecorator
     {
         protected static Task<TResponse> HandleCancellationException<TResponse>(Func<Task<TResponse>> action)
-
         {
             try
             {
@@ -31,7 +30,6 @@ namespace Octopus.Tentacle.Client.Decorators
         }
 
         protected static TResponse HandleCancellationException<TResponse>(Func<TResponse> action)
-
         {
             try
             {

--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
@@ -1,222 +1,60 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
-using Halibut;
-using Halibut.ServiceModel;
-using Octopus.Tentacle.Client.ClientServices;
-using Octopus.Tentacle.Contracts.Capabilities;
-using Octopus.Tentacle.Contracts.ClientServices;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
 namespace Octopus.Tentacle.Client.Decorators
 {
-    /// <summary>
-    /// Halibut Listening Client during connection throws the OperationCancelledException wrapped in a HalibutClientException
-    /// </summary>
-    internal class HalibutExceptionTentacleServiceDecorator : ITentacleServiceDecorator
+    public abstract class HalibutExceptionTentacleServiceDecorator
     {
-        public IClientScriptService Decorate(IClientScriptService service)
-        {
-            return service;
-        }
+        protected static Task<TResponse> HandleCancellationException<TResponse>(Func<Task<TResponse>> action)
 
-        public IAsyncClientScriptService Decorate(IAsyncClientScriptService service)
-        {
-            return service;
-        }
-
-        public IClientScriptServiceV2 Decorate(IClientScriptServiceV2 service)
-        {
-            return new HalibutExceptionScriptServiceV2Decorator(service);
-        }
-
-        public IAsyncClientScriptServiceV2 Decorate(IAsyncClientScriptServiceV2 service)
-        {
-            return new HalibutExceptionAsyncScriptServiceV2Decorator(service);
-        }
-
-        public IClientFileTransferService Decorate(IClientFileTransferService service)
-        {
-            return service;
-        }
-
-        public IAsyncClientFileTransferService Decorate(IAsyncClientFileTransferService service)
-        {
-            return service;
-        }
-
-        public IClientCapabilitiesServiceV2 Decorate(IClientCapabilitiesServiceV2 service)
-        {
-            return new HalibutExceptionCapabilitiesServiceV2Decorator(service);
-        }
-
-        public IAsyncClientCapabilitiesServiceV2 Decorate(IAsyncClientCapabilitiesServiceV2 service)
-        {
-            return new HalibutExceptionAsyncCapabilitiesServiceV2Decorator(service);
-        }
-
-        public static bool IsHalibutOperationCancellationException(Exception e)
-        {
-            return e is HalibutClientException && e.Message.Contains("The operation was canceled");
-        }
-    }
-
-    class HalibutExceptionScriptServiceV2Decorator : IClientScriptServiceV2
-    {
-        private readonly IClientScriptServiceV2 inner;
-
-        public HalibutExceptionScriptServiceV2Decorator(IClientScriptServiceV2 inner)
-        {
-            this.inner = inner;
-        }
-
-        public ScriptStatusResponseV2 StartScript(StartScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
         {
             try
             {
-                return inner.StartScript(command, halibutProxyRequestOptions);
+                return action();
             }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
+            catch (Exception e) when (e.IsHalibutOperationCancellationException())
             {
-                throw new OperationCanceledException("The operation was cancelled", e);
+                throw CreateOperationCanceledException(e);
             }
         }
 
-        public ScriptStatusResponseV2 GetStatus(ScriptStatusRequestV2 request, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        protected static Task HandleCancellationException(Func<Task> action)
         {
             try
             {
-                return inner.GetStatus(request, halibutProxyRequestOptions);
+                return action();
             }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
+            catch (Exception e) when (e.IsHalibutOperationCancellationException())
             {
-                throw new OperationCanceledException("The operation was cancelled", e);
+                throw CreateOperationCanceledException(e);
             }
         }
 
-        public ScriptStatusResponseV2 CancelScript(CancelScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        protected static TResponse HandleCancellationException<TResponse>(Func<TResponse> action)
+
         {
             try
             {
-                return inner.CancelScript(command, halibutProxyRequestOptions);
+                return action();
             }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
+            catch (Exception e) when (e.IsHalibutOperationCancellationException())
             {
-                throw new OperationCanceledException("The operation was cancelled", e);
+                throw CreateOperationCanceledException(e);
             }
         }
 
-        public void CompleteScript(CompleteScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        protected static void HandleCancellationException(Action action)
         {
             try
             {
-                inner.CompleteScript(command, halibutProxyRequestOptions);
+                action();
             }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
+            catch (Exception e) when (e.IsHalibutOperationCancellationException())
             {
-                throw new OperationCanceledException("The operation was cancelled", e);
-            }
-        }
-    }
-
-    class HalibutExceptionAsyncScriptServiceV2Decorator : IAsyncClientScriptServiceV2
-    {
-        private readonly IAsyncClientScriptServiceV2 inner;
-
-        public HalibutExceptionAsyncScriptServiceV2Decorator(IAsyncClientScriptServiceV2 inner)
-        {
-            this.inner = inner;
-        }
-
-        public async Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
-        {
-            try
-            {
-                return await inner.StartScriptAsync(command, halibutProxyRequestOptions);
-            }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
-            {
-                throw new OperationCanceledException("The operation was cancelled", e);
+                throw CreateOperationCanceledException(e);
             }
         }
 
-        public async Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request, HalibutProxyRequestOptions halibutProxyRequestOptions)
-        {
-            try
-            {
-                return await inner.GetStatusAsync(request, halibutProxyRequestOptions);
-            }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
-            {
-                throw new OperationCanceledException("The operation was cancelled", e);
-            }
-        }
-
-        public async Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
-        {
-            try
-            {
-                return await inner.CancelScriptAsync(command, halibutProxyRequestOptions);
-            }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
-            {
-                throw new OperationCanceledException("The operation was cancelled", e);
-            }
-        }
-
-        public async Task CompleteScriptAsync(CompleteScriptCommandV2 command, HalibutProxyRequestOptions halibutProxyRequestOptions)
-        {
-            try
-            {
-                await inner.CompleteScriptAsync(command, halibutProxyRequestOptions);
-            }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
-            {
-                throw new OperationCanceledException("The operation was cancelled", e);
-            }
-        }
-    }
-
-    class HalibutExceptionCapabilitiesServiceV2Decorator : IClientCapabilitiesServiceV2
-    {
-        private readonly IClientCapabilitiesServiceV2 inner;
-
-        public HalibutExceptionCapabilitiesServiceV2Decorator(IClientCapabilitiesServiceV2 inner)
-        {
-            this.inner = inner;
-        }
-
-        public CapabilitiesResponseV2 GetCapabilities(HalibutProxyRequestOptions halibutProxyRequestOptions)
-        {
-            try
-            {
-                return inner.GetCapabilities(halibutProxyRequestOptions);
-            }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
-            {
-                throw new OperationCanceledException("The operation was cancelled", e);
-            }
-        }
-    }
-
-    class HalibutExceptionAsyncCapabilitiesServiceV2Decorator : IAsyncClientCapabilitiesServiceV2
-    {
-        private readonly IAsyncClientCapabilitiesServiceV2 inner;
-
-        public HalibutExceptionAsyncCapabilitiesServiceV2Decorator(IAsyncClientCapabilitiesServiceV2 inner)
-        {
-            this.inner = inner;
-        }
-
-        public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(HalibutProxyRequestOptions halibutProxyRequestOptions)
-        {
-            try
-            {
-                return await inner.GetCapabilitiesAsync(halibutProxyRequestOptions);
-            }
-            catch (Exception e) when (HalibutExceptionTentacleServiceDecorator.IsHalibutOperationCancellationException(e))
-            {
-                throw new OperationCanceledException("The operation was cancelled", e);
-            }
-        }
+        static OperationCanceledException CreateOperationCanceledException(Exception e) => throw new OperationCanceledException("The operation was cancelled", e);
     }
 }

--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
@@ -55,6 +55,6 @@ namespace Octopus.Tentacle.Client.Decorators
             }
         }
 
-        static OperationCanceledException CreateOperationCanceledException(Exception e) => throw new OperationCanceledException("The operation was cancelled", e);
+        static OperationCanceledException CreateOperationCanceledException(Exception e) => new("The operation was cancelled", e);
     }
 }

--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecorator.cs
@@ -5,11 +5,11 @@ namespace Octopus.Tentacle.Client.Decorators
 {
     public abstract class HalibutExceptionTentacleServiceDecorator
     {
-        protected static Task<TResponse> HandleCancellationException<TResponse>(Func<Task<TResponse>> action)
+        protected static async Task<TResponse> HandleCancellationException<TResponse>(Func<Task<TResponse>> action)
         {
             try
             {
-                return action();
+                return await action();
             }
             catch (Exception e) when (e.IsHalibutOperationCancellationException())
             {
@@ -17,11 +17,11 @@ namespace Octopus.Tentacle.Client.Decorators
             }
         }
 
-        protected static Task HandleCancellationException(Func<Task> action)
+        protected static async Task HandleCancellationException(Func<Task> action)
         {
             try
             {
-                return action();
+                await action();
             }
             catch (Exception e) when (e.IsHalibutOperationCancellationException())
             {

--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecoratorFactory.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecoratorFactory.cs
@@ -1,0 +1,52 @@
+using System;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Decorators
+{
+    /// <summary>
+    /// Halibut Listening Client during connection throws the OperationCancelledException wrapped in a HalibutClientException
+    /// </summary>
+    class HalibutExceptionTentacleServiceDecoratorFactory : ITentacleServiceDecoratorFactory
+    {
+        public IClientScriptService Decorate(IClientScriptService service)
+        {
+            return service;
+        }
+
+        public IAsyncClientScriptService Decorate(IAsyncClientScriptService service)
+        {
+            return service;
+        }
+
+        public IClientScriptServiceV2 Decorate(IClientScriptServiceV2 service)
+        {
+            return new HalibutExceptionScriptServiceV2Decorator(service);
+        }
+
+        public IAsyncClientScriptServiceV2 Decorate(IAsyncClientScriptServiceV2 service)
+        {
+            return new HalibutExceptionAsyncScriptServiceV2Decorator(service);
+        }
+
+        public IClientFileTransferService Decorate(IClientFileTransferService service)
+        {
+            return service;
+        }
+
+        public IAsyncClientFileTransferService Decorate(IAsyncClientFileTransferService service)
+        {
+            return service;
+        }
+
+        public IClientCapabilitiesServiceV2 Decorate(IClientCapabilitiesServiceV2 service)
+        {
+            return new HalibutExceptionCapabilitiesServiceV2Decorator(service);
+        }
+
+        public IAsyncClientCapabilitiesServiceV2 Decorate(IAsyncClientCapabilitiesServiceV2 service)
+        {
+            return new HalibutExceptionAsyncCapabilitiesServiceV2Decorator(service);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/ITentacleServiceDecoratorFactory.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleServiceDecoratorFactory.cs
@@ -3,7 +3,7 @@ using Octopus.Tentacle.Contracts.ClientServices;
 
 namespace Octopus.Tentacle.Client
 {
-    internal interface ITentacleServiceDecorator
+    internal interface ITentacleServiceDecoratorFactory
     {
         public IClientScriptService Decorate(IClientScriptService scriptService);
 

--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -67,7 +67,7 @@ namespace Octopus.Tentacle.Client
             IScriptObserverBackoffStrategy scriptObserverBackOffStrategy,
             ITentacleClientObserver tentacleClientObserver,
             RpcRetrySettings rpcRetrySettings,
-            ITentacleServiceDecorator? tentacleServicesDecorator)
+            ITentacleServiceDecoratorFactory? tentacleServicesDecorator)
         {
             this.scriptObserverBackOffStrategy = scriptObserverBackOffStrategy;
             this.tentacleClientObserver = tentacleClientObserver.DecorateWithNonThrowingTentacleClientObserver();
@@ -90,7 +90,7 @@ namespace Octopus.Tentacle.Client
                 var syncCapabilitiesServiceV2 = halibutRuntime.CreateClient<ICapabilitiesServiceV2, IClientCapabilitiesServiceV2>(serviceEndPoint).WithBackwardsCompatability();
 #pragma warning restore CS0612
 
-                var exceptionDecorator = new HalibutExceptionTentacleServiceDecorator();
+                var exceptionDecorator = new HalibutExceptionTentacleServiceDecoratorFactory();
                 syncScriptServiceV2 = exceptionDecorator.Decorate(syncScriptServiceV2);
                 syncCapabilitiesServiceV2 = exceptionDecorator.Decorate(syncCapabilitiesServiceV2);
 
@@ -114,7 +114,7 @@ namespace Octopus.Tentacle.Client
                 var asyncFileTransferServiceV1 = halibutRuntime.CreateAsyncClient<IFileTransferService, IAsyncClientFileTransferService>(serviceEndPoint);
                 var asyncCapabilitiesServiceV2 = halibutRuntime.CreateAsyncClient<ICapabilitiesServiceV2, IAsyncClientCapabilitiesServiceV2>(serviceEndPoint).WithBackwardsCompatability();
 
-                var exceptionDecorator = new HalibutExceptionTentacleServiceDecorator();
+                var exceptionDecorator = new HalibutExceptionTentacleServiceDecoratorFactory();
                 asyncScriptServiceV2 = exceptionDecorator.Decorate(asyncScriptServiceV2);
                 asyncCapabilitiesServiceV2 = exceptionDecorator.Decorate(asyncCapabilitiesServiceV2);
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -19,7 +19,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 {
     public class ClientAndTentacleBuilder
     {
-        ITentacleServiceDecorator? tentacleServiceDecorator;
+        ITentacleServiceDecoratorFactory? tentacleServiceDecorator;
         TimeSpan retryDuration = TimeSpan.FromMinutes(2);
         bool retriesEnabled = true;
         IScriptObserverBackoffStrategy scriptObserverBackoffStrategy = new DefaultScriptObserverBackoffStrategy();
@@ -51,9 +51,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             return this;
         }
 
-        internal ClientAndTentacleBuilder WithTentacleServiceDecorator(ITentacleServiceDecorator tentacleServiceDecorator)
+        internal ClientAndTentacleBuilder WithTentacleServiceDecorator(ITentacleServiceDecoratorFactory tentacleServiceDecoratorFactory)
         {
-            this.tentacleServiceDecorator = tentacleServiceDecorator;
+            this.tentacleServiceDecorator = tentacleServiceDecoratorFactory;
 
             return this;
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
@@ -64,9 +64,9 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             return this;
         }
 
-        internal ITentacleServiceDecorator Build()
+        internal ITentacleServiceDecoratorFactory Build()
         {
-            return new FooTentacleServiceDecorator(Combine(scriptServiceDecorator), Combine(scriptServiceV2Decorator), Combine(fileTransferServiceDecorator), Combine(capabilitiesServiceV2Decorator));
+            return new FooTentacleServiceDecoratorFactory(Combine(scriptServiceDecorator), Combine(scriptServiceV2Decorator), Combine(fileTransferServiceDecorator), Combine(capabilitiesServiceV2Decorator));
         }
 
         public static Decorator<T> Combine<T>(List<Decorator<T>> chain) where T : class
@@ -86,9 +86,9 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             };
         }
 
-        private class FooTentacleServiceDecorator : AsyncToSyncTentacleServiceDecorator, ITentacleServiceDecorator
+        private class FooTentacleServiceDecoratorFactory : AsyncToSyncTentacleServiceDecorator, ITentacleServiceDecoratorFactory
         {
-            public FooTentacleServiceDecorator(Decorator<IAsyncClientScriptService> scriptServiceDecorator,
+            public FooTentacleServiceDecoratorFactory(Decorator<IAsyncClientScriptService> scriptServiceDecorator,
                 Decorator<IAsyncClientScriptServiceV2> scriptServiceV2Decorator,
                 Decorator<IAsyncClientFileTransferService> fileTransferServiceDecorator,
                 Decorator<IAsyncClientCapabilitiesServiceV2> capabilitiesServiceV2Decorator) : 


### PR DESCRIPTION
# Background

In preparation for adding the ScriptServiceV3Alpha to TentacleClient, this PR just cleans up some duplicate code around the halibut exception decorators.

# Results

- Renamed `ITentacleServiceDecorator` to `ITentacleServiceDecoratorFactory` (as well as implementations) to make it clear that it's not a decorator itself, but creates decorators
- Added a new abstract `HalibutExceptionTentacleServiceDecorator` to consolidate the exception handling logic and to reduce code reuse
- Move all decorators to their own files (but co-located the sync/async versions of the decorators)

Shortcut story: [sc-62862]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.