### PR TITLE
Removing Sync Halibut from Tentacle 

### DIFF
--- a/source/Octopus.Tentacle.Client/Scripts/ScriptOrchestratorFactory.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptOrchestratorFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.ServiceModel;

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptOrchestratorFactory.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptOrchestratorFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.ServiceModel;

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="6.0.1457" />
+    <PackageReference Include="Halibut" Version="7.0.66-pull-523" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.66-pull-523" />
+    <PackageReference Include="Halibut" Version="7.0.113" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
@@ -49,7 +49,8 @@ namespace Octopus.Tentacle.Tests.Integration
             fileTransferServiceException.UploadLatestException.Should().NotBeNull();
             fileTransferServiceCallCounts.UploadFileCallCountStarted.Should().Be(2);
 
-            var actuallySent = (await clientTentacle.TentacleClient.DownloadFile(remotePath, CancellationToken)).GetUtf8String();
+            var downloadFile = await clientTentacle.TentacleClient.DownloadFile(remotePath, CancellationToken);
+            var actuallySent = await downloadFile.GetUtf8String(CancellationToken);
             actuallySent.Should().Be("Hello");
 
             inMemoryLog.ShouldHaveLoggedRetryAttemptsAndNoRetryFailures();
@@ -85,7 +86,8 @@ namespace Octopus.Tentacle.Tests.Integration
             var remotePath = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "UploadFile.txt");
 
             await clientTentacle.TentacleClient.UploadFile(remotePath, DataStream.FromString("Hello"), CancellationToken);
-            var actuallySent = (await clientTentacle.TentacleClient.DownloadFile(remotePath, CancellationToken, inMemoryLog)).GetUtf8String();
+            var downloadFile = await clientTentacle.TentacleClient.DownloadFile(remotePath, CancellationToken, inMemoryLog);
+            var actuallySent = await downloadFile.GetUtf8String(CancellationToken);
 
             fileTransferServiceException.DownloadFileLatestException.Should().NotBeNull();
             fileTransferServiceCallCounts.DownloadFileCallCountStarted.Should().Be(2);

--- a/source/Octopus.Tentacle.Tests.Integration/FileTransferServiceTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/FileTransferServiceTests.cs
@@ -53,7 +53,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 new(CancellationToken, null));
 
             var sourceBytes = File.ReadAllBytes(fileToDownload.File.FullName);
-            var destinationBytes = downloadedData.ToBytes();
+            var destinationBytes = await downloadedData.ToBytes(CancellationToken);
 
             destinationBytes.Should().BeEquivalentTo(sourceBytes);
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut;
+using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Octopus.Tentacle.Client;
 using Octopus.Tentacle.Client.Retries;
@@ -167,6 +168,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
             logger.Information($"Tentacle.exe location: {tentacleExe}");
 
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
             if (TentacleType == TentacleType.Polling)
             {
                 portForwarder = BuildPortForwarder(serverListeningPort, null);
@@ -178,9 +180,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 runningTentacle = await pollingTentacleBuilder.Build(logger, cancellationToken);
 
-#pragma warning disable CS0612
-                tentacleEndPoint = new ServiceEndPoint(runningTentacle.ServiceUri, runningTentacle.Thumbprint);
-#pragma warning restore CS0612
+                tentacleEndPoint = new ServiceEndPoint(runningTentacle.ServiceUri, runningTentacle.Thumbprint, halibutTimeoutsAndLimits);
             }
             else
             {
@@ -193,9 +193,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 portForwarder = BuildPortForwarder(runningTentacle.ServiceUri.Port, null);
 
-#pragma warning disable CS0612
-                tentacleEndPoint = new ServiceEndPoint(portForwarder?.PublicEndpoint ?? runningTentacle.ServiceUri, runningTentacle.Thumbprint);
-#pragma warning restore CS0612
+                tentacleEndPoint = new ServiceEndPoint(portForwarder?.PublicEndpoint ?? runningTentacle.ServiceUri, runningTentacle.Thumbprint, halibutTimeoutsAndLimits);
             }
 
             if (portForwarderReference != null && portForwarder != null)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -141,8 +141,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             // Server
             var serverHalibutRuntimeBuilder = new HalibutRuntimeBuilder()
                 .WithServerCertificate(Certificates.Server)
