### PR TITLE
Update TentacleClient to use ScriptServiceV3Alpha if available

### DIFF
--- a/source/Octopus.Tentacle.Client/Capabilities/CapabilitiesResponseV2ExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Client/Capabilities/CapabilitiesResponseV2ExtensionMethods.cs
@@ -2,6 +2,7 @@
 using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 
 namespace Octopus.Tentacle.Client.Capabilities
 {
@@ -15,6 +16,16 @@ namespace Octopus.Tentacle.Client.Capabilities
             }
 
             return capabilities.SupportedCapabilities.Contains(nameof(IScriptServiceV2));
+        }
+
+        public static bool HasScriptServiceV3Alpha(this CapabilitiesResponseV2 capabilities)
+        {
+            if (capabilities?.SupportedCapabilities?.Any() != true)
+            {
+                return false;
+            }
+
+            return capabilities.SupportedCapabilities.Contains(nameof(IScriptServiceV3Alpha));
         }
     }
 }

--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionScriptServiceV3AlphaDecorator.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionScriptServiceV3AlphaDecorator.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+
+namespace Octopus.Tentacle.Client.Decorators
+{
+    class HalibutExceptionScriptServiceV3AlphaDecorator : HalibutExceptionTentacleServiceDecorator, IAsyncClientScriptServiceV3Alpha
+    {
+        readonly IAsyncClientScriptServiceV3Alpha inner;
+
+        public HalibutExceptionScriptServiceV3AlphaDecorator(IAsyncClientScriptServiceV3Alpha inner)
+        {
+            this.inner = inner;
+        }
+
+        public async Task<ScriptStatusResponseV3Alpha> StartScriptAsync(StartScriptCommandV3Alpha command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return await HandleCancellationException(async () => await inner.StartScriptAsync(command, halibutProxyRequestOptions));
+        }
+
+        public async Task<ScriptStatusResponseV3Alpha> GetStatusAsync(ScriptStatusRequestV3Alpha request, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return await HandleCancellationException(async () => await inner.GetStatusAsync(request, halibutProxyRequestOptions));
+        }
+
+        public async Task<ScriptStatusResponseV3Alpha> CancelScriptAsync(CancelScriptCommandV3Alpha command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            return await HandleCancellationException(async () => await inner.CancelScriptAsync(command, halibutProxyRequestOptions));
+        }
+
+        public async Task CompleteScriptAsync(CompleteScriptCommandV3Alpha command, HalibutProxyRequestOptions halibutProxyRequestOptions)
+        {
+            await HandleCancellationException(async () => await inner.CompleteScriptAsync(command, halibutProxyRequestOptions));
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecoratorFactory.cs
+++ b/source/Octopus.Tentacle.Client/Decorators/HalibutExceptionTentacleServiceDecoratorFactory.cs
@@ -27,5 +27,10 @@ namespace Octopus.Tentacle.Client.Decorators
         {
             return new HalibutExceptionAsyncCapabilitiesServiceV2Decorator(service);
         }
+
+        public IAsyncClientScriptServiceV3Alpha Decorate(IAsyncClientScriptServiceV3Alpha service)
+        {
+            return new HalibutExceptionScriptServiceV3AlphaDecorator(service);
+        }
     }
 }

--- a/source/Octopus.Tentacle.Client/ITentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleClient.cs
@@ -6,6 +6,7 @@ using Octopus.Diagnostics;
 using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 
 namespace Octopus.Tentacle.Client
 {
@@ -24,8 +25,7 @@ namespace Octopus.Tentacle.Client
         /// <param name="logger">Used to output user orientated log messages</param>
         /// <param name="scriptExecutionCancellationToken">When cancelled, will attempt to stop the execution of the script on Tentacle before returning.</param>
         /// <returns></returns>
-        Task<ScriptExecutionResult> ExecuteScript(
-            StartScriptCommandV2 startScriptCommand,
+        Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV3Alpha startScriptCommand,
             OnScriptStatusResponseReceived onScriptStatusResponseReceived,
             OnScriptCompleted onScriptCompleted,
             ILog logger,

--- a/source/Octopus.Tentacle.Client/ITentacleServiceDecoratorFactory.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleServiceDecoratorFactory.cs
@@ -11,5 +11,6 @@ namespace Octopus.Tentacle.Client
         public IAsyncClientFileTransferService Decorate(IAsyncClientFileTransferService service);
 
         public IAsyncClientCapabilitiesServiceV2 Decorate(IAsyncClientCapabilitiesServiceV2 service);
+        public IAsyncClientScriptServiceV3Alpha Decorate(IAsyncClientScriptServiceV3Alpha service);
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/IScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/IScriptOrchestrator.cs
@@ -2,11 +2,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 
 namespace Octopus.Tentacle.Client.Scripts
 {
     interface IScriptOrchestrator
     {
-        Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV2 startScriptCommand, CancellationToken scriptExecutionCancellationToken);
+        Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV3Alpha startScriptCommand, CancellationToken scriptExecutionCancellationToken);
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 
 namespace Octopus.Tentacle.Client.Scripts
 {
@@ -26,7 +27,7 @@ namespace Octopus.Tentacle.Client.Scripts
             this.onScriptCompleted = onScriptCompleted;
         }
 
-        public async Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV2 startScriptCommand, CancellationToken scriptExecutionCancellationToken)
+        public async Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV3Alpha startScriptCommand, CancellationToken scriptExecutionCancellationToken)
         {
             var mappedStartCommand = Map(startScriptCommand);
 
@@ -112,7 +113,7 @@ namespace Octopus.Tentacle.Client.Scripts
             return lastStatusResponse;
         }
 
-        protected abstract TStartCommand Map(StartScriptCommandV2 command);
+        protected abstract TStartCommand Map(StartScriptCommandV3Alpha command);
 
         protected abstract ScriptExecutionStatus MapToStatus(TScriptStatusResponse response);
         protected abstract ScriptExecutionResult MapToResult(TScriptStatusResponse response);

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptOrchestratorFactory.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptOrchestratorFactory.cs
@@ -137,12 +137,18 @@ namespace Octopus.Tentacle.Client.Scripts
 
             if (tentacleCapabilities.HasScriptServiceV3Alpha())
             {
-                logger.Verbose("Using ScriptServiceV3Alpha");
-                logger.Verbose(clientOptions.RpcRetrySettings.RetriesEnabled
-                    ? $"RPC call retries are enabled. Retry timeout {rpcCallExecutor.RetryTimeout.TotalSeconds} seconds"
-                    : "RPC call retries are disabled.");
-                return ScriptServiceVersion.Version3Alpha;
-			}
+                //if the service is not disabled, we can use it :)
+                if (!clientOptions.DisableScriptServiceV3Alpha)
+                {
+                    logger.Verbose("Using ScriptServiceV3Alpha");
+                    logger.Verbose(clientOptions.RpcRetrySettings.RetriesEnabled
+                        ? $"RPC call retries are enabled. Retry timeout {rpcCallExecutor.RetryTimeout.TotalSeconds} seconds"
+                        : "RPC call retries are disabled.");
+                    return ScriptServiceVersion.Version3Alpha;
+                }
+
+                logger.Verbose("ScriptServiceV3Alpha is disabled and will not be used.");
+            }
 
             if (tentacleCapabilities.HasScriptServiceV2())
             {

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Orchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Orchestrator.cs
@@ -9,6 +9,7 @@ using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.Observability;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using ILog = Octopus.Diagnostics.ILog;
 
 namespace Octopus.Tentacle.Client.Scripts
@@ -42,7 +43,7 @@ namespace Octopus.Tentacle.Client.Scripts
             this.logger = logger;
         }
 
