### PR TITLE
Adding environment variable to use recommended timeouts and limits

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.144" />
+    <PackageReference Include="Halibut" Version="7.0.209" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -26,10 +26,13 @@ namespace Octopus.Tentacle.Communications
                 var services = c.Resolve<IServiceFactory>();
 
                 bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled), out var tcpKeepAliveEnabled);
-                var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits
-                {
-                    TcpKeepAliveEnabled = tcpKeepAliveEnabled
-                };
+                bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseRecommendedTimeoutsAndLimits), out var useRecommendedTimeoutsAndLimits);
+
+                var halibutTimeoutsAndLimits = useRecommendedTimeoutsAndLimits 
+                    ? HalibutTimeoutsAndLimits.RecommendedValues() 
+                    : new HalibutTimeoutsAndLimits();
+
+                halibutTimeoutsAndLimits.TcpKeepAliveEnabled = tcpKeepAliveEnabled;
 
                 var halibutRuntime = new HalibutRuntimeBuilder()
                     .WithServiceFactory(services)

--- a/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
+++ b/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
@@ -21,5 +21,6 @@ namespace Octopus.Tentacle.Variables
         public const string TentacleProgramDirectoryPath = "TentacleProgramDirectoryPath";
         public const string AgentProgramDirectoryPath = "AgentProgramDirectoryPath";
         public const string TentacleTcpKeepAliveEnabled = "TentacleTcpKeepAliveEnabled";
+        public const string TentacleUseRecommendedTimeoutsAndLimits = "TentacleUseRecommendedTimeoutsAndLimits";
     }
 }


### PR DESCRIPTION
[sc-42848]

# Background

While enhancing all the timeouts and limits within Halibut, we wanted to be able to try them out before making them the permanent defaults. 

# Results


## Before

The existing timeouts are retained, so that we can simply keep using them while we test out these values.

## After

We now have an environment variable that allows us to use the recommended values and limits.

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.