### PR TITLE
Upgrade System.ServiceProcess.ServiceController library

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Startup/WindowsServiceConfiguratorFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/WindowsServiceConfiguratorFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -18,6 +19,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
     [TestFixture]
     [WindowsTest]
     [NonParallelizable]
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     public class WindowsServiceConfiguratorFixture
     {
         [Test]

--- a/source/Octopus.Tentacle/Diagnostics/EventLogTarget.cs
+++ b/source/Octopus.Tentacle/Diagnostics/EventLogTarget.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using NLog;
 using NLog.Common;
@@ -54,6 +55,7 @@ namespace Octopus.Tentacle.Diagnostics
     ///     </p>
     ///     <code lang="C#" source="examples/targets/Configuration API/EventLog/Simple/Example.cs" />
     /// </example>
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     public class EventLogTarget : TargetWithLayout, IInstallable
     {
         EventLog eventLogInstance;

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -89,10 +89,10 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
-		<PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0" />
+		<PackageReference Include="System.ServiceProcess.ServiceController" Version="7.0.1" />
 		<PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
 		<PackageReference Include="NLog" Version="5.0.4" />
-		<PackageReference Include="System.Diagnostics.EventLog" Version="4.5.0" />
+		<PackageReference Include="System.Diagnostics.EventLog" Version="7.0.0" />
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
 		<PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
 		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="5.0.0" />

--- a/source/Octopus.Tentacle/Startup/CheckServicesCommand.cs
+++ b/source/Octopus.Tentacle/Startup/CheckServicesCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.ServiceProcess;
 using System.Threading;
@@ -10,6 +11,7 @@ using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Startup
 {
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     public class CheckServicesCommand : AbstractCommand
     {
         readonly ISystemLog log;

--- a/source/Octopus.Tentacle/Startup/WindowsServiceAdapter.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.ServiceProcess;
 using System.Threading;
 using Octopus.Diagnostics;
@@ -7,6 +8,7 @@ using Octopus.Tentacle.Diagnostics.KnowledgeBase;
 
 namespace Octopus.Tentacle.Startup
 {
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     public class WindowsServiceAdapter : ServiceBase
     {
         readonly Action execute;

--- a/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Management;
@@ -12,6 +13,7 @@ using Polly;
 
 namespace Octopus.Tentacle.Startup
 {
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     public class WindowsServiceConfigurator : IServiceConfigurator
     {
         readonly ISystemLog log;

--- a/source/Octopus.Tentacle/Startup/WindowsServiceHost.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceHost.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.ServiceProcess;
 using Octopus.Diagnostics;
 
 namespace Octopus.Tentacle.Startup
 {
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     public class WindowsServiceHost : ICommandHost, ICommandRuntime
     {
         readonly ISystemLog log;


### PR DESCRIPTION
Upgrade System.ServiceProcess.ServiceController library and required dependencies. 

# Background
There was a [CVE](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112) in the version of the library we were using. 

# Results
Had to decorate some of the Windows-specific code with compiler warning suppressions. Due to targeting .NET Framework in Tentacle, we can't use the slightly cleaner `[SupportedOSPlatform("Windows")]` Attribute instead of the warning suppression.

The changes primarily focus on the `EventLog` code - this is a log sink used only on Windows. We've tested it by building and running Tentacle via the CLI on a Windows machine and can see that it is successfully logging. 

Other than needing to add the platform-specific handling, no other changes were required for the upgrade.

# How to review this PR
There isn't too much to review here - the changes should be a no-op.

Quality :heavy_check_mark:

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.