-        protected override StartScriptCommand Map(StartScriptCommandV2 command)
+        protected override StartScriptCommand Map(StartScriptCommandV3Alpha command)
             => new(
                 command.ScriptBody,
                 command.Isolation,

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,22 +10,21 @@ using Octopus.Tentacle.Client.Retries;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.Observability;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using ILog = Octopus.Diagnostics.ILog;
 
 namespace Octopus.Tentacle.Client.Scripts
 {
-    class ScriptServiceV2Orchestrator : ObservingScriptOrchestrator<StartScriptCommandV2, ScriptStatusResponseV2>
+    class ScriptServiceV3AlphaOrchestrator : ObservingScriptOrchestrator<StartScriptCommandV3Alpha, ScriptStatusResponseV3Alpha>
     {
-        readonly IAsyncClientScriptServiceV2 clientScriptServiceV2;
+        readonly IAsyncClientScriptServiceV3Alpha clientScriptServiceV3Alpha;
         readonly RpcCallExecutor rpcCallExecutor;
         readonly ClientOperationMetricsBuilder clientOperationMetricsBuilder;
         readonly TimeSpan onCancellationAbandonCompleteScriptAfter;
         readonly ILog logger;
 
-        public ScriptServiceV2Orchestrator(
-            IAsyncClientScriptServiceV2 clientScriptServiceV2,
+        public ScriptServiceV3AlphaOrchestrator(
+            IAsyncClientScriptServiceV3Alpha clientScriptServiceV3Alpha,
             IScriptObserverBackoffStrategy scriptObserverBackOffStrategy,
             RpcCallExecutor rpcCallExecutor,
             ClientOperationMetricsBuilder clientOperationMetricsBuilder,
@@ -39,53 +38,40 @@ namespace Octopus.Tentacle.Client.Scripts
                 onScriptCompleted,
                 clientOptions)
         {
-            this.clientScriptServiceV2 = clientScriptServiceV2;
+            this.clientScriptServiceV3Alpha = clientScriptServiceV3Alpha;
             this.rpcCallExecutor = rpcCallExecutor;
             this.clientOperationMetricsBuilder = clientOperationMetricsBuilder;
             this.onCancellationAbandonCompleteScriptAfter = onCancellationAbandonCompleteScriptAfter;
             this.logger = logger;
         }
 
-        protected override StartScriptCommandV2 Map(StartScriptCommandV3Alpha command)
-            => new(
-                command.ScriptBody,
-                command.Isolation,
-                command.ScriptIsolationMutexTimeout,
-                command.IsolationMutexName!,
-                command.Arguments,
-                command.TaskId,
-                command.ScriptTicket,
-                command.DurationToWaitForScriptToFinish,
-                command.Scripts,
-                command.Files.ToArray());
+        protected override StartScriptCommandV3Alpha Map(StartScriptCommandV3Alpha command) => command;
 
-        protected override ScriptExecutionStatus MapToStatus(ScriptStatusResponseV2 response)
+        protected override ScriptExecutionStatus MapToStatus(ScriptStatusResponseV3Alpha response)
             => new(response.Logs);
 
-        protected override ScriptExecutionResult MapToResult(ScriptStatusResponseV2 response)
+        protected override ScriptExecutionResult MapToResult(ScriptStatusResponseV3Alpha response)
             => new(response.State, response.ExitCode);
 
-        protected override ProcessState GetState(ScriptStatusResponseV2 response) => response.State;
+        protected override ProcessState GetState(ScriptStatusResponseV3Alpha response) => response.State;
 
-        protected override async Task<ScriptStatusResponseV2> StartScript(StartScriptCommandV2 command, CancellationToken scriptExecutionCancellationToken)
+        protected override async Task<ScriptStatusResponseV3Alpha> StartScript(StartScriptCommandV3Alpha command, CancellationToken scriptExecutionCancellationToken)
         {
-            ScriptStatusResponseV2 scriptStatusResponse;
+            ScriptStatusResponseV3Alpha scriptStatusResponse;
             var startScriptCallCount = 0;
             try
             {
-                async Task<ScriptStatusResponseV2> StartScriptAction(CancellationToken ct)
+                async Task<ScriptStatusResponseV3Alpha> StartScriptAction(CancellationToken ct)
                 {
                     ++startScriptCallCount;
 
-                    var result = await clientScriptServiceV2.StartScriptAsync(command, new HalibutProxyRequestOptions(ct, CancellationToken.None));
-
-                    return result;
+                    return await clientScriptServiceV3Alpha.StartScriptAsync(command, new HalibutProxyRequestOptions(ct, CancellationToken.None));
                 }
 
                 if (ClientOptions.RpcRetrySettings.RetriesEnabled)
                 {
                     scriptStatusResponse = await rpcCallExecutor.ExecuteWithRetries(
-                        RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.StartScript)),
+                        RpcCall.Create<IScriptServiceV3Alpha>(nameof(IScriptServiceV3Alpha.StartScript)),
                         StartScriptAction,
                         logger,
                         // If we are cancelling script execution we can abandon a call to start script
@@ -99,7 +85,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 else
                 {
                     scriptStatusResponse = await rpcCallExecutor.ExecuteWithNoRetries(
-                        RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.StartScript)),
+                        RpcCall.Create<IScriptServiceV3Alpha>(nameof(IScriptServiceV3Alpha.StartScript)),
                         StartScriptAction,
                         logger,
                         abandonActionOnCancellation: true,
@@ -117,7 +103,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
                 // Otherwise we have to assume the script started executing and call CancelScript and CompleteScript
                 // We don't have a response so we need to create one to continue the execution flow
-                scriptStatusResponse = new ScriptStatusResponseV2(
+                scriptStatusResponse = new ScriptStatusResponseV3Alpha(
                     command.ScriptTicket,
                     ProcessState.Pending,
                     ScriptExitCodes.RunningExitCode,
@@ -133,23 +119,21 @@ namespace Octopus.Tentacle.Client.Scripts
             return scriptStatusResponse;
         }
 
-        protected override async Task<ScriptStatusResponseV2> GetStatus(ScriptStatusResponseV2 lastStatusResponse, CancellationToken cancellationToken)
+        protected override async Task<ScriptStatusResponseV3Alpha> GetStatus(ScriptStatusResponseV3Alpha lastStatusResponse, CancellationToken cancellationToken)
         {
             try
             {
-                async Task<ScriptStatusResponseV2> GetStatusAction(CancellationToken ct)
+                async Task<ScriptStatusResponseV3Alpha> GetStatusAction(CancellationToken ct)
                 {
-                    var request = new ScriptStatusRequestV2(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence);
+                    var request = new ScriptStatusRequestV3Alpha(lastStatusResponse.ScriptTicket, lastStatusResponse.NextLogSequence);
 
-                    var result = await clientScriptServiceV2.GetStatusAsync(request, new HalibutProxyRequestOptions(ct, CancellationToken.None));
-
-                    return result;
+                    return await clientScriptServiceV3Alpha.GetStatusAsync(request, new HalibutProxyRequestOptions(ct, CancellationToken.None));
                 }
 
                 if (ClientOptions.RpcRetrySettings.RetriesEnabled)
                 {
                     return await rpcCallExecutor.ExecuteWithRetries(
-                        RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.GetStatus)),
+                        RpcCall.Create<IScriptServiceV3Alpha>(nameof(IScriptServiceV3Alpha.GetStatus)),
                         GetStatusAction,
                         logger,
                         // If cancelling script execution we can abandon a call to GetStatus and go straight into the CancelScript and CompleteScript flow
@@ -159,7 +143,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 }
 
                 return await rpcCallExecutor.ExecuteWithNoRetries(
-                    RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.GetStatus)),
+                    RpcCall.Create<IScriptServiceV3Alpha>(nameof(IScriptServiceV3Alpha.GetStatus)),
                     GetStatusAction,
                     logger,
                     abandonActionOnCancellation: true,
@@ -169,25 +153,23 @@ namespace Octopus.Tentacle.Client.Scripts
             catch (Exception e) when (e is OperationCanceledException && cancellationToken.IsCancellationRequested)
             {
                 // Return the last known response without logs when cancellation occurs and let the script execution go into the CancelScript and CompleteScript flow
-                return new ScriptStatusResponseV2(lastStatusResponse.Ticket, lastStatusResponse.State, lastStatusResponse.ExitCode, new List<ProcessOutput>(), lastStatusResponse.NextLogSequence);
+                return new ScriptStatusResponseV3Alpha(lastStatusResponse.ScriptTicket, lastStatusResponse.State, lastStatusResponse.ExitCode, new List<ProcessOutput>(), lastStatusResponse.NextLogSequence);
             }
         }
 
-        protected override async Task<ScriptStatusResponseV2> Cancel(ScriptStatusResponseV2 lastStatusResponse, CancellationToken cancellationToken)
+        protected override async Task<ScriptStatusResponseV3Alpha> Cancel(ScriptStatusResponseV3Alpha lastStatusResponse, CancellationToken cancellationToken)
         {
-            async Task<ScriptStatusResponseV2> CancelScriptAction(CancellationToken ct)
+            async Task<ScriptStatusResponseV3Alpha> CancelScriptAction(CancellationToken ct)
             {
-                var request = new CancelScriptCommandV2(lastStatusResponse.Ticket, lastStatusResponse.NextLogSequence);
+                var request = new CancelScriptCommandV3Alpha(lastStatusResponse.ScriptTicket, lastStatusResponse.NextLogSequence);
 
-                var result = await clientScriptServiceV2.CancelScriptAsync(request, new HalibutProxyRequestOptions(ct, CancellationToken.None));
-
-                return result;
+                return await clientScriptServiceV3Alpha.CancelScriptAsync(request, new HalibutProxyRequestOptions(ct, CancellationToken.None));
             }
 
             if (ClientOptions.RpcRetrySettings.RetriesEnabled)
             {
                 return await rpcCallExecutor.ExecuteWithRetries(
-                    RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.CancelScript)),
+                    RpcCall.Create<IScriptServiceV3Alpha>(nameof(IScriptServiceV3Alpha.CancelScript)),
                     CancelScriptAction,
                     logger,
                     // We don't want to abandon this operation as it is responsible for stopping the script executing on the Tentacle
@@ -197,7 +179,7 @@ namespace Octopus.Tentacle.Client.Scripts
             }
 
             return await rpcCallExecutor.ExecuteWithNoRetries(
-                RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.CancelScript)),
+                RpcCall.Create<IScriptServiceV3Alpha>(nameof(IScriptServiceV3Alpha.CancelScript)),
                 CancelScriptAction,
                 logger,
                 abandonActionOnCancellation: false,
@@ -205,19 +187,19 @@ namespace Octopus.Tentacle.Client.Scripts
                 cancellationToken).ConfigureAwait(false);
         }
 
-        protected override async Task<ScriptStatusResponseV2> Finish(ScriptStatusResponseV2 lastStatusResponse, CancellationToken scriptExecutionCancellationToken)
+        protected override async Task<ScriptStatusResponseV3Alpha> Finish(ScriptStatusResponseV3Alpha lastStatusResponse, CancellationToken scriptExecutionCancellationToken)
         {
             // Best effort cleanup of Tentacle
             try
             {
                 var actionTask =
                     rpcCallExecutor.ExecuteWithNoRetries(
-                        RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.CompleteScript)),
+                        RpcCall.Create<IScriptServiceV3Alpha>(nameof(IScriptServiceV3Alpha.CompleteScript)),
                         async ct =>
                         {
-                            var request = new CompleteScriptCommandV2(lastStatusResponse.Ticket);
+                            var request = new CompleteScriptCommandV3Alpha(lastStatusResponse.ScriptTicket);
 
-                            await clientScriptServiceV2.CompleteScriptAsync(request, new HalibutProxyRequestOptions(ct, CancellationToken.None));
+                            await clientScriptServiceV3Alpha.CompleteScriptAsync(request, new HalibutProxyRequestOptions(ct, CancellationToken.None));
                         },
                         logger,
                         abandonActionOnCancellation: false,

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceVersion.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceVersion.cs
@@ -3,6 +3,7 @@
     internal enum ScriptServiceVersion
     {
         Version1,
-        Version2
+        Version2,
+        Version3Alpha
     }
 }

--- a/source/Octopus.Tentacle.Client/TentacleClientOptions.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClientOptions.cs
@@ -7,6 +7,11 @@ namespace Octopus.Tentacle.Client
     {
         public RpcRetrySettings RpcRetrySettings { get; }
         
+        /// <summary>
+        /// Disables the use of ScriptServiceV3Alpha, even if it's supported on the Tentacle
+        /// </summary>
+        public bool DisableScriptServiceV3Alpha { get; set; }
+
         public TentacleClientOptions(RpcRetrySettings rpcRetrySettings)
         {
             RpcRetrySettings = rpcRetrySettings;

--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/LatestStartScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/LatestStartScriptCommandBuilder.cs
@@ -1,0 +1,6 @@
+﻿namespace Octopus.Tentacle.CommonTestUtils.Builders
+{
+    public class LatestStartScriptCommandBuilder : StartScriptCommandV3AlphaBuilder
+    {
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientScriptServiceV3Alpha.cs
+++ b/source/Octopus.Tentacle.Contracts/ClientServices/IAsyncClientScriptServiceV3Alpha.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+
+namespace Octopus.Tentacle.Contracts.ClientServices
+{
+    public interface IAsyncClientScriptServiceV3Alpha
+    {
+        Task<ScriptStatusResponseV3Alpha> StartScriptAsync(StartScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
+        Task<ScriptStatusResponseV3Alpha> GetStatusAsync(ScriptStatusRequestV3Alpha request, HalibutProxyRequestOptions proxyRequestOptions);
+        Task<ScriptStatusResponseV3Alpha> CancelScriptAsync(CancelScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
+        Task CompleteScriptAsync(CompleteScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
+    }
+}

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -29,6 +29,7 @@
   </Choose>
   <ItemGroup>
     <PackageReference Include="Halibut" Version="7.0.113" />
+    <PackageReference Include="Halibut" Version="6.0.1558" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -29,7 +29,6 @@
   </Choose>
   <ItemGroup>
     <PackageReference Include="Halibut" Version="7.0.113" />
-    <PackageReference Include="Halibut" Version="6.0.1558" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
@@ -69,7 +69,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("Running..."))
                 .Build();

--- a/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
@@ -30,15 +30,20 @@ namespace Octopus.Tentacle.Tests.Integration
             capabilities.Should().Contain("IScriptService");
             capabilities.Should().Contain("IFileTransferService");
 
+            //all versions have ScriptServiceV1
+            var expectedCapabilitiesCount = 2;
+            if (version.HasScriptServiceV3Alpha())
+            {
+                capabilities.Should().Contain("IScriptServiceV3Alpha");
+                expectedCapabilitiesCount++;
+            }
             if (version.HasScriptServiceV2())
             {
                 capabilities.Should().Contain("IScriptServiceV2");
-                capabilities.Count.Should().Be(3);
+                expectedCapabilitiesCount++;
             }
-            else
-            {
-                capabilities.Count.Should().Be(2);
-            }
+
+            capabilities.Count.Should().Be(expectedCapabilitiesCount);
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
@@ -74,7 +74,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("Running..."))
                 .Build();

--- a/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/CapabilitiesServiceV2Test.cs
@@ -30,7 +30,7 @@ namespace Octopus.Tentacle.Tests.Integration
             capabilities.Should().Contain("IScriptService");
             capabilities.Should().Contain("IFileTransferService");
 
-            //all versions have ScriptServiceV1
+            //all versions have ScriptServiceV1 & IFileTransferService
             var expectedCapabilitiesCount = 2;
             if (version.HasScriptServiceV3Alpha())
             {

--- a/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
@@ -12,6 +12,7 @@ using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.Observability;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
@@ -45,7 +46,20 @@ namespace Octopus.Tentacle.Tests.Integration
             var executeScriptMetrics = tentacleClientObserver.ExecuteScriptMetrics.Should().ContainSingle().Subject;
             ThenClientOperationMetricsShouldBeSuccessful(executeScriptMetrics);
 
-            var expectedScriptService = tentacleConfigurationTestCase.Version.HasScriptServiceV2() ? nameof(IScriptServiceV2) : nameof(IScriptService);
+            string expectedScriptService;
+            if (tentacleConfigurationTestCase.Version.HasScriptServiceV3Alpha())
+            {
+                expectedScriptService = nameof(IScriptServiceV3Alpha);
+            }
+            else if (tentacleConfigurationTestCase.Version.HasScriptServiceV2())
+            {
+                expectedScriptService = nameof(IScriptServiceV2);
+            }
+            else
+            {
+                expectedScriptService = nameof(IScriptService);
+            }
+
             tentacleClientObserver.RpcCallMetrics.Should().NotBeEmpty();
             tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCall.Name == nameof(ICapabilitiesServiceV2.GetCapabilities) && m.RpcCall.Service == nameof(ICapabilitiesServiceV2));
             tentacleClientObserver.RpcCallMetrics.Should().ContainSingle(m => m.RpcCall.Name == nameof(IScriptServiceV2.StartScript) && m.RpcCall.Service == expectedScriptService);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
@@ -32,7 +32,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b.Print("Hello"))
                 .Build();
 
@@ -69,7 +69,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b.Print("Hello"))
                 .Build();
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
@@ -13,7 +13,6 @@ using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.Observability;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
-using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
 using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;

--- a/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientGathersRpcCallMetrics.cs
@@ -32,7 +32,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithTentacleClientObserver(tentacleClientObserver)
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b.Print("Hello"))
                 .Build();
 
@@ -82,7 +82,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b.Print("Hello"))
                 .Build();
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
@@ -28,7 +28,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .CreateFile(path) // How files are made are different in bash and powershell, doing this ensures the client and tentacle really are using the correct script.
                 .Print("Hello");
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithAdditionalScriptTypes(ScriptType.Bash, scriptBuilder.BuildBashScript())
                 // Additional Scripts don't actually work on tentacle for anything other than bash.
                 // Below is what we would have expected to tentacle to work with.

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
@@ -28,7 +28,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .CreateFile(path) // How files are made are different in bash and powershell, doing this ensures the client and tentacle really are using the correct script.
                 .Print("Hello");
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithAdditionalScriptTypes(ScriptType.Bash, scriptBuilder.BuildBashScript())
                 // Additional Scripts don't actually work on tentacle for anything other than bash.
                 // Below is what we would have expected to tentacle to work with.

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
@@ -13,6 +13,7 @@ using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util;
@@ -75,7 +76,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("Should not run this script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -186,7 +187,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -304,7 +305,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -388,7 +389,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             clientAndTentacle.TentacleClient.OnCancellationAbandonCompleteScriptAfter = TimeSpan.FromSeconds(20);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromSeconds(5)))
@@ -443,7 +444,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
         private async Task<(ScriptExecutionResult response, Exception? actualException, TimeSpan cancellationDuration)> ExecuteScriptThenCancelExecutionWhenRpcCallHasStarted(
             ClientAndTentacle clientAndTentacle,
-            StartScriptCommandV2 startScriptCommand,
+            StartScriptCommandV3Alpha startScriptCommand,
             Reference<bool> rpcCallHasStarted,
             SemaphoreSlim whenTheRequestCanBeCancelled)
         {

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
@@ -75,7 +75,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("Should not run this script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -175,7 +175,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -293,7 +293,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -377,7 +377,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             clientAndTentacle.TentacleClient.OnCancellationAbandonCompleteScriptAfter = TimeSpan.FromSeconds(20);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromSeconds(5)))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
@@ -129,11 +129,9 @@ namespace Octopus.Tentacle.Tests.Integration
 
             // ARRANGE
             var rpcCallHasStarted = new Reference<bool>(false);
-            TimeSpan? lastCallDuration = null;
             var restartedPortForwarderForCancel = false;
             var hasPausedOrStoppedPortForwarder = false;
             SemaphoreSlim ensureCancellationOccursDuringAnRpcCall = new SemaphoreSlim(0, 1);
-            var timer = new Stopwatch();
 
             await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
                 .WithPendingRequestQueueFactory(new CancellationObservingPendingRequestQueueFactory()) // Partially works around disconnected polling tentacles take work from the queue
@@ -161,15 +159,6 @@ namespace Octopus.Tentacle.Tests.Integration
                                     await tcpConnectionUtilities.EnsurePollingQueueWontSendMessageToDisconnectedTentacles();
                                 }
                             }
-
-                            timer.Restart();
-                        },
-                        async (_, _) =>
-                        {
-                            await Task.CompletedTask;
-
-                            timer.Stop();
-                            lastCallDuration = timer.Elapsed;
                         })
                     .HookServiceMethod(tentacleConfigurationTestCase,
                         nameof(IAsyncClientScriptServiceV2.CancelScriptAsync),

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
@@ -12,7 +12,6 @@ using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ClientServices;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
@@ -51,7 +50,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithTcpConnectionUtilities(Logger, out var tcpConnectionUtilities)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
                     .RecordMethodUsages<IAsyncClientCapabilitiesServiceV2>(out var capabilitiesMethodUsages)
-                    .RecordMethodUsages<IAsyncClientScriptServiceV2>(out var scriptMethodUsages)
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var scriptMethodUsages)
                     .HookServiceMethod<IAsyncClientCapabilitiesServiceV2, object, CapabilitiesResponseV2>(
                         nameof(IAsyncClientCapabilitiesServiceV2.GetCapabilitiesAsync),
                         async (_, _) =>

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
@@ -13,6 +13,7 @@ using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util;
@@ -88,7 +89,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("Should not run this script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -225,7 +226,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -380,7 +381,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -476,7 +477,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             clientAndTentacle.TentacleClient.OnCancellationAbandonCompleteScriptAfter = TimeSpan.FromSeconds(20);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromSeconds(5)))
@@ -542,7 +543,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
         private async Task<(ScriptExecutionResult response, Exception? actualException, TimeSpan cancellationDuration)> ExecuteScriptThenCancelExecutionWhenRpcCallHasStarted(
             ClientAndTentacle clientAndTentacle,
-            StartScriptCommandV2 startScriptCommand,
+            StartScriptCommandV3Alpha startScriptCommand,
             Reference<bool> rpcCallHasStarted,
             SemaphoreSlim whenTheRequestCanBeCancelled)
         {

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
@@ -56,7 +56,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithTcpConnectionUtilities(Logger, out var tcpConnectionUtilities)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
                     .RecordMethodUsages<IAsyncClientCapabilitiesServiceV2>(out var capabilitiesMethodUsages)
-                    .RecordMethodUsages<IAsyncClientScriptServiceV2>(out var scriptMethodUsages)
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var scriptMethodUsages)
                     .HookServiceMethod<IAsyncClientCapabilitiesServiceV2, object, CapabilitiesResponseV2>(
                         nameof(IAsyncClientCapabilitiesServiceV2.GetCapabilitiesAsync),
                         async (_, _) =>
@@ -174,7 +174,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithPortForwarder(out var portForwarder)
                 .WithTcpConnectionUtilities(Logger, out var tcpConnectionUtilities)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
-                    .RecordMethodUsages<IAsyncClientScriptServiceV2>(out var recordedUsages)
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var recordedUsages)
                     .HookServiceMethod(tentacleConfigurationTestCase,
                         nameof(IAsyncClientScriptServiceV2.StartScriptAsync),
                         async (_, _) =>
@@ -329,7 +329,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithPortForwarder(out var portForwarder)
                 .WithTcpConnectionUtilities(Logger, out var tcpConnectionUtilities)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
-                    .RecordMethodUsages<IAsyncClientScriptServiceV2>(out var recordedUsages)
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var recordedUsages)
                     .HookServiceMethod(tentacleConfigurationTestCase,
                         nameof(IAsyncClientScriptServiceV2.GetStatusAsync),
                         async (_, _) =>

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
@@ -12,7 +12,6 @@ using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ClientServices;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
@@ -88,7 +88,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("Should not run this script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -225,7 +225,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -380,7 +380,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromHours(1)))
@@ -476,7 +476,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             clientAndTentacle.TentacleClient.OnCancellationAbandonCompleteScriptAfter = TimeSpan.FromSeconds(20);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("The script")
                     .Sleep(TimeSpan.FromSeconds(5)))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -38,7 +38,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var scriptHasStartFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "scripthasstarted");
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .CreateFile(scriptHasStartFile)
                     .WaitForFileToExist(waitForFile)
@@ -100,7 +100,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -162,7 +162,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .Build(CancellationToken);
             portForwarder = clientTentacle.PortForwarder;
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder().Print("hello").Sleep(TimeSpan.FromSeconds(1)))
                 .Build();
 
@@ -213,7 +213,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .CreateFile(scriptIsRunningFlag)
@@ -278,7 +278,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder().Print("hello"))
                 .Build();
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -36,7 +36,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var scriptHasStartFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "scripthasstarted");
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .CreateFile(scriptHasStartFile)
                     .WaitForFileToExist(waitForFile)
@@ -98,7 +98,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -160,7 +160,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .Build(CancellationToken);
             portForwarder = clientTentacle.PortForwarder;
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder().Print("hello").Sleep(TimeSpan.FromSeconds(1)))
                 .Build();
 
@@ -211,7 +211,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .CreateFile(scriptIsRunningFlag)
@@ -276,7 +276,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder().Print("hello"))
                 .Build();
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -9,8 +9,6 @@ using Octopus.Tentacle.Client;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ClientServices;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
-using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util;

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
@@ -32,7 +32,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var secondScriptStart = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "secondScriptStartFile");
 
