### PR TITLE
Ensure test coverage of ScriptServiceV2 now ScriptServiceV3Alpha has been added

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV3AlphaIntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV3AlphaIntegrationTest.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Tests.Integration
     public class ScriptServiceV3AlphaIntegrationTest : IntegrationTest
     {
         [Test]
-        [TentacleConfigurations]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task CanRunScript(TentacleConfigurationTestCase tentacleConfigurationTestCase)
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
@@ -50,7 +50,7 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [TentacleConfigurations]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task DelayInStartScriptSavesNetworkCalls(TentacleConfigurationTestCase tentacleConfigurationTestCase)
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
@@ -83,7 +83,7 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [TentacleConfigurations]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task WhenTentacleRestartsWhileRunningAScript_TheExitCodeShouldBe_UnknownResultExitCode(TentacleConfigurationTestCase tentacleConfigurationTestCase)
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
@@ -130,7 +130,7 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        [TentacleConfigurations]
+        [TentacleConfigurations(testCurrentVersionOnly: true)]
         public async Task WhenALongRunningScriptIsCancelled_TheScriptShouldStop(TentacleConfigurationTestCase tentacleConfigurationTestCase)
         {
             await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -39,8 +39,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             [TentacleVersions.v5_0_15_LastOfVersion5] = ScriptServiceV1Type,
             [TentacleVersions.v6_3_417_LastWithScriptServiceV1Only] = ScriptServiceV1Type,
             [TentacleVersions.v6_3_451_NoCapabilitiesService] = ScriptServiceV1Type,
-            [TentacleVersions.v7_1_189_ScriptServiceV2Added] = ScriptServiceV2Type,
-            [TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha] = ScriptServiceV2Type
+            [TentacleVersions.v7_1_189_SyncHalibutAndScriptServiceV2] = ScriptServiceV2Type,
+            [TentacleVersions.v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha] = ScriptServiceV2Type
         };
 
         public static IEnumerator GetEnumerator(
@@ -61,8 +61,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.Current,
                     TentacleVersions.v5_0_15_LastOfVersion5,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
-                    TentacleVersions.v7_1_189_ScriptServiceV2Added,
-                    TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha
+                    TentacleVersions.v7_1_189_SyncHalibutAndScriptServiceV2,
+                    TentacleVersions.v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha
                 });
             }
 
@@ -74,8 +74,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     TentacleVersions.v5_0_4_FirstLinuxRelease,
                     TentacleVersions.v5_0_12_AutofacServiceFactoryIsInShared,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only, // the autofac service is in tentacle, but tentacle does not have the capabilities service.
-                    TentacleVersions.v7_1_189_ScriptServiceV2Added,
-                    TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha
+                    TentacleVersions.v7_1_189_SyncHalibutAndScriptServiceV2,
+                    TentacleVersions.v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha
                 });
             }
 
@@ -85,8 +85,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 {
                     TentacleVersions.Current,
                     TentacleVersions.v6_3_417_LastWithScriptServiceV1Only,
-                    TentacleVersions.v7_1_189_ScriptServiceV2Added, // Testing against v1 and v2 script services
-                    TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha // Testing against v1 and v2 script services
+                    TentacleVersions.v7_1_189_SyncHalibutAndScriptServiceV2, // Testing against v1 and v2 script services
+                    TentacleVersions.v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha // Testing against v1 and v2 script services
                 });
             }
 
@@ -101,6 +101,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             if (versions.Count == 0)
             {
                 versions.Add(TentacleVersions.Current);
+                versions.Add(TentacleVersions.v7_1_189_SyncHalibutAndScriptServiceV2);
+                versions.Add(TentacleVersions.v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha);
             }
 
             var runtimes = new List<TentacleRuntime> { DefaultTentacleRuntime.Value };

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -15,11 +15,19 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             bool testNoCapabilitiesServiceVersions = false,
             bool testScriptIsolationLevelVersions = false,
             bool testDefaultTentacleRuntimeOnly = false,
