### PR TITLE
Adding option to enable TCP keep alives in Tentacle

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.115-sast-tcp-keep-alives-post-async-halibut-20231113084413" />
+    <PackageReference Include="Halibut" Version="7.0.142-pull-533" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.142-pull-533" />
+    <PackageReference Include="Halibut" Version="7.0.144" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -29,6 +29,8 @@
   </Choose>
   <ItemGroup>
     <PackageReference Include="Halibut" Version="7.0.113" />
+    <PackageReference Include="Halibut" Version="7.0.66-pull-523" />
+    <PackageReference Include="Halibut" Version="7.0.115-sast-tcp-keep-alives-post-async-halibut-20231113084413" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,8 +28,6 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.113" />
-    <PackageReference Include="Halibut" Version="7.0.66-pull-523" />
     <PackageReference Include="Halibut" Version="7.0.115-sast-tcp-keep-alives-post-async-halibut-20231113084413" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -35,6 +35,7 @@ namespace Octopus.Tentacle.Commands
         int wait;
         bool halibutHasStarted;
         bool workspaceCleanerHasStarted;
+        bool tcpKeepAliveEnabled;
 
         public override bool CanRunAsService => true;
 
@@ -70,6 +71,7 @@ namespace Octopus.Tentacle.Commands
                 // There's actually nothing to do here. The CommandHost should have already been determined before Start() was called
                 // This option is added to show help
             });
+            Options.Add("tcp-keep-alive-enabled", "Whether TCP keep alive is enabled", _ => tcpKeepAliveEnabled = true);
         }
 
         protected override void Start()
@@ -118,6 +120,7 @@ namespace Octopus.Tentacle.Commands
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, proxyConfiguration.Value.CustomProxyPassword);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, proxyConfiguration.Value.CustomProxyHost);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, proxyConfiguration.Value.CustomProxyPort.ToString());
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, tcpKeepAliveEnabled.ToString());
 
             LogWarningIfNotRunningAsAdministrator();
 

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -35,7 +35,6 @@ namespace Octopus.Tentacle.Commands
         int wait;
         bool halibutHasStarted;
         bool workspaceCleanerHasStarted;
-        bool tcpKeepAliveEnabled;
 
         public override bool CanRunAsService => true;
 
@@ -71,7 +70,6 @@ namespace Octopus.Tentacle.Commands
                 // There's actually nothing to do here. The CommandHost should have already been determined before Start() was called
                 // This option is added to show help
             });
-            Options.Add("tcp-keep-alive-enabled", "Whether TCP keep alive is enabled", _ => tcpKeepAliveEnabled = true);
         }
 
         protected override void Start()
@@ -120,7 +118,6 @@ namespace Octopus.Tentacle.Commands
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPassword, proxyConfiguration.Value.CustomProxyPassword);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, proxyConfiguration.Value.CustomProxyHost);
             Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, proxyConfiguration.Value.CustomProxyPort.ToString());
-            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, tcpKeepAliveEnabled.ToString());
 
             LogWarningIfNotRunningAsAdministrator();
 

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using Autofac;
 using Halibut;
+using Halibut.Diagnostics;
 using Halibut.ServiceModel;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Contracts.Legacy;
+using Octopus.Tentacle.Variables;
 
 namespace Octopus.Tentacle.Communications
 {
@@ -22,10 +24,18 @@ namespace Octopus.Tentacle.Communications
             {
                 var configuration = c.Resolve<ITentacleConfiguration>();
                 var services = c.Resolve<IServiceFactory>();
+
+                bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled), out var tcpKeepAliveEnabled);
+                var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits
+                {
+                    TcpKeepAliveEnabled = tcpKeepAliveEnabled
+                };
+
                 var halibutRuntime = new HalibutRuntimeBuilder()
                     .WithServiceFactory(services)
                     .WithServerCertificate(configuration.TentacleCertificate)
                     .WithMessageSerializer(serializerBuilder => serializerBuilder.WithLegacyContractSupport())
+                    .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
                     .Build();
 
                 halibutRuntime.SetFriendlyHtmlPageContent(FriendlyHtmlPageContent);

--- a/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
+++ b/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
@@ -60,8 +60,6 @@ namespace Octopus.Tentacle.Services.FileTransfer
 
         public async Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload, CancellationToken cancellationToken)
         {
-            await Task.CompletedTask;
-
             if (upload == null)
             {
                 log.Trace("Client requested a file upload, but no content stream was provided.");
@@ -76,7 +74,7 @@ namespace Octopus.Tentacle.Services.FileTransfer
             fileSystem.EnsureDiskHasEnoughFreeSpace(parentDirectory, upload.Length);
 
             log.Trace("Copying uploaded data stream to: " + fullPath);
-            upload.Receiver().SaveToAsync(fullPath, CancellationToken.None).Wait();
+            await upload.Receiver().SaveToAsync(fullPath, CancellationToken.None);
             return new UploadResult(fullPath, HashFile(fullPath), fileSystem.GetFileSize(fullPath));
         }
 

--- a/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
+++ b/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
@@ -20,5 +20,6 @@ namespace Octopus.Tentacle.Variables
         public const string TentacleExecutablePath = "TentacleExecutablePath";
         public const string TentacleProgramDirectoryPath = "TentacleProgramDirectoryPath";
         public const string AgentProgramDirectoryPath = "AgentProgramDirectoryPath";
+        public const string TentacleTcpKeepAliveEnabled = "TentacleTcpKeepAliveEnabled";
     }
 }


### PR DESCRIPTION
[sc-45141]

# Background

Updating Tentacle and Tentacle Client to use TCP Keep Alives, as well as adding an option to turn this on for Tentacle.


# How to review this PR


Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.