-            var firstStartScriptCommand = new StartScriptCommandV2Builder()
+            var firstStartScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .CreateFile(firstScriptStartFile)
                     .WaitForFileToExist(firstScriptWaitFile))
@@ -40,7 +40,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithMutexName("mymutex")
                 .Build();
 
-            var secondStartScriptCommand = new StartScriptCommandV2Builder()
+            var secondStartScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder().CreateFile(secondScriptStart))
                 .WithIsolation(levelOfSecondScript)
                 .WithMutexName("mymutex")
@@ -86,7 +86,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var secondScriptStart = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "secondScriptStartFile");
 
-            var firstStartScriptCommand = new StartScriptCommandV2Builder()
+            var firstStartScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .CreateFile(firstScriptStartFile)
                     .WaitForFileToExist(firstScriptWaitFile))
@@ -94,7 +94,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithMutexName(scriptsInParallelTestCase.MutexForFirstScript)
                 .Build();
 
-            var secondStartScriptCommand = new StartScriptCommandV2Builder()
+            var secondStartScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder().CreateFile(secondScriptStart))
                 .WithIsolation(scriptsInParallelTestCase.LevelOfSecondScript)
                 .WithMutexName(scriptsInParallelTestCase.MutexForSecondScript)

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
@@ -32,7 +32,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var secondScriptStart = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "secondScriptStartFile");
 
