### PR TITLE
Update force option so it's not applied to register-k8s-cluster

### DIFF
--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -145,7 +145,9 @@ function registerTentacle() {
     local ARGS=()
 
     if [[ ! -z "$TargetWorkerPool" ]]; then
-        ARGS+=('register-worker')
+        ARGS+=(
+        'register-worker'
+        '--force')
 
         IFS=',' read -ra WORKER_POOLS <<<"$TargetWorkerPool"
         for i in "${WORKER_POOLS[@]}"; do
@@ -155,7 +157,9 @@ function registerTentacle() {
         if [[ ! -z "$AsKubernetesTentacle" ]]; then
             ARGS+=('register-k8s-cluster')
         else
-            ARGS+=('register-with')
+            ARGS+=(
+            'register-with'
+            '--force')
         fi
 
         if [[ ! -z "$TargetEnvironment" ]]; then
@@ -191,8 +195,7 @@ function registerTentacle() {
         '--instance' "$instanceName"
         '--server' "$ServerUrl"
         '--space' "$Space"
-        '--policy' "$MachinePolicy"
-        '--force')
+        '--policy' "$MachinePolicy")
 
     if [[ ! -z "$ServerCommsAddress" || ! -z "$ServerPort" ]]; then
         ARGS+=('--comms-style' 'TentacleActive')


### PR DESCRIPTION
# Background

Part of #project-k8s-agent

I missed this change as part of updating tentacle to better handle container restarts in kubernetes: https://github.com/OctopusDeploy/OctopusClients/pull/802

# Results

This change basically makes it so that when the container is registering itself as a kubernetes cluster, it won't use the `--force` flag. This aligns with the PR above where, now registering a kubernetes tentacle doesn't require the --force flag to register successfully, even if the tentacle is already registered.

[sc-60420]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.