-                .WithLegacyContractSupport()
-                .WithAsyncHalibutFeatureEnabled();
+                .WithLegacyContractSupport();
             
             if (queueFactory != null)
             {
@@ -168,7 +167,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
             logger.Information($"Tentacle.exe location: {tentacleExe}");
 
-            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
             if (TentacleType == TentacleType.Polling)
             {
                 portForwarder = BuildPortForwarder(serverListeningPort, null);
@@ -180,7 +178,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 runningTentacle = await pollingTentacleBuilder.Build(logger, cancellationToken);
 
-                tentacleEndPoint = new ServiceEndPoint(runningTentacle.ServiceUri, runningTentacle.Thumbprint, halibutTimeoutsAndLimits);
+                tentacleEndPoint = new ServiceEndPoint(runningTentacle.ServiceUri, runningTentacle.Thumbprint, serverHalibutRuntime.TimeoutsAndLimits);
             }
             else
             {
@@ -193,7 +191,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 portForwarder = BuildPortForwarder(runningTentacle.ServiceUri.Port, null);
 
-                tentacleEndPoint = new ServiceEndPoint(portForwarder?.PublicEndpoint ?? runningTentacle.ServiceUri, runningTentacle.Thumbprint, halibutTimeoutsAndLimits);
+                tentacleEndPoint = new ServiceEndPoint(portForwarder?.PublicEndpoint ?? runningTentacle.ServiceUri, runningTentacle.Thumbprint, serverHalibutRuntime.TimeoutsAndLimits);
             }
 
             if (portForwarderReference != null && portForwarder != null)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
@@ -73,6 +73,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
             
             logger.Information($"Tentacle.exe location: {tentacleExe}");
 
+            var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
             if (tentacleType == TentacleType.Polling)
             {
                 portForwarder = PortForwarderBuilder.ForwardingToLocalPort(serverListeningPort, new SerilogLoggerBuilder().Build()).Build();
@@ -81,9 +82,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
                     .WithTentacleExe(tentacleExe)
                     .Build(logger, cancellationToken);
 
-#pragma warning disable CS0612
-                tentacleEndPoint = new ServiceEndPoint(runningTentacle.ServiceUri, runningTentacle.Thumbprint);
-#pragma warning restore CS0612
+                tentacleEndPoint = new ServiceEndPoint(runningTentacle.ServiceUri, runningTentacle.Thumbprint, halibutTimeoutsAndLimits);
             }
             else
             {
@@ -92,10 +91,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
                     .Build(logger, cancellationToken);
 
                 portForwarder = new PortForwarderBuilder(runningTentacle.ServiceUri, new SerilogLoggerBuilder().Build()).Build();
-
-#pragma warning disable CS0612
-                tentacleEndPoint = new ServiceEndPoint(portForwarder.PublicEndpoint, runningTentacle.Thumbprint);
-#pragma warning restore CS0612
+                
+                tentacleEndPoint = new ServiceEndPoint(portForwarder.PublicEndpoint, runningTentacle.Thumbprint, halibutTimeoutsAndLimits);
             }
 
             var tentacleClient = new LegacyTentacleClientBuilder(server.ServerHalibutRuntime, tentacleEndPoint)

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationTokenObservingPendingRequestQueueDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationTokenObservingPendingRequestQueueDecorator.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Halibut;
 using Halibut.ServiceModel;
@@ -27,10 +28,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
         
         public Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-#pragma warning disable CS0612
-            return pendingRequestQueue.QueueAndWaitAsync(request, cancellationToken);
-#pragma warning restore CS0612
+            throw new InvalidOperationException("This method is obsolete, and should not be called in Tentacle");
         }
 
         public Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationTokenObservingPendingRequestQueueDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationTokenObservingPendingRequestQueueDecorator.cs