-            var firstStartScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var firstStartScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .CreateFile(firstScriptStartFile)
                     .WaitForFileToExist(firstScriptWaitFile))
@@ -40,7 +40,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithMutexName("mymutex")
                 .Build();
 
-            var secondStartScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var secondStartScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder().CreateFile(secondScriptStart))
                 .WithIsolation(levelOfSecondScript)
                 .WithMutexName("mymutex")
@@ -86,7 +86,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var secondScriptStart = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "secondScriptStartFile");
 
-            var firstStartScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var firstStartScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .CreateFile(firstScriptStartFile)
                     .WaitForFileToExist(firstScriptWaitFile))
@@ -94,7 +94,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithMutexName(scriptsInParallelTestCase.MutexForFirstScript)
                 .Build();
 
-            var secondStartScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var secondStartScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder().CreateFile(secondScriptStart))
                 .WithIsolation(scriptsInParallelTestCase.LevelOfSecondScript)
                 .WithMutexName(scriptsInParallelTestCase.MutexForSecondScript)

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -72,7 +72,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("Should not run this script"))
                 .Build();
@@ -125,7 +125,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .Build();
 
             var executeScriptTask = clientAndTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog);
@@ -182,7 +182,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("Start Script")
                     .Sleep(TimeSpan.FromHours(1))
@@ -234,7 +234,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Sleep(TimeSpan.FromHours(1)))
                 .Build();
@@ -295,7 +295,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("Start Script")
                     .Sleep(TimeSpan.FromHours(1))
@@ -350,7 +350,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Sleep(TimeSpan.FromHours(1)))
                 // Don't wait in start script as we want to test get status
@@ -413,7 +413,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Print("Start Script")
                     .Sleep(TimeSpan.FromHours(1))
@@ -481,7 +481,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b
                     .Sleep(TimeSpan.FromHours(1)))
                 // Don't wait in start script as we want to test get status

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -7,8 +7,6 @@ using Halibut;
 using NUnit.Framework;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts.ClientServices;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
-using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util;

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -70,7 +70,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("Should not run this script"))
                 .Build();
@@ -123,7 +123,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .Build();
 
             var executeScriptTask = clientAndTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog);
@@ -180,7 +180,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("Start Script")
                     .Sleep(TimeSpan.FromHours(1))
@@ -232,7 +232,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Sleep(TimeSpan.FromHours(1)))
                 .Build();
@@ -293,7 +293,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("Start Script")
                     .Sleep(TimeSpan.FromHours(1))
@@ -348,7 +348,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Sleep(TimeSpan.FromHours(1)))
                 // Don't wait in start script as we want to test get status
@@ -411,7 +411,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Print("Start Script")
                     .Sleep(TimeSpan.FromHours(1))
@@ -479,7 +479,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var inMemoryLog = new InMemoryLog();
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b
                     .Sleep(TimeSpan.FromHours(1)))
                 // Don't wait in start script as we want to test get status

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder().Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder().PrintArguments())
                 .WithArguments("First", "Second", "AndSpacesAreNotHandledWellInTentacle")
                 .Build();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder().Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder().PrintArguments())
                 .WithArguments("First", "Second", "AndSpacesAreNotHandledWellInTentacle")
                 .Build();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder().Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder().PrintFileContents("foo.txt"))
                 .WithFiles(new ScriptFile("foo.txt", DataStream.FromString("The File Contents")))
                 .Build();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder().Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder().PrintFileContents("foo.txt"))
                 .WithFiles(new ScriptFile("foo.txt", DataStream.FromString("The File Contents")))
                 .Build();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceNonV1IsNotRetriedWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceNonV1IsNotRetriedWhenRetriesAreDisabled.cs
