### PR TITLE
Test against known latest script service on Tentacle

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
@@ -23,7 +23,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
-                    .TraceService(tentacleConfigurationTestCase.LatestScriptServiceTypes, out var tracingStats)
+                    .TraceService(tentacleConfigurationTestCase.LatestScriptServiceType, out var tracingStats)
                     .Build())
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
@@ -23,7 +23,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
-                    .TraceService(tentacleConfigurationTestCase.LatestScriptServiceType, out var tracingStats)
+                    .RecordMethodUsage(tentacleConfigurationTestCase.LatestScriptServiceType, out var tracingStats)
                     .Build())
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
@@ -22,8 +23,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
-                    .CountCallsToScriptServiceV2(out var scriptServiceV2CallCounts)
-                    .CountCallsToScriptService(out var scriptServiceCallCounts)
+                    .TraceService(tentacleConfigurationTestCase.LatestScriptServiceTypes, out var tracingStats)
                     .Build())
                 .Build(CancellationToken);
 
@@ -56,7 +56,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var secondScriptExecution = Task.Run(async () => await tentacleClient.ExecuteScript(secondStartScriptCommand, CancellationToken));
 
             // Wait for the second script start script RPC call to return.
-            await Wait.For(() => (scriptServiceV2CallCounts.StartScriptCallCountComplete + scriptServiceCallCounts.StartScriptCallCountComplete) == 2, CancellationToken);
+            await Wait.For(() => tracingStats.For(nameof(IAsyncClientScriptServiceV2.StartScriptAsync)).Completed == 2, CancellationToken);
 
             // Give Tentacle some more time to run the script (although it should not).
             await Task.Delay(TimeSpan.FromSeconds(2));

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
@@ -21,7 +21,7 @@ namespace Octopus.Tentacle.Tests.Integration
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
                 .WithScriptObserverBackoffStrategy(new FuncScriptObserverBackoffStrategy(iters => TimeSpan.FromSeconds(20)))
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
-                    .TraceService(tentacleConfigurationTestCase.LatestScriptServiceType, out var tracingStats)
+                    .RecordMethodUsage(tentacleConfigurationTestCase.LatestScriptServiceType, out var tracingStats)
                     .Build())
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
@@ -21,7 +21,7 @@ namespace Octopus.Tentacle.Tests.Integration
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
                 .WithScriptObserverBackoffStrategy(new FuncScriptObserverBackoffStrategy(iters => TimeSpan.FromSeconds(20)))
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
-                    .TraceService(tentacleConfigurationTestCase.LatestScriptServiceTypes, out var tracingStats)
+                    .TraceService(tentacleConfigurationTestCase.LatestScriptServiceType, out var tracingStats)
                     .Build())
                 .Build(CancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
@@ -12,18 +12,18 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         /// <summary>
         /// An array of <see cref="Type">Types</see> of the latest script service available on the tentacle version
         /// </summary>
-        public Type[] LatestScriptServiceTypes { get; }
+        public Type LatestScriptServiceType { get; }
 
         public TentacleConfigurationTestCase(
             TentacleType tentacleType,
             TentacleRuntime tentacleRuntime,
             Version? version,
-            Type[] latestScriptServiceTypes)
+            Type latestScriptServiceType)
         {
             TentacleType = tentacleType;
             TentacleRuntime = tentacleRuntime;
             Version = version;
-            LatestScriptServiceTypes = latestScriptServiceTypes;
+            LatestScriptServiceType = latestScriptServiceType;
         }
 
         internal ClientAndTentacleBuilder CreateBuilder()

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
@@ -9,17 +9,23 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public TentacleType TentacleType { get; }
         public TentacleRuntime TentacleRuntime { get; }
         public Version? Version { get; }
+        /// <summary>
+        /// An array of <see cref="Type">Types</see> of the latest script service available on the tentacle version
+        /// </summary>
+        public Type[] LatestScriptServiceTypes { get; }
 
         public TentacleConfigurationTestCase(
             TentacleType tentacleType,
             TentacleRuntime tentacleRuntime,
-            Version? version)
+            Version? version,
+            Type[] latestScriptServiceTypes)
         {
             TentacleType = tentacleType;
             TentacleRuntime = tentacleRuntime;
             Version = version;
+            LatestScriptServiceTypes = latestScriptServiceTypes;
         }
