### PR TITLE
Allow the MachineConfigurationHomeDirectory to be changed and use a unique directory per test to isolate cross test issues

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/MachineConfigurationHomeDirectoryTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/MachineConfigurationHomeDirectoryTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.CommonTestUtils;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Variables;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [IntegrationTestTimeout]
+    public class MachineConfigurationHomeDirectoryTests : IntegrationTest
+    {
+        [Test]
+        [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
+        public async Task ShouldUseTheDefaultMachineConfigurationHomeDirectoryWhenACustomLocationIsNotProvided(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using (var clientAndTentacle = await tentacleConfigurationTestCase
+                             .CreateBuilder()
+                             .UseDefaultMachineConfigurationHomeDirectory()
+                             .Build(CancellationToken))
+            {
+                
+                var defaultMachineConfigurationHomeDirectory = PlatformDetection.IsRunningOnWindows ? 
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Octopus", "Tentacle", "Instances") : 
+                    "/etc/octopus/Tentacle/Instances";
+
+                var expectedInstanceConfigurationFilePath = new FileInfo(Path.Combine(defaultMachineConfigurationHomeDirectory, $"{clientAndTentacle.RunningTentacle.InstanceName}.config"));
+
+                expectedInstanceConfigurationFilePath.Exists.Should().BeTrue("Instance configuration file should exist");
+            }
+        }
+
+        [Test]
+        [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
+        public async Task ShouldUseTheCustomMachineConfigurationHomeDirectoryWhenACustomLocationIsProvided(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            using var tempDirectory = new TemporaryDirectory();
+            await using var clientAndTentacle = await tentacleConfigurationTestCase
+                .CreateBuilder()
+                .UseDefaultMachineConfigurationHomeDirectory()
+                .WithTentacle(x =>
+                {
+                    x.WithRunTentacleEnvironmentVariable(EnvironmentVariables.TentacleMachineConfigurationHomeDirectory, tempDirectory.DirectoryPath);
+                })
+                .Build(CancellationToken);
+
+            var expectedInstanceConfigurationFilePath = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "Tentacle", "Instances", $"{clientAndTentacle.RunningTentacle.InstanceName}.config"));
+
+            expectedInstanceConfigurationFilePath.Exists.Should().BeTrue("Instance configuration file should exist");
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/MachineConfigurationHomeDirectoryTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/MachineConfigurationHomeDirectoryTests.cs
@@ -28,7 +28,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
                 var expectedInstanceConfigurationFilePath = new FileInfo(Path.Combine(defaultMachineConfigurationHomeDirectory, $"{clientAndTentacle.RunningTentacle.InstanceName}.config"));
 
-                expectedInstanceConfigurationFilePath.Exists.Should().BeTrue("Instance configuration file should exist");
+                expectedInstanceConfigurationFilePath.Exists.Should().BeTrue($"Instance configuration file should exist {expectedInstanceConfigurationFilePath.FullName}");
             }
         }
 
@@ -48,7 +48,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var expectedInstanceConfigurationFilePath = new FileInfo(Path.Combine(tempDirectory.DirectoryPath, "Tentacle", "Instances", $"{clientAndTentacle.RunningTentacle.InstanceName}.config"));
 
-            expectedInstanceConfigurationFilePath.Exists.Should().BeTrue("Instance configuration file should exist");
+            expectedInstanceConfigurationFilePath.Exists.Should().BeTrue($"Instance configuration file should exist {expectedInstanceConfigurationFilePath.FullName}");
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,15 +18,15 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         private readonly Func<CancellationToken, Task> deleteInstanceFunction;
         private ILogger logger;
 