@@ -20,7 +20,7 @@ using Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers;
 namespace Octopus.Tentacle.Tests.Integration
 {
     [IntegrationTestTimeout]
-    public class ClientScriptExecutionScriptServiceV2IsNotRetriedWhenRetriesAreDisabled : IntegrationTest
+    public class ClientScriptExecutionScriptServiceNonV1IsNotRetriedWhenRetriesAreDisabled : IntegrationTest
     {
         [Test]
         [TentacleConfigurations]
@@ -52,7 +52,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder().Print("hello")).Build();
 
             var logs = new List<ProcessOutput>();
@@ -99,7 +99,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Print("AllDone"))
@@ -150,7 +150,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -214,7 +214,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -264,7 +264,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Print("AllDone"))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceNonV1IsNotRetriedWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceNonV1IsNotRetriedWhenRetriesAreDisabled.cs
@@ -9,8 +9,6 @@ using NUnit.Framework;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ClientServices;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
-using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceNonV1IsNotRetriedWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceNonV1IsNotRetriedWhenRetriesAreDisabled.cs
@@ -50,7 +50,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder().Print("hello")).Build();
 
             var logs = new List<ProcessOutput>();
@@ -97,7 +97,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Print("AllDone"))
@@ -148,7 +148,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -212,7 +212,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -262,7 +262,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Print("AllDone"))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
@@ -47,7 +47,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithIsolation(ScriptIsolationLevel.FullIsolation)
                 .WithMutexName("bob")
                 .WithScriptBody(new ScriptBuilder()
@@ -103,7 +103,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -168,7 +168,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -218,7 +218,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder().WithScriptBody(new ScriptBuilder().Print("hello")).Build();
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder().WithScriptBody(new ScriptBuilder().Print("hello")).Build();
 
             List<ProcessOutput> logs = new List<ProcessOutput>();
             Assert.ThrowsAsync<HalibutClientException>(async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, logs, CancellationToken));

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut;
-using Halibut.Util;
 using NUnit.Framework;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
@@ -46,7 +46,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithIsolation(ScriptIsolationLevel.FullIsolation)
                 .WithMutexName("bob")
                 .WithScriptBody(new ScriptBuilder()
@@ -102,7 +102,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -167,7 +167,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
@@ -217,7 +217,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder().WithScriptBody(new ScriptBuilder().Print("hello")).Build();
+            var startScriptCommand = new LatestStartScriptCommandBuilder().WithScriptBody(new ScriptBuilder().Print("hello")).Build();
 
             List<ProcessOutput> logs = new List<ProcessOutput>();
             Assert.ThrowsAsync<HalibutClientException>(async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, logs, CancellationToken));

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWorksWithMultipleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWorksWithMultipleVersions.cs
@@ -19,7 +19,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder().Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWorksWithMultipleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWorksWithMultipleVersions.cs
@@ -19,7 +19,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder().Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
@@ -25,7 +25,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder().PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1)))
                 .Build();
 

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
@@ -25,7 +25,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder().PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1)))
                 .Build();
 

--- a/source/Octopus.Tentacle.Tests.Integration/DisablingScriptServiceV3AlphaTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/DisablingScriptServiceV3AlphaTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.CommonTestUtils.Builders;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Util;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [TestFixture]
+    public class DisablingScriptServiceV3AlphaTests : IntegrationTest
+    {
+        [Test]
+        [TentacleConfigurations]
+        public async Task DisablingScriptServiceV3AlphaViaConfigUsesToScriptServiceV2(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages<IAsyncClientScriptServiceV2>(out var scriptServiceV2Usages)
+                    .RecordMethodUsages<IAsyncClientScriptServiceV3Alpha>(out var scriptServiceV3AlphaUsages)
+                    .Build())
+                .WithClientOptions(options =>
+                {
+                    options.DisableScriptServiceV3Alpha = true;
+                })
+                .Build(CancellationToken);
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBody(new ScriptBuilder()
+                    .Print("Lets do it")
+                    .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
+                    .Print("All done"))
+                .Build();
+
+            var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().Be(0);
+
+            var allLogs = logs.JoinLogs();
+
+            allLogs.Should().MatchRegex(".*Lets do it\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nAll done.*");
+
+            // there should be no calls to the Script Service V3 Alpha service.
+            scriptServiceV3AlphaUsages.ForAll().Started.Should().Be(0);
+            scriptServiceV3AlphaUsages.ForAll().Completed.Should().Be(0);
+
+
+            //there should be _some_ calls to ScriptServiceV2
+            scriptServiceV2Usages.ForAll().Started.Should().NotBe(0);
+            scriptServiceV2Usages.ForAll().Completed.Should().NotBe(0);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/DisablingScriptServiceV3AlphaTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/DisablingScriptServiceV3AlphaTests.cs
@@ -30,7 +30,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 })
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("Lets do it")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
@@ -27,7 +27,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("Lets do it")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
@@ -59,7 +59,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("Lets do it")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
@@ -92,7 +92,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Sleep(TimeSpan.FromSeconds(1))
@@ -139,7 +139,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Sleep(TimeSpan.FromSeconds(1))

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
@@ -22,6 +22,7 @@ namespace Octopus.Tentacle.Tests.Integration
         public async Task CanRunScript(TentacleConfigurationTestCase tentacleConfigurationTestCase)
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithClientOptions(options => options.DisableScriptServiceV3Alpha = true)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
                     .RecordMethodUsages<IAsyncClientScriptServiceV2>(out var methodUsages)
                     .Build())
@@ -54,6 +55,7 @@ namespace Octopus.Tentacle.Tests.Integration
         public async Task DelayInStartScriptSavesNetworkCalls(TentacleConfigurationTestCase tentacleConfigurationTestCase)
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithClientOptions(options => options.DisableScriptServiceV3Alpha = true)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
                     .RecordMethodUsages<IAsyncClientScriptServiceV2>(out var recordedUsages)
                     .Build())
@@ -87,6 +89,7 @@ namespace Octopus.Tentacle.Tests.Integration
         public async Task WhenTentacleRestartsWhileRunningAScript_TheExitCodeShouldBe_UnknownResultExitCode(TentacleConfigurationTestCase tentacleConfigurationTestCase)
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithClientOptions(options => options.DisableScriptServiceV3Alpha = true)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
                     .RecordMethodUsages<IAsyncClientScriptServiceV2>(out var recordedUsages)
                     .Build())
