### PR TITLE
Enable Halibut TCP Keepalives by default! Again!!

### DIFF
--- a/source/Octopus.Tentacle.Tests/Communications/TentacleCommunicationsModuleFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Communications/TentacleCommunicationsModuleFixture.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Autofac;
+using FluentAssertions;
+using Halibut;
+using NUnit.Framework;
+using Octopus.Tentacle.Communications;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Tests.Commands;
+using Octopus.Tentacle.Variables;
+
+namespace Octopus.Tentacle.Tests.Communications
+{
+    public class TentacleCommunicationsModuleFixture
+    {
+        [Test]
+        [NonParallelizable]
+        public void HalibutTcpKeepAlivesShouldBeEnabledByDefault()
+        {
+            var container = BuildContainer();
+
+            var halibutRuntime = container.Resolve<HalibutRuntime>();
+
+            halibutRuntime.TimeoutsAndLimits.TcpKeepAliveEnabled.Should().BeTrue();
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void HalibutTcpKeepAlivesCanBeDisabledWithAnEnvironmentVariable()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "False");
+
+                var container = BuildContainer();
+
+                var halibutRuntime = container.Resolve<HalibutRuntime>();
+
+                halibutRuntime.TimeoutsAndLimits.TcpKeepAliveEnabled.Should().BeFalse();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "");
+            }
+        } 
+        
+        [Test]
+        [NonParallelizable]
+        public void AnEmptyHalibutTcpKeepAlivesEnvironmentVariableIsIgnored()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "");
+
+            var container = BuildContainer();
+
+            var halibutRuntime = container.Resolve<HalibutRuntime>();
+
+            halibutRuntime.TimeoutsAndLimits.TcpKeepAliveEnabled.Should().BeTrue();
+        } 
+
+        [Test]
+        [NonParallelizable]
+        public void AnInvalidHalibutTcpKeepAlivesEnvironmentVariableIsIgnored()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "NOTABOOL");
+
+                var container = BuildContainer();
+
+                var halibutRuntime = container.Resolve<HalibutRuntime>();
+
+                halibutRuntime.TimeoutsAndLimits.TcpKeepAliveEnabled.Should().BeTrue();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled, "");
+            }
+        } 
+
+        static IContainer BuildContainer()
+        {
+            var builder = new ContainerBuilder();
+            var configuration = new StubTentacleConfiguration();
+            configuration.TentacleCertificate = configuration.GenerateNewCertificate();
+            configuration.AddOrUpdateTrustedOctopusServer(new OctopusServerConfiguration("NOPE"));
+            builder.RegisterInstance(configuration).As<ITentacleConfiguration>();
+            builder.RegisterModule<TentacleCommunicationsModule>();
+            var container = builder.Build();
+            return container;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -25,7 +25,12 @@ namespace Octopus.Tentacle.Communications
                 var configuration = c.Resolve<ITentacleConfiguration>();
                 var services = c.Resolve<IServiceFactory>();
 
-                bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled), out var tcpKeepAliveEnabled);
+                if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled), out var tcpKeepAliveEnabled))
+                {
+                    // Default to enabled if the environment variable is not provided
+                    tcpKeepAliveEnabled = true;
+                }
+
                 bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseRecommendedTimeoutsAndLimits), out var useRecommendedTimeoutsAndLimits);
 
                 var halibutTimeoutsAndLimits = useRecommendedTimeoutsAndLimits 


### PR DESCRIPTION
Reverts OctopusDeploy/OctopusTentacle#714 which results in Tcp KeepAlives being enabled by default.

TcpKeep Alives were reverted as it was thought it may be causing issues stopping and starting Tentacle on Dynamic Workers.

This issue was actually found to have been introduced with Async Halibut https://github.com/OctopusDeploy/OctopusTentacle/pull/716

[sc-64824]

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/692