-        public RunningTentacle(
-            FileInfo tentacleExe,
+        public RunningTentacle(FileInfo tentacleExe,
             TemporaryDirectory temporaryDirectory,
             Func<CancellationToken, Task<(Task, Uri)>> startTentacleFunction,
-            string thumbprint, 
-            string instanceName, 
-            string homeDirectory, 
-            string applicationDirectory, 
+            string thumbprint,
+            string instanceName,
+            string homeDirectory,
+            string applicationDirectory,
             Func<CancellationToken, Task> deleteInstanceFunction,
+            Dictionary<string, string> runTentacleEnvironmentVariables,
             ILogger logger)
         {
             this.startTentacleFunction = startTentacleFunction;
@@ -37,6 +38,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             InstanceName = instanceName;
             HomeDirectory = homeDirectory;
             ApplicationDirectory = applicationDirectory;
+            RunTentacleEnvironmentVariables = runTentacleEnvironmentVariables;
 
             this.logger = logger.ForContext<RunningTentacle>();
         }
@@ -46,6 +48,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public string Thumbprint { get; }
         public string HomeDirectory { get; }
         public string ApplicationDirectory { get; }
+        public IReadOnlyDictionary<string, string> RunTentacleEnvironmentVariables { get; }
         public FileInfo TentacleExe { get; }
         public string LogFilePath => Path.Combine(HomeDirectory, "Logs", "OctopusTentacle.txt");
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/RunningTentacle.cs
@@ -26,7 +26,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             string homeDirectory,
             string applicationDirectory,
             Func<CancellationToken, Task> deleteInstanceFunction,
-            Dictionary<string, string> runTentacleEnvironmentVariables,
+            IReadOnlyDictionary<string, string> runTentacleEnvironmentVariables,
             ILogger logger)
         {
             this.startTentacleFunction = startTentacleFunction;

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -399,7 +399,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 args, 
                 tmp, 
                 _ => { }, 
-                new Dictionary<string, string?>(), 
+                runTentacleEnvironmentVariables,
                 logger,
                 cancellationToken);
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -390,7 +390,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         internal string InstanceNameGenerator()
         {
-            return $"TentacleIT-{Guid.NewGuid():N}";
+            // Ensure this is lower case to avoid issues with tests on linux with case sensitive file paths.
+            return $"TentacleIT-{Guid.NewGuid():N}".ToLower();
         }
 
         async Task RunTentacleCommand(string tentacleExe, string[] args, TemporaryDirectory tmp, ILogger logger, CancellationToken cancellationToken)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -109,6 +109,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 HomeDirectory.DirectoryPath,
                 applicationDirectory,
                 deleteInstanceFunction: ct => DeleteInstanceIgnoringFailure(installAsService, tentacleExe, instanceName, tempDirectory, logger, ct),
+                runTentacleEnvironmentVariables,
                 logger);
 
             try

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleCommandLineTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleCommandLineTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -15,6 +16,7 @@ using NUnit.Framework;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Support.TestAttributes;
 using Octopus.Tentacle.Util;
+using Octopus.Tentacle.Variables;
 using Polly;
 
 namespace Octopus.Tentacle.Tests.Integration
@@ -30,7 +32,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task TentacleExeNoArguments(TentacleConfigurationTestCase tc)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tc);
+            var (exitCode, stdout, stderr) = await RunCommand(tc, null);
             
             exitCode.Should().Be(2, "the exit code should be 2 if the command wasn't understood");
             stdout.Should().StartWithEquivalentOf("Usage: Tentacle <command> [<options>]", "should show help by default if no other commands are specified");
@@ -42,7 +44,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task UnknownCommand(TentacleConfigurationTestCase tc)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tc, "unknown-command");
+            var (exitCode, stdout, stderr) = await RunCommand(tc, null, "unknown-command");
             
             exitCode.Should().Be(2, "the exit code should be 2 if the command wasn't understood");
             stderr.Should().StartWithEquivalentOf("Command 'unknown-command' is not supported", "the error should clearly indicate the command which is not understood");