-        
+
         internal ClientAndTentacleBuilder CreateBuilder()
         {
             return new ClientAndTentacleBuilder(TentacleType)
@@ -37,7 +43,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public override string ToString()
         {
             StringBuilder builder = new();
-            
+
             builder.Append($"{TentacleType},");
             string version = Version?.ToString() ?? "Latest";
             builder.Append($"{version}");

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationTestCase.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public TentacleRuntime TentacleRuntime { get; }
         public Version? Version { get; }
         /// <summary>
-        /// An array of <see cref="Type">Types</see> of the latest script service available on the tentacle version
+        /// The <see cref="Type"/> of the latest script service available on the tentacle version
         /// </summary>
         public Type LatestScriptServiceType { get; }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -2,6 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Octopus.Tentacle.Client.ClientServices;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
@@ -18,13 +20,28 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             : base(
                 typeof(TentacleConfigurationTestCases),
                 nameof(TentacleConfigurationTestCases.GetEnumerator),
-                new object[] {testCommonVersions, testCapabilitiesServiceVersions, testNoCapabilitiesServiceVersions, testScriptIsolationLevelVersions, testDefaultTentacleRuntimeOnly, additionalParameterTypes})
+                new object[] { testCommonVersions, testCapabilitiesServiceVersions, testNoCapabilitiesServiceVersions, testScriptIsolationLevelVersions, testDefaultTentacleRuntimeOnly, additionalParameterTypes })
         {
         }
     }
 
     static class TentacleConfigurationTestCases
     {
+        static readonly Type[] ScriptServiceV2Types = { typeof(IClientScriptServiceV2), typeof(IAsyncClientScriptServiceV2) };
+        static readonly Type[] ScriptServiceV1Types = { typeof(IClientScriptService), typeof(IAsyncClientScriptService) };
+
+        static readonly Type[] CurrentScriptServiceTypes = ScriptServiceV2Types;
+
+        static readonly Dictionary<Version?, Type[]> ScriptServiceVersionTypesMap = new()
+        {
+            [TentacleVersions.v5_0_4_FirstLinuxRelease] = ScriptServiceV1Types,
+            [TentacleVersions.v5_0_12_AutofacServiceFactoryIsInShared] = ScriptServiceV1Types,
+            [TentacleVersions.v5_0_15_LastOfVersion5] = ScriptServiceV1Types,
+            [TentacleVersions.v6_3_417_LastWithScriptServiceV1Only] = ScriptServiceV1Types,
+            [TentacleVersions.v6_3_451_NoCapabilitiesService] = ScriptServiceV1Types,
+            [TentacleVersions.v7_0_1_ScriptServiceV2Added] = ScriptServiceV2Types
+        };
+
         public static IEnumerator GetEnumerator(
             bool testCommonVersions,
             bool testCapabilitiesVersions,
@@ -33,7 +50,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             bool testDefaultTentacleRuntimeOnly,
             object[] additionalParameterTypes)
         {
-            var tentacleTypes = new[] {TentacleType.Listening, TentacleType.Polling};
+            var tentacleTypes = new[] { TentacleType.Listening, TentacleType.Polling };
             List<Version?> versions = new();
 
             if (testCommonVersions)
@@ -71,7 +88,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
             if (testNoCapabilitiesServiceVersions)
             {
-                versions.AddRange(new []
+                versions.AddRange(new[]
                 {
                     TentacleVersions.v6_3_451_NoCapabilitiesService
                 });
@@ -86,7 +103,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 #if !NETFRAMEWORK
             if (!testDefaultTentacleRuntimeOnly && PlatformDetection.IsRunningOnWindows)
             {
-                runtimes = new List<TentacleRuntime> {TentacleRuntime.DotNet6, TentacleRuntime.Framework48};
+                runtimes = new List<TentacleRuntime> { TentacleRuntime.DotNet6, TentacleRuntime.Framework48 };
             }
 #endif
 
@@ -97,7 +114,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 select new TentacleConfigurationTestCase(
                     tentacleType,
                     runtime,
-                    version);
+                    version,
+                    //null == current version and you can't have a null dictionary key
+                    version != null ?
+                        ScriptServiceVersionTypesMap[version]
+                        : CurrentScriptServiceTypes);
 
             if (additionalParameterTypes.Length == 0)
             {
@@ -133,7 +154,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 {
                     throw new ArgumentException($"Enumerable type does not contain any values: '{additionalEnum}'");
                 }
-                
+
                 enums.And(values);
             }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Octopus.Tentacle.Client.ClientServices;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Util;
 
@@ -27,19 +26,19 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
     static class TentacleConfigurationTestCases
     {
-        static readonly Type[] ScriptServiceV2Types = { typeof(IClientScriptServiceV2), typeof(IAsyncClientScriptServiceV2) };
-        static readonly Type[] ScriptServiceV1Types = { typeof(IClientScriptService), typeof(IAsyncClientScriptService) };
+        static readonly Type ScriptServiceV2Type =  typeof(IAsyncClientScriptServiceV2);
+        static readonly Type ScriptServiceV1Type =  typeof(IAsyncClientScriptService);
 
-        static readonly Type[] CurrentScriptServiceTypes = ScriptServiceV2Types;
+        static readonly Type CurrentScriptServiceTypes = ScriptServiceV2Type;
 
-        static readonly Dictionary<Version, Type[]> ScriptServiceVersionTypesMap = new()
+        static readonly Dictionary<Version, Type> ScriptServiceVersionTypesMap = new()
         {
-            [TentacleVersions.v5_0_4_FirstLinuxRelease] = ScriptServiceV1Types,
-            [TentacleVersions.v5_0_12_AutofacServiceFactoryIsInShared] = ScriptServiceV1Types,
-            [TentacleVersions.v5_0_15_LastOfVersion5] = ScriptServiceV1Types,
-            [TentacleVersions.v6_3_417_LastWithScriptServiceV1Only] = ScriptServiceV1Types,
-            [TentacleVersions.v6_3_451_NoCapabilitiesService] = ScriptServiceV1Types,
-            [TentacleVersions.v7_0_1_ScriptServiceV2Added] = ScriptServiceV2Types
+            [TentacleVersions.v5_0_4_FirstLinuxRelease] = ScriptServiceV1Type,
+            [TentacleVersions.v5_0_12_AutofacServiceFactoryIsInShared] = ScriptServiceV1Type,
+            [TentacleVersions.v5_0_15_LastOfVersion5] = ScriptServiceV1Type,
+            [TentacleVersions.v6_3_417_LastWithScriptServiceV1Only] = ScriptServiceV1Type,
+            [TentacleVersions.v6_3_451_NoCapabilitiesService] = ScriptServiceV1Type,
+            [TentacleVersions.v7_0_1_ScriptServiceV2Added] = ScriptServiceV2Type
         };
 
         public static IEnumerator GetEnumerator(

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -32,7 +32,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         static readonly Type[] CurrentScriptServiceTypes = ScriptServiceV2Types;
 
-        static readonly Dictionary<Version?, Type[]> ScriptServiceVersionTypesMap = new()
+        static readonly Dictionary<Version, Type[]> ScriptServiceVersionTypesMap = new()
         {
             [TentacleVersions.v5_0_4_FirstLinuxRelease] = ScriptServiceV1Types,
             [TentacleVersions.v5_0_12_AutofacServiceFactoryIsInShared] = ScriptServiceV1Types,

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/Proxies/MethodUsageProxyDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/Proxies/MethodUsageProxyDecorator.cs
@@ -23,6 +23,20 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.Proxies
             return proxiedService;
         }
 
+
+        public static object Create(Type scriptServiceType, object targetService, IRecordedMethodUsages usages)
+        {
+            var genericCreateMethod = typeof(DispatchProxyAsync).GetMethod(nameof(DispatchProxyAsync.Create), BindingFlags.Public | BindingFlags.Static);
+            var concreteMethodInfo = genericCreateMethod!.MakeGenericMethod(scriptServiceType, typeof(MethodUsageProxyDecorator));
+
+            var proxiedService = concreteMethodInfo.Invoke(null, null);
+            var proxy = (proxiedService as MethodUsageProxyDecorator)!;
+            proxy!.SetTargetService(targetService);
+            proxy!.Configure((MethodUsages)usages);
+
+            return proxiedService!;
+        }
+
         protected override void OnStartingInvocation(MethodInfo targetMethod)
         {
             usages.RecordCallStart(targetMethod);

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilderExtensions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilderExtensions.cs
@@ -13,17 +13,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             return builder.RegisterProxyDecorator<TService>(service => MethodUsageProxyDecorator.Create(service, localTracingStats));
         }
 
-        public static TentacleServiceDecoratorBuilder TraceService(this TentacleServiceDecoratorBuilder builder, IEnumerable<Type> latestScriptServiceTypes, out IRecordedMethodTracingStats recordedTracingStats)
+        public static TentacleServiceDecoratorBuilder TraceService(this TentacleServiceDecoratorBuilder builder, Type latestScriptServiceType, out IRecordedMethodTracingStats recordedTracingStats)
         {
             var localTracingStats = new MethodTracingStats();
             recordedTracingStats = localTracingStats;
 
-            foreach (var scriptServiceType in latestScriptServiceTypes)
-            {
-                builder.RegisterProxyDecorator(scriptServiceType, service => MethodTracingProxyDecorator.Create(scriptServiceType, service, localTracingStats));
-            }
-
-            return builder;
+            return builder.RegisterProxyDecorator(latestScriptServiceType, service => MethodTracingProxyDecorator.Create(latestScriptServiceType, service, localTracingStats));
         }
 
         public static TentacleServiceDecoratorBuilder HookServiceMethod<TService>(this TentacleServiceDecoratorBuilder builder, string methodName, MethodInvocationHook<TService>? preInvocation) where TService : class

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilderExtensions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             return builder.RegisterProxyDecorator<TService>(service => MethodUsageProxyDecorator.Create(service, localTracingStats));
         }
 
-        public static TentacleServiceDecoratorBuilder TraceService(this TentacleServiceDecoratorBuilder builder, Type latestScriptServiceType, out IRecordedMethodUsages recordMethodUsages)
+        public static TentacleServiceDecoratorBuilder RecordMethodUsage(this TentacleServiceDecoratorBuilder builder, Type latestScriptServiceType, out IRecordedMethodUsages recordMethodUsages)
         {
             var localTracingStats = new MethodUsages();
             recordMethodUsages = localTracingStats;

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilderExtensions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.Proxies;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.Proxies;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
@@ -11,6 +11,19 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             recordedUsages = localTracingStats;
 
             return builder.RegisterProxyDecorator<TService>(service => MethodUsageProxyDecorator.Create(service, localTracingStats));
+        }
+
+        public static TentacleServiceDecoratorBuilder TraceService(this TentacleServiceDecoratorBuilder builder, IEnumerable<Type> latestScriptServiceTypes, out IRecordedMethodTracingStats recordedTracingStats)
+        {
+            var localTracingStats = new MethodTracingStats();
+            recordedTracingStats = localTracingStats;
+
+            foreach (var scriptServiceType in latestScriptServiceTypes)
+            {
+                builder.RegisterProxyDecorator(scriptServiceType, service => MethodTracingProxyDecorator.Create(scriptServiceType, service, localTracingStats));
+            }
+
+            return builder;
         }
 
         public static TentacleServiceDecoratorBuilder HookServiceMethod<TService>(this TentacleServiceDecoratorBuilder builder, string methodName, MethodInvocationHook<TService>? preInvocation) where TService : class

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilderExtensions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.Proxies;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
@@ -13,12 +14,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             return builder.RegisterProxyDecorator<TService>(service => MethodUsageProxyDecorator.Create(service, localTracingStats));
         }
 
-        public static TentacleServiceDecoratorBuilder TraceService(this TentacleServiceDecoratorBuilder builder, Type latestScriptServiceType, out IRecordedMethodTracingStats recordedTracingStats)
+        public static TentacleServiceDecoratorBuilder TraceService(this TentacleServiceDecoratorBuilder builder, Type latestScriptServiceType, out IRecordedMethodUsages recordMethodUsages)
         {
-            var localTracingStats = new MethodTracingStats();
-            recordedTracingStats = localTracingStats;
+            var localTracingStats = new MethodUsages();
+            recordMethodUsages = localTracingStats;
 
-            return builder.RegisterProxyDecorator(latestScriptServiceType, service => MethodTracingProxyDecorator.Create(latestScriptServiceType, service, localTracingStats));
+            return builder.RegisterProxyDecorator(latestScriptServiceType, service => MethodUsageProxyDecorator.Create(latestScriptServiceType, service, localTracingStats));
         }
 
         public static TentacleServiceDecoratorBuilder HookServiceMethod<TService>(this TentacleServiceDecoratorBuilder builder, string methodName, MethodInvocationHook<TService>? preInvocation) where TService : class


### PR DESCRIPTION
# Background

As we test more versions of TentacleClient against older versions of Tentacle, we need to adjust the tests to know which script service is running on the target version of tentacle, so we can correctly test that version.

# Results

Adds a new static mapping of Tentacle Version -> Latest script service type supported on that version of tentacle. This is then included in the `TentacleConfigurationTestCase`.

I added an overload to the `RecordMethodUsages` extension method to create the dynamic proxy given a type (rather than a generic parameter).

I updated 2 tests to use this new logic.

Shortcut story: [sc-62862]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.