### PR TITLE
Migrate Tentacle command line tests from Octopus E2ETests

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -34,6 +34,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         Reference<PortForwarder>? portForwarderReference;
         ITentacleClientObserver tentacleClientObserver = new NoTentacleClientObserver();
         Action<ITentacleBuilder>? tentacleBuilderAction;
+        string? instanceName;
         Action<TentacleClientOptions>? configureClientOptions;
         TcpConnectionUtilities? tcpConnectionUtilities;
 
@@ -140,6 +141,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             this.configureClientOptions = configureClientOptions;
             return this;
         }
+        
+        public ClientAndTentacleBuilder WithInstanceName(string customInstanceName)
+        {
+            instanceName = customInstanceName;
+            return this;
+        }
 
         PortForwarder? BuildPortForwarder(int localPort, int? listeningPort)
         {
@@ -192,7 +199,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 tentacleBuilderAction?.Invoke(pollingTentacleBuilder);
 
-                runningTentacle = await pollingTentacleBuilder.Build(logger, cancellationToken);
+                runningTentacle = await pollingTentacleBuilder.Build(logger, cancellationToken, instanceName);
 
                 tentacleEndPoint = new ServiceEndPoint(runningTentacle.ServiceUri, runningTentacle.Thumbprint, serverHalibutRuntime.TimeoutsAndLimits);
             }
@@ -203,7 +210,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 tentacleBuilderAction?.Invoke(listeningTentacleBuilder);
 
-                runningTentacle = await listeningTentacleBuilder.Build(logger, cancellationToken);
+                runningTentacle = await listeningTentacleBuilder.Build(logger, cancellationToken, instanceName);
 
                 portForwarder = BuildPortForwarder(runningTentacle.ServiceUri.Port, null);
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -34,7 +34,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         Reference<PortForwarder>? portForwarderReference;
         ITentacleClientObserver tentacleClientObserver = new NoTentacleClientObserver();
         Action<ITentacleBuilder>? tentacleBuilderAction;
-        string? instanceName;
         Action<TentacleClientOptions>? configureClientOptions;
         TcpConnectionUtilities? tcpConnectionUtilities;
 
@@ -141,12 +140,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             this.configureClientOptions = configureClientOptions;
             return this;
         }
-        
-        public ClientAndTentacleBuilder WithInstanceName(string customInstanceName)
-        {
-            instanceName = customInstanceName;
-            return this;
-        }
 
         PortForwarder? BuildPortForwarder(int localPort, int? listeningPort)
         {
@@ -178,7 +171,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             serverHalibutRuntime.Trust(Certificates.TentaclePublicThumbprint);
             var serverListeningPort = serverHalibutRuntime.Listen();
 
-            var server = new Server(serverHalibutRuntime, serverListeningPort, logger);
+            var server = new Server(serverHalibutRuntime, serverListeningPort, Certificates.ServerPublicThumbprint, logger);
 
             // Port Forwarder
             PortForwarder? portForwarder;
@@ -199,7 +192,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 tentacleBuilderAction?.Invoke(pollingTentacleBuilder);
 
-                runningTentacle = await pollingTentacleBuilder.Build(logger, cancellationToken, instanceName);
+                runningTentacle = await pollingTentacleBuilder.Build(logger, cancellationToken);
 
                 tentacleEndPoint = new ServiceEndPoint(runningTentacle.ServiceUri, runningTentacle.Thumbprint, serverHalibutRuntime.TimeoutsAndLimits);
             }
@@ -210,7 +203,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 tentacleBuilderAction?.Invoke(listeningTentacleBuilder);
 
-                runningTentacle = await listeningTentacleBuilder.Build(logger, cancellationToken, instanceName);
+                runningTentacle = await listeningTentacleBuilder.Build(logger, cancellationToken);
 
                 portForwarder = BuildPortForwarder(runningTentacle.ServiceUri.Port, null);
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
@@ -57,7 +57,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
             serverHalibutRuntime.Trust(Certificates.TentaclePublicThumbprint);
             var serverListeningPort = serverHalibutRuntime.Listen();
 
-            var server = new Server(serverHalibutRuntime, serverListeningPort, logger);
+            var server = new Server(serverHalibutRuntime, serverListeningPort, Certificates.ServerPublicThumbprint, logger);
 
             // Port Forwarder
             PortForwarder portForwarder;

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -14,9 +14,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             ServerThumbprint = serverThumbprint;
         }
 
