### PR TITLE
Update Octopus.Tentacle dependencies to mitigate System.Drawing.Common CVE

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Util/TestUserPrincipal.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TestUserPrincipal.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.DirectoryServices.AccountManagement;
 using System.Net;
 using System.Security.Principal;
 
 namespace Octopus.Tentacle.Tests.Integration.Util
 {
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     class TestUserPrincipal
     {
         public TestUserPrincipal(string username, string password = "Password01!")

--- a/source/Octopus.Tentacle.Tests/Util/TestUserPrincipal.cs
+++ b/source/Octopus.Tentacle.Tests/Util/TestUserPrincipal.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.DirectoryServices.AccountManagement;
 using System.Net;
 using System.Security.Principal;
 
 namespace Octopus.Tentacle.Tests.Util
 {
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
     class TestUserPrincipal
     {
         public TestUserPrincipal(string username, string password = "Password01!")

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -92,10 +92,10 @@
 		<PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
 		<PackageReference Include="System.ServiceProcess.ServiceController" Version="7.0.1" />
 		<PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-		<PackageReference Include="System.Diagnostics.EventLog" Version="7.0.0" />
+		<PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
-		<PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
-		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="5.0.0" />
+		<PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
+		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
 		<PackageReference Include="System.Runtime" Version="4.3.0" />


### PR DESCRIPTION
Remove implicit dependencies on `System.Drawing.Common` to address [CVE-2021-24112](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112). This is achieved by updating the following references in `Octopus.Tentacle` to the latest versions:

* `System.Diagnostics.EventLog` (7.0.0 -> 8.0.0)
* `System.DirectoryServices.AccountManagement` (5.0.0 -> 8.0.0)
* `System.Security.Cryptography.ProtectedData` (4.5.0 -> 8.0.0)

# Background
There is a [CVE ](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112) lodged against the version of `System.Drawing.Common` being referenced.

# Results

Partially fixes [Upgrade all usages of System.Drawing.Common in Tentacle](https://github.com/OctopusDeploy/OctopusTentacle/issues/689).

The following will be completed in future PRs to fully address the CVE:
* Halibut must be updated to a new version that mitigates this vulnerability
* Implicit references in `Octopus.Tentacle.Contracts` must be removed.

## Before
`Octopus.Tentacle` implicitly references `System.Drawing.Common` 5.0.0

![20231127-141029_rider64_BcO0zgUZHO](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/bc2a4a63-ccfb-46c3-b168-fd5dc171c0ba)

## After
No implicit references to `System.Drawing.Common` in `Octopus.Tentacle`

![20231127-140159_rider64_Cg1ndyHukP](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/d330acb8-59c4-435a-9410-0ae244f1bc84)

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.