### PR TITLE
Attempt to download tentacles multiple times

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/OctopusPackageDownloader.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/OctopusPackageDownloader.cs
@@ -86,7 +86,7 @@ namespace Octopus.Tentacle.Tests.Integration
                             
                             totalTime.Stop();
 
-                            logger.Information("Download Finished in {totalTime}", totalTime.ElapsedMilliseconds);
+                            logger.Information("Download Finished in {totalTime}ms", totalTime.ElapsedMilliseconds);
                         }
                     }
                 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/OctopusPackageDownloader.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/OctopusPackageDownloader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -17,56 +18,99 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         public static async Task DownloadPackage(string downloadUrl, string filePath, ILogger logger)
         {
-            string expectedHash = null;
-            using (var client = new HttpClient())
+            var exceptions = new List<Exception>();
+            for (int i = 0; i < 5; i++)
             {
-                client.Timeout = TimeSpan.FromSeconds(150);
-                using (var response = await client.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead))
+                try
                 {
-                    response.EnsureSuccessStatusCode();
-                    var totalLength = response.Content.Headers.ContentLength;
-                    if (response.Headers.TryGetValues("x-amz-meta-sha256", out var expectedHashs))
-                    {
-                        expectedHash = expectedHashs.FirstOrDefault();
-                    }
-
-                    logger.Information($"Downloading {downloadUrl} ({totalLength} bytes)");
-                    var sw = new Stopwatch();
-                    sw.Start();
-                    using (Stream contentStream = await response.Content.ReadAsStreamAsync(),
-                           fileStream = new FileStream(
-                               filePath,
-                               FileMode.Create,
-                               FileAccess.Write,
-                               FileShare.None,
-                               8192,
-                               true))
-                    {
-                        var totalRead = 0L;
-                        var buffer = new byte[8192];
-
-                        var read = await contentStream.ReadAsync(buffer, 0, buffer.Length);
-                        while (read != 0)
-                        {
-                            await fileStream.WriteAsync(buffer, 0, read);
-
-                            if (totalLength.HasValue && sw.ElapsedMilliseconds >= TimeSpan.FromSeconds(7).TotalMilliseconds)
-                            {
-                                var percentRead = totalRead * 1.0 / totalLength.Value * 100;
-                                logger.Information($"Downloading Completed {percentRead}%");
-                                sw.Reset();
-                                sw.Start();
-                            }
-
-                            read = await contentStream.ReadAsync(buffer, 0, buffer.Length);
-                            totalRead += read;
-                        }
-
-                        logger.Information("Download Finished");
-                    }
+                    await AttemptToDownloadPackage(downloadUrl, filePath, logger);
+                    return;
+                }
+                catch (Exception e)
+                {
+                    exceptions.Add(e);
                 }
             }
 
+            throw new AggregateException(exceptions);
+        }
+        static async Task AttemptToDownloadPackage(string downloadUrl, string filePath, ILogger logger)
+        {
+            var totalTime = Stopwatch.StartNew();
+            var totalRead = 0L;
+            string expectedHash = null;
+            try
+            {
+                using (var client = new HttpClient())
+                {
+                    // This appears to be the time it takes to do a single read/write, not the entire download.
+                    client.Timeout = TimeSpan.FromSeconds(20);
+                    using (var response = await client.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead))
+                    {
+                        response.EnsureSuccessStatusCode();
+                        var totalLength = response.Content.Headers.ContentLength;
+                        expectedHash = TryGetExpectedHashFromHeaders(response, expectedHash);
+
+                        logger.Information($"Downloading {downloadUrl} ({totalLength} bytes)");
+
+                        var sw = new Stopwatch();
+                        sw.Start();
+                        using (Stream contentStream = await response.Content.ReadAsStreamAsync(),
+                               fileStream = new FileStream(
+                                   filePath,
+                                   FileMode.Create,
+                                   FileAccess.Write,
+                                   FileShare.None,
+                                   8192,
+                                   true))
+                        {
+
+                            var buffer = new byte[8192];
+
+                            var read = await contentStream.ReadAsync(buffer, 0, buffer.Length);
+                            while (read != 0)
+                            {
+                                await fileStream.WriteAsync(buffer, 0, read);
+
+                                if (totalLength.HasValue && sw.ElapsedMilliseconds >= TimeSpan.FromSeconds(7).TotalMilliseconds)
+                                {
+                                    var percentRead = totalRead * 1.0 / totalLength.Value * 100;
+                                    logger.Information($"Downloading Completed {percentRead}%");
+                                    sw.Reset();
+                                    sw.Start();
+                                }
+
+                                read = await contentStream.ReadAsync(buffer, 0, buffer.Length);
+                                totalRead += read;
+                            }
+                            
+                            totalTime.Stop();
+
+                            logger.Information("Download Finished in {totalTime}", totalTime.ElapsedMilliseconds);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Failure to download: {downloadUrl}. After {totalTime.Elapsed.TotalSeconds} seconds we only downloaded, {totalRead}", e);
+            }
+
+            ValidateDownload(filePath, expectedHash);
+        }
+
+        static string TryGetExpectedHashFromHeaders(HttpResponseMessage response, string expectedHash)
+        {
+            if (response.Headers.TryGetValues("x-amz-meta-sha256", out var expectedHashs))
+            {
+                expectedHash = expectedHashs.FirstOrDefault();
+            }
+
+            return expectedHash;
+        }
+
+        static void ValidateDownload(string filePath, string expectedHash)
+        {
             if (!expectedHash.IsNullOrEmpty())
             {
                 using (var sha256 = SHA256.Create())


### PR DESCRIPTION
# Background

We are seeing time outs when downloading older tentacle versions, where the timeout is set to 150s.

This PR attempts to help with that by:
* Reducing the timoeut to 20s, since the timeout appears to apply to each read/write rather than the operation as a whole.
* Attempt 5 times (with a simple for loop since the problem we have is a timout of 20s to read any bytes so we probably don't have a reason to get fancy).

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.