### PR TITLE
Bump Halibut to fix a polling tentacle cooperative cancellation issue causing request to time out to quickly

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.256" />
+    <PackageReference Include="Halibut" Version="7.0.270-pull-558" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Tests.Integration/PollingRequestAndResponseTimeouts.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/PollingRequestAndResponseTimeouts.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut;
+using NUnit.Framework;
+using Octopus.Tentacle.CommonTestUtils.Builders;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Util;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.Proxies;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [IntegrationTestTimeout]
+    public class PollingRequestAndResponseTimeouts : IntegrationTest
+    {
+        [Test]
+        [TentacleConfigurations(testListening: false)]
+        public async Task WhenThePollingRequestQueueTimeoutIsReached_ForARequestThatHasNotBeenDequeuedByTentacle_TheRequestShouldTimeout(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithRetriesDisabled()
+                .WithPortForwarder()
+                .WithServiceEndpointModifier(serviceEndpoint =>
+                {
+                    serviceEndpoint.PollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
+                })
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages<IAsyncClientCapabilitiesServiceV2>(out var capabilitiesMethodUsages)
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var scriptServiceMethodUsages)
+                    .Build())
+                .Build(CancellationToken);
+
+            // Stop the request from being dequeued by stopping the Tentacle from connecting
+            clientTentacle.PortForwarder!.EnterKillNewAndExistingConnectionsMode();
+            
+            var startScriptCommand = new LatestStartScriptCommandBuilder().WithScriptBody(new ScriptBuilder().Print("Script Executed")).Build();
+
+            (await AssertionExtensions.Should(() => clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken)).ThrowAsync<HalibutClientException>())
+                .And.Message.Should().Contain("A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:00:05), so the request timed out.");
+            
+            capabilitiesMethodUsages.ForGetCapabilitiesAsync().Completed.Should().Be(1);
+            scriptServiceMethodUsages.ForStartScriptAsync().Completed.Should().Be(0, "Get Capabilities should have timed out and cancelled script execution");
+        }
+
+        [Test]
+        [TentacleConfigurations(testListening: false)]
+        public async Task WhenThePollingRequestQueueTimeoutIsReached_ForARequestBeingProcessedByTentacle_AndTheResponseIsReceivedBeforeThePollingRequestMaximumMessageProcessingTimeoutIsReached_TheRequestShouldSucceed(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var pollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
+            var buffer = TimeSpan.FromSeconds(5);
+
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithPortForwarder()
+                .WithRetriesDisabled()
+                .WithServiceEndpointModifier(serviceEndpoint =>
+                {
+                    serviceEndpoint.PollingRequestQueueTimeout = pollingRequestQueueTimeout;
+                    serviceEndpoint.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromHours(1);
+                })
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages<IAsyncClientCapabilitiesServiceV2>(out var capabilitiesMethodUsages)
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var scriptServiceMethodUsages)
+                    .Build())
+                .Build(CancellationToken);
+
+            // Ensure the script takes longer than the pollingRequestQueueTimeout but less than the PollingRequestMaximumMessageProcessingTimeout
+            var scriptDuration = pollingRequestQueueTimeout + buffer;
+
+            var startScriptCommand = new LatestStartScriptCommandBuilder().WithScriptBody(new ScriptBuilder()
+                    .Sleep(scriptDuration)
+                    .Print("Script Executed"))
+                    // Allow the Start Script call to take longer than the script being executed
+                    .WithDurationStartScriptCanWaitForScriptToFinish(scriptDuration * 2)
+                    .Build();
+
+            var (finalResponse, _) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+
+            finalResponse.State.Should().Be(ProcessState.Complete);
+            finalResponse.ExitCode.Should().Be(0);
+
+            capabilitiesMethodUsages.ForGetCapabilitiesAsync().Completed.Should().Be(1);
+            scriptServiceMethodUsages.ForStartScriptAsync().Completed.Should().Be(1);
+            scriptServiceMethodUsages.ForGetStatusAsync().Completed.Should().Be(0, "The test should have allowed StartScript long enough to complete the script, ensuring it took longer than PollingRequestQueueTimeout");
+            scriptServiceMethodUsages.ForCompleteScriptAsync().Completed.Should().Be(1);
+        }
+
+        [Test]
+        [TentacleConfigurations(testListening: false)]
+        public async Task WhenThePollingRequestMaximumMessageProcessingTimeoutIsReached_ForARequestBeingProcessedByTentacle_TheRequestShouldTimeout(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            var pollingRequestQueueTimeout = TimeSpan.FromSeconds(5);
+            var pollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(10);
+            var buffer = TimeSpan.FromSeconds(5);
+
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithPortForwarder()
+                .WithRetriesDisabled()
+                .WithServiceEndpointModifier(serviceEndpoint =>
+                {
+                    serviceEndpoint.PollingRequestQueueTimeout = pollingRequestQueueTimeout;
+                    serviceEndpoint.PollingRequestMaximumMessageProcessingTimeout = pollingRequestMaximumMessageProcessingTimeout;
+                })
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages<IAsyncClientCapabilitiesServiceV2>(out var capabilitiesMethodUsages)
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var scriptServiceMethodUsages)
+                    .Build())
+                .Build(CancellationToken);
+
+            // Ensure the script takes longer than the pollingRequestQueueTimeout + pollingRequestMaximumMessageProcessingTimeout
+            var scriptDuration = pollingRequestQueueTimeout + pollingRequestMaximumMessageProcessingTimeout + buffer + buffer;
+
+            var startScriptCommand = new LatestStartScriptCommandBuilder().WithScriptBody(new ScriptBuilder()
+                    .Sleep(scriptDuration)
+                    .Print("Script Executed"))
+                    // Allow the Start Script call to take longer than the script being executed
+                    .WithDurationStartScriptCanWaitForScriptToFinish(scriptDuration * 2)
+                    .Build();
+
+            (await AssertionExtensions.Should(() => clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken)).ThrowAsync<HalibutClientException>())
+                .And.Message.Should().Contain("A request was sent to a polling endpoint, the polling endpoint collected it but did not respond in the allowed time (00:00:10), so the request timed out.");
+            
+            capabilitiesMethodUsages.ForGetCapabilitiesAsync().Completed.Should().Be(1);
+            scriptServiceMethodUsages.ForStartScriptAsync().Completed.Should().Be(1);
+            scriptServiceMethodUsages.ForGetStatusAsync().Completed.Should().Be(0, "The test should have allowed StartScript long enough to cause the PollingRequestMaximumMessageProcessingTimeout to elapse");
+            scriptServiceMethodUsages.ForCancelScriptAsync().Completed.Should().Be(0);
+            scriptServiceMethodUsages.ForCompleteScriptAsync().Completed.Should().Be(0);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -15,13 +15,23 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             bool testScriptIsolationLevelVersions = false,
             bool testDefaultTentacleRuntimeOnly = false,
             ScriptServiceVersionToTest scriptServiceToTest = ScriptServiceVersionToTest.TentacleSupported,
