### PR TITLE
Update Halibut

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.209" />
+    <PackageReference Include="Halibut" Version="7.0.285" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -31,6 +31,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+        <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
         <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <Reference Include="System.DirectoryServices.AccountManagement" Condition="'$(TargetFramework)' == 'net48'" />

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="4.5.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.36" />
   </ItemGroup>
   <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -94,7 +94,6 @@
 		<PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
 		<PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
-		<PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
 		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">


### PR DESCRIPTION
Update Halibut to `7.0.285` in order to get fixes for [CVE-2021-24112](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112) (as introduced in https://github.com/OctopusDeploy/Halibut/pull/554)

As an added bonus, I pulled up a dependency from `Octopus.Tentacle` into the automated test projects where it is actually needed.

# Background
There is a [CVE ](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-24112)lodged against the version of System.Drawing.Common being referenced.

# Results
Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/689
_(The other part of the fix is in https://github.com/OctopusDeploy/OctopusTentacle/pull/694 which has already been merged)_

The main result is that there is no remaining production Tentacle code that depends on `System.Drawing.Common`, implicitly or explicitly.

The `_build` project still holds an implicit dependency via Nuke.

`Octopus.Tentacle` had a dependency on `System.DirectoryServices.AccountManagement` even though there was no code that depended on it. The only indirect usage was in the two instances of TestUserPrincipal (one in [Octopus.Tentacle.Tests](https://github.com/OctopusDeploy/OctopusTentacle/blob/015c093cb7d904d7382d8453b57b598c31e3b339/source/Octopus.Tentacle.Tests/Util/TestUserPrincipal.cs), the other in [Octopus.Tentacle.Tests.Integration](https://github.com/OctopusDeploy/OctopusTentacle/blob/015c093cb7d904d7382d8453b57b598c31e3b339/source/Octopus.Tentacle.Tests.Integration/Util/TestUserPrincipal.cs)), so the dependency has been added to those test projects instead.

Keen eyes may notice that the version of `System.DirectoryServices.AccountManagement` has also changed, now downgraded from `8.0.0` to `4.5.0`. [The upgrade from v4.5 -> v8 was done recently as part of this PR](https://github.com/OctopusDeploy/OctopusTentacle/pull/694), but due to implicit dependencies and the continued need to support .NET Framework 4.8, it caused the following warning to be raised:

```
3>Microsoft.Common.CurrentVersion.targets(2302,5): Warning MSB3277 : Found conflicts between different versions of "System.Security.Permissions" that could not be resolved.
There was a conflict between "System.Security.Permissions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" and "System.Security.Permissions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51".
    "System.Security.Permissions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" was chosen because it was primary and "System.Security.Permissions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" was not.
    References which depend on "System.Security.Permissions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" [C:\Users\AdrianCodrington\.nuget\packages\system.security.permissions\4.4.0\ref\netstandard2.0\System.Security.Permissions.dll].
        C:\Users\AdrianCodrington\.nuget\packages\system.security.permissions\4.4.0\ref\netstandard2.0\System.Security.Permissions.dll
          Project file item includes which caused reference "C:\Users\AdrianCodrington\.nuget\packages\system.security.permissions\4.4.0\ref\netstandard2.0\System.Security.Permissions.dll".
            C:\Users\AdrianCodrington\.nuget\packages\system.security.permissions\4.4.0\ref\netstandard2.0\System.Security.Permissions.dll
    References which depend on "System.Security.Permissions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" [].
        C:\Users\AdrianCodrington\.nuget\packages\system.directoryservices\8.0.0\lib\net6.0\System.DirectoryServices.dll
          Project file item includes which caused reference "C:\Users\AdrianCodrington\.nuget\packages\system.directoryservices\8.0.0\lib\net6.0\System.DirectoryServices.dll".
            C:\Users\AdrianCodrington\.nuget\packages\system.directoryservices\8.0.0\lib\net6.0\System.DirectoryServices.dll
        C:\Users\AdrianCodrington\.nuget\packages\taskscheduler\2.7.2\lib\netstandard2.0\Microsoft.Win32.TaskScheduler.dll
          Project file item includes which caused reference "C:\Users\AdrianCodrington\.nuget\packages\taskscheduler\2.7.2\lib\netstandard2.0\Microsoft.Win32.TaskScheduler.dll".
            C:\Users\AdrianCodrington\.nuget\packages\taskscheduler\2.7.2\lib\netstandard2.0\Microsoft.Win32.TaskScheduler.dll
            C:\dev\OctopusTentacle\source\Octopus.Tentacle\bin\net6.0\Tentacle.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Configuration.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Configuration.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/System.Configuration.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Data.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Data.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/System.Data.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Drawing.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Drawing.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/System.Drawing.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Net.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Net.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/System.Net.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Security.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Security.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/System.Security.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.ServiceProcess.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.ServiceProcess.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/System.ServiceProcess.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Transactions.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.Transactions.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/System.Transactions.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\System.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/System.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\WindowsBase.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\WindowsBase.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/WindowsBase.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\mscorlib.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref\net6.0\mscorlib.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\6.0.25\ref/net6.0/mscorlib.dll
            C:\Users\AdrianCodrington\.nuget\packages\microsoft.codecoverage\17.3.2\lib\netcoreapp1.0\Microsoft.VisualStudio.CodeCoverage.Shim.dll
            C:\Users\AdrianCodrington\.nuget\packages\octopus.client\14.3.980\lib\netstandard2.0\Octopus.Client.dll
            C:\dev\OctopusTentacle\source\Octopus.Tentacle\bin\net6.0\Tentacle.dll
```

As there was no reason other than the CVE to upgrade this assembly, I reverted this upgrade to avoid unnecessary warnings and potential conflicts.

## Before
![20231128-155453_rider64_BCfi7wTcJo](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/31a3b29c-1127-4aaf-b4b5-d7fc4ff00705)

## After
![20231128-154102_rider64_NC5tzdQ64Q](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/cddf488a-57df-4ddb-9913-e562384093b6)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.