### PR TITLE
When a scripts tentacle log is corrupt, return all valid logs up to the corrupted log line.

### DIFF
--- a/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
@@ -75,13 +75,13 @@ namespace Octopus.Tentacle.Tests.Integration
                 appender.WriteOutput(ProcessOutputSource.StdOut, "World");
             }
 
-            using (var fs = File.Open(logFile, FileMode.Open))
+            using (var logFileStream = File.Open(logFile, FileMode.Open))
             {
-                FileInfo fi = new FileInfo(logFile);
-                fs.SetLength(fi.Length - 10);
+                var logFileInfo = new FileInfo(logFile);
+                logFileStream.SetLength(logFileInfo.Length - 10);
             }
             
-            var logs = sut.GetOutput(long.MinValue, out var next);
+            var logs = sut.GetOutput(long.MinValue, out _);
             logs.Count.Should().Be(2);
 
             logs[1].Text.Should().Be("Corrupt Tentacle log at line 2, no more logs will be read");


### PR DESCRIPTION
# Background
[SC-63899]

Fixes a bug where calls to `GetStatus` would fail when a script log line was corrupt e.g. incomplete because tentacle was killed while writing the logs for a running script.

# Results
Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/655

## Before

Previously the call to `GetStatus` would fail and no further logs could be read.

## After

The call to `GetStatus` will succeed, and we will read up to but not including the corrupt log line.

We do report the fact that the log was corrupt.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.