### PR TITLE
Support overriding configuration directories in K8s Container

### DIFF
--- a/build-k8s-docker-local.ps1
+++ b/build-k8s-docker-local.ps1
@@ -1,0 +1,24 @@
+param (
+    [Parameter(Mandatory=$True)]
+    [string]
+    $BuildNumber,
+    
+    [Parameter()]
+    [string]
+    $BuildArch = "amd64",
+
+    
+    [Parameter()]
+    [string]
+    $LocalRegistryDomain = "localhost:5500"
+)
+
+$env:BUILD_NUMBER=$BuildNumber
+$env:BUILD_DATE= Get-Date -Format "yyyy-MM-dd"
+$env:BUILD_ARCH=$BuildArch
+
+& docker compose -f docker-compose.build.yml -v build --pull octopusdeploy-kubernetes-tentacle-linux
+
+& docker tag "docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:$BuildNumber-linux-$BuildArch" "$LocalRegistryDomain/kubernetes-tentacle"
+
+& docker push "$LocalRegistryDomain/kubernetes-tentacle"

--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -46,6 +46,8 @@ ENV OCTOPUS__K8STENTACLE__NAMESPACE=""
 ENV OCTOPUS__K8STENTACLE__USEJOBS="True"
 ENV OCTOPUS__K8STENTACLE__JOBSERVICEACCOUNTNAME=""
 ENV OCTOPUS__K8STENTACLE__JOBVOLUMEYAML=""
+ENV TentacleHome=""
+ENV TentacleApplications=""
 
 CMD /scripts/configure-tentacle.sh && /scripts/run-tentacle.sh
 

--- a/docker/kubernetes-tentacle/scripts/configure-tentacle.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-tentacle.sh
@@ -67,13 +67,13 @@ function validateVariables() {
     echo " - server endpoint '$ServerUrl'"
     echo " - api key '##########'"
 
-    if [[ ! -z "$ServerCommsAddress" || ! -z "$ServerPort" ]]; then
+    if [[ -n "$ServerCommsAddress" || -n "$ServerPort" ]]; then
         echo " - communication mode 'Kubernetes' (Polling)"
 
-        if [[ ! -z "$ServerCommsAddress" ]]; then
+        if [[ -n "$ServerCommsAddress" ]]; then
             echo " - server comms address $ServerCommsAddress"
         fi
-        if [[ ! -z "$ServerPort" ]]; then
+        if [[ -n "$ServerPort" ]]; then
             echo " - server port $ServerPort"
         fi
     else
@@ -85,19 +85,19 @@ function validateVariables() {
     echo " - role '$TargetRole'"
     echo " - host '$PublicHostNameConfiguration'"
 
-    if [[ ! -z "$TargetName" ]]; then
+    if [[ -n "$TargetName" ]]; then
         echo " - name '$TargetName'"
     fi
-    if [[ ! -z "$TargetTenant" ]]; then
+    if [[ -n "$TargetTenant" ]]; then
         echo " - tenant '$TargetTenant'"
     fi
-    if [[ ! -z "$TargetTenantTag" ]]; then
+    if [[ -n "$TargetTenantTag" ]]; then
         echo " - tenant tag '$TargetTenantTag'"
     fi
-    if [[ ! -z "$TargetTenantedDeploymentParticipation" ]]; then
+    if [[ -n "$TargetTenantedDeploymentParticipation" ]]; then
         echo " - tenanted deployment participation '$TargetTenantedDeploymentParticipation'"
     fi
-    if [[ ! -z "$Space" ]]; then
+    if [[ -n "$Space" ]]; then
         echo " - space '$Space'"
     fi
 }
@@ -109,7 +109,7 @@ function configureTentacle() {
     tentacle configure --instance "$instanceName" --app "$applicationsDirectory"
 
     echo "Configuring communication type ..."
-    if [[ ! -z "$ServerCommsAddress" || ! -z "$ServerPort" ]]; then
+    if [[ -n "$ServerCommsAddress" || -n "$ServerPort" ]]; then
         tentacle configure --instance "$instanceName" --noListen "True"
     else
         tentacle configure --instance "$instanceName" --port $internalListeningPort --noListen "False"
@@ -129,28 +129,28 @@ function registerTentacle() {
 
     ARGS+=('register-k8s-cluster')
 
-    if [[ ! -z "$TargetEnvironment" ]]; then
+    if [[ -n "$TargetEnvironment" ]]; then
         IFS=',' read -ra ENVIRONMENTS <<<"$TargetEnvironment"
         for i in "${ENVIRONMENTS[@]}"; do
             ARGS+=('--environment' "$i")
         done
     fi
 
-    if [[ ! -z "$TargetRole" ]]; then
+    if [[ -n "$TargetRole" ]]; then
         IFS=',' read -ra ROLES <<<"$TargetRole"
         for i in "${ROLES[@]}"; do
             ARGS+=('--role' "$i")
         done
     fi
 
-    if [[ ! -z "$TargetTenant" ]]; then
+    if [[ -n "$TargetTenant" ]]; then
         IFS=',' read -ra TENANTS <<<"$TargetTenant"
         for i in "${TENANTS[@]}"; do
             ARGS+=('--tenant' "$i")
         done
     fi
 
-    if [[ ! -z "$TargetTenantTag" ]]; then
+    if [[ -n "$TargetTenantTag" ]]; then
         IFS=',' read -ra TENANTTAGS <<<"$TargetTenantTag"
         for i in "${TENANTTAGS[@]}"; do
             ARGS+=('--tenanttag' "$i")
@@ -163,14 +163,14 @@ function registerTentacle() {
         '--space' "$Space"
         '--policy' "$MachinePolicy")
 
-    if [[ ! -z "$ServerCommsAddress" || ! -z "$ServerPort" ]]; then
+    if [[ -n "$ServerCommsAddress" || -n "$ServerPort" ]]; then
         ARGS+=('--comms-style' 'TentacleActive')
 
-        if [[ ! -z "$ServerCommsAddress" ]]; then
+        if [[ -n "$ServerCommsAddress" ]]; then
             ARGS+=('--server-comms-address' $ServerCommsAddress)
         fi
 
-        if [[ ! -z "$ServerPort" ]]; then
+        if [[ -n "$ServerPort" ]]; then
             ARGS+=('--server-comms-port' $ServerPort)
         fi
     else
@@ -178,15 +178,15 @@ function registerTentacle() {
             '--comms-style' 'TentaclePassive'
             '--publicHostName' $(getPublicHostName))
 
-        if [[ ! -z "$ListeningPort" && "$ListeningPort" != "$internalListeningPort" ]]; then
+        if [[ -n "$ListeningPort" && "$ListeningPort" != "$internalListeningPort" ]]; then
             ARGS+=('--tentacle-comms-port' $ListeningPort)
         fi
     fi
 
-    if [[ ! -z "$ServerApiKey" ]]; then
+    if [[ -n "$ServerApiKey" ]]; then
         echo "Registering Tentacle with API key"
         ARGS+=('--apiKey' $ServerApiKey)
-    elif [[ ! -z "$BearerToken" ]]; then
+    elif [[ -n "$BearerToken" ]]; then
         echo "Registering Tentacle with Bearer Token"
         ARGS+=('--bearerToken' "$BearerToken")
     else
@@ -196,11 +196,11 @@ function registerTentacle() {
             '--password' "$ServerPassword")
     fi
 
-    if [[ ! -z "$TargetName" ]]; then
+    if [[ -n "$TargetName" ]]; then
         ARGS+=('--name' "$TargetName")
     fi
 
-    if [[ ! -z "$TargetTenantedDeploymentParticipation" ]]; then
+    if [[ -n "$TargetTenantedDeploymentParticipation" ]]; then
         ARGS+=('--tenanted-deployment-participation' "$TargetTenantedDeploymentParticipation")
     fi
 

--- a/docker/kubernetes-tentacle/scripts/configure-tentacle.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-tentacle.sh
@@ -103,7 +103,7 @@ function validateVariables() {
 }
 
 function configureTentacle() {
-    tentacle create-instance --instance "$instanceName" --config "$configurationDirectory/tentacle.config"
+    tentacle create-instance --instance "$instanceName" --config "$configurationDirectory/tentacle.config" --home "$configurationDirectory"
 
     echo "Setting directory paths ..."
     tentacle configure --instance "$instanceName" --app "$applicationsDirectory"

--- a/docker/kubernetes-tentacle/scripts/configure-tentacle.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-tentacle.sh
@@ -8,9 +8,19 @@ fi
 
 # Tentacle Docker images only support once instance per container. Running multiple instances can be achieved by running multiple containers.
 instanceName=Tentacle
-configurationDirectory=/etc/octopus
-applicationsDirectory=/home/Octopus/Applications
 internalListeningPort=10933
+
+#If TentacleHome environment variable exists, use that
+configurationDirectory=/etc/octopus
+if [[ -n "$TentacleHome"]]; then
+    configurationDirectory="$TentacleHome"
+fi
+
+#If TentacleApplications environment variable exists, use that
+applicationsDirectory=/home/Octopus/Applications
+if [[ -n "$TentacleApplications"]]; then
+    configurationDirectory="$TentacleApplications"
+fi
 
 mkdir -p $configurationDirectory
 mkdir -p $applicationsDirectory

--- a/docker/kubernetes-tentacle/scripts/configure-tentacle.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-tentacle.sh
@@ -12,14 +12,14 @@ internalListeningPort=10933
 
 #If TentacleHome environment variable exists, use that
 configurationDirectory=/etc/octopus
-if [[ -n "$TentacleHome"]]; then
+if [[ -n "$TentacleHome" ]]; then
     configurationDirectory="$TentacleHome"
 fi
 
 #If TentacleApplications environment variable exists, use that
 applicationsDirectory=/home/Octopus/Applications
-if [[ -n "$TentacleApplications"]]; then
-    configurationDirectory="$TentacleApplications"
+if [[ -n "$TentacleApplications" ]]; then
+    applicationsDirectory="$TentacleApplications"
 fi
 
 mkdir -p $configurationDirectory


### PR DESCRIPTION
# Background

The Kubernetes Tentacle needs to be able to configure the directory path for the home + application directories so they can be specified to be on a NFS/volume mount 

# Results

The container now takes the `TentacleHome` and `TentacleApplications` environment variables and uses them in `configure-tentacle.sh` if they are set to override the default values.

We also now explicitly set the `home` directory in the `create-instance` command (for clarity).

Also some minor bash cleanups: `! -z` is the same as `-n`

Shortcut story: [sc-66137]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.