### PR TITLE
Add a test category and apply to tests that require sudo on Linux

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
@@ -20,12 +20,14 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
     public class LinuxConfigureServiceHelperFixture
     {
         [Test]
+        [RequiresSudoOnLinux]
         public void CanInstallServiceAsRoot()
         {
             CanInstallService(null, null);
         }
 
         [Test]
+        [RequiresSudoOnLinux]
         public void CanInstallServiceAsUser()
         {
             var user = new LinuxTestUserPrincipal("octo-shared-svc-test");
@@ -33,6 +35,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
         }
 
         [Test]
+        [RequiresSudoOnLinux]
         public void CannotWriteToServiceFileAsUser()
         {
             const string serviceName = "OctopusShared.ServiceHelperTest";

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TestAttributes/RequiresSudoOnLinuxAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TestAttributes/RequiresSudoOnLinuxAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class RequiresSudoOnLinuxAttribute : CategoryAttribute
+    { }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/OctopusPhysicalFileSystemFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/OctopusPhysicalFileSystemFixture.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Diagnostics;
+using Octopus.Tentacle.Tests.Integration.Support.TestAttributes;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Integration.Util
@@ -26,6 +27,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         }
 
         [Test]
+        [RequiresSudoOnLinux]
         public void DeleteDirectory_WithReadOnlyFiles_ShouldSucceed()
         {
             // Arrange


### PR DESCRIPTION
# Background

Add a test category and apply to tests that require sudo on Linux.

This will allow these tests to be filtered out of integration test runs on agents where tests cannot run as Sudo

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/7ef71060-2bbb-44d8-8858-1f9be142496f)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.