@@ -134,6 +137,7 @@ namespace Octopus.Tentacle.Tests.Integration
         public async Task WhenALongRunningScriptIsCancelled_TheScriptShouldStop(TentacleConfigurationTestCase tentacleConfigurationTestCase)
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithClientOptions(options => options.DisableScriptServiceV3Alpha = true)
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
                     .RecordMethodUsages<IAsyncClientScriptServiceV2>(out var recordedUsages)
                     .Build())

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
@@ -28,7 +28,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("Lets do it")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("Lets do it")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
@@ -95,7 +95,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Sleep(TimeSpan.FromSeconds(1))
@@ -143,7 +143,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Sleep(TimeSpan.FromSeconds(1))

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV3AlphaIntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV3AlphaIntegrationTest.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.CommonTestUtils.Builders;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Util;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [IntegrationTestTimeout]
+    public class ScriptServiceV3AlphaIntegrationTest : IntegrationTest
+    {
+        [Test]
+        [TentacleConfigurations]
+        public async Task CanRunScript(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages<IAsyncClientScriptServiceV3Alpha>(out var methodUsages)
+                    .Build())
+                .Build(CancellationToken);
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBody(new ScriptBuilder()
+                    .Print("Lets do it")
+                    .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
+                    .Print("All done"))
+                .Build();
+
+            var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().Be(0);
+
+            var allLogs = logs.JoinLogs();
+
+            allLogs.Should().MatchRegex(".*Lets do it\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nAll done.*");
+
+            methodUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.StartScriptAsync)).Started.Should().Be(1);
+            methodUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.GetStatusAsync)).Started.Should().BeGreaterThan(2).And.BeLessThan(30);
+            methodUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.CompleteScriptAsync)).Started.Should().Be(1);
+            methodUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.CancelScriptAsync)).Started.Should().Be(0);
+        }
+
+        [Test]
+        [TentacleConfigurations]
+        public async Task DelayInStartScriptSavesNetworkCalls(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages<IAsyncClientScriptServiceV3Alpha>(out var recordedUsages)
+                    .Build())
+                .Build(CancellationToken);
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBody(new ScriptBuilder()
+                    .Print("Lets do it")
+                    .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
+                    .Print("All done"))
+                .WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromMinutes(1))
+                .Build();
+
+            var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().Be(0);
+
+            var allLogs = logs.JoinLogs();
+
+            allLogs.Should().MatchRegex(".*Lets do it\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nanother one\nAll done.*");
+
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.StartScriptAsync)).Started.Should().Be(1);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.GetStatusAsync)).Started.Should().Be(0, "Since start script should wait for the script to finish so we don't need to call get status");
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.CompleteScriptAsync)).Started.Should().Be(1);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.CancelScriptAsync)).Started.Should().Be(0);
+        }
+
+        [Test]
+        [TentacleConfigurations]
+        public async Task WhenTentacleRestartsWhileRunningAScript_TheExitCodeShouldBe_UnknownResultExitCode(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages<IAsyncClientScriptServiceV3Alpha>(out var recordedUsages)
+                    .Build())
+                .Build(CancellationToken);
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBody(new ScriptBuilder()
+                    .Print("hello")
+                    .Sleep(TimeSpan.FromSeconds(1))
+                    .Print("waitingtobestopped")
+                    .Sleep(TimeSpan.FromSeconds(100)))
+                .Build();
+
+            var semaphoreSlim = new SemaphoreSlim(0, 1);
+
+            var executingScript = Task.Run(async () =>
+                await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, onScriptStatusResponseReceived =>
+                {
+                    if (onScriptStatusResponseReceived.Logs.JoinLogs().Contains("waitingtobestopped"))
+                    {
+                        semaphoreSlim.Release();
+                    }
+                }));
+
+            await semaphoreSlim.WaitAsync(CancellationToken);
+
+            Logger.Information("Stopping and starting tentacle now.");
+            await clientTentacle.RunningTentacle.Restart(CancellationToken);
+
+            var (finalResponse, logs) = await executingScript;
+
+            finalResponse.Should().NotBeNull();
+            logs.JoinLogs().Should().Contain("waitingtobestopped");
+            finalResponse.State.Should().Be(ProcessState.Complete); // This is technically a lie, the process is still running on linux
+            finalResponse.ExitCode.Should().Be(ScriptExitCodes.UnknownResultExitCode);
+
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.StartScriptAsync)).Started.Should().Be(1);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.GetStatusAsync)).Started.Should().BeGreaterThan(1);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.CompleteScriptAsync)).Started.Should().Be(1);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.CancelScriptAsync)).Started.Should().Be(0);
+        }
+
+        [Test]
+        [TentacleConfigurations]
+        public async Task WhenALongRunningScriptIsCancelled_TheScriptShouldStop(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages<IAsyncClientScriptServiceV3Alpha>(out var recordedUsages)
+                    .Build())
+                .Build(CancellationToken);
+
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+                .WithScriptBody(new ScriptBuilder()
+                    .Print("hello")
+                    .Sleep(TimeSpan.FromSeconds(1))
+                    .Print("waitingtobestopped")
+                    .Sleep(TimeSpan.FromSeconds(100)))
+                .Build();
+
+            var scriptCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
+            var stopWatch = Stopwatch.StartNew();
+            Exception? actualException = null;
+
+            try
+            {
+                await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, scriptCancellationTokenSource.Token, onScriptStatusResponseReceived =>
+                {
+                    if (onScriptStatusResponseReceived.Logs.JoinLogs().Contains("waitingtobestopped"))
+                    {
+                        scriptCancellationTokenSource.Cancel();
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                actualException = ex;
+            }
+
+            stopWatch.Stop();
+
+            actualException.Should().NotBeNull().And.BeOfType<OperationCanceledException>().And.Match<Exception>(x => x.Message == "Script execution was cancelled");
+            stopWatch.Elapsed.Should().BeLessOrEqualTo(TimeSpan.FromSeconds(10));
+
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.StartScriptAsync)).Started.Should().Be(1);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.GetStatusAsync)).Started.Should().BeGreaterThan(1);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.CompleteScriptAsync)).Started.Should().Be(1);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV3Alpha.CancelScriptAsync)).Started.Should().BeGreaterThanOrEqualTo(1);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV3AlphaIntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV3AlphaIntegrationTest.cs
@@ -27,7 +27,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("Lets do it")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
@@ -59,7 +59,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("Lets do it")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
@@ -92,7 +92,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Sleep(TimeSpan.FromSeconds(1))
@@ -139,7 +139,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(new ScriptBuilder()
                     .Print("hello")
                     .Sleep(TimeSpan.FromSeconds(1))

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -34,6 +34,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         Reference<PortForwarder>? portForwarderReference;
         ITentacleClientObserver tentacleClientObserver = new NoTentacleClientObserver();
         Action<ITentacleBuilder>? tentacleBuilderAction;
+        Action<TentacleClientOptions>? configureClientOptions;
         TcpConnectionUtilities? tcpConnectionUtilities;
 
         public ClientAndTentacleBuilder(TentacleType tentacleType)
@@ -134,6 +135,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             return this;
         }
 
+        public ClientAndTentacleBuilder WithClientOptions(Action<TentacleClientOptions> configureClientOptions)
+        {
+            this.configureClientOptions = configureClientOptions;
+            return this;
+        }
+
         PortForwarder? BuildPortForwarder(int localPort, int? listeningPort)
         {
             if (portForwarderModifiers.Count == 0) return null;
@@ -220,6 +227,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
             var retrySettings = new RpcRetrySettings(retriesEnabled, retryDuration);
             var clientOptions = new TentacleClientOptions(retrySettings);
+
+            //configure the client options
+            configureClientOptions?.Invoke(clientOptions);
 
             var tentacleClient = new TentacleClient(
                 tentacleEndPoint,

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacle.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Octopus.TestPortForwarder;
 using Serilog;

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyTentacleClientBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyTentacleClientBuilder.cs
@@ -1,6 +1,4 @@
-using System.Threading;
 using Halibut;
-using Halibut.Util;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
 using Octopus.Tentacle.Contracts.ClientServices;

--- a/source/Octopus.Tentacle.Tests.Integration/Support/OctopusPackageDownloader.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/OctopusPackageDownloader.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
-using NUnit.Framework;
 using Octopus.Tentacle.Util;
 using Serilog;
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Tentacle.Client.Retries;

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TemporaryDirectory.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TemporaryDirectory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Data;
 using System.IO;
 using System.Reflection;
 using Octopus.Tentacle.Util;

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -26,10 +26,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
     static class TentacleConfigurationTestCases
     {
+        static readonly Type ScriptServiceV3AlphaType =  typeof(IAsyncClientScriptServiceV3Alpha);
         static readonly Type ScriptServiceV2Type =  typeof(IAsyncClientScriptServiceV2);
         static readonly Type ScriptServiceV1Type =  typeof(IAsyncClientScriptService);
 
-        static readonly Type CurrentScriptServiceTypes = ScriptServiceV2Type;
+        static readonly Type CurrentScriptServiceTypes = ScriptServiceV3AlphaType;
 
         static readonly Dictionary<Version, Type> ScriptServiceVersionTypesMap = new()
         {
@@ -38,7 +39,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             [TentacleVersions.v5_0_15_LastOfVersion5] = ScriptServiceV1Type,
             [TentacleVersions.v6_3_417_LastWithScriptServiceV1Only] = ScriptServiceV1Type,
             [TentacleVersions.v6_3_451_NoCapabilitiesService] = ScriptServiceV1Type,
-            [TentacleVersions.v7_0_1_ScriptServiceV2Added] = ScriptServiceV2Type
+            [TentacleVersions.v7_0_1_ScriptServiceV2Added] = ScriptServiceV2Type,
+            [TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha] = ScriptServiceV2Type
         };
 
         public static IEnumerator GetEnumerator(
@@ -59,7 +61,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.Current,
                     TentacleVersions.v5_0_15_LastOfVersion5,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
-                    TentacleVersions.v7_0_1_ScriptServiceV2Added
+                    TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha
                 });
             }
 
@@ -71,7 +73,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.v5_0_4_FirstLinuxRelease,
                     TentacleVersions.v5_0_12_AutofacServiceFactoryIsInShared,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only, // the autofac service is in tentacle, but tentacle does not have the capabilities service.
-                    TentacleVersions.v7_0_1_ScriptServiceV2Added
+                    TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha
                 });
             }
 
@@ -81,7 +83,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 {
                     TentacleVersions.Current,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
-                    TentacleVersions.v7_0_1_ScriptServiceV2Added // Testing against v1 and v2 script services
+                    TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha // Testing against v1 and v2 script services
                 });
             }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -39,8 +39,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             [TentacleVersions.v5_0_15_LastOfVersion5] = ScriptServiceV1Type,
             [TentacleVersions.v6_3_417_LastWithScriptServiceV1Only] = ScriptServiceV1Type,
             [TentacleVersions.v6_3_451_NoCapabilitiesService] = ScriptServiceV1Type,
-            [TentacleVersions.v7_0_189_ScriptServiceV2Added] = ScriptServiceV2Type,
-            [TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha] = ScriptServiceV2Type
+            [TentacleVersions.v7_1_189_ScriptServiceV2Added] = ScriptServiceV2Type,
+            [TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha] = ScriptServiceV2Type
         };
 
         public static IEnumerator GetEnumerator(
@@ -61,8 +61,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.Current,
                     TentacleVersions.v5_0_15_LastOfVersion5,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
-                    TentacleVersions.v7_0_189_ScriptServiceV2Added,
-                    TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha
+                    TentacleVersions.v7_1_189_ScriptServiceV2Added,
+                    TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha
                 });
             }
 
@@ -74,8 +74,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.v5_0_4_FirstLinuxRelease,
                     TentacleVersions.v5_0_12_AutofacServiceFactoryIsInShared,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only, // the autofac service is in tentacle, but tentacle does not have the capabilities service.
-                    TentacleVersions.v7_0_189_ScriptServiceV2Added,
-                    TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha
+                    TentacleVersions.v7_1_189_ScriptServiceV2Added,
+                    TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha
                 });
             }
 