-        internal async Task<RunningTentacle> Build(ILogger log, CancellationToken cancellationToken)
+        internal async Task<RunningTentacle> Build(ILogger log, CancellationToken cancellationToken, string? customInstanceName = null)
         {
-            var instanceName = InstanceNameGenerator();
+            var instanceName = customInstanceName ?? InstanceNameGenerator();
             var configFilePath = Path.Combine(HomeDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
             

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -14,9 +14,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             ServerThumbprint = serverThumbprint;
         }
 
-        internal async Task<RunningTentacle> Build(ILogger log, CancellationToken cancellationToken, string? customInstanceName = null)
+        internal async Task<RunningTentacle> Build(ILogger log, CancellationToken cancellationToken)
         {
-            var instanceName = customInstanceName ?? InstanceNameGenerator();
+            var instanceName = InstanceNameGenerator();
             var configFilePath = Path.Combine(HomeDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
             
@@ -25,13 +25,15 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
             await CreateInstance(tentacleExe, configFilePath, instanceName, HomeDirectory, cancellationToken);
             await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, HomeDirectory, cancellationToken);
-            ConfigureTentacleToListen(configFilePath);
+            var applicationDirectory = Path.Combine(HomeDirectory.DirectoryPath, "appdir");
+            ConfigureTentacleToListen(configFilePath, applicationDirectory);
 
             var runningTentacle = await StartTentacle(
                 null,
                 tentacleExe,
                 instanceName,
                 HomeDirectory,
+                applicationDirectory,
                 TentacleThumbprint,
                 logger,
                 cancellationToken);
@@ -41,7 +43,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             return runningTentacle;
         }
 
-        private void ConfigureTentacleToListen(string configFilePath)
+        private void ConfigureTentacleToListen(string configFilePath, string applicationDirectory)
         {
             WithWritableTentacleConfiguration(configFilePath, writableTentacleConfiguration =>
             {
@@ -50,7 +52,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     CommunicationStyle = CommunicationStyle.TentaclePassive,
                 });
 
-                writableTentacleConfiguration.SetApplicationDirectory(Path.Combine(new DirectoryInfo(configFilePath).Parent.FullName, "appdir"));
+                writableTentacleConfiguration.SetApplicationDirectory(applicationDirectory);
 
                 writableTentacleConfiguration.SetServicesPortNumber(0); // Find a random available port
                 writableTentacleConfiguration.SetNoListen(false);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -20,9 +20,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             ServerThumbprint = serverThumbprint;
         }
 
-        internal async Task<RunningTentacle> Build(ILogger log, CancellationToken cancellationToken)
+        internal async Task<RunningTentacle> Build(ILogger log, CancellationToken cancellationToken, string? customInstanceName = null)
         {
-            var instanceName = InstanceNameGenerator();
+            var instanceName = customInstanceName ?? InstanceNameGenerator();
             var configFilePath = Path.Combine(HomeDirectory.DirectoryPath, instanceName + ".cfg");
             var tentacleExe = TentacleExePath ?? TentacleExeFinder.FindTentacleExe();
             var subscriptionId = PollingSubscriptionId.Generate();

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Server.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Server.cs
@@ -12,12 +12,14 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         private readonly ILogger logger;
         public IHalibutRuntime ServerHalibutRuntime { get; }
         public int ServerListeningPort { get; }
+        public string Thumbprint { get; set; }
 
-        public Server(IHalibutRuntime serverHalibutRuntime, int serverListeningPort, ILogger logger)
+        public Server(IHalibutRuntime serverHalibutRuntime, int serverListeningPort, string thumbprint, ILogger logger)
         {
             this.logger = logger.ForContext<Server>();
             this.ServerHalibutRuntime = serverHalibutRuntime;
             ServerListeningPort = serverListeningPort;
+            Thumbprint = thumbprint;
         }
 
         public async ValueTask DisposeAsync()

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Policy;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -84,6 +85,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             string tentacleExe,
             string instanceName,
             TemporaryDirectory tempDirectory,
+            string applicationDirectory,
             string tentacleThumbprint,
             ILogger logger,
             CancellationToken cancellationToken)
@@ -92,6 +94,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 tempDirectory,
                 startTentacleFunction: ct => RunTentacle(serviceUri, tentacleExe, instanceName, tempDirectory, ct),
                 tentacleThumbprint,
+                instanceName,
+                HomeDirectory.DirectoryPath,
+                applicationDirectory,
                 deleteInstanceFunction: ct => DeleteInstanceIgnoringFailure(tentacleExe, instanceName, tempDirectory, logger, ct),
                 logger);
 

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleCommandLineTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleCommandLineTests.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using CliWrap;
+using CliWrap.Exceptions;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [IntegrationTestTimeout]
+    public class TentacleCommandLineTests : IntegrationTest
+    {
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task TentacleExeNoArguments(TentacleConfigurationTestCase tc)
+        {
+            var (exitCode, stdout, stderr) = await RunCommand(tc, "");
+            
+            exitCode.Should().Be(2, "the exit code should be 2 if the command wasn't understood");
+            stdout.Should().StartWithEquivalentOf("Usage: Tentacle <command> [<options>]", "should show help by default if no other commands are specified");
+            stdout.Should().ContainEquivalentOf("Or use <command> --help for more details.", "should provide the hint for command-specific help");
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+        
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task UnknownCommand(TentacleConfigurationTestCase tc)
+        {
+            var (exitCode, stdout, stderr) = await RunCommand(tc, "unknown-command");
+            
+            exitCode.Should().Be(2, "the exit code should be 2 if the command wasn't understood");
+            stderr.Should().StartWithEquivalentOf("Command 'unknown-command' is not supported", "the error should clearly indicate the command which is not understood");
+            stdout.Should().StartWithEquivalentOf("See 'Tentacle help'", "should provide the hint to use help");
+            await Task.CompletedTask;
+        }     
+        
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task UnknownArgument(TentacleConfigurationTestCase tc)
+        {
+            var (exitCode, stdout, stderr) = await RunCommand(tc, "version --unknown=argument");
+            
+            exitCode.Should().Be(1, "the exit code should be 1 if the command has unknown arguments");
+            stdout.Should().BeNullOrEmpty("the error message should be written to stderr, not stdout");
+            stderr.Should().ContainEquivalentOf("Unrecognized command line arguments: --unknown=argument", "the error message (written to stderr) should clearly indicate which arguments couldn't be parsed.");
+            await Task.CompletedTask;
+        }
+        
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task InvalidArgument(TentacleConfigurationTestCase tc)
+        {
+            var (exitCode, stdout, stderr) = await RunCommand(tc, "version --format=unsupported");
+            
+            exitCode.Should().Be(1, "the exit code should be 1 if the command has unknown arguments");
+            stdout.Should().BeNullOrEmpty("the error message should be written to stderr, not stdout");
+            stderr.Should().ContainEquivalentOf("The format 'unsupported' is not supported. Try text or json.", "the error message (written to stderr) should clearly indicate which argument was invalid.");
+            await Task.CompletedTask;
+        }
+        
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task NoConsoleLoggingSwitchStillSilentlySupportedForBackwardsCompat(TentacleConfigurationTestCase tc)
+        {
+            var (_, _, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --noconsolelogging");
+
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+        
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task NoLogoSwitchStillSilentlySupportedForBackwardsCompat(TentacleConfigurationTestCase tc)
+        {
+            var (_, _, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --nologo");
+
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task ConsoleSwitchStillSilentlySupportedForBackwardsCompat(TentacleConfigurationTestCase tc)
+        {
+            var (_, _, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --console");
+
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+        
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task ShouldSupportFuzzyCommandParsing(TentacleConfigurationTestCase tc)
+        {
+            await RunCommandWithValidExitCodeAssert(tc, "version");
+            await RunCommandWithValidExitCodeAssert(tc, "--version");
+            await RunCommandWithValidExitCodeAssert(tc, "/version");
+        }
+
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task VersionCommandTextFormat(TentacleConfigurationTestCase tc)
+        {
+            var (_, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version");
+
+            var expectedVersion = GetVersionInfo(tc);
+
+            stdout.Should().Be(expectedVersion.ProductVersion, "The version command should print the informational version as text");
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task VersionCommandJsonFormat(TentacleConfigurationTestCase tc)
+        {
+            var (_, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --format=json");
+
+            var expectedVersion = GetVersionInfo(tc);
+            var output = JObject.Parse(stdout);
+
+            output["InformationalVersion"].Value<string>().Should().Be(expectedVersion.ProductVersion, "The version command should print the informational version in the JSON output");
+            output["MajorMinorPatch"].Value<string>().Should().Be($"{expectedVersion.FileMajorPart}.{expectedVersion.FileMinorPart}.{expectedVersion.FileBuildPart}", "The version command should print the version in the json output");
+            output["NuGetVersion"].Value<string>().Should().NotBeNull("The version command should print the NuGet version in the JSON output");
+            output["SourceBranchName"].Value<string>().Should().NotBeNull("The version command should print the source branch in the JSON output");
+
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+        
+        
+        
+        // [Test]
+        // [TentacleConfigurations(testCommonVersions: true)]
+        // public async Task CanGetHelpForHelp()
+        // {
+        //     RunCommand("help --help", out var stdout, out var stderr);
+        //     stderr.Should().BeNullOrEmpty();
+        //     assentRunner.AssentUnScrubbedContent(this, stdout);
+        //     await Task.CompletedTask;
+        // }
+        //
+        // [Test]
+        // [TentacleConfigurations(testCommonVersions: true)]
+        // public async Task HelpAsSwitchShouldShowCommandSpecificHelp()
+        // {
+        //     RunCommand("version --help", out var stdout, out var stderr);
+        //     stderr.Should().BeNullOrEmpty();
+        //     assentRunner.AssentUnScrubbedContent(this, stdout);
+        //     await Task.CompletedTask;
+        // }
+
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task GeneralHelpAsJsonCanBeParsedByAutomationScripts(TentacleConfigurationTestCase tc)
+        {
+            var (_, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, "help --format=json");
+
+            stderr.Should().BeNullOrEmpty();
+            var help = JsonConvert.DeserializeAnonymousType(
+                stdout,
+                new
+                {
+                    Commands = new[]
+                    {
+                        new
+                        {
+                            Name = "",
+                            Description = "",
+                            Aliases = new string[0]
+                        }
+                    }
+                });
+
+            help.Commands.Select(c => c.Name)
+                .Should()
+                .Contain(
+                    "configure",
+                    "help",
+                    "run",
+                    "version",
+                    "show-master-key",
+                    "show-thumbprint");
+
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task CommandSpecificHelpAsJsonCanBeParsedByAutomationScripts(TentacleConfigurationTestCase tc)
+        {
+            var (_, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --help --format=json");
+
+            stderr.Should().BeNullOrEmpty();
+            var help = JsonConvert.DeserializeAnonymousType(
+                stdout,
+                new
+                {
+                    Name = "",
+                    Description = "",
+                    Aliases = new string[0],
+                    Options = new[]
+                    {
+                        new
+                        {
+                            Name = "",
+                            Description = ""
+                        }
+                    }
+                });
+
+            help.Name.Should().Be("version");
+            help.Options.Select(o => o.Name).Should().Contain("format");
+
+            await Task.CompletedTask;
+        }
+
+        // [Test]
+        // [TentacleConfigurations(testCommonVersions: true)]
+        // public async Task CommandSpecificHelpAsJsonLooksSensibleToHumans()
+        // {
+        //     RunCommand("version --help --format=json", out var stdout, out var stderr);
+        //     stderr.Should().BeNullOrEmpty();
+        //     assentRunner.AssentUnScrubbedContent(this, stdout);
+        //     await Task.CompletedTask;
+        // }
+
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task HelpForInstanceSpecificCommandsAlwaysWorks(TentacleConfigurationTestCase tc)
+        {
+            // Get all the commands using command-line - talk about dog fooding!
+            var (_, stdout, stderr) = await RunCommand(tc, "help --format=json");
+
+            stderr.Should().BeNullOrEmpty();
+            var help = JsonConvert.DeserializeAnonymousType(
+                stdout,
+                new
+                {
+                    Commands = new[]
+                    {
+                        new
+                        {
+                            Name = "",
+                            Description = "",
+                            Aliases = new string[0]
+                        }
+                    }
+                });
+
+            var failed = help.Commands.Select(async c =>
+                    {
+                        var (exitCode2, stdout2, stderr2) = await RunCommand(tc,$"{c.Name} --help");
+                        return new
+                        {
+                            Command = c,
+                            ExitCode = exitCode2,
+                            StdOut = stdout2,
+                            StdErr = stderr2,
+                            HasExpectedExitCode = exitCode2 == 0,
+                            HasExpectedHelpMessage = stdout2.StartsWith($"Usage: Tentacle {c.Name} [<options>]")
+                        };
+                    })
+                .Where(r => !(r.Result.HasExpectedExitCode && r.Result.HasExpectedHelpMessage))
+                .ToArray();
+
+            if (failed.Any())
+            {
+                // Log.Error(JsonConvert.SerializeObject(failed));
+                Assert.Fail($"The following commands cannot show help without specifying the --instance argument:{Environment.NewLine}" + $"{string.Join(Environment.NewLine, failed.Select(x => x.Result.Command.Name))}{Environment.NewLine}" + "The details are logged above. These commands probably need to take Lazy<T> dependencies so they can be instantiated for showing help without requiring every dependency to be resolvable.");
+            }
+
+            await Task.CompletedTask;
+        }
+        
+        [Test]
+        [TentacleConfigurations(testCommonVersions: true)]
+        public async Task InvalidInstance(TentacleConfigurationTestCase tc)
+        {
+            var (exitCode, stdout, stderr) = await RunCommand(tc, "show-thumbprint --instance=invalidinstance");
+            
+            exitCode.Should().Be(1, $"the exit code should be 1 if the instance is not able to be resolved");
+            stderr.Should().ContainEquivalentOf("Instance invalidinstance of tentacle has not been configured", "the error message should make it clear the instance has not been configured");
+            stderr.Should().ContainEquivalentOf("Available instances:", "should provide a hint as to which instances are available on the machine");
+            stdout.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+
+        // [Test]
+        // [TentacleConfigurations(testCommonVersions: true)]
+        public async Task ShowThumbprintCommandText(TentacleConfigurationTestCase tc)
+        {
+            string instanceName = $"test-instance-for-{nameof(ShowThumbprintCommandText)}";
+            await using var clientAndTentacle = await tc.CreateBuilder().WithInstanceName(instanceName).Build(CancellationToken);
+            var (exitCode, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, $"show-thumbprint --instance={instanceName}");
+
+            exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
+            stdout.Should().Be(Support.Certificates.TentaclePublicThumbprint, "the thumbprint should be written directly to stdout");
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+
+        // [Test]
+        // [TentacleConfigurations(testCommonVersions: true)]
+        public async Task ShowThumbprintCommandJson(TentacleConfigurationTestCase tc)
+        {
+            string instanceName = $"test-instance-for-{nameof(ShowThumbprintCommandJson)}";
+            await using var clientAndTentacle = await tc.CreateBuilder().WithInstanceName(instanceName).Build(CancellationToken);
+            var (exitCode, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, $"show-thumbprint --instance={instanceName} --format=json");
+            
+            exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
+            stdout.Should().Be(JsonConvert.SerializeObject(new { Support.Certificates.TentaclePublicThumbprint }), "the thumbprint should be written directly to stdout as JSON");
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+
+        // [Test]
+        // [TentacleConfigurations(testCommonVersions: true)]
+        public async Task ListInstancesCommandText(TentacleConfigurationTestCase tc)
+        {
+            string instanceName = $"test-instance-for-{nameof(ListInstancesCommandText)}";
+            await using var clientAndTentacle = await tc.CreateBuilder().WithInstanceName(instanceName).Build(CancellationToken);
+            var (exitCode, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, $"list-instances --format=text");
+            
+            exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
+            stdout.Should().ContainEquivalentOf($"Instance '{instanceName}' uses configuration '{clientAndTentacle.RunningTentacle.HomeDirectory}'.", "the current instance should be listed");
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+
+        // [Test]
+        // [TentacleConfigurations(testCommonVersions: true)]
+        public async Task ListInstancesCommandJson(TentacleConfigurationTestCase tc)
+        {
+            string instanceName = $"test-instance-for-{nameof(ListInstancesCommandJson)}";
+            await using var clientAndTentacle = await tc.CreateBuilder().WithInstanceName(instanceName).Build(CancellationToken);
+            var (exitCode, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, $"list-instances --format=json");
+            
+            stdout.Should().Contain($"\"InstanceName\": \"{instanceName}\"", "the current instance should be listed");
+            var jsonFormattedPath = clientAndTentacle.RunningTentacle.HomeDirectory.Replace(@"\", @"\\");
+            stdout.Should().Contain($"\"ConfigurationFilePath\": \"{jsonFormattedPath}\"", "the path to the config file for the current instance should be listed");
+            stderr.Should().BeNullOrEmpty();
+            await Task.CompletedTask;
+        }
+        
+        FileVersionInfo GetVersionInfo(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var tentacleExe = TentacleExeFinder.FindTentacleExe(tentacleConfigurationTestCase.TentacleRuntime);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return FileVersionInfo.GetVersionInfo(tentacleExe);
+            }
+
+            //todo: change this to trust the value set in the context.TentacleExePath (will need a renovation of ExePathResolver to be non windows specific)
+            return FileVersionInfo.GetVersionInfo($"{tentacleExe}.dll");
+        }
+
+        async Task<(int, string, string)> RunCommandWithValidExitCodeAssert(TentacleConfigurationTestCase tentacleConfigurationTestCase, string input)
+        {
+            var (exitCode, stdout, stderr) = await RunCommand(tentacleConfigurationTestCase, input);
+            exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
+            return (exitCode, stdout, stderr);
+        }
+
+        async Task<(int, string, string)> RunCommand(TentacleConfigurationTestCase tentacleConfigurationTestCase, string input)
+        {
+            var tentacleExe = TentacleExeFinder.FindTentacleExe(tentacleConfigurationTestCase.TentacleRuntime);
+            var args = input;
+            var output = new StringBuilder();
+            var errorOut = new StringBuilder();
+            
+            var result = await RetryHelper.RetryAsync<CommandResult, CommandExecutionException>(
+                () => Cli.Wrap(tentacleExe)
+                    .WithArguments(args)
+                    .WithValidation(CommandResultValidation.None)
+                    .WithStandardOutputPipe(PipeTarget.ToStringBuilder(output))
+                    .WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOut))
+                    .ExecuteAsync(CancellationToken));
+
+            return (result.ExitCode, output.ToString(), errorOut.ToString());
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleCommandLineTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleCommandLineTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
 using CliWrap;
@@ -11,28 +13,33 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Support.TestAttributes;
 using Octopus.Tentacle.Util;
+using Polly;
 
 namespace Octopus.Tentacle.Tests.Integration
 {
+    /// <summary>
+    /// These tests provide guarantees around how our command-line interface works, especially for scenarios where people automate setup.
+    /// Please review any changes to the assertions made by these tests carefully.
+    /// </summary>
     [IntegrationTestTimeout]
     public class TentacleCommandLineTests : IntegrationTest
     {
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task TentacleExeNoArguments(TentacleConfigurationTestCase tc)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tc, "");
+            var (exitCode, stdout, stderr) = await RunCommand(tc);
             
             exitCode.Should().Be(2, "the exit code should be 2 if the command wasn't understood");
             stdout.Should().StartWithEquivalentOf("Usage: Tentacle <command> [<options>]", "should show help by default if no other commands are specified");
             stdout.Should().ContainEquivalentOf("Or use <command> --help for more details.", "should provide the hint for command-specific help");
             stderr.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
         }
         
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task UnknownCommand(TentacleConfigurationTestCase tc)
         {
             var (exitCode, stdout, stderr) = await RunCommand(tc, "unknown-command");
@@ -40,90 +47,83 @@ namespace Octopus.Tentacle.Tests.Integration
             exitCode.Should().Be(2, "the exit code should be 2 if the command wasn't understood");
             stderr.Should().StartWithEquivalentOf("Command 'unknown-command' is not supported", "the error should clearly indicate the command which is not understood");
             stdout.Should().StartWithEquivalentOf("See 'Tentacle help'", "should provide the hint to use help");
-            await Task.CompletedTask;
         }     
         
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task UnknownArgument(TentacleConfigurationTestCase tc)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tc, "version --unknown=argument");
+            var (exitCode, stdout, stderr) = await RunCommand(tc, "version", "--unknown=argument");
             
             exitCode.Should().Be(1, "the exit code should be 1 if the command has unknown arguments");
             stdout.Should().BeNullOrEmpty("the error message should be written to stderr, not stdout");
             stderr.Should().ContainEquivalentOf("Unrecognized command line arguments: --unknown=argument", "the error message (written to stderr) should clearly indicate which arguments couldn't be parsed.");
-            await Task.CompletedTask;
         }
         
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task InvalidArgument(TentacleConfigurationTestCase tc)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tc, "version --format=unsupported");
+            var (exitCode, stdout, stderr) = await RunCommand(tc, "version", "--format=unsupported");
             
             exitCode.Should().Be(1, "the exit code should be 1 if the command has unknown arguments");
             stdout.Should().BeNullOrEmpty("the error message should be written to stderr, not stdout");
             stderr.Should().ContainEquivalentOf("The format 'unsupported' is not supported. Try text or json.", "the error message (written to stderr) should clearly indicate which argument was invalid.");
-            await Task.CompletedTask;
         }
         
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task NoConsoleLoggingSwitchStillSilentlySupportedForBackwardsCompat(TentacleConfigurationTestCase tc)
         {
-            var (_, _, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --noconsolelogging");
+            var (_, _, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--noconsolelogging");
 
             stderr.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
         }
         
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task NoLogoSwitchStillSilentlySupportedForBackwardsCompat(TentacleConfigurationTestCase tc)
         {
-            var (_, _, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --nologo");
+            var (_, _, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--nologo");
 
             stderr.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
         }
 
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task ConsoleSwitchStillSilentlySupportedForBackwardsCompat(TentacleConfigurationTestCase tc)
         {
-            var (_, _, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --console");
+            var (_, _, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--console");
 
             stderr.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
         }
         
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task ShouldSupportFuzzyCommandParsing(TentacleConfigurationTestCase tc)
         {
-            await RunCommandWithValidExitCodeAssert(tc, "version");
-            await RunCommandWithValidExitCodeAssert(tc, "--version");
-            await RunCommandWithValidExitCodeAssert(tc, "/version");
+            await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version");
+            await RunCommandAndAssertExitsWithSuccessExitCode(tc, "--version");
+            await RunCommandAndAssertExitsWithSuccessExitCode(tc, "/version");
         }
 
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task VersionCommandTextFormat(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version");
 
             var expectedVersion = GetVersionInfo(tc);
 
             stdout.Should().Be(expectedVersion.ProductVersion, "The version command should print the informational version as text");
             stderr.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
         }
 
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task VersionCommandJsonFormat(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --format=json");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--format=json");
 
             var expectedVersion = GetVersionInfo(tc);
             var output = JObject.Parse(stdout);
@@ -134,36 +134,55 @@ namespace Octopus.Tentacle.Tests.Integration
             output["SourceBranchName"].Value<string>().Should().NotBeNull("The version command should print the source branch in the JSON output");
 
             stderr.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
         }
-        
-        
-        
-        // [Test]
-        // [TentacleConfigurations(testCommonVersions: true)]
-        // public async Task CanGetHelpForHelp()
-        // {
-        //     RunCommand("help --help", out var stdout, out var stderr);
-        //     stderr.Should().BeNullOrEmpty();
-        //     assentRunner.AssentUnScrubbedContent(this, stdout);
-        //     await Task.CompletedTask;
-        // }
-        //
-        // [Test]
-        // [TentacleConfigurations(testCommonVersions: true)]
-        // public async Task HelpAsSwitchShouldShowCommandSpecificHelp()
-        // {
-        //     RunCommand("version --help", out var stdout, out var stderr);
-        //     stderr.Should().BeNullOrEmpty();
-        //     assentRunner.AssentUnScrubbedContent(this, stdout);
-        //     await Task.CompletedTask;
-        // }
 
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        public async Task CanGetHelpForHelp(TentacleConfigurationTestCase tc)
+        {
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "help", "--help");
+            stderr.Should().BeNullOrEmpty();
+
+            stdout.Should().Be(
+@"Usage: Tentacle help [<options>]
+
+Where [<options>] is any of: 
+
+      --format=VALUE         The format of the output (text,json). Defaults 
+                               to text.
+
+Or one of the common options: 
+
+      --help                 Show detailed help for this command
+");
+        }
+
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        public async Task HelpAsSwitchShouldShowCommandSpecificHelp(TentacleConfigurationTestCase tc)
+        {
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--help");
+            stderr.Should().BeNullOrEmpty();
+
+            stdout.Should().Be(
+                @"Usage: Tentacle version [<options>]
+
+Where [<options>] is any of: 
+
+      --format=VALUE         The format of the output (text,json). Defaults 
+                               to text.
+
+Or one of the common options: 
+
+      --help                 Show detailed help for this command
+");
+        }
+
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task GeneralHelpAsJsonCanBeParsedByAutomationScripts(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, "help --format=json");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "help", "--format=json");
 
             stderr.Should().BeNullOrEmpty();
             var help = JsonConvert.DeserializeAnonymousType(
@@ -176,7 +195,7 @@ namespace Octopus.Tentacle.Tests.Integration
                         {
                             Name = "",
                             Description = "",
-                            Aliases = new string[0]
+                            Aliases = Array.Empty<string>()
                         }
                     }
                 });
@@ -190,15 +209,13 @@ namespace Octopus.Tentacle.Tests.Integration
                     "version",
                     "show-master-key",
                     "show-thumbprint");
-
-            await Task.CompletedTask;
         }
 
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task CommandSpecificHelpAsJsonCanBeParsedByAutomationScripts(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, "version --help --format=json");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--help", "--format=json");
 
             stderr.Should().BeNullOrEmpty();
             var help = JsonConvert.DeserializeAnonymousType(
@@ -207,7 +224,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 {
                     Name = "",
                     Description = "",
-                    Aliases = new string[0],
+                    Aliases = Array.Empty<string>(),
                     Options = new[]
                     {
                         new
@@ -220,26 +237,40 @@ namespace Octopus.Tentacle.Tests.Integration
 
             help.Name.Should().Be("version");
             help.Options.Select(o => o.Name).Should().Contain("format");
-
-            await Task.CompletedTask;
         }
 
-        // [Test]
-        // [TentacleConfigurations(testCommonVersions: true)]
-        // public async Task CommandSpecificHelpAsJsonLooksSensibleToHumans()
-        // {
-        //     RunCommand("version --help --format=json", out var stdout, out var stderr);
-        //     stderr.Should().BeNullOrEmpty();
-        //     assentRunner.AssentUnScrubbedContent(this, stdout);
-        //     await Task.CompletedTask;
-        // }
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        public async Task CommandSpecificHelpAsJsonLooksSensibleToHumans(TentacleConfigurationTestCase tc)
+        {
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--help", "--format=json");
+            stderr.Should().BeNullOrEmpty();
+
+            stdout.Should().Be(
+@"{
+  ""Name"": ""version"",
+  ""Description"": ""Show the Tentacle version information"",
+  ""Aliases"": [],
+  ""Options"": [
+    {
+      ""Name"": ""format"",
+      ""Description"": ""The format of the output (text,json). Defaults to text.""
+    }
+  ],
+  ""CommonOptions"": [
+    {
+      ""Name"": ""help"",
+      ""Description"": ""Show detailed help for this command""
+    }
+  ]
+}");
+        }
 
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task HelpForInstanceSpecificCommandsAlwaysWorks(TentacleConfigurationTestCase tc)
         {
-            // Get all the commands using command-line - talk about dog fooding!
-            var (_, stdout, stderr) = await RunCommand(tc, "help --format=json");
+            var (_, stdout, stderr) = await RunCommand(tc, "help", "--format=json");
 
             stderr.Should().BeNullOrEmpty();
             var help = JsonConvert.DeserializeAnonymousType(
@@ -257,9 +288,11 @@ namespace Octopus.Tentacle.Tests.Integration
                     }
                 });
 
+            help.Commands.Should().HaveCountGreaterThan(0);
+
             var failed = help.Commands.Select(async c =>
                     {
-                        var (exitCode2, stdout2, stderr2) = await RunCommand(tc,$"{c.Name} --help");
+                        var (exitCode2, stdout2, stderr2) = await RunCommand(tc,$"{c.Name}", "--help");
                         return new
                         {
                             Command = c,
@@ -275,81 +308,307 @@ namespace Octopus.Tentacle.Tests.Integration
 
             if (failed.Any())
             {
-                // Log.Error(JsonConvert.SerializeObject(failed));
-                Assert.Fail($"The following commands cannot show help without specifying the --instance argument:{Environment.NewLine}" + $"{string.Join(Environment.NewLine, failed.Select(x => x.Result.Command.Name))}{Environment.NewLine}" + "The details are logged above. These commands probably need to take Lazy<T> dependencies so they can be instantiated for showing help without requiring every dependency to be resolvable.");
-            }
+                var failureDetails = string.Empty;
 
-            await Task.CompletedTask;
+                foreach (var failure in failed)
+                {
+                    failureDetails += $@"{failure.Result.Command.Name}
+StdErr:{failure.Result.StdErr}
+StdOut:{failure.Result.StdOut}";
+                }
+
+                Assert.Fail(
+$@"The following commands cannot show help without specifying the --instance argument:
+{failureDetails}
+The details are logged above. These commands probably need to take Lazy<T> dependencies so they can be instantiated for showing help without requiring every dependency to be resolvable.");
+            }
         }
         
         [Test]
-        [TentacleConfigurations(testCommonVersions: true)]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task InvalidInstance(TentacleConfigurationTestCase tc)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tc, "show-thumbprint --instance=invalidinstance");
+            var (exitCode, stdout, stderr) = await RunCommand(tc, "show-thumbprint", "--instance=invalidinstance");
             
             exitCode.Should().Be(1, $"the exit code should be 1 if the instance is not able to be resolved");
             stderr.Should().ContainEquivalentOf("Instance invalidinstance of tentacle has not been configured", "the error message should make it clear the instance has not been configured");
             stderr.Should().ContainEquivalentOf("Available instances:", "should provide a hint as to which instances are available on the machine");
             stdout.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
         }
 
-        // [Test]
-        // [TentacleConfigurations(testCommonVersions: true)]
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task ShowThumbprintCommandText(TentacleConfigurationTestCase tc)
         {
-            string instanceName = $"test-instance-for-{nameof(ShowThumbprintCommandText)}";
-            await using var clientAndTentacle = await tc.CreateBuilder().WithInstanceName(instanceName).Build(CancellationToken);
-            var (exitCode, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, $"show-thumbprint --instance={instanceName}");
+            await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
+            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-thumbprint", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
 
             exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
             stdout.Should().Be(Support.Certificates.TentaclePublicThumbprint, "the thumbprint should be written directly to stdout");
             stderr.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
         }
 
-        // [Test]
-        // [TentacleConfigurations(testCommonVersions: true)]
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task ShowThumbprintCommandJson(TentacleConfigurationTestCase tc)
         {
-            string instanceName = $"test-instance-for-{nameof(ShowThumbprintCommandJson)}";
-            await using var clientAndTentacle = await tc.CreateBuilder().WithInstanceName(instanceName).Build(CancellationToken);
-            var (exitCode, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, $"show-thumbprint --instance={instanceName} --format=json");
+            await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
+            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-thumbprint", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}", "--format=json");
             
             exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
-            stdout.Should().Be(JsonConvert.SerializeObject(new { Support.Certificates.TentaclePublicThumbprint }), "the thumbprint should be written directly to stdout as JSON");
+            stdout.Should().Be(JsonConvert.SerializeObject(new { Thumbprint = Support.Certificates.TentaclePublicThumbprint }), "the thumbprint should be written directly to stdout as JSON");
             stderr.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
         }
 
-        // [Test]
-        // [TentacleConfigurations(testCommonVersions: true)]
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task ListInstancesCommandText(TentacleConfigurationTestCase tc)
         {
-            string instanceName = $"test-instance-for-{nameof(ListInstancesCommandText)}";
-            await using var clientAndTentacle = await tc.CreateBuilder().WithInstanceName(instanceName).Build(CancellationToken);
-            var (exitCode, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, $"list-instances --format=text");
+            await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
+            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "list-instances", "--format=text");
             
             exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
-            stdout.Should().ContainEquivalentOf($"Instance '{instanceName}' uses configuration '{clientAndTentacle.RunningTentacle.HomeDirectory}'.", "the current instance should be listed");
+            var configPath = Path.Combine(clientAndTentacle.RunningTentacle.HomeDirectory, clientAndTentacle.RunningTentacle.InstanceName + ".cfg");
+            stdout.Should().Contain($"Instance '{clientAndTentacle.RunningTentacle.InstanceName}' uses configuration '{configPath}'.", "the current instance should be listed");
             stderr.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        public async Task ListInstancesCommandJson(TentacleConfigurationTestCase tc)
+        {
+            await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "list-instances", "--format=json");
+            
+            stdout.Should().Contain($"\"InstanceName\": \"{clientAndTentacle.RunningTentacle.InstanceName}\"", "the current instance should be listed");
+            var configPath = Path.Combine(clientAndTentacle.RunningTentacle.HomeDirectory, clientAndTentacle.RunningTentacle.InstanceName + ".cfg");
+            var jsonFormattedPath = JsonFormattedPath(configPath);
+            stdout.Should().Contain($"\"ConfigurationFilePath\": \"{jsonFormattedPath}\"", "the path to the config file for the current instance should be listed");
+            stderr.Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        public async Task ShouldLogStartupDiagnosticsToInstanceLogFileOnly(TentacleConfigurationTestCase tc)
+        {
+            await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
+            var startingLogText = clientAndTentacle.RunningTentacle.ReadAllLogFileText();
+
+            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-thumbprint", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
+
+            try
+            {
+                var logFileText = Policy
+                    .Handle<NotLoggedYetException>()
+                    .WaitAndRetry(
+                        20,
+                        i => TimeSpan.FromMilliseconds(100 * i),
+                        (exception, _) => { Logger.Information($"Failed to get new log content: {exception.Message}. Retrying!"); })
+                    .Execute(
+                        () =>
+                        {
+                            var wholeLog = clientAndTentacle.RunningTentacle.ReadAllLogFileText();
+                            var newLog = wholeLog.Replace(startingLogText, string.Empty);
+                            if (string.IsNullOrWhiteSpace(newLog) || !newLog.Contains("CommandLine:"))
+                            {
+                                throw new NotLoggedYetException();
+                            }
+
+                            return newLog;
+                        });
+
+                logFileText.Should().ContainEquivalentOf($"OperatingSystem: {RuntimeInformation.OSDescription}", "the OSVersion should be in our diagnostics");
+                logFileText.Should().ContainEquivalentOf("OperatingSystem:", "the OSVersion should be in our diagnostics");
+                logFileText.Should().ContainEquivalentOf($"OsBitVersion: {(Environment.Is64BitOperatingSystem ? "x64" : "x86")}", "the OsBitVersion should be in our diagnostics");
+                logFileText.Should().ContainEquivalentOf($"Is64BitProcess: {Environment.Is64BitProcess}", "the Is64BitProcess should be in our diagnostics");
+
+                if (PlatformDetection.IsRunningOnWindows)
+                {
+#pragma warning disable CA1416
+                    logFileText.Should().ContainEquivalentOf($"CurrentUser: {WindowsIdentity.GetCurrent().Name}", "the CurrentUser should be in our diagnostics");
+#pragma warning disable CA1416
+                }
+                else
+                {
+                    logFileText.Should().ContainEquivalentOf($"CurrentUser: {Environment.UserName}", "the CurrentUser should be in our diagnostics");
+                }
+                
+                logFileText.Should().ContainEquivalentOf($"MachineName: {Environment.MachineName}", "the MachineName should be in our diagnostics");
+                logFileText.Should().ContainEquivalentOf($"ProcessorCount: {Environment.ProcessorCount}", "the ProcessorCount should be in our diagnostics");
+                logFileText.Should().ContainEquivalentOf($"CurrentDirectory: {Directory.GetCurrentDirectory()}", "the CurrentDirectory should be in our diagnostics");
+                logFileText.Should().ContainEquivalentOf($"TempDirectory: {Path.GetTempPath()}", "the TempDirectory should be in our diagnostics");
+                logFileText.Should().ContainEquivalentOf("HostProcessName: ", "the HostProcessName should be in our diagnostics");
+                stdout.Should().NotContainEquivalentOf($"{RuntimeInformation.OSDescription}", "the OSVersion should not be written to stdout");
+                await Task.CompletedTask;
+            }
+            catch (NotLoggedYetException)
+            {
+                Logger.Error("Failed to get new log content");
+                Logger.Error($"Process exit code {exitCode}");
+                Logger.Error($"Starting log text: {Environment.NewLine}{startingLogText}");
+                Logger.Error($"Current log text: {Environment.NewLine}{clientAndTentacle.RunningTentacle.ReadAllLogFileText()}");
+                Logger.Error($"Command StdOut: {Environment.NewLine}{stdout}");
+                Logger.Error($"Command StdErr: {Environment.NewLine}{stderr}");
+
+                throw;
+            }
+        }
+
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        public async Task HelpAsFirstArgumentShouldShowCommandSpecificHelp(TentacleConfigurationTestCase tc)
+        {
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "help", "version");
+            stderr.Should().BeNullOrEmpty();
+
+            stdout.Should().Be(
+@"Usage: Tentacle version [<options>]
+
+Where [<options>] is any of: 
+
+      --format=VALUE         The format of the output (text,json). Defaults 
+                               to text.
+
+Or one of the common options: 
+
+      --help                 Show detailed help for this command
+");
+        }
+
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        public async Task ShowConfigurationCommand(TentacleConfigurationTestCase tc)
+        {
+            await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-configuration", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
+            stderr.Should().BeNullOrEmpty();
+
+            // Actually parse and query the document just like our consumer will
+            dynamic? settings = JsonConvert.DeserializeObject(stdout);
+
+            ((string)settings.Octopus.Home).Should().Be(clientAndTentacle.RunningTentacle.HomeDirectory, "the home directory should match");
+            ((string)settings.Tentacle.Deployment.ApplicationDirectory).Should().Be(clientAndTentacle.RunningTentacle.ApplicationDirectory, "the application directory should match");
+        }
+
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        public async Task ShowConfigurationCommandOnPartiallyConfiguredTentacle(TentacleConfigurationTestCase tc)
+        {
+            var instanceId = Guid.NewGuid().ToString();
+            using var temporaryDirectory = new TemporaryDirectory();
+            await RunCommandAndAssertExitsWithSuccessExitCode(tc, "create-instance", $"--instance={instanceId}", "--config", Path.Combine(temporaryDirectory.DirectoryPath, instanceId + ".cfg"));
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-configuration", $"--instance={instanceId}");
+            stderr.Should().BeNullOrEmpty();
+
+            // Actually parse and query the document just like our consumer will
+            dynamic? settings = JsonConvert.DeserializeObject(stdout);
+            ((string)settings.Octopus.Home).Should().Be(temporaryDirectory.DirectoryPath, "the home directory should match");
+        }
+
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        [NonParallelizable]
+        public async Task ShowConfigurationCommandLooksSensibleToHumans(TentacleConfigurationTestCase tc)
+        {
+            await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-configuration", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
+            stderr.Should().BeNullOrEmpty();
+
+            if (tc.TentacleType == TentacleType.Polling)
+            {
+                stdout.Should().Be($@"{{
+  ""Octopus"": {{
+    ""Home"": ""{JsonFormattedPath(clientAndTentacle.RunningTentacle.HomeDirectory)}"",
+    ""Watchdog"": {{
+      ""Enabled"": false,
+      ""Instances"": ""*"",
+      ""Interval"": 0
+    }}
+  }},
+  ""Tentacle"": {{
+    ""CertificateThumbprint"": ""{clientAndTentacle.RunningTentacle.Thumbprint}"",
+    ""Communication"": {{
+      ""TrustedOctopusServers"": [
+        {{
+          ""Thumbprint"": ""{clientAndTentacle.Server.Thumbprint}"",
+          ""CommunicationStyle"": 2,
+          ""KubernetesTentacleCommunicationMode"": {{
+            ""Value"": ""Polling""
+          }},
+          ""Address"": ""https://localhost:{clientAndTentacle.Server.ServerListeningPort}"",
+          ""Squid"": null,
+          ""SubscriptionId"": ""{clientAndTentacle.RunningTentacle.ServiceUri}""
+        }}
+      ]
+    }},
+    ""Deployment"": {{
+      ""ApplicationDirectory"": ""{JsonFormattedPath(clientAndTentacle.RunningTentacle.ApplicationDirectory)}""
+    }},
+    ""Services"": {{
+      ""ListenIP"": null,
+      ""NoListen"": true,
+      ""PortNumber"": 10933
+    }}
+  }}
+}}
+");
+            }
+            else
+            {
+                stdout.Should().Be($@"{{
+  ""Octopus"": {{
+    ""Home"": ""{JsonFormattedPath(clientAndTentacle.RunningTentacle.HomeDirectory)}"",
+    ""Watchdog"": {{
+      ""Enabled"": false,
+      ""Instances"": ""*"",
+      ""Interval"": 0
+    }}
+  }},
+  ""Tentacle"": {{
+    ""CertificateThumbprint"": ""{clientAndTentacle.RunningTentacle.Thumbprint}"",
+    ""Communication"": {{
+      ""TrustedOctopusServers"": [
+        {{
+          ""Thumbprint"": ""{clientAndTentacle.Server.Thumbprint}"",
+          ""CommunicationStyle"": 1,
+          ""KubernetesTentacleCommunicationMode"": {{
+            ""Value"": ""Polling""
+          }},
+          ""Address"": null,
+          ""Squid"": null,
+          ""SubscriptionId"": null
+        }}
+      ]
+    }},
+    ""Deployment"": {{
+      ""ApplicationDirectory"": ""{JsonFormattedPath(clientAndTentacle.RunningTentacle.ApplicationDirectory)}""
+    }},
+    ""Services"": {{
+      ""ListenIP"": null,
+      ""NoListen"": false,
+      ""PortNumber"": {clientAndTentacle.RunningTentacle.ServiceUri.Port}
+    }}
+  }}
+}}
+");
+            }
+
             await Task.CompletedTask;
         }
 
-        // [Test]
-        // [TentacleConfigurations(testCommonVersions: true)]
-        public async Task ListInstancesCommandJson(TentacleConfigurationTestCase tc)
+        [Test]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
+        [WindowsTest]
+        [NonParallelizable]
+        public async Task WatchdogCreateAndDeleteCommand(TentacleConfigurationTestCase tc)
         {
-            string instanceName = $"test-instance-for-{nameof(ListInstancesCommandJson)}";
-            await using var clientAndTentacle = await tc.CreateBuilder().WithInstanceName(instanceName).Build(CancellationToken);
-            var (exitCode, stdout, stderr) = await RunCommandWithValidExitCodeAssert(tc, $"list-instances --format=json");
-            
-            stdout.Should().Contain($"\"InstanceName\": \"{instanceName}\"", "the current instance should be listed");
-            var jsonFormattedPath = clientAndTentacle.RunningTentacle.HomeDirectory.Replace(@"\", @"\\");
-            stdout.Should().Contain($"\"ConfigurationFilePath\": \"{jsonFormattedPath}\"", "the path to the config file for the current instance should be listed");
-            stderr.Should().BeNullOrEmpty();
-            await Task.CompletedTask;
+            await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
+            var create = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "watchdog", "--create", $"--instances={clientAndTentacle.RunningTentacle.InstanceName}");
+            create.StdError.Should().BeNullOrEmpty();
+            create.StdOut.Should().ContainEquivalentOf("Creating watchdog task");
+            var delete = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "watchdog", "--delete", $"--instances={clientAndTentacle.RunningTentacle.InstanceName}");
+            delete.StdError.Should().BeNullOrEmpty();
+            delete.StdOut.Should().ContainEquivalentOf("Removing watchdog task");
         }
         
         FileVersionInfo GetVersionInfo(TentacleConfigurationTestCase tentacleConfigurationTestCase)
@@ -365,29 +624,37 @@ namespace Octopus.Tentacle.Tests.Integration
             return FileVersionInfo.GetVersionInfo($"{tentacleExe}.dll");
         }
 
-        async Task<(int, string, string)> RunCommandWithValidExitCodeAssert(TentacleConfigurationTestCase tentacleConfigurationTestCase, string input)
+        async Task<(int ExitCode, string StdOut, string StdError)> RunCommandAndAssertExitsWithSuccessExitCode(TentacleConfigurationTestCase tentacleConfigurationTestCase, params string[] arguments)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tentacleConfigurationTestCase, input);
+            var (exitCode, stdout, stderr) = await RunCommand(tentacleConfigurationTestCase, arguments);
             exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
             return (exitCode, stdout, stderr);
         }
 
-        async Task<(int, string, string)> RunCommand(TentacleConfigurationTestCase tentacleConfigurationTestCase, string input)
+        async Task<(int ExitCode, string StdOut, string StdError)> RunCommand(TentacleConfigurationTestCase tentacleConfigurationTestCase, params string[] arguments)
         {
             var tentacleExe = TentacleExeFinder.FindTentacleExe(tentacleConfigurationTestCase.TentacleRuntime);
-            var args = input;
             var output = new StringBuilder();
             var errorOut = new StringBuilder();
             
             var result = await RetryHelper.RetryAsync<CommandResult, CommandExecutionException>(
                 () => Cli.Wrap(tentacleExe)
-                    .WithArguments(args)
+                    .WithArguments(arguments)
                     .WithValidation(CommandResultValidation.None)
                     .WithStandardOutputPipe(PipeTarget.ToStringBuilder(output))
                     .WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOut))
                     .ExecuteAsync(CancellationToken));
 
             return (result.ExitCode, output.ToString(), errorOut.ToString());
+        }
+
+        static string JsonFormattedPath(string path)
+        {
+            return path.Replace(@"\", @"\\");
+        }
+
+        public class NotLoggedYetException : Exception
+        {
         }
     }
 }


### PR DESCRIPTION
# Background

[Server E2E Tests contain](https://github.com/OctopusDeploy/OctopusDeploy/blob/b05682cda766c915af18eac21f6c3a9b35468756/source/Octopus.E2ETests.API/Scripts/CommandLineInterface/TentacleCommandLineInterfaceTestScript.cs#L31) a set of tests that ensure the Tentacle command line works as expected. As these tests are in the Server build chain, it was possible to break the Tentacle command line and only discover this sometime later when that version of Tentacle is updated in Server.

This PR moves those tests to the OctousTentacle repo so regressions cannot be introduced into the Tetnacle solution.

https://github.com/OctopusDeploy/OctopusDeploy/pull/21424 will remove the tests from the Server E2E tests

[sc-61799]

# Results

The following tests have been copied from `Octopus.E2ETests.API.Scripts.CommandLineInterface.TentacleCommandLineInterfaceTestScript ` and updated to run in the Tentacle solution:

- TentacleExeNoArguments
- UnknownCommand
- UnknownArgument
- InvalidArgument
- NoConsoleLoggingSwitchStillSilentlySupportedForBackwardsCompat
- NoLogoSwitchStillSilentlySupportedForBackwardsCompat
- ConsoleSwitchStillSilentlySupportedForBackwardsCompat
- ShouldLogStartupDiagnosticsToInstanceLogFileOnly
- ShouldSupportFuzzyCommandParsing
- VersionCommandTextFormat
- VersionCommandJsonFormat
- CanGetHelpForHelp
- HelpAsFirstArgumentShouldShowCommandSpecificHelp
- HelpAsSwitchShouldShowCommandSpecificHelp
- GeneralHelpAsJsonCanBeParsedByAutomationScripts
- CommandSpecificHelpAsJsonCanBeParsedByAutomationScripts
- CommandSpecificHelpAsJsonLooksSensibleToHumans
- HelpForInstanceSpecificCommandsAlwaysWorks
- InvalidInstance
- ShowThumbprintCommandText
- ShowThumbprintCommandJson
- ListInstancesCommandText
- ListInstancesCommandJson
- ShowConfigurationCommand
- ShowConfigurationCommandLooksSensibleToHumans
 - ShowConfigurationCommandOnPartiallyConfiguredTentacle
- WatchdogCreateCommand
- WatchdogDeleteCommand

The following tests cannot be ported easily as they require a running Octopus Server instance.

- ShowConfigurationCommandWithCredentials

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.