@@ -53,7 +55,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task UnknownArgument(TentacleConfigurationTestCase tc)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tc, "version", "--unknown=argument");
+            var (exitCode, stdout, stderr) = await RunCommand(tc, null, "version", "--unknown=argument");
             
             exitCode.Should().Be(1, "the exit code should be 1 if the command has unknown arguments");
             stdout.Should().BeNullOrEmpty("the error message should be written to stderr, not stdout");
@@ -64,7 +66,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task InvalidArgument(TentacleConfigurationTestCase tc)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tc, "version", "--format=unsupported");
+            var (exitCode, stdout, stderr) = await RunCommand(tc, null, "version", "--format=unsupported");
             
             exitCode.Should().Be(1, "the exit code should be 1 if the command has unknown arguments");
             stdout.Should().BeNullOrEmpty("the error message should be written to stderr, not stdout");
@@ -75,7 +77,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task NoConsoleLoggingSwitchStillSilentlySupportedForBackwardsCompat(TentacleConfigurationTestCase tc)
         {
-            var (_, _, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--noconsolelogging");
+            var (_, _, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "version", "--noconsolelogging");
 
             stderr.Should().BeNullOrEmpty();
         }
@@ -84,7 +86,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task NoLogoSwitchStillSilentlySupportedForBackwardsCompat(TentacleConfigurationTestCase tc)
         {
-            var (_, _, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--nologo");
+            var (_, _, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "version", "--nologo");
 
             stderr.Should().BeNullOrEmpty();
         }
@@ -93,7 +95,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task ConsoleSwitchStillSilentlySupportedForBackwardsCompat(TentacleConfigurationTestCase tc)
         {
-            var (_, _, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--console");
+            var (_, _, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "version", "--console");
 
             stderr.Should().BeNullOrEmpty();
         }
@@ -102,16 +104,16 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task ShouldSupportFuzzyCommandParsing(TentacleConfigurationTestCase tc)
         {
-            await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version");
-            await RunCommandAndAssertExitsWithSuccessExitCode(tc, "--version");
-            await RunCommandAndAssertExitsWithSuccessExitCode(tc, "/version");
+            await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "version");
+            await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "--version");
+            await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "/version");
         }
 
         [Test]
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task VersionCommandTextFormat(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "version");
 
             var expectedVersion = GetVersionInfo(tc);
 