+            bool testCurrentVersionOnly = false,
             params object[] additionalParameterTypes)
             : base(
                 typeof(TentacleConfigurationTestCases),
                 nameof(TentacleConfigurationTestCases.GetEnumerator),
-                new object[] { testCommonVersions, testCapabilitiesServiceVersions, testNoCapabilitiesServiceVersions, testScriptIsolationLevelVersions, testDefaultTentacleRuntimeOnly, additionalParameterTypes })
+                new object[] { 
+                    testCommonVersions, 
+                    testCapabilitiesServiceVersions, 
+                    testNoCapabilitiesServiceVersions, 
+                    testScriptIsolationLevelVersions, 
+                    testDefaultTentacleRuntimeOnly, 
+                    testCurrentVersionOnly,
+                    additionalParameterTypes })
         {
         }
     }
@@ -49,6 +57,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             bool testNoCapabilitiesServiceVersions,
             bool testScriptIsolationLevel,
             bool testDefaultTentacleRuntimeOnly,
+            bool testCurrentVersionOnly,
             object[] additionalParameterTypes)
         {
             var tentacleTypes = new[] { TentacleType.Listening, TentacleType.Polling };
@@ -96,6 +105,16 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 {
                     TentacleVersions.v6_3_451_NoCapabilitiesService
                 });
+            }
+
+            if (testCurrentVersionOnly)
+            {
+                if (versions.Count != 0)
+                {
+                    throw new ArgumentException("testCurrentVersionOnly cannot be used when other versions are also being tested", nameof(testCurrentVersionOnly));
+                }
+
+                versions.Add(TentacleVersions.Current);
             }
 
             if (versions.Count == 0)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
@@ -20,11 +20,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public static Version v6_3_451_NoCapabilitiesService = new("6.3.451");
 
         // Last version of v7 with ScriptServiceV2
-        public static readonly Version v7_1_189_ScriptServiceV2Added = new("7.1.189");
+        public static readonly Version v7_1_189_SyncHalibutAndScriptServiceV2 = new("7.1.189");
 
         // Last version without ScriptServiceV3Alpha
         // Contains ScriptServiceV1 and ScriptServiceV2
-        public static readonly Version v8_0_81_LastWithoutScriptServiceV3Alpha = new("8.0.81");
+        public static readonly Version v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha = new("8.0.81");
 
         // The version compiled from the current source
         public static readonly Version? Current = null;
@@ -36,8 +36,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             v5_0_15_LastOfVersion5,
             v6_3_417_LastWithScriptServiceV1Only,
             v6_3_451_NoCapabilitiesService,
-            v7_1_189_ScriptServiceV2Added,
-            v8_0_81_LastWithoutScriptServiceV3Alpha
+            v7_1_189_SyncHalibutAndScriptServiceV2,
+            v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha
         };
     }
 
@@ -45,12 +45,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         public static bool HasScriptServiceV3Alpha(this Version? version)
         {
-            return version == TentacleVersions.Current || version > TentacleVersions.v8_0_81_LastWithoutScriptServiceV3Alpha;
+            return version == TentacleVersions.Current || version > TentacleVersions.v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha;
         }
 
         public static bool HasScriptServiceV2(this Version? version)
         {
-            return version == TentacleVersions.Current || version >= TentacleVersions.v7_1_189_ScriptServiceV2Added;
+            return version == TentacleVersions.Current || version >= TentacleVersions.v7_1_189_SyncHalibutAndScriptServiceV2;
         }
     }
 }


### PR DESCRIPTION
# Background

If a test was using the `[TentacleConfigurations]` without explicitly including other versions of Tentacle, it would only run against the latest Tentacle. 

The latest tentacle has ScriptServiceV3Alpha, this resulted in a number of tests such as `ClientScriptExecutionRetriesTimeout` now only testing ScriptServiceV3Apha and not ScriptServiceV2 leaving significant code paths in TentacleClient untested.

# Results

This PR changes the default `[TentacleConfigurations]` to run against

- Latest Tentacle (build from source code)
- v7.1.189 which is the latest Tentacle with Sync Halibut and without ScriptServiceV3Alpha
- v8.0.81 which is the latest Tentacle with Async Halibut and without ScriptServiceV3Alpha

This will result in an increase in Tests run in the Halibut Build Chain

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.