+            bool testPolling = true,
+            bool testListening = true,
             params object[] additionalParameterTypes)
             : base(
                 typeof(TentacleConfigurationTestCases),
                 nameof(TentacleConfigurationTestCases.GetEnumerator),
                 new object[]
                 {
-                    testCommonVersions, testCapabilitiesServiceVersions, testNoCapabilitiesServiceVersions, testScriptIsolationLevelVersions, testDefaultTentacleRuntimeOnly, scriptServiceToTest, additionalParameterTypes
+                    testCommonVersions, 
+                    testCapabilitiesServiceVersions, 
+                    testNoCapabilitiesServiceVersions, 
+                    testScriptIsolationLevelVersions, 
+                    testDefaultTentacleRuntimeOnly, 
+                    scriptServiceToTest, 
+                    testPolling,
+                    testListening,
+                    additionalParameterTypes
                 })
         {
         }
@@ -53,9 +63,27 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             bool testScriptIsolationLevel,
             bool testDefaultTentacleRuntimeOnly,
             ScriptServiceVersionToTest scriptServiceToTest,
+            bool testPolling,
+            bool testListening,
             object[] additionalParameterTypes)
         {
-            var tentacleTypes = new[] { TentacleType.Listening, TentacleType.Polling };
+            var tentacleTypes = new List<TentacleType>();
+
+            if (testPolling)
+            {
+                tentacleTypes.Add(TentacleType.Polling);
+            }
+
+            if (testListening)
+            {
+                tentacleTypes.Add(TentacleType.Listening);
+            }
+
+            if (!tentacleTypes.Any())
+            {
+                throw new ArgumentException("At least one TentacleType must be tested.");
+            }
+
             List<Version?> versions = new();
 
             if (testCommonVersions)


### PR DESCRIPTION
# Background

This PR bumps Halibut to fixe a bug in cooperative cancellation for Polling Requests which causes the transferring request to be cancelled after the PollingRequestQueueTimeout rather than waiting for the PollingRequestMaximumMessageProcessingTimeout

Additional integration tests have also been added to ensure this does not regress.

Related [Fix a bug in cooperative cancellation for Polling Services causing a request to be cancelled before it should be](https://github.com/OctopusDeploy/Halibut/pull/558)

[sc-58429]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.