@@ -9,7 +9,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
 {
     public class CancellationTokenObservingPendingRequestQueueDecorator : IPendingRequestQueue
     {
-        private readonly IPendingRequestQueue pendingRequestQueue;
+        readonly IPendingRequestQueue pendingRequestQueue;
 
         public CancellationTokenObservingPendingRequestQueueDecorator(IPendingRequestQueue pendingRequestQueue)
         {
@@ -24,11 +24,6 @@ namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
         public async Task<RequestMessage> DequeueAsync(CancellationToken cancellationToken)
         {
             return await pendingRequestQueue.DequeueAsync(cancellationToken);
-        }
-        
-        public Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
-        {
-            throw new InvalidOperationException("This method is obsolete, and should not be called in Tentacle");
         }
 
         public Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, RequestCancellationTokens requestCancellationTokens)

--- a/source/Octopus.Tentacle.Tests/Capabilities/CapabilitiesServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Capabilities/CapabilitiesServiceV2Fixture.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Tentacle.Services.Capabilities;
@@ -7,10 +9,10 @@ namespace Octopus.Tentacle.Tests.Capabilities
     public class CapabilitiesServiceV2Fixture
     {
         [Test]
-        public void CapabilitiesAreReturned()
+        public async Task CapabilitiesAreReturned()
         {
-            var capabilities = new CapabilitiesServiceV2()
-                .GetCapabilities()
+            var capabilities = (await new CapabilitiesServiceV2()
+                .GetCapabilitiesAsync(CancellationToken.None))
                 .SupportedCapabilities;
 
             capabilities.Should().Contain("IScriptService");

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
@@ -95,7 +95,6 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var tasks = new ConcurrentBag<Task>();
 
-            // Act
             Parallel.ForEach(scripts, script =>
             {
                 var task = Task.Run(async () => script.Response = await service.StartScriptAsync(script.Command, CancellationToken.None));

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -35,7 +35,6 @@ namespace Octopus.Tentacle.Commands
         int wait;
         bool halibutHasStarted;
         bool workspaceCleanerHasStarted;
-        bool enableAsyncHalibut;
 
         public override bool CanRunAsService => true;
 
@@ -71,7 +70,6 @@ namespace Octopus.Tentacle.Commands
                 // There's actually nothing to do here. The CommandHost should have already been determined before Start() was called
                 // This option is added to show help
             });
-            Options.Add("async-halibut", "Enables async Halibut support for running services asynchronously", _ => enableAsyncHalibut = true);
         }
 
         protected override void Start()
@@ -120,7 +118,6 @@ namespace Octopus.Tentacle.Commands
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, proxyConfiguration.Value.CustomProxyPassword);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, proxyConfiguration.Value.CustomProxyHost);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, proxyConfiguration.Value.CustomProxyPort.ToString());
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleEnableAsyncHalibut, enableAsyncHalibut.ToString());
 
             LogWarningIfNotRunningAsAdministrator();
 

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using Halibut;
+using Halibut.Diagnostics;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
 using Octopus.Diagnostics;
@@ -95,9 +97,10 @@ namespace Octopus.Tentacle.Communications
 
                 log.Info($"Agent will poll Octopus Server at {pollingEndPoint.Address} for subscription {pollingEndPoint.SubscriptionId} expecting thumbprint {pollingEndPoint.Thumbprint}");
                 var halibutProxy = proxyConfigParser.ParseToHalibutProxy(configuration.PollingProxyConfiguration, pollingEndPoint.Address, log);
-#pragma warning disable CS0612
-                halibut.Poll(new Uri(pollingEndPoint.SubscriptionId), new ServiceEndPoint(pollingEndPoint.Address, pollingEndPoint.Thumbprint, halibutProxy));
-#pragma warning restore CS0612
+
+                var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
+                var serviceEndPoint = new ServiceEndPoint(pollingEndPoint.Address, pollingEndPoint.Thumbprint, halibutProxy, halibutTimeoutsAndLimits);
+                halibut.Poll(new Uri(pollingEndPoint.SubscriptionId), serviceEndPoint, CancellationToken.None);
             }
         }
 

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -22,12 +22,11 @@ namespace Octopus.Tentacle.Communications
             {
                 var configuration = c.Resolve<ITentacleConfiguration>();
                 var services = c.Resolve<IServiceFactory>();
-                var halibutRuntimeBuilder = new HalibutRuntimeBuilder()
+                var halibutRuntime = new HalibutRuntimeBuilder()
                     .WithServiceFactory(services)
                     .WithServerCertificate(configuration.TentacleCertificate)
-                    .WithMessageSerializer(serializerBuilder => serializerBuilder.WithLegacyContractSupport());
-                
-                var halibutRuntime = halibutRuntimeBuilder.Build();
+                    .WithMessageSerializer(serializerBuilder => serializerBuilder.WithLegacyContractSupport())
+                    .Build();
 
                 halibutRuntime.SetFriendlyHtmlPageContent(FriendlyHtmlPageContent);
                 halibutRuntime.SetFriendlyHtmlPageHeaders(FriendlyHtmlPageHeaders);

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -5,7 +5,6 @@ using Halibut;
 using Halibut.ServiceModel;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Contracts.Legacy;
-using Octopus.Tentacle.Variables;
 
 namespace Octopus.Tentacle.Communications
 {
@@ -27,13 +26,7 @@ namespace Octopus.Tentacle.Communications
                     .WithServiceFactory(services)
                     .WithServerCertificate(configuration.TentacleCertificate)
                     .WithMessageSerializer(serializerBuilder => serializerBuilder.WithLegacyContractSupport());
-
-                //if we have the environment variable to enable async halibut, enable it :)
-                if (bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleEnableAsyncHalibut), out var isEnabled) && isEnabled)
-                {
-                    halibutRuntimeBuilder.WithAsyncHalibutFeatureEnabled();
-                }
-
+                
                 var halibutRuntime = halibutRuntimeBuilder.Build();
 
                 halibutRuntime.SetFriendlyHtmlPageContent(FriendlyHtmlPageContent);

