### PR TITLE
Bump Halibut so HalibutRuntime is Disposed correctly on Tentacle Shutdown

### DIFF
--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -37,7 +37,7 @@ namespace Octopus.Tentacle.Client
             var innerHandler = halibutRuntime.OverrideErrorResponseMessageCaching;
             halibutRuntime.OverrideErrorResponseMessageCaching = response =>
             {
-                if (BackwardsCompatibleCapabilitiesV2Helper.ExceptionTypeLooksLikeTheServiceWasNotFound(response.Error.HalibutErrorType) ||
+                if (BackwardsCompatibleCapabilitiesV2Helper.ExceptionTypeLooksLikeTheServiceWasNotFound(response.Error!.HalibutErrorType!) ||
                     BackwardsCompatibleCapabilitiesV2Helper.ExceptionMessageLooksLikeTheServiceWasNotFound(response.Error.Message))
                 {
                     return true;

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.285" />
+    <PackageReference Include="Halibut" Version="7.0.359" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Halibut;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 using Octopus.Tentacle.Client;
 using Octopus.Tentacle.Client.Retries;
 using Octopus.Tentacle.Tests.Integration.Support.Legacy;
@@ -50,6 +53,22 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         public async ValueTask DisposeAsync()
         {
+#if DEBUG
+            var tentacleLog = RunningTentacle.ReadAllLogFileText();
+            logger.Information("############################################");
+            logger.Information("#########    START TENTACLE LOG    #########");
+            logger.Information("############################################");
+            logger.Information(tentacleLog);
+            logger.Information("############################################");
+            logger.Information("#########     END TENTACLE LOG     #########");
+            logger.Information("############################################");
+#endif
+
+            logger.Information("****** ****** ****** ****** ****** ****** ******");
+            logger.Information("****** CLIENT AND TENTACLE DISPOSE CALLED  *****");
+            logger.Information("*     Subsequent errors should be ignored      *");
+            logger.Information("****** ****** ****** ****** ****** ****** ******");
+
             logger.Information("Starting DisposeAsync");
 
             logger.Information("Starting RunningTentacle.DisposeAsync and Server.Dispose and PortForwarder.Dispose");

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
@@ -53,7 +53,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         public async ValueTask DisposeAsync()
         {
-#if DEBUG
             var tentacleLog = RunningTentacle.ReadAllLogFileText();
             logger.Information("############################################");
             logger.Information("#########    START TENTACLE LOG    #########");
@@ -62,7 +61,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             logger.Information("############################################");
             logger.Information("#########     END TENTACLE LOG     #########");
             logger.Information("############################################");
-#endif
 
             logger.Information("****** ****** ****** ****** ****** ****** ******");
             logger.Information("****** CLIENT AND TENTACLE DISPOSE CALLED  *****");

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
@@ -53,15 +53,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         public async ValueTask DisposeAsync()
         {
-            var tentacleLog = RunningTentacle.ReadAllLogFileText();
-            logger.Information("############################################");
-            logger.Information("#########    START TENTACLE LOG    #########");
-            logger.Information("############################################");
-            logger.Information(tentacleLog);
-            logger.Information("############################################");
-            logger.Information("#########     END TENTACLE LOG     #########");
-            logger.Information("############################################");
-
             logger.Information("****** ****** ****** ****** ****** ****** ******");
             logger.Information("****** CLIENT AND TENTACLE DISPOSE CALLED  *****");
             logger.Information("*     Subsequent errors should be ignored      *");

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -36,6 +36,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         Action<ITentacleBuilder>? tentacleBuilderAction;
         Action<TentacleClientOptions>? configureClientOptions;
         TcpConnectionUtilities? tcpConnectionUtilities;
+        bool installAsAService = false;
 
         public ClientAndTentacleBuilder(TentacleType tentacleType)
         {
@@ -140,6 +141,13 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             this.configureClientOptions = configureClientOptions;
             return this;
         }
+        
+        public ClientAndTentacleBuilder InstallAsAService()
+        {
+            installAsAService = true;
+
+            return this;
+        }
 
         PortForwarder? BuildPortForwarder(int localPort, int? listeningPort)
         {
@@ -192,6 +200,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
                 tentacleBuilderAction?.Invoke(pollingTentacleBuilder);
 
+                if (installAsAService)
+                { 
+                    pollingTentacleBuilder.InstallAsAService();
+                }
+
                 runningTentacle = await pollingTentacleBuilder.Build(logger, cancellationToken);
 
                 tentacleEndPoint = new ServiceEndPoint(runningTentacle.ServiceUri, runningTentacle.Thumbprint, serverHalibutRuntime.TimeoutsAndLimits);
@@ -202,6 +215,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                     .WithTentacleExe(tentacleExe);
 
                 tentacleBuilderAction?.Invoke(listeningTentacleBuilder);
+                
+                if (installAsAService)
+                { 
+                    listeningTentacleBuilder.InstallAsAService();
+                }
 
                 runningTentacle = await listeningTentacleBuilder.Build(logger, cancellationToken);
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -23,8 +23,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var logger = log.ForContext<ListeningTentacleBuilder>();
             logger.Information($"Tentacle.exe location: {tentacleExe}");
 
-            await CreateInstance(tentacleExe, configFilePath, instanceName, HomeDirectory, cancellationToken);
-            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, HomeDirectory, cancellationToken);
+            await CreateInstance(tentacleExe, configFilePath, instanceName, HomeDirectory, logger, cancellationToken);
+            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, HomeDirectory, logger, cancellationToken);
             var applicationDirectory = Path.Combine(HomeDirectory.DirectoryPath, "appdir");
             ConfigureTentacleToListen(configFilePath, applicationDirectory);
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -30,10 +30,10 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var logger = log.ForContext<PollingTentacleBuilder>();
             logger.Information($"Tentacle.exe location: {tentacleExe}");
 
-            await CreateInstance(tentacleExe, configFilePath, instanceName, HomeDirectory, cancellationToken);
+            await CreateInstance(tentacleExe, configFilePath, instanceName, HomeDirectory, logger, cancellationToken);
             var applicationDirectory = Path.Combine(HomeDirectory.DirectoryPath, "appdir");
             ConfigureTentacleToPollOctopusServer(configFilePath, subscriptionId, applicationDirectory);
-            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, HomeDirectory, cancellationToken);
+            await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, HomeDirectory, logger,cancellationToken);
             
             return await StartTentacle(
                 subscriptionId,

--- a/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
@@ -18,6 +18,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         private ILogger logger;
 
         public RunningTentacle(
+            FileInfo tentacleExe,
             TemporaryDirectory temporaryDirectory,
             Func<CancellationToken, Task<(Task, Uri)>> startTentacleFunction,
             string thumbprint, 
@@ -30,7 +31,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             this.startTentacleFunction = startTentacleFunction;
             this.temporaryDirectory = temporaryDirectory;
             this.deleteInstanceFunction = deleteInstanceFunction;
-            
+
+            TentacleExe = tentacleExe;
             Thumbprint = thumbprint;
             InstanceName = instanceName;
             HomeDirectory = homeDirectory;
@@ -44,6 +46,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public string Thumbprint { get; }
         public string HomeDirectory { get; }
         public string ApplicationDirectory { get; }
+        public FileInfo TentacleExe { get; }
 
         public async Task Start(CancellationToken cancellationToken)
         {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/TurnOnTraceLoggingForLogFileForLatestTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/TurnOnTraceLoggingForLogFileForLatestTentacle.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using Serilog;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.SetupFixtures
+{
+    public class TurnOnTraceLoggingForLogFileForLatestTentacle : ISetupFixture
+    {
+        private CancellationTokenSource cts = new();
+
+        public void OneTimeSetUp(ILogger logger)
+        {
+            TryTurnOnTraceLoggingForTentacleRuntime(TentacleRuntime.DotNet6, logger);
+            TryTurnOnTraceLoggingForTentacleRuntime(TentacleRuntime.Framework48, logger);
+        }
+
+        void TryTurnOnTraceLoggingForTentacleRuntime(TentacleRuntime runtime, ILogger logger)
+        {
+            try
+            {
+                var exePath = TentacleExeFinder.FindTentacleExe(runtime);
+                var exeFileInfo = new FileInfo(exePath);
+                var nlogFileInfo = new FileInfo(Path.Combine(exeFileInfo.DirectoryName!, "Tentacle.exe.nlog"));
+
+                var content = File.ReadAllText(nlogFileInfo.FullName);
+                content = content.Replace("<logger name=\"*\" minlevel=\"Info\" writeTo=\"octopus-log-file\" />", "<logger name=\"*\" minlevel=\"Trace\" writeTo=\"octopus-log-file\" />");
+                File.WriteAllText(nlogFileInfo.FullName, content);
+            }
+            catch (Exception e)
+            {
+                logger.Error(e, $"Unable to turn on Trace logging for {runtime}");
+            }
+        }
+        
+        public void OneTimeTearDown(ILogger logger)
+        {
+            cts.Cancel();
+            cts.Dispose();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Security.Policy;
+using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,8 +28,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         protected string? TentacleExePath;
         protected string CertificatePfxPath = Certificates.TentaclePfxPath;
         protected string TentacleThumbprint = Certificates.TentaclePublicThumbprint;
-        
-        readonly Regex listeningPortRegex = new (@"^listen:\/\/.+:(\d+)\/");
+        bool installAsService = false;
+
+        static readonly Regex ListeningPortRegex = new (@"listen:\/\/.+:(\d+)\/");
         readonly Dictionary<string, string> runTentacleEnvironmentVariables = new();
 
         TemporaryDirectory? homeDirectory;
@@ -80,6 +81,13 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             action(writableTentacleConfiguration);
         }
 
+        public ITentacleBuilder InstallAsAService()
+        {
+            installAsService = true;
+
+            return this;
+        }
+
         protected async Task<RunningTentacle> StartTentacle(
             Uri? serviceUri,
             string tentacleExe,
@@ -90,14 +98,17 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             ILogger logger,
             CancellationToken cancellationToken)
         {
+            var log = new SerilogLoggerBuilder().Build().ForContext<ITentacleBuilder>();
+
             var runningTentacle = new RunningTentacle(
+                new FileInfo(tentacleExe),
                 tempDirectory,
-                startTentacleFunction: ct => RunTentacle(serviceUri, tentacleExe, instanceName, tempDirectory, ct),
+                startTentacleFunction: ct => RunTentacle(serviceUri, tentacleExe, instanceName, tempDirectory, log, ct),
                 tentacleThumbprint,
                 instanceName,
                 HomeDirectory.DirectoryPath,
                 applicationDirectory,
-                deleteInstanceFunction: ct => DeleteInstanceIgnoringFailure(tentacleExe, instanceName, tempDirectory, logger, ct),
+                deleteInstanceFunction: ct => DeleteInstanceIgnoringFailure(installAsService, tentacleExe, instanceName, tempDirectory, logger, ct),
                 logger);
 
             try
@@ -113,7 +124,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 }
                 catch (Exception e)
                 {
-                    new SerilogLoggerBuilder().Build().Information(e, "Error disposing tentacle after tentacle failed to start.");
+                    log.Information(e, "Error disposing tentacle after tentacle failed to start.");
                 }
 
                 throw;
@@ -125,6 +136,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             string tentacleExe,
             string instanceName,
             TemporaryDirectory tempDirectory, 
+            ILogger log,
             CancellationToken cancellationToken)
         {
             var hasTentacleStarted = new ManualResetEventSlim();
@@ -135,23 +147,121 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             {
                 try
                 {
-                    await RunTentacleCommandOutOfProcess(
-                        tentacleExe, 
-                        new[] {"agent", $"--instance={instanceName}", "--noninteractive"}, 
-                        tempDirectory,
-                        s =>
+                    if (installAsService)
+                    {
+                        var serviceInstalled = false;
+                        var serviceStarted = false;
+
+                        await RunTentacleCommandOutOfProcess(
+                            tentacleExe, 
+                            new[] {"service", "--install", $"--instance={instanceName}"}, 
+                            tempDirectory,
+                            s =>
+                            {
+                                if (s.Contains("Service installed"))
+                                {
+                                    serviceInstalled = true;
+                                }
+                            },
+                            runTentacleEnvironmentVariables, 
+                            cancellationToken);
+
+                        if (!serviceInstalled)
                         {
-                            if (s.Contains("Listener started"))
+                            throw new Exception("Failed to install service");
+                        }
+
+                        await RunTentacleCommandOutOfProcess(
+                            tentacleExe,
+                            new[] { "service", "--start", $"--instance={instanceName}" },
+                            tempDirectory,
+                            s =>
                             {
-                                listeningPort = Convert.ToInt32(listeningPortRegex.Match(s).Groups[1].Value);
-                            }
-                            else if (s.Contains("Agent will not listen") || s.Contains("Agent listening on"))
+                                if (s.Contains("Service started"))
+                                {
+                                    serviceStarted = true;
+                                }
+                            },
+                            runTentacleEnvironmentVariables,
+                            cancellationToken);
+
+                        if (!serviceStarted)
+                        {
+                            throw new Exception("Failed to start service");
+                        }
+
+                        using var timeoutCancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                        using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
+                        
+                        log.Information("Waiting for the Tentacle Service to start up and assign a Listening Port / no port if Polling");
+                        var tentacleState = await WaitForTentacleToStart(tempDirectory, linkedCancellationTokenSource.Token);
+                        
+                        if (tentacleState.Started)
+                        {
+                            listeningPort = tentacleState.ListeningPort;
+                            hasTentacleStarted.Set();
+                        }
+                        else
+                        {
+                            log.Warning("The Tentacle failed to start correctly. Trying Again. Last Log File Content");
+                            log.Warning(tentacleState.LogContent);
+
+                            File.Delete(Path.Combine(tempDirectory.DirectoryPath, "Logs", "OctopusTentacle.txt"));
+
+                            await RunTentacleCommandOutOfProcess(
+                                tentacleExe,
+                                new[] { "service", "--stop", $"--instance={instanceName}" },
+                                tempDirectory,
+                                s =>
+                                { },
+                                runTentacleEnvironmentVariables,
+                                cancellationToken);
+
+                            File.Delete(Path.Combine(tempDirectory.DirectoryPath, "Logs", "OctopusTentacle.txt"));
+
+                            await RunTentacleCommandOutOfProcess(
+                                tentacleExe,
+                                new[] { "service", "--start", $"--instance={instanceName}" },
+                                tempDirectory,
+                                s =>
+                                { },
+                                runTentacleEnvironmentVariables,
+                                cancellationToken);
+
+                            tentacleState = await WaitForTentacleToStart(tempDirectory, cancellationToken);
+
+                            if (tentacleState.Started)
                             {
+                                listeningPort = tentacleState.ListeningPort;
                                 hasTentacleStarted.Set();
                             }
-                        },
-                        runTentacleEnvironmentVariables, 
-                        cancellationToken);
+                            else
+                            {
+                                log.Error("The Tentacle failed to start correctly. Last Log File Content");
+                                log.Error(tentacleState.LogContent);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        await RunTentacleCommandOutOfProcess(
+                            tentacleExe, 
+                            new[] {"agent", $"--instance={instanceName}", "--noninteractive"}, 
+                            tempDirectory,
+                            s =>
+                            {
+                                if (s.Contains("Listener started"))
+                                {
+                                    listeningPort = Convert.ToInt32(ListeningPortRegex.Match(s).Groups[1].Value);
+                                }
+                                else if (s.Contains("Agent will not listen") || s.Contains("Agent listening on"))
+                                {
+                                    hasTentacleStarted.Set();
+                                }
+                            },
+                            runTentacleEnvironmentVariables, 
+                            cancellationToken);
+                    }
                 }
                 catch (Exception e)
                 {
@@ -160,7 +270,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 }
             }, cancellationToken);
 
-            await Task.WhenAny(runningTentacle, WaitHandleAsyncFactory.FromWaitHandle(hasTentacleStarted.WaitHandle, TimeSpan.FromMinutes(1)));
+            await Task.WhenAny(runningTentacle, WaitHandleAsyncFactory.FromWaitHandle(hasTentacleStarted.WaitHandle, TimeSpan.FromMinutes(1), cancellationToken));
 
             // Will throw.
             if (runningTentacle.IsCompleted)
@@ -181,6 +291,38 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             return (runningTentacle, serviceUri);
         }
 
+        static async Task<(bool Started, int? ListeningPort, string LogContent)> WaitForTentacleToStart(TemporaryDirectory tempDirectory, CancellationToken localCancellationToken)
+        {
+            var lastLogFileContents = string.Empty;
+            int? listeningPort = null;
+
+            while (listeningPort == null && !localCancellationToken.IsCancellationRequested)
+            {
+                var logFilePath = Path.Combine(tempDirectory.DirectoryPath, "Logs", "OctopusTentacle.txt");
+
+                await using (var stream = new FileStream(logFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                using (var reader = new StreamReader(stream))
+                {
+                    var logContent = await reader.ReadToEndAsync();
+                    lastLogFileContents = logContent;
+                }
+
+                if (lastLogFileContents.Contains("Listener started"))
+                {
+                    listeningPort = Convert.ToInt32(ListeningPortRegex.Match(lastLogFileContents).Groups[1].Value);
+                }
+
+                if (lastLogFileContents.Contains("Agent will not listen") || lastLogFileContents.Contains("Agent listening on"))
+                {
+                    return (true, listeningPort, lastLogFileContents);
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1), CancellationToken.None);
+            }
+
+            return (false, listeningPort, lastLogFileContents);
+        }
+
         protected async Task AddCertificateToTentacle(string tentacleExe, string instanceName, string tentaclePfxPath, TemporaryDirectory tmp, CancellationToken cancellationToken)
         {
             await RunTentacleCommand(tentacleExe, new[] {"import-certificate", $"--from-file={tentaclePfxPath}", $"--instance={instanceName}"}, tmp, cancellationToken);
@@ -193,8 +335,35 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             cancellationToken.ThrowIfCancellationRequested();
         }
 
-        internal async Task DeleteInstanceIgnoringFailure(string tentacleExe, string instanceName, TemporaryDirectory tmp, ILogger logger, CancellationToken cancellationToken)
+        internal async Task DeleteInstanceIgnoringFailure(bool runningAsService, string tentacleExe, string instanceName, TemporaryDirectory tmp, ILogger logger, CancellationToken cancellationToken)
         {
+            if (runningAsService)
+            {
+                try
+                {
+                    await RunTentacleCommandOutOfProcess(
+                        tentacleExe,
+                        new[] { "service", $"--instance={instanceName}", "--stop" },
+                        tmp,
+                        s => {},
+                        runTentacleEnvironmentVariables,
+                        cancellationToken);
+
+                    await RunTentacleCommandOutOfProcess(
+                        tentacleExe, 
+                        new[] {"service", "--uninstall", $"--instance={instanceName}"}, 
+                        tmp,
+                        s => {},
+                        runTentacleEnvironmentVariables, 
+                        cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    logger.Warning(e, "Could not uninstall service for instance: {InstanceName}", instanceName);
+                    throw;
+                }
+            }
+
             try
             {
                 await DeleteInstanceAsync(tentacleExe, instanceName, tmp, cancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleIntegrationSetupFixtures.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleIntegrationSetupFixtures.cs
@@ -19,6 +19,7 @@ namespace Octopus.Tentacle.Tests.Integration
     {
         private ISetupFixture[] setupFixtures = new ISetupFixture[]
         {
+            new TurnOnTraceLoggingForLogFileForLatestTentacle(),
             new BumpThreadPoolForAllTests(),
             new WarmTentacleCache()
         };

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleStartupAndShutdownTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleStartupAndShutdownTests.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.CommonTestUtils.Builders;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Support.TestAttributes;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [IntegrationTestTimeout]
+    public class TentacleStartupAndShutdownTests : IntegrationTest
+    {
+        [Test]
+        [TentacleConfigurations]
+        [RequiresSudoOnLinux]
+        public async Task WhenRunningTentacleAsAServiceItShouldBeAbleToRestartItself(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using (var clientAndTentacle = await tentacleConfigurationTestCase
+                             .CreateBuilder()
+                             .InstallAsAService()
+                             .Build(CancellationToken))
+            {
+                var startScriptCommand = new LatestStartScriptCommandBuilder()                    
+                    .WithScriptBodyForCurrentOs(
+$@"cd ""{clientAndTentacle.RunningTentacle.TentacleExe.DirectoryName}""
+.\Tentacle.exe service --instance {clientAndTentacle.RunningTentacle.InstanceName} --stop --start",
+$@"#!/bin/sh
+cd ""{clientAndTentacle.RunningTentacle.TentacleExe.DirectoryName}""
+./Tentacle service --instance {clientAndTentacle.RunningTentacle.InstanceName} --stop --start")
+                    .Build();
+
+                var result = await clientAndTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+
+                var scriptOutput = new StringBuilder();
+                result.ProcessOutput.ForEach(x => scriptOutput.AppendLine($"{x.Source} {x.Occurred} {x.Text}"));
+
+                Logger.Information($@"Script Output:
+{scriptOutput}");
+
+                result.ProcessOutput.Any(x => x.Text.Contains("Stopping service")).Should().BeTrue("Stopping service should be logged");
+                result.ScriptExecutionResult.State.Should().Be(ProcessState.Complete);
+
+                startScriptCommand = new LatestStartScriptCommandBuilder()                    
+                    .WithScriptBody(new ScriptBuilder().Print("Running..."))
+                    .Build();
+
+                result = await clientAndTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
+                result.ProcessOutput.Any(x => x.Text.Contains("Running...")).Should().BeTrue("Running... should be logged");
+                result.ScriptExecutionResult.ExitCode.Should().Be(0);
+                result.ScriptExecutionResult.State.Should().Be(ProcessState.Complete);
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TentacleClientExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TentacleClientExtensionMethods.cs
@@ -16,7 +16,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders
 {
     public static class TentacleClientExtensionMethods
     {
-        public static async Task<(ScriptExecutionResult, List<ProcessOutput>)> ExecuteScript(
+        public static async Task<(ScriptExecutionResult ScriptExecutionResult, List<ProcessOutput> ProcessOutput)> ExecuteScript(
             this TentacleClient tentacleClient,
             StartScriptCommandV3Alpha startScriptCommand,
             CancellationToken token,

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -41,7 +41,7 @@ namespace Octopus.Tentacle.Communications
 
                 var halibutRuntime = new HalibutRuntimeBuilder()
                     .WithServiceFactory(services)
-                    .WithServerCertificate(configuration.TentacleCertificate)
+                    .WithServerCertificate(configuration.TentacleCertificate!)
                     .WithMessageSerializer(serializerBuilder => serializerBuilder.WithLegacyContractSupport())
                     .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
                     .Build();

--- a/source/Octopus.Tentacle/Configuration/ProxyConfigParser.cs
+++ b/source/Octopus.Tentacle/Configuration/ProxyConfigParser.cs
@@ -59,12 +59,12 @@ namespace Octopus.Tentacle.Configuration
             {
                 log.Info($"Agent will use the octopus configured proxy at {config.CustomProxyHost}:{config.CustomProxyPort} for server at {destination}");
                 return string.IsNullOrWhiteSpace(config.CustomProxyUsername)
-                    ? new ProxyDetails(config.CustomProxyHost,
+                    ? new ProxyDetails(config.CustomProxyHost!,
                         config.CustomProxyPort,
                         ProxyType.HTTP,
                         null,
                         null) //Don't use default creds for custom proxy if user has not supplied any
-                    : new ProxyDetails(config.CustomProxyHost,
+                    : new ProxyDetails(config.CustomProxyHost!,
                         config.CustomProxyPort,
                         ProxyType.HTTP,
                         config.CustomProxyUsername,

--- a/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
+++ b/source/Octopus.Tentacle/Services/FileTransfer/FileTransferService.cs
@@ -60,7 +60,7 @@ namespace Octopus.Tentacle.Services.FileTransfer
 
         public async Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload, CancellationToken cancellationToken)
         {
-            if (upload == null)
+            if (upload == null!)
             {
                 log.Trace("Client requested a file upload, but no content stream was provided.");
                 return new UploadResult(ResolvePath(remotePath), null!, 0);


### PR DESCRIPTION
# Background

Fix a bug where Tentacle does not dispose of the HalibutRuntime on shutdown.

This can result in the listening port for a listening tentacle not being freed up quickly and stop the tentacle service from being stopped and started quickly.

The HalibutRuntime only had a DisposeAsync method, Dispose has also been added so it works correctly with the version of Autofac used in Tentacle.

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/725 

[sc-66309]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.