### PR TITLE
Remove instance name from K8s Job file paths

### DIFF
--- a/source/Octopus.Tentacle/Scripts/Kubernetes/RunningKubernetesJobScript.cs
+++ b/source/Octopus.Tentacle/Scripts/Kubernetes/RunningKubernetesJobScript.cs
@@ -215,9 +215,9 @@ namespace Octopus.Tentacle.Scripts.Kubernetes
                                     Command = new List<string> { "bash" },
                                     Args = new List<string>
                                     {
-                                        $"/data/tentacle-home/{instanceName}/Work/{scriptTicket.TaskId}/bootstrapRunner.sh",
-                                        $"/data/tentacle-home/{instanceName}/Work/{scriptTicket.TaskId}",
-                                        $"/data/tentacle-home/{instanceName}/Work/{scriptTicket.TaskId}/{scriptName}"
+                                        $"/data/tentacle-home/Work/{scriptTicket.TaskId}/bootstrapRunner.sh",
+                                        $"/data/tentacle-home/Work/{scriptTicket.TaskId}",
+                                        $"/data/tentacle-home/Work/{scriptTicket.TaskId}/{scriptName}"
                                     }.Concat((workspace.ScriptArguments ?? Array.Empty<string>())
                                         .SelectMany(arg => new[]
                                         {
@@ -229,8 +229,8 @@ namespace Octopus.Tentacle.Scripts.Kubernetes
                                     },
                                     Env = new List<V1EnvVar>
                                     {
-                                        new(EnvironmentVariables.TentacleHome, $"/data/tentacle-home/{instanceName}"),
-                                        new(EnvironmentVariables.TentacleJournal, $"/data/tentacle-home/{instanceName}/DeploymentJournal.xml"),
+                                        new(EnvironmentVariables.TentacleHome, $"/data/tentacle-home"),
+                                        new(EnvironmentVariables.TentacleJournal, $"/data/tentacle-home/DeploymentJournal.xml"),
                                         new(EnvironmentVariables.TentacleInstanceName, instanceName),
                                         new(EnvironmentVariables.TentacleVersion, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleVersion)),
                                         new(EnvironmentVariables.TentacleCertificateSignatureAlgorithm, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleCertificateSignatureAlgorithm)),


### PR DESCRIPTION
# Background

When running in K8s, we don't actually have an instance name in the home directory (as there is only one instance). The existing job code assumed there would be an instance name under the home directory

# Results

Removes the instance name from relevant paths

Shortcut story: [sc-66137]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.