@@ -85,8 +85,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 {
                     TentacleVersions.Current,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
-                    TentacleVersions.v7_0_189_ScriptServiceV2Added, // Testing against v1 and v2 script services
-                    TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha // Testing against v1 and v2 script services
+                    TentacleVersions.v7_1_189_ScriptServiceV2Added, // Testing against v1 and v2 script services
+                    TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha // Testing against v1 and v2 script services
                 });
             }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -40,7 +40,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             [TentacleVersions.v6_3_417_LastWithScriptServiceV1Only] = ScriptServiceV1Type,
             [TentacleVersions.v6_3_451_NoCapabilitiesService] = ScriptServiceV1Type,
             [TentacleVersions.v7_0_1_ScriptServiceV2Added] = ScriptServiceV2Type,
-            [TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha] = ScriptServiceV2Type
+            [TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha] = ScriptServiceV2Type
         };
 
         public static IEnumerator GetEnumerator(
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.Current,
                     TentacleVersions.v5_0_15_LastOfVersion5,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
-                    TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha
+                    TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha
                 });
             }
 
@@ -73,7 +73,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.v5_0_4_FirstLinuxRelease,
                     TentacleVersions.v5_0_12_AutofacServiceFactoryIsInShared,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only, // the autofac service is in tentacle, but tentacle does not have the capabilities service.
-                    TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha
+                    TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha
                 });
             }
 
@@ -83,7 +83,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 {
                     TentacleVersions.Current,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
-                    TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha // Testing against v1 and v2 script services
+                    TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha // Testing against v1 and v2 script services
                 });
             }
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -39,7 +39,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             [TentacleVersions.v5_0_15_LastOfVersion5] = ScriptServiceV1Type,
             [TentacleVersions.v6_3_417_LastWithScriptServiceV1Only] = ScriptServiceV1Type,
             [TentacleVersions.v6_3_451_NoCapabilitiesService] = ScriptServiceV1Type,
-            [TentacleVersions.v7_0_1_ScriptServiceV2Added] = ScriptServiceV2Type,
+            [TentacleVersions.v7_0_189_ScriptServiceV2Added] = ScriptServiceV2Type,
             [TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha] = ScriptServiceV2Type
         };
 
@@ -61,6 +61,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.Current,
                     TentacleVersions.v5_0_15_LastOfVersion5,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
+                    TentacleVersions.v7_0_189_ScriptServiceV2Added,
                     TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha
                 });
             }
@@ -73,6 +74,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.v5_0_4_FirstLinuxRelease,
                     TentacleVersions.v5_0_12_AutofacServiceFactoryIsInShared,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only, // the autofac service is in tentacle, but tentacle does not have the capabilities service.
+                    TentacleVersions.v7_0_189_ScriptServiceV2Added,
                     TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha
                 });
             }
@@ -83,6 +85,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 {
                     TentacleVersions.Current,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
+                    TentacleVersions.v7_0_189_ScriptServiceV2Added, // Testing against v1 and v2 script services
                     TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha // Testing against v1 and v2 script services
                 });
             }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleRuntime.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
@@ -47,7 +47,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         }
         public static bool HasScriptServiceV2(this Version? version)
         {
-            return version >= TentacleVersions.v7_0_1_ScriptServiceV2Added && version <= TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha;
+            return version == TentacleVersions.Current || version >= TentacleVersions.v7_0_1_ScriptServiceV2Added;
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
@@ -22,6 +22,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         // First version with ScriptServiceV2
         public static readonly Version v7_0_1_ScriptServiceV2Added = new("7.0.1");
 
+        // Last version without ScriptServiceV3Alpha
+        public static readonly Version v8_0_34_LastWithoutScriptServiceV3Alpha = new("8.0.34");
+
         // The version compiled from the current source
         public static readonly Version? Current = null;
 
@@ -32,15 +35,19 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             v5_0_15_LastOfVersion5,
             v6_3_417_LastWithScriptServiceV1Only,
             v6_3_451_NoCapabilitiesService,
-            v7_0_1_ScriptServiceV2Added
+            v8_0_34_LastWithoutScriptServiceV3Alpha
         };
     }
 
     public static class VersionExtensionMethods
     {
+        public static bool HasScriptServiceV3Alpha(this Version? version)
+        {
+            return version == TentacleVersions.Current || version > TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha;
+        }
         public static bool HasScriptServiceV2(this Version? version)
         {
-            return version == TentacleVersions.Current || version >= TentacleVersions.v7_0_1_ScriptServiceV2Added;
+            return version >= TentacleVersions.v7_0_1_ScriptServiceV2Added && version <= TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha;
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
@@ -23,7 +23,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public static readonly Version v7_0_1_ScriptServiceV2Added = new("7.0.1");
 
         // Last version without ScriptServiceV3Alpha
-        public static readonly Version v8_0_34_LastWithoutScriptServiceV3Alpha = new("8.0.34");
+        // Contains ScriptServiceV1 and ScriptServiceV2
+        public static readonly Version v8_0_73_LastWithoutScriptServiceV3Alpha = new("8.0.73");
 
         // The version compiled from the current source
         public static readonly Version? Current = null;
@@ -35,7 +36,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             v5_0_15_LastOfVersion5,
             v6_3_417_LastWithScriptServiceV1Only,
             v6_3_451_NoCapabilitiesService,
-            v8_0_34_LastWithoutScriptServiceV3Alpha
+            v8_0_73_LastWithoutScriptServiceV3Alpha
         };
     }
 
@@ -43,8 +44,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         public static bool HasScriptServiceV3Alpha(this Version? version)
         {
-            return version == TentacleVersions.Current || version > TentacleVersions.v8_0_34_LastWithoutScriptServiceV3Alpha;
+            return version == TentacleVersions.Current || version > TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha;
         }
+
         public static bool HasScriptServiceV2(this Version? version)
         {
             return version == TentacleVersions.Current || version >= TentacleVersions.v7_0_1_ScriptServiceV2Added;

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
@@ -19,8 +19,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         // No capabilities service
         public static Version v6_3_451_NoCapabilitiesService = new("6.3.451");
 
-        // First version with ScriptServiceV2
-        public static readonly Version v7_0_1_ScriptServiceV2Added = new("7.0.1");
+        // Last version of v7 with ScriptServiceV2
+        public static readonly Version v7_0_189_ScriptServiceV2Added = new("7.0.189");
 
         // Last version without ScriptServiceV3Alpha
         // Contains ScriptServiceV1 and ScriptServiceV2
@@ -36,6 +36,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             v5_0_15_LastOfVersion5,
             v6_3_417_LastWithScriptServiceV1Only,
             v6_3_451_NoCapabilitiesService,
+            v7_0_189_ScriptServiceV2Added,
             v8_0_73_LastWithoutScriptServiceV3Alpha
         };
     }
@@ -49,7 +50,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         public static bool HasScriptServiceV2(this Version? version)
         {
-            return version == TentacleVersions.Current || version >= TentacleVersions.v7_0_1_ScriptServiceV2Added;
+            return version == TentacleVersions.Current || version >= TentacleVersions.v7_0_189_ScriptServiceV2Added;
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
@@ -20,11 +20,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public static Version v6_3_451_NoCapabilitiesService = new("6.3.451");
 
         // Last version of v7 with ScriptServiceV2
-        public static readonly Version v7_0_189_ScriptServiceV2Added = new("7.0.189");
+        public static readonly Version v7_1_189_ScriptServiceV2Added = new("7.1.189");
 
         // Last version without ScriptServiceV3Alpha
         // Contains ScriptServiceV1 and ScriptServiceV2
-        public static readonly Version v8_0_73_LastWithoutScriptServiceV3Alpha = new("8.0.73");
+        public static readonly Version v8_0_81_LastWithoutScriptServiceV3Alpha = new("8.0.81");
 
         // The version compiled from the current source
         public static readonly Version? Current = null;
@@ -36,8 +36,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             v5_0_15_LastOfVersion5,
             v6_3_417_LastWithScriptServiceV1Only,
             v6_3_451_NoCapabilitiesService,
-            v7_0_189_ScriptServiceV2Added,
-            v8_0_73_LastWithoutScriptServiceV3Alpha
+            v7_1_189_ScriptServiceV2Added,
+            v8_0_81_LastWithoutScriptServiceV3Alpha
         };
     }
 
@@ -45,12 +45,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         public static bool HasScriptServiceV3Alpha(this Version? version)
         {
-            return version == TentacleVersions.Current || version > TentacleVersions.v8_0_73_LastWithoutScriptServiceV3Alpha;
+            return version == TentacleVersions.Current || version > TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha;
         }
 
         public static bool HasScriptServiceV2(this Version? version)
         {
-            return version == TentacleVersions.Current || version >= TentacleVersions.v7_0_189_ScriptServiceV2Added;
+            return version == TentacleVersions.Current || version >= TentacleVersions.v7_1_189_ScriptServiceV2Added;
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
@@ -32,7 +32,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b.Print("Hello"))
                 .Build();
 
@@ -58,7 +58,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV2Builder()
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
                 .WithScriptBody(b => b.Print("Hello"))
                 .Build();
 

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
@@ -31,7 +31,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b.Print("Hello"))
                 .Build();
 
@@ -57,7 +57,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Build())
                 .Build(CancellationToken);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(b => b.Print("Hello"))
                 .Build();
 

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleClientObserver.cs
@@ -8,7 +8,6 @@ using Octopus.Diagnostics;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.Observability;
-using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
 using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
@@ -60,6 +60,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             public IAsyncClientFileTransferService Decorate(IAsyncClientFileTransferService service) => GetDecoratedProxy(service);
 
             public IAsyncClientCapabilitiesServiceV2 Decorate(IAsyncClientCapabilitiesServiceV2 service) => GetDecoratedProxy(service);
