### PR TITLE
Generate machine key in home directory in K8s

### DIFF
--- a/build-k8s-docker-local.ps1
+++ b/build-k8s-docker-local.ps1
@@ -19,6 +19,6 @@ $env:BUILD_ARCH=$BuildArch
 
 & docker compose -f docker-compose.build.yml -v build --pull octopusdeploy-kubernetes-tentacle-linux
 
-& docker tag "docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:$BuildNumber-linux-$BuildArch" "$LocalRegistryDomain/kubernetes-tentacle"
+& docker tag "docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:$BuildNumber-linux-$BuildArch" "$LocalRegistryDomain/kubernetes-tentacle:$BuildNumber-linux-$BuildArch"
 
-& docker push "$LocalRegistryDomain/kubernetes-tentacle"
+& docker push "$LocalRegistryDomain/kubernetes-tentacle:$BuildNumber-linux-$BuildArch"

--- a/source/Octopus.Tentacle/Configuration/Crypto/LinuxGeneratedMachineKey.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/LinuxGeneratedMachineKey.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Security.Cryptography;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Util;
+using Octopus.Tentacle.Variables;
 
 namespace Octopus.Tentacle.Configuration.Crypto
 {
@@ -10,7 +11,12 @@ namespace Octopus.Tentacle.Configuration.Crypto
     {
         readonly ISystemLog log;
         readonly IOctopusFileSystem fileSystem;
-        static string FileName = "/etc/octopus/machinekey";
+
+        static string FileName =>
+            PlatformDetection.Kubernetes.IsRunningInKubernetes
+                //if we are running in K8S, we want to save the machine key to the home directory, which is likely on a network drives
+                ? Path.Combine(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleHome)!, "machinekey")
+                : "/etc/octopus/machinekey";
 
         public LinuxGeneratedMachineKey(ISystemLog log, IOctopusFileSystem fileSystem)
         {

--- a/source/Octopus.Tentacle/Configuration/Crypto/MachineKeyEncryptor.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/MachineKeyEncryptor.cs
@@ -21,11 +21,11 @@ namespace Octopus.Tentacle.Configuration.Crypto
             // first but still fallback to the existing Octopus generated one if that doesnt work.
             var keySources = new ICryptoKeyNixSource[]
             {
-                new LinuxMachineIdKey(filesystem), new LinuxGeneratedMachineKey(log, filesystem)
+                new LinuxMachineIdKey(filesystem),
+                new LinuxGeneratedMachineKey(log, filesystem)
             };
 
             return new LinuxMachineKeyEncryptor(log, keySources);
-
         }
 
         MachineKeyEncryptor()

--- a/source/Octopus.Tentacle/Util/PlatformDetection.cs
+++ b/source/Octopus.Tentacle/Util/PlatformDetection.cs
@@ -14,8 +14,7 @@ namespace Octopus.Tentacle.Util
             /// <summary>
             /// Indicates if the Tentacle is running inside a Kubernetes cluster.
             /// </summary>
-            public static bool IsRunningInKubernetes => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST")) ||
-                (bool.TryParse(Environment.GetEnvironmentVariable("OCTOPUS__TENTACLE__FORCEK8S"), out var b) && b);
+            public static bool IsRunningInKubernetes => bool.TryParse(Environment.GetEnvironmentVariable("OCTOPUS__K8STENTACLE__FORCE"), out var b) && b;
         }
     }
 }


### PR DESCRIPTION
# Background

The machine key is currently generated for linux in `/etc/octopus/machinekey`. This then is _regenerated_ when the pod restarts, so the encrypted values (which are stored in the home directory, on a NFS share) can't be decrypted

# Results

When running in K8S only, we change the location of the file to generate the machine key to be in the configured environment variable `TentacleHome` (which currently is the NFS share `/octopus`). This results in the key being persisted across pod restarts and the cert can be decrypted

Shortcut story: [sc-66137]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.