--- a/source/Octopus.Tentacle/Scripts/IScriptWorkspaceFactory.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptWorkspaceFactory.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Contracts;
 
 namespace Octopus.Tentacle.Scripts
@@ -8,7 +10,7 @@ namespace Octopus.Tentacle.Scripts
     {
         IScriptWorkspace GetWorkspace(ScriptTicket ticket);
 
-        IScriptWorkspace PrepareWorkspace(
+        Task<IScriptWorkspace> PrepareWorkspace(
             ScriptTicket ticket,
             string scriptBody,
             Dictionary<ScriptType, string> scripts,
@@ -16,7 +18,8 @@ namespace Octopus.Tentacle.Scripts
             TimeSpan scriptMutexAcquireTimeout,
             string? scriptMutexName,
             string[]? scriptArguments,
-            List<ScriptFile> files);
+            List<ScriptFile> files,
+            CancellationToken cancellationToken);
 
         List<IScriptWorkspace> GetUncompletedWorkspaces();
     }

--- a/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesServiceV2.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
@@ -6,10 +8,11 @@ using Octopus.Tentacle.Contracts.ScriptServiceV2;
 namespace Octopus.Tentacle.Services.Capabilities
 {
     [Service(typeof(ICapabilitiesServiceV2))]
-    public class CapabilitiesServiceV2 : ICapabilitiesServiceV2
+    public class CapabilitiesServiceV2 : IAsyncCapabilitiesServiceV2
     {
-        public CapabilitiesResponseV2 GetCapabilities()
+        public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(CancellationToken cancellationToken)
         {
+            await Task.CompletedTask;
             return new CapabilitiesResponseV2(new List<string>() {nameof(IScriptService), nameof(IFileTransferService), nameof(IScriptServiceV2)});
         }
     }

--- a/source/Octopus.Tentacle/Services/Capabilities/IAsyncCapabilitiesServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Capabilities/IAsyncCapabilitiesServiceV2.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut.Transport.Caching;
+using Octopus.Tentacle.Contracts.Capabilities;
+
+namespace Octopus.Tentacle.Services.Capabilities
+{
+    public interface IAsyncCapabilitiesServiceV2
+    {
+        [CacheResponse(600)]
+        Task<CapabilitiesResponseV2> GetCapabilitiesAsync(CancellationToken cancellationToken);
+    }
+}

--- a/source/Octopus.Tentacle/Services/FileTransfer/IAsyncFileTransferService.cs
+++ b/source/Octopus.Tentacle/Services/FileTransfer/IAsyncFileTransferService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Services.FileTransfer
+{
+    public interface IAsyncFileTransferService
+    {
+        Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload, CancellationToken cancellationToken);
+        Task<DataStream> DownloadFileAsync(string remotePath, CancellationToken cancellationToken);
+    }
+}

