### PR TITLE
Abstract script execution in ScriptServiceV3Alpha

### DIFF
--- a/source/Octopus.Tentacle.Contracts/ScriptServiceV3Alpha/StartScriptCommandV3Alpha.cs
+++ b/source/Octopus.Tentacle.Contracts/ScriptServiceV3Alpha/StartScriptCommandV3Alpha.cs
@@ -16,13 +16,13 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV3Alpha
             string taskId,
             ScriptTicket scriptTicket,
             TimeSpan? durationToWaitForScriptToFinish,
-            IScriptExecutionContext scriptExecutionContext)
+            IScriptExecutionContext executionContext)
         {
             Arguments = arguments;
             TaskId = taskId;
             ScriptTicket = scriptTicket;
             DurationToWaitForScriptToFinish = durationToWaitForScriptToFinish;
-            ExecutionContext = scriptExecutionContext;
+            ExecutionContext = executionContext;
             ScriptBody = scriptBody;
             Isolation = isolation;
             ScriptIsolationMutexTimeout = scriptIsolationMutexTimeout;
@@ -37,7 +37,7 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV3Alpha
             string taskId,
             ScriptTicket scriptTicket,
             TimeSpan? durationToWaitForScriptToFinish,
-            IScriptExecutionContext scriptExecutionContext,
+            IScriptExecutionContext executionContext,
             params ScriptFile[]? additionalFiles)
             : this(scriptBody,
                 isolation,
@@ -47,7 +47,7 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV3Alpha
                 taskId,
                 scriptTicket,
                 durationToWaitForScriptToFinish,
-                scriptExecutionContext)
+                executionContext)
         {
             if (additionalFiles != null)
                 Files.AddRange(additionalFiles);
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV3Alpha
             string taskId,
             ScriptTicket scriptTicket,
             TimeSpan? durationToWaitForScriptToFinish,
-            IScriptExecutionContext scriptExecutionContext,
+            IScriptExecutionContext executionContext,
             Dictionary<ScriptType, string>? additionalScripts,
             params ScriptFile[]? additionalFiles)
             : this(scriptBody,
@@ -72,7 +72,7 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV3Alpha
                 taskId,
                 scriptTicket,
                 durationToWaitForScriptToFinish,
-                scriptExecutionContext,
+                executionContext,
                 additionalFiles)
         {
             if (additionalScripts == null || !additionalScripts.Any())

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
@@ -15,7 +15,7 @@ using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Scripts;
-using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
+using Octopus.Tentacle.Services.Scripts;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration

--- a/source/Octopus.Tentacle/Maintenance/WorkspaceCleaner.cs
+++ b/source/Octopus.Tentacle/Maintenance/WorkspaceCleaner.cs
@@ -6,7 +6,6 @@ using Octopus.Diagnostics;
 using Octopus.Tentacle.Communications;
 using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Services.Scripts;
-using Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha;
 using Octopus.Time;
 
 namespace Octopus.Tentacle.Maintenance

--- a/source/Octopus.Tentacle/Scripts/Bash.cs
+++ b/source/Octopus.Tentacle/Scripts/Bash.cs
@@ -5,6 +5,8 @@ namespace Octopus.Tentacle.Scripts
 {
     public class Bash : IShell
     {
+        public string Name => nameof(Bash);
+
         public string GetFullPath()
             => GetFullBashPath();
 

--- a/source/Octopus.Tentacle/Scripts/IRunningScript.cs
+++ b/source/Octopus.Tentacle/Scripts/IRunningScript.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Scripts
+{
+    public interface IRunningScript
+    {
+        int ExitCode { get; }
+        ProcessState State { get; }
+        IScriptLog ScriptLog { get; }
+    }
+}

--- a/source/Octopus.Tentacle/Scripts/IScriptExecutor.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptExecutor.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+
+namespace Octopus.Tentacle.Scripts
+{
+    public interface IScriptExecutor
+    {
+        IRunningScript ExecuteOnBackgroundThread(StartScriptCommandV3Alpha command, IScriptWorkspace workspace, ScriptStateStore? scriptStateStore, CancellationToken cancellationToken);
+    }
+}

--- a/source/Octopus.Tentacle/Scripts/IScriptExecutorFactory.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptExecutorFactory.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Octopus.Tentacle.Scripts
+{
+    public interface IScriptExecutorFactory
+    {
+        IScriptExecutor GetExecutor();
+    }
+}

--- a/source/Octopus.Tentacle/Scripts/IShell.cs
+++ b/source/Octopus.Tentacle/Scripts/IShell.cs
@@ -4,6 +4,7 @@ namespace Octopus.Tentacle.Scripts
 {
     public interface IShell
     {
+        string Name { get; }
         string GetFullPath();
 
         string FormatCommandArguments(string bootstrapFile, string[]? scriptArguments, bool allowInteractive);

--- a/source/Octopus.Tentacle/Scripts/LocalShellScriptExecutor.cs
+++ b/source/Octopus.Tentacle/Scripts/LocalShellScriptExecutor.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+
+namespace Octopus.Tentacle.Scripts
+{
+    class LocalShellScriptExecutor : IScriptExecutor
+    {
+        readonly IShell shell;
+        readonly ISystemLog log;
+
+        public LocalShellScriptExecutor(IShell shell, ISystemLog log)
+        {
+            this.shell = shell;
+            this.log = log;
+        }
+
+        public IRunningScript ExecuteOnBackgroundThread(StartScriptCommandV3Alpha command, IScriptWorkspace workspace, ScriptStateStore? scriptStateStore, CancellationToken cancellationToken)
+        {
+            if (command.ExecutionContext is not LocalShellScriptExecutionContext)
+                throw new InvalidOperationException($"Cannot execute start script command as the execution context is not of type {nameof(LocalShellScriptExecutionContext)}.");
+
+            var runningScript = new RunningScript(shell, workspace,  scriptStateStore, workspace.CreateLog(), command.TaskId, cancellationToken, log);
+
+            var thread = new Thread(runningScript.Execute) { Name = $"Executing {shell.Name} script for " + command.ScriptTicket.TaskId };
+            thread.Start();
+
+            return runningScript;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Scripts/PowerShell.cs
+++ b/source/Octopus.Tentacle/Scripts/PowerShell.cs
@@ -9,6 +9,8 @@ namespace Octopus.Tentacle.Scripts
         const string EnvPowerShellPath = "PowerShell.exe";
         static string? powerShellPath;
 
+        public string Name => nameof(PowerShell);
+
         public string GetFullPath()
             => GetFullPowerShellPath();
 

--- a/source/Octopus.Tentacle/Scripts/RunningScript.cs
+++ b/source/Octopus.Tentacle/Scripts/RunningScript.cs
@@ -6,7 +6,7 @@ using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Scripts
 {
-    public class RunningScript
+    public class RunningScript: IRunningScript
     {
         readonly IScriptWorkspace workspace;
         readonly IScriptStateStore? stateStore;

--- a/source/Octopus.Tentacle/Scripts/ScriptExecutorFactory.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptExecutorFactory.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Octopus.Tentacle.Scripts
+{
+    class ScriptExecutorFactory : IScriptExecutorFactory
+    {
+        readonly Lazy<LocalShellScriptExecutor> shellScriptExecutor;
+
+        public ScriptExecutorFactory(Lazy<LocalShellScriptExecutor> shellScriptExecutor)
+        {
+            this.shellScriptExecutor = shellScriptExecutor;
+        }
+
+        public IScriptExecutor GetExecutor()
+        {
+            return shellScriptExecutor.Value;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Services/Scripts/IAsyncScriptServiceV3Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/IAsyncScriptServiceV3Alpha.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 
-namespace Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha
+namespace Octopus.Tentacle.Services.Scripts
 {
     /// <remarks>
     /// This interface should mirror <see cref="IScriptServiceV3Alpha"/>.

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha.cs
@@ -9,7 +9,7 @@ using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Util;
 
-namespace Octopus.Tentacle.Services.Scripts.ScriptServiceV3Alpha
+namespace Octopus.Tentacle.Services.Scripts
 {
     [Service(typeof(IScriptServiceV3Alpha))]
     public class ScriptServiceV3Alpha : IAsyncScriptServiceV3Alpha

--- a/source/Octopus.Tentacle/Services/ServicesModule.cs
+++ b/source/Octopus.Tentacle/Services/ServicesModule.cs
@@ -20,6 +20,10 @@ namespace Octopus.Tentacle.Services
 
             builder.RegisterType<NuGetPackageInstaller>().As<IPackageInstaller>();
 
+            // Register the script executor logic
+            builder.RegisterType<ScriptExecutorFactory>().As<IScriptExecutorFactory>();
+            builder.RegisterType<LocalShellScriptExecutor>().AsSelf().As<IScriptExecutor>();
+
             // Register our Halibut services
             var knownServices = ThisAssembly.GetTypes()
                 .Select(t => (ServiceImplementationType: t, ServiceAttribute: t.GetCustomAttribute<ServiceAttribute>()))


### PR DESCRIPTION
# Background

We need a way to abstract the execution of a script so we can support Kubernetes Jobs as a script execution mechanism in `ScriptServiceV3Alpha`

# Results

This PR adds 3 new interfaces and some derived implementations

`IScriptExecutor` -> Represents a distinct way to execute a script
`IScriptExecutorFactory` -> A factory that constructs/returns an IScriptExecutor
`IRunningScript` -> Represents a running script

The intent is that there will be a `KubernetesJobScriptExecutor` and a `KubernetesJobRunningScript` implementations that will be used when the script is being executed via k8s jobs.

Shortcut story: [sc-61762]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.