@@ -123,7 +125,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task VersionCommandJsonFormat(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--format=json");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "version", "--format=json");
 
             var expectedVersion = GetVersionInfo(tc);
             var output = JObject.Parse(stdout);
@@ -140,7 +142,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task CanGetHelpForHelp(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "help", "--help");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "help", "--help");
             stderr.Should().BeNullOrEmpty();
 
             stdout.Should().Be(
@@ -161,7 +163,7 @@ Or one of the common options:
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task HelpAsSwitchShouldShowCommandSpecificHelp(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--help");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "version", "--help");
             stderr.Should().BeNullOrEmpty();
 
             stdout.Should().Be(
@@ -182,7 +184,7 @@ Or one of the common options:
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task GeneralHelpAsJsonCanBeParsedByAutomationScripts(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "help", "--format=json");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "help", "--format=json");
 
             stderr.Should().BeNullOrEmpty();
             var help = JsonConvert.DeserializeAnonymousType(
@@ -215,7 +217,7 @@ Or one of the common options:
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task CommandSpecificHelpAsJsonCanBeParsedByAutomationScripts(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--help", "--format=json");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "version", "--help", "--format=json");
 
             stderr.Should().BeNullOrEmpty();
             var help = JsonConvert.DeserializeAnonymousType(
@@ -243,7 +245,7 @@ Or one of the common options:
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task CommandSpecificHelpAsJsonLooksSensibleToHumans(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "version", "--help", "--format=json");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "version", "--help", "--format=json");
             stderr.Should().BeNullOrEmpty();
 
             stdout.Should().Be(
@@ -270,7 +272,7 @@ Or one of the common options:
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task HelpForInstanceSpecificCommandsAlwaysWorks(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommand(tc, "help", "--format=json");
+            var (_, stdout, stderr) = await RunCommand(tc, null, "help", "--format=json");
 
             stderr.Should().BeNullOrEmpty();
             var help = JsonConvert.DeserializeAnonymousType(
@@ -292,7 +294,7 @@ Or one of the common options:
 
             var failed = help.Commands.Select(async c =>
                     {
-                        var (exitCode2, stdout2, stderr2) = await RunCommand(tc,$"{c.Name}", "--help");
+                        var (exitCode2, stdout2, stderr2) = await RunCommand(tc, null,$"{c.Name}", "--help");
                         return new
                         {
                             Command = c,
@@ -330,7 +332,12 @@ The details are logged above. These commands probably need to take Lazy<T> depen
         [NonParallelizable]
         public async Task InvalidInstance(TentacleConfigurationTestCase tc)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tc, "show-thumbprint", "--instance=invalidinstance");
+            using var tempDirectory = new TemporaryDirectory();
+
+            var (exitCode, stdout, stderr) = await RunCommand(
+                tc, 
+                new Dictionary<string, string?>{ { EnvironmentVariables.TentacleMachineConfigurationHomeDirectory, tempDirectory.DirectoryPath } },
+                "show-thumbprint", "--instance=invalidinstance");
             
             exitCode.Should().Be(1, $"the exit code should be 1 if the instance is not able to be resolved");
             stderr.Should().ContainEquivalentOf("Instance invalidinstance of tentacle has not been configured", "the error message should make it clear the instance has not been configured");
@@ -345,7 +352,10 @@ The details are logged above. These commands probably need to take Lazy<T> depen
         public async Task ShowThumbprintCommandText(TentacleConfigurationTestCase tc)
         {
             await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
-            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-thumbprint", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
+            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                clientAndTentacle.RunningTentacle.RunTentacleEnvironmentVariables, 
+                "show-thumbprint", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
 
             exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
             stdout.Should().Be(Support.Certificates.TentaclePublicThumbprint, "the thumbprint should be written directly to stdout");
@@ -359,7 +369,10 @@ The details are logged above. These commands probably need to take Lazy<T> depen
         public async Task ShowThumbprintCommandJson(TentacleConfigurationTestCase tc)
         {
             await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
-            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-thumbprint", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}", "--format=json");
+            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                clientAndTentacle.RunningTentacle.RunTentacleEnvironmentVariables,
+                "show-thumbprint", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}", "--format=json");
             
             exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
             stdout.Should().Be(JsonConvert.SerializeObject(new { Thumbprint = Support.Certificates.TentaclePublicThumbprint }), "the thumbprint should be written directly to stdout as JSON");
@@ -373,7 +386,10 @@ The details are logged above. These commands probably need to take Lazy<T> depen
         public async Task ListInstancesCommandText(TentacleConfigurationTestCase tc)
         {
             await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
-            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "list-instances", "--format=text");
+            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                clientAndTentacle.RunningTentacle.RunTentacleEnvironmentVariables, 
+                "list-instances", "--format=text");
             
             exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
             var configPath = Path.Combine(clientAndTentacle.RunningTentacle.HomeDirectory, clientAndTentacle.RunningTentacle.InstanceName + ".cfg");
@@ -388,7 +404,10 @@ The details are logged above. These commands probably need to take Lazy<T> depen
         public async Task ListInstancesCommandJson(TentacleConfigurationTestCase tc)
         {
             await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "list-instances", "--format=json");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                clientAndTentacle.RunningTentacle.RunTentacleEnvironmentVariables, 
+                "list-instances", "--format=json");
             
             stdout.Should().Contain($"\"InstanceName\": \"{clientAndTentacle.RunningTentacle.InstanceName}\"", "the current instance should be listed");
             var configPath = Path.Combine(clientAndTentacle.RunningTentacle.HomeDirectory, clientAndTentacle.RunningTentacle.InstanceName + ".cfg");
@@ -406,7 +425,10 @@ The details are logged above. These commands probably need to take Lazy<T> depen
             await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
             var startingLogText = clientAndTentacle.RunningTentacle.ReadAllLogFileText();
 
-            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-thumbprint", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
+            var (exitCode, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                clientAndTentacle.RunningTentacle.RunTentacleEnvironmentVariables, 
+                "show-thumbprint", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
 
             try
             {
@@ -470,7 +492,7 @@ The details are logged above. These commands probably need to take Lazy<T> depen
         [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.None)]
         public async Task HelpAsFirstArgumentShouldShowCommandSpecificHelp(TentacleConfigurationTestCase tc)
         {
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "help", "version");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, null, "help", "version");
             stderr.Should().BeNullOrEmpty();
 
             stdout.Should().Be(
@@ -494,7 +516,11 @@ Or one of the common options:
         public async Task ShowConfigurationCommand(TentacleConfigurationTestCase tc)
         {
             await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-configuration", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                clientAndTentacle.RunningTentacle.RunTentacleEnvironmentVariables, 
+                "show-configuration", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
+
             stderr.Should().BeNullOrEmpty();
 
             // Actually parse and query the document just like our consumer will
@@ -510,10 +536,22 @@ Or one of the common options:
         [NonParallelizable]
         public async Task ShowConfigurationCommandOnPartiallyConfiguredTentacle(TentacleConfigurationTestCase tc)
         {
+            using var homeDirectory = new TemporaryDirectory();
+            var environmentVariables = new Dictionary<string, string?> { { EnvironmentVariables.TentacleMachineConfigurationHomeDirectory, homeDirectory.DirectoryPath } };
+
             var instanceId = Guid.NewGuid().ToString();
             using var temporaryDirectory = new TemporaryDirectory();
-            await RunCommandAndAssertExitsWithSuccessExitCode(tc, "create-instance", $"--instance={instanceId}", "--config", Path.Combine(temporaryDirectory.DirectoryPath, instanceId + ".cfg"));
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-configuration", $"--instance={instanceId}");
+            await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                environmentVariables,
+                "create-instance", $"--instance={instanceId}", "--config", Path.Combine(temporaryDirectory.DirectoryPath, instanceId + ".cfg"));
+
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                environmentVariables,
+                "show-configuration", 
+                $"--instance={instanceId}");
+
             stderr.Should().BeNullOrEmpty();
 
             // Actually parse and query the document just like our consumer will
@@ -528,7 +566,11 @@ Or one of the common options:
         public async Task ShowConfigurationCommandLooksSensibleToHumans(TentacleConfigurationTestCase tc)
         {
             await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
-            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "show-configuration", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
+            var (_, stdout, stderr) = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                clientAndTentacle.RunningTentacle.RunTentacleEnvironmentVariables,
+                "show-configuration", $"--instance={clientAndTentacle.RunningTentacle.InstanceName}");
+
             stderr.Should().BeNullOrEmpty();
 
             if (tc.TentacleType == TentacleType.Polling)
@@ -621,10 +663,18 @@ Or one of the common options:
         public async Task WatchdogCreateAndDeleteCommand(TentacleConfigurationTestCase tc)
         {
             await using var clientAndTentacle = await tc.CreateBuilder().Build(CancellationToken);
-            var create = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "watchdog", "--create", $"--instances={clientAndTentacle.RunningTentacle.InstanceName}");
+            var create = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                clientAndTentacle.RunningTentacle.RunTentacleEnvironmentVariables,
+                "watchdog", "--create", $"--instances={clientAndTentacle.RunningTentacle.InstanceName}");
+
             create.StdError.Should().BeNullOrEmpty();
             create.StdOut.Should().ContainEquivalentOf("Creating watchdog task");
-            var delete = await RunCommandAndAssertExitsWithSuccessExitCode(tc, "watchdog", "--delete", $"--instances={clientAndTentacle.RunningTentacle.InstanceName}");
+            var delete = await RunCommandAndAssertExitsWithSuccessExitCode(
+                tc, 
+                clientAndTentacle.RunningTentacle.RunTentacleEnvironmentVariables,
+                "watchdog", "--delete", $"--instances={clientAndTentacle.RunningTentacle.InstanceName}");
+
             delete.StdError.Should().BeNullOrEmpty();
             delete.StdOut.Should().ContainEquivalentOf("Removing watchdog task");
         }
@@ -642,14 +692,20 @@ Or one of the common options:
             return FileVersionInfo.GetVersionInfo($"{tentacleExe}.dll");
         }
 
-        async Task<(int ExitCode, string StdOut, string StdError)> RunCommandAndAssertExitsWithSuccessExitCode(TentacleConfigurationTestCase tentacleConfigurationTestCase, params string[] arguments)
+        async Task<(int ExitCode, string StdOut, string StdError)> RunCommandAndAssertExitsWithSuccessExitCode(
+            TentacleConfigurationTestCase tentacleConfigurationTestCase, 
+            IReadOnlyDictionary<string, string?>? environmentVariables,
+            params string[] arguments)
         {
-            var (exitCode, stdout, stderr) = await RunCommand(tentacleConfigurationTestCase, arguments);
+            var (exitCode, stdout, stderr) = await RunCommand(tentacleConfigurationTestCase, environmentVariables, arguments);
             exitCode.Should().Be(0, $"we expected the command to succeed.\r\nStdErr: '{stderr}'\r\nStdOut: '{stdout}'");
             return (exitCode, stdout, stderr);
         }
 
-        async Task<(int ExitCode, string StdOut, string StdError)> RunCommand(TentacleConfigurationTestCase tentacleConfigurationTestCase, params string[] arguments)
+        async Task<(int ExitCode, string StdOut, string StdError)> RunCommand(
+            TentacleConfigurationTestCase tentacleConfigurationTestCase, 
+            IReadOnlyDictionary<string, string?>? environmentVariables,
+            params string[] arguments)
         {
             var tentacleExe = TentacleExeFinder.FindTentacleExe(tentacleConfigurationTestCase.TentacleRuntime);
             var output = new StringBuilder();
@@ -661,6 +717,7 @@ Or one of the common options:
                     .WithValidation(CommandResultValidation.None)
                     .WithStandardOutputPipe(PipeTarget.ToStringBuilder(output))
                     .WithStandardErrorPipe(PipeTarget.ToStringBuilder(errorOut))
+                    .WithEnvironmentVariables(environmentVariables ?? new Dictionary<string, string?>())
                     .ExecuteAsync(CancellationToken));
 
             return (result.ExitCode, output.ToString(), errorOut.ToString());

--- a/source/Octopus.Tentacle.Tests/Configuration/ApplicationInstanceStoreFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Configuration/ApplicationInstanceStoreFixture.cs
@@ -25,7 +25,7 @@ namespace Octopus.Tentacle.Tests.Configuration
             registryStore = Substitute.For<IRegistryApplicationInstanceStore>();
             fileSystem = Substitute.For<IOctopusFileSystem>();
             var log = Substitute.For<ISystemLog>();
-            instanceStore = new ApplicationInstanceStore(ApplicationName.OctopusServer, log, fileSystem, registryStore);
+            instanceStore = new ApplicationInstanceStore(ApplicationName.Tentacle, log, fileSystem, registryStore);
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests/Startup/CheckServicesCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Startup/CheckServicesCommandFixture.cs
@@ -25,7 +25,7 @@ namespace Octopus.Tentacle.Tests.Startup
             windowsLocalAdminRightsChecker = Substitute.For<IWindowsLocalAdminRightsChecker>();
             var log = Substitute.For<ISystemLog>();
             var fileLog = Substitute.For<ILogFileOnlyLogger>();
-            command = new CheckServicesCommand(log, instanceStore, ApplicationName.OctopusServer, windowsLocalAdminRightsChecker, fileLog);
+            command = new CheckServicesCommand(log, instanceStore, ApplicationName.Tentacle, windowsLocalAdminRightsChecker, fileLog);
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests/Startup/WatchdogCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Startup/WatchdogCommandFixture.cs
@@ -25,7 +25,7 @@ namespace Octopus.Tentacle.Tests.Startup
             var watchdog = new Lazy<IWatchdog>(() => Substitute.For<IWatchdog>());
 
             var fileLog = Substitute.For<ILogFileOnlyLogger>();
-            command = new WatchdogCommand(log, ApplicationName.OctopusServer, watchdog, windowsLocalAdminRightsChecker, fileLog);
+            command = new WatchdogCommand(log, ApplicationName.Tentacle, watchdog, windowsLocalAdminRightsChecker, fileLog);
         }
 
         [Test]

--- a/source/Octopus.Tentacle/Configuration/ApplicationName.cs
+++ b/source/Octopus.Tentacle/Configuration/ApplicationName.cs
@@ -5,9 +5,6 @@ namespace Octopus.Tentacle.Configuration
 {
     public enum ApplicationName
     {
-        [Description("Octopus Server")]
-        OctopusServer,
-
         [Description("Tentacle")]
         Tentacle
     }

--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceStore.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceStore.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Util;
+using Octopus.Tentacle.Variables;
 
 namespace Octopus.Tentacle.Configuration.Instances
 {
@@ -26,11 +27,19 @@ namespace Octopus.Tentacle.Configuration.Instances
             this.fileSystem = fileSystem;
             this.applicationName = applicationName;
             this.registryApplicationInstanceStore = registryApplicationInstanceStore;
+            
+            var customMachineConfigurationHomeDirectory = Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleMachineConfigurationHomeDirectory);
 
-            machineConfigurationHomeDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Octopus");
-
-            if (!PlatformDetection.IsRunningOnWindows)
-                machineConfigurationHomeDirectory = "/etc/octopus";
+            if(!string.IsNullOrWhiteSpace(customMachineConfigurationHomeDirectory))
+            {
+                machineConfigurationHomeDirectory = customMachineConfigurationHomeDirectory;
+            }
+            else
+            {
+                machineConfigurationHomeDirectory = PlatformDetection.IsRunningOnWindows ? 
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Octopus") : 
+                    "/etc/octopus";
+            }
         }
 
         public ApplicationInstanceRecord LoadInstanceDetails(string? instanceName)

--- a/source/Octopus.Tentacle/Configuration/ServiceName.cs
+++ b/source/Octopus.Tentacle/Configuration/ServiceName.cs
@@ -11,9 +11,6 @@ namespace Octopus.Tentacle.Configuration
 
             switch (application)
             {
-                case ApplicationName.OctopusServer:
-                    name = "OctopusDeploy";
-                    break;
                 case ApplicationName.Tentacle:
                     name = "OctopusDeploy Tentacle";
                     break;

--- a/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
+++ b/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
@@ -22,5 +22,6 @@ namespace Octopus.Tentacle.Variables
         public const string AgentProgramDirectoryPath = "AgentProgramDirectoryPath";
         public const string TentacleTcpKeepAliveEnabled = "TentacleTcpKeepAliveEnabled";
         public const string TentacleUseRecommendedTimeoutsAndLimits = "TentacleUseRecommendedTimeoutsAndLimits";
+        public const string TentacleMachineConfigurationHomeDirectory = "TentacleMachineConfigurationHomeDirectory";
     }
 }


### PR DESCRIPTION
# Background

Allow the MachineConfigurationHomeDirectory to be changed and use a unique directory per test to isolate cross test issues

[sc-66742]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.