--- a/source/Octopus.Tentacle/Services/Scripts/IAsyncScriptService.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/IAsyncScriptService.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Services.Scripts
+{
+    public interface IAsyncScriptService
+    {
+        Task<ScriptTicket> StartScriptAsync(StartScriptCommand command, CancellationToken cancellationToken);
+        Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request, CancellationToken cancellationToken);
+        Task<ScriptStatusResponse> CancelScriptAsync(CancelScriptCommand command, CancellationToken cancellationToken);
+        Task<ScriptStatusResponse> CompleteScriptAsync(CompleteScriptCommand command, CancellationToken cancellationToken);
+    }
+}

--- a/source/Octopus.Tentacle/Services/Scripts/IAsyncScriptServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/IAsyncScriptServiceV2.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Octopus.Tentacle.Services.Scripts
+{
+    public interface IAsyncScriptServiceV2
+    {
+        Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, CancellationToken cancellationToken);
+        Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request, CancellationToken cancellationToken);
+        Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command, CancellationToken cancellationToken);
+        Task CompleteScriptAsync(CompleteScriptCommandV2 command, CancellationToken cancellationToken);
+    }
+}

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
@@ -34,8 +34,6 @@ namespace Octopus.Tentacle.Services.Scripts
 
         public async Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, CancellationToken cancellationToken)
         {
-            await Task.CompletedTask;
-
             var runningScript = runningScripts.GetOrAdd(
                 command.ScriptTicket,
                 _ =>
@@ -63,7 +61,7 @@ namespace Octopus.Tentacle.Services.Scripts
                 }
                 else
                 {
-                    workspace = workspaceFactory.PrepareWorkspace(command.ScriptTicket,
+                    workspace = await workspaceFactory.PrepareWorkspace(command.ScriptTicket,
                         command.ScriptBody,
                         command.Scripts,
                         command.Isolation,
@@ -71,7 +69,7 @@ namespace Octopus.Tentacle.Services.Scripts
                         command.IsolationMutexName,
                         command.Arguments,
                         command.Files,
-                        CancellationToken.None).Result;
+                        CancellationToken.None);
 
                     runningScript.ScriptStateStore.Create();
                 }

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha/ScriptServiceV3Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha/ScriptServiceV3Alpha.cs
@@ -61,14 +61,15 @@ namespace Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha
                 }
                 else
                 {
-                    workspace = workspaceFactory.PrepareWorkspace(command.ScriptTicket,
+                    workspace = await workspaceFactory.PrepareWorkspace(command.ScriptTicket,
                         command.ScriptBody,
                         command.Scripts,
                         command.Isolation,
                         command.ScriptIsolationMutexTimeout,
                         command.IsolationMutexName,
                         command.Arguments,
-                        command.Files);
+                        command.Files,
+                        cancellationToken);
 
                     runningScript.ScriptStateStore.Create();
                 }

--- a/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
+++ b/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
@@ -20,6 +20,5 @@ namespace Octopus.Tentacle.Variables
         public const string TentacleExecutablePath = "TentacleExecutablePath";
         public const string TentacleProgramDirectoryPath = "TentacleProgramDirectoryPath";
         public const string AgentProgramDirectoryPath = "AgentProgramDirectoryPath";
-        public const string TentacleEnableAsyncHalibut = "TentacleEnableAsyncHalibut";
     }
 }


### PR DESCRIPTION
# Background

Sync operations have been removed from Halibut in favour of Async operations. 

This PR updates the version of Halibut used in the Tentacle solution to one with Sync Halibut removed.

This PR also changes Tentacle to support only Async Halibut and updates the Services implemented in Tentacle to use the Async Service Contract along with modifications to the implementation to use async methods where it makes sense.

# Results

The Tentacle solution has all Sync Halibut operations removed.

Related to OctopusDeploy/Issues#8266

[sc-58528]
[sc-56576]

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered the [appropriate target version for this PR](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1145896982/Which+versions+should+I+patch#Process).
- [ ] I have considered appropriate testing for my change.
  - Automated testing / Exploratory testing / Nothing required?
  - Is the build green?
- [ ] I have considered manually testing my changes on a [branch instance](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1262256152/Use+a+Core+Feature+Branch+Instance) to check correctness, stability and performance on Octopus Cloud.
- [ ] I have considered safety nets to reduce any time-to-recovery for my change.
<!--
If these changes caused a problem that resulted in a cord pull, what options do you have to unblock the pipeline and how long would it take to recover?
-->