+            public IAsyncClientScriptServiceV3Alpha Decorate(IAsyncClientScriptServiceV3Alpha service) => GetDecoratedProxy(service);
 
             T GetDecoratedProxy<T>(T service) where T : class
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TentacleClientExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TentacleClientExtensionMethods.cs
@@ -8,6 +8,7 @@ using Octopus.Tentacle.Client;
 using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
@@ -18,7 +19,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders
     {
         public static async Task<(ScriptExecutionResult, List<ProcessOutput>)> ExecuteScript(
             this TentacleClient tentacleClient,
-            StartScriptCommandV2 startScriptCommand,
+            StartScriptCommandV3Alpha startScriptCommand,
             CancellationToken token,
             OnScriptStatusResponseReceived? onScriptStatusResponseReceivedAction = null,
             Log? log = null)

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TentacleClientExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TentacleClientExtensionMethods.cs
@@ -7,7 +7,6 @@ using Halibut;
 using Octopus.Tentacle.Client;
 using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.Contracts;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Tests.Integration.Support;

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Security.Principal;
 using System.Text;
 using System.Threading;
 using FluentAssertions;

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading;
-using NSubstitute;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.TestPortForwarder;
 using Serilog;

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TentacleClientTestExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TentacleClientTestExtensionMethods.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Tentacle.Client;
 using Octopus.Tentacle.Contracts;
-using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Tests.Integration.Support;
 
 namespace Octopus.Tentacle.Tests.Integration.Util
@@ -12,7 +12,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
     {
         public static async Task ExecuteScript(
             this TentacleClient tentacleClient,
-            StartScriptCommandV2 startScriptCommand,
+            StartScriptCommandV3Alpha startScriptCommand,
             List<ProcessOutput> logs,
             CancellationToken token)
         {

--- a/source/Octopus.Tentacle.Tests.Integration/WorkspaceCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/WorkspaceCleanerTests.cs
@@ -26,7 +26,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var existingHomeDirectory = new TemporaryDirectory();
 
             var waitBeforeCompletingScriptFile = Path.Combine(existingHomeDirectory.DirectoryPath, "WaitForMeToExist.txt");
-            var startScriptCommand = new StartScriptCommandV2Builder().WithScriptBody(b => b.WaitForFileToExist(waitBeforeCompletingScriptFile)).Build();
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder().WithScriptBody(b => b.WaitForFileToExist(waitBeforeCompletingScriptFile)).Build();
             var startScriptWorkspaceDirectory = GetWorkspaceDirectoryPath(existingHomeDirectory.DirectoryPath, startScriptCommand.ScriptTicket.TaskId);
 
             await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var cleanerDelay = TimeSpan.FromMilliseconds(500);
             var deleteWorkspacesOlderThan = TimeSpan.FromMilliseconds(500);
 
-            var startScriptCommand = new StartScriptCommandV2Builder().WithScriptBody(b => b.Print("Hello")).Build();
+            var startScriptCommand = new StartScriptCommandV3AlphaBuilder().WithScriptBody(b => b.Print("Hello")).Build();
 
             await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
                 .WithTentacle(b =>

--- a/source/Octopus.Tentacle.Tests.Integration/WorkspaceCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/WorkspaceCleanerTests.cs
@@ -26,7 +26,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var existingHomeDirectory = new TemporaryDirectory();
 
             var waitBeforeCompletingScriptFile = Path.Combine(existingHomeDirectory.DirectoryPath, "WaitForMeToExist.txt");
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder().WithScriptBody(b => b.WaitForFileToExist(waitBeforeCompletingScriptFile)).Build();
+            var startScriptCommand = new LatestStartScriptCommandBuilder().WithScriptBody(b => b.WaitForFileToExist(waitBeforeCompletingScriptFile)).Build();
             var startScriptWorkspaceDirectory = GetWorkspaceDirectoryPath(existingHomeDirectory.DirectoryPath, startScriptCommand.ScriptTicket.TaskId);
 
             await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var cleanerDelay = TimeSpan.FromMilliseconds(500);
             var deleteWorkspacesOlderThan = TimeSpan.FromMilliseconds(500);
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder().WithScriptBody(b => b.Print("Hello")).Build();
+            var startScriptCommand = new LatestStartScriptCommandBuilder().WithScriptBody(b => b.Print("Hello")).Build();
 
             await using var clientAndTentacle = await tentacleConfigurationTestCase.CreateBuilder()
                 .WithTentacle(b =>

--- a/source/Octopus.Tentacle.Tests/Capabilities/CapabilitiesServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Capabilities/CapabilitiesServiceV2Fixture.cs
@@ -18,7 +18,8 @@ namespace Octopus.Tentacle.Tests.Capabilities
             capabilities.Should().Contain("IScriptService");
             capabilities.Should().Contain("IFileTransferService");
             capabilities.Should().Contain("IScriptServiceV2");
-            capabilities.Count.Should().Be(3);
+            capabilities.Should().Contain("IScriptServiceV3Alpha");
+            capabilities.Count.Should().Be(4);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
@@ -49,7 +49,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var windowsScript = "& ping.exe localhost -n 1";
             var bashScript = "ping localhost -c 1";
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBodyForCurrentOs(windowsScript, bashScript)
                 .Build();
 
@@ -67,7 +67,7 @@ namespace Octopus.Tentacle.Tests.Integration
             const string windowsScript = "& ping.exe nope -n 1";
             const string bashScript = "ping nope -c 1";
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBodyForCurrentOs(windowsScript, bashScript)
                 .Build();
 
@@ -86,7 +86,7 @@ namespace Octopus.Tentacle.Tests.Integration
             const string windowsScript = "Start-Sleep -Seconds 10";
 
             var scripts = Enumerable.Range(0, 5).Select(x =>
-                new StartScriptCommandAndResponse(command: new StartScriptCommandV3AlphaBuilder()
+                new StartScriptCommandAndResponse(command: new LatestStartScriptCommandBuilder()
                     .WithScriptBodyForCurrentOs(windowsScript, bashScript)
                     .Build())).ToList();
 
@@ -122,7 +122,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             var script = "echo \"finished\"";
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(script)
                 .Build();
 
@@ -155,7 +155,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var bashScript = "sleep 10";
             var windowsScript = "Start-Sleep -Seconds 10";
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBodyForCurrentOs(windowsScript, bashScript)
                 .Build();
 
@@ -169,7 +169,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [Test]
         public async Task StartScriptShouldWaitForAShortScriptToFinish()
         {
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody("echo \"finished\"")
                 .WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromSeconds(5))
                 .Build();
@@ -189,7 +189,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var bashScript = "sleep 10";
             var windowsScript = "Start-Sleep -Seconds 10";
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBodyForCurrentOs(windowsScript, bashScript)
                 .WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromSeconds(5))
                 .Build();
@@ -266,7 +266,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var bashScript = "sleep 60";
             var windowsScript = "Start-Sleep -Seconds 60";
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBodyForCurrentOs(windowsScript, bashScript)
                 .Build();
 
@@ -308,7 +308,7 @@ namespace Octopus.Tentacle.Tests.Integration
         {
             var script = "echo \"finished\"";
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody(script)
                 .Build();
 
@@ -390,7 +390,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var bashScript = "sleep 10";
             var windowsScript = "Start-Sleep -Seconds 10";
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBodyForCurrentOs(windowsScript, bashScript)
                 .Build();
 
@@ -427,7 +427,7 @@ namespace Octopus.Tentacle.Tests.Integration
         public async Task ScriptTicketCasingShouldNotAffectCommands()
         {
             // Arrange
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBody("echo \"finished\"")
                 .Build();
 
@@ -480,7 +480,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 windowsScript += $"{Environment.NewLine} Start-Sleep -Seconds {scriptDelayInSeconds}";
             }
 
-            var startScriptCommand = new StartScriptCommandV3AlphaBuilder()
+            var startScriptCommand = new LatestStartScriptCommandBuilder()
                 .WithScriptBodyForCurrentOs(windowsScript, bashScript)
                 .WithScriptTicket(scriptTicket)
                 .Build();

--- a/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Capabilities/CapabilitiesServiceV2.cs
@@ -3,7 +3,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 
 namespace Octopus.Tentacle.Services.Capabilities
 {
@@ -13,7 +15,7 @@ namespace Octopus.Tentacle.Services.Capabilities
         public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return new CapabilitiesResponseV2(new List<string>() {nameof(IScriptService), nameof(IFileTransferService), nameof(IScriptServiceV2)});
+            return new CapabilitiesResponseV2(new List<string>() {nameof(IScriptService), nameof(IFileTransferService), nameof(IScriptServiceV2), nameof(IScriptServiceV3Alpha)});
         }
     }
 }


### PR DESCRIPTION
# Background

Adds support for `ScriptServiceV3Alpha` to TentacleClient. To allow this service to be disabled/ignored, there is a new flag on `TentacleClientOptions.DisableScriptServiceV3Alpha` to explicitly disable this.

At this stage, this contains the same logic as `ScriptServiceV2`, but this will start to change as we add support for Kubernetes Jobs

# Results

Adds a new `ScriptServiceV3AlphaOrchestrator` which is used when the tentacle returns `IScriptServiceV3Alpha` from the GetCapabilities call.

Updates the main entrypoint for executing a script in TentacleClient to take a `StartScriptCommandV3Alpha`. This will require a change to Server to use this.

A lot of the changes in the Tests are just change to use `StartScriptCommandV3AlphaBuilder`

Shortcut story: [sc-62862]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.