### PR TITLE
Enable Halibut TCP Keepalives by default

### DIFF
--- a/source/Octopus.Tentacle.Tests/Communications/TentacleCommunicationsModuleFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Communications/TentacleCommunicationsModuleFixture.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Autofac;
+using FluentAssertions;
+using Halibut;
+using NUnit.Framework;
+using Octopus.Tentacle.Communications;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Tests.Commands;
+using Octopus.Tentacle.Variables;
+
+namespace Octopus.Tentacle.Tests.Communications
+{
+    public class TentacleCommunicationsModuleFixture
+    {
+        [Test]
+        [NonParallelizable]
+        public void HalibutTcpKeepAlivesShouldBeEnabledByDefault()
+        {
+            var container = BuildContainer();
+
+            var halibutRuntime = container.Resolve<HalibutRuntime>();
+
+            halibutRuntime.TimeoutsAndLimits.TcpKeepAliveEnabled.Should().BeTrue();
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void HalibutTcpKeepAlivesCanBeDisabledWithAnEnvironmentVariable()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "False");
+
+                var container = BuildContainer();
+
+                var halibutRuntime = container.Resolve<HalibutRuntime>();
+
+                halibutRuntime.TimeoutsAndLimits.TcpKeepAliveEnabled.Should().BeFalse();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "");
+            }
+        } 
+        
+        [Test]
+        [NonParallelizable]
+        public void AnEmptyHalibutTcpKeepAlivesEnvironmentVariableIsIgnored()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "");
+
+            var container = BuildContainer();
+
+            var halibutRuntime = container.Resolve<HalibutRuntime>();
+
+            halibutRuntime.TimeoutsAndLimits.TcpKeepAliveEnabled.Should().BeTrue();
+        } 
+
+        [Test]
+        [NonParallelizable]
+        public void AnInvalidHalibutTcpKeepAlivesEnvironmentVariableIsIgnored()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "NOTABOOL");
+
+                var container = BuildContainer();
+
+                var halibutRuntime = container.Resolve<HalibutRuntime>();
+
+                halibutRuntime.TimeoutsAndLimits.TcpKeepAliveEnabled.Should().BeTrue();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "");
+            }
+        } 
+
+        static IContainer BuildContainer()
+        {
+            var builder = new ContainerBuilder();
+            var configuration = new StubTentacleConfiguration();
+            configuration.TentacleCertificate = configuration.GenerateNewCertificate();
+            configuration.AddOrUpdateTrustedOctopusServer(new OctopusServerConfiguration("NOPE"));
+            builder.RegisterInstance(configuration).As<ITentacleConfiguration>();
+            builder.RegisterModule<TentacleCommunicationsModule>();
+            var container = builder.Build();
+            return container;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -25,7 +25,12 @@ namespace Octopus.Tentacle.Communications
                 var configuration = c.Resolve<ITentacleConfiguration>();
                 var services = c.Resolve<IServiceFactory>();
 
-                bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled), out var tcpKeepAliveEnabled);
+                if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled), out var tcpKeepAliveEnabled))
+                {
+                    // Default to enabled if the environment variable is not provided
+                    tcpKeepAliveEnabled = true;
+                }
+
                 bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseRecommendedTimeoutsAndLimits), out var useRecommendedTimeoutsAndLimits);
 
                 var halibutTimeoutsAndLimits = useRecommendedTimeoutsAndLimits 


### PR DESCRIPTION
# Background

Enable Halibut TCP Keepalives by default

The environment variable has been left so that TCP keep alive can be disabled if required.

[sc-64824]

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/692

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.