### PR TITLE
Allow more time to download tentacle binaries

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/OctopusPackageDownloader.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/OctopusPackageDownloader.cs
@@ -20,6 +20,7 @@ namespace Octopus.Tentacle.Tests.Integration
             string expectedHash = null;
             using (var client = new HttpClient())
             {
+                client.Timeout = TimeSpan.FromSeconds(150);
                 using (var response = await client.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead))
                 {
                     response.EnsureSuccessStatusCode();


### PR DESCRIPTION
# Background

We are seeing timeouts downloading tentacle binaries 

```
OneTimeSetUp: System.Threading.Tasks.TaskCanceledException : The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
  ----> System.TimeoutException : The operation was canceled.
  ----> System.Threading.Tasks.TaskCanceledException : The operation was canceled.
  ----> System.IO.IOException : Unable to read data from the transport connection: The I/O operation has been aborted because of either a thread exit or an application request..
  ----> System.Net.Sockets.SocketException : The I/O operation has been aborted because of either a thread exit or an application request.
```

This PR bumps the allowed time to see if it can reduce the occurrence of hte issue.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.