### PR TITLE
Additional Logging for Flakey Workspace Cleanup Test and removal of Sync over Async while deleting a workspace

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacle.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Halibut;
 using Octopus.Tentacle.Client;
@@ -53,10 +54,16 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         {
             SafelyMoveTentacleLogFileToSharedLocation();
 
-            logger.Information("****** ****** ****** ****** ****** ****** ******");
-            logger.Information("****** CLIENT AND TENTACLE DISPOSE CALLED  *****");
-            logger.Information("*     Subsequent errors should be ignored      *");
-            logger.Information("****** ****** ****** ****** ****** ****** ******");
+            var banner = new StringBuilder();
+            banner.AppendLine("");
+            banner.AppendLine("");
+
+            banner.AppendLine("****** ****** ****** ****** ****** ****** ******");
+            banner.AppendLine("****** CLIENT AND TENTACLE DISPOSE CALLED  *****");
+            banner.AppendLine("*     Subsequent errors should be ignored      *");
+            banner.AppendLine("****** ****** ****** ****** ****** ****** ******");
+
+            logger.Information(banner.ToString());
 
             logger.Information("Starting DisposeAsync");
 

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/ScriptExecutionResultExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ExtensionMethods/ScriptExecutionResultExtensionMethods.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using Octopus.Tentacle.Client.Scripts;
+using Octopus.Tentacle.Contracts;
+using Serilog;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods
+{
+    public static class ScriptExecutionResultExtensionMethods
+    {
+        public static void LogExecuteScriptOutput(this (ScriptExecutionResult ScriptExecutionResult, List<ProcessOutput> ProcessOutput) result, ILogger logger)
+        {
+            var scriptOutput = new StringBuilder();
+
+            scriptOutput.AppendLine("");
+            scriptOutput.AppendLine("");
+            scriptOutput.AppendLine("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+            scriptOutput.AppendLine("~~ Start Execute Script Output ~~");
+            scriptOutput.AppendLine("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+
+            scriptOutput.AppendLine($"ScriptExecutionResult.State: {result.ScriptExecutionResult.State}");
+            scriptOutput.AppendLine($"ScriptExecutionResult.ExitCode: {result.ScriptExecutionResult.ExitCode}");
+            scriptOutput.AppendLine("");
+            
+            result.ProcessOutput.ForEach(x => scriptOutput.AppendLine($"{x.Source} {x.Occurred} {x.Text}"));
+
+            scriptOutput.AppendLine($@"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+            scriptOutput.AppendLine($@"~~~ End Execute Script Output ~~~");
+            scriptOutput.AppendLine($@"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+
+            logger.Information(scriptOutput.ToString());
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleStartupAndShutdownTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleStartupAndShutdownTests.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Halibut.Exceptions;
@@ -10,6 +9,7 @@ using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Support.TestAttributes;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
 
@@ -53,11 +53,7 @@ cd ""{clientAndTentacle.RunningTentacle.TentacleExe.DirectoryName}""
                     result = await clientAndTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
                 }
 
-                var scriptOutput = new StringBuilder();
-                result.ProcessOutput.ForEach(x => scriptOutput.AppendLine($"{x.Source} {x.Occurred} {x.Text}"));
-
-                Logger.Information($@"Script Output:
-{scriptOutput}");
+                result.LogExecuteScriptOutput(Logger);
 
                 result.ProcessOutput.Any(x => x.Text.Contains("Stopping service")).Should().BeTrue("Stopping service should be logged");
                 result.ScriptExecutionResult.State.Should().Be(ProcessState.Complete);

--- a/source/Octopus.Tentacle.Tests.Integration/WorkspaceCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/WorkspaceCleanerTests.cs
@@ -4,9 +4,11 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Tentacle.CommonTestUtils.Builders;
+using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Support.ExtensionMethods;
 using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Tests.Integration.Util.Builders;
 using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
@@ -49,9 +51,13 @@ namespace Octopus.Tentacle.Tests.Integration
             Directory.Exists(startScriptWorkspaceDirectory).Should().BeTrue("Workspace should not have been cleaned up");
 
             File.WriteAllText(waitBeforeCompletingScriptFile, "Write file that makes script continue executing");
-            await runningScriptTask;
+            var runningScriptResult = await runningScriptTask;
 
-            Directory.Exists(startScriptWorkspaceDirectory).Should().BeFalse("Workspace should be naturally cleaned up after completion");
+            runningScriptResult.LogExecuteScriptOutput(Logger);
+
+            runningScriptResult.ScriptExecutionResult.ExitCode.Should().Be(0, "Script should have completed successfully");
+            runningScriptResult.ScriptExecutionResult.State.Should().Be(ProcessState.Complete, "Script should have completed successfully");
+            Directory.Exists(startScriptWorkspaceDirectory).Should().BeFalse($"Workspace {startScriptWorkspaceDirectory} should have been cleaned up when CompleteScript was called");
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
@@ -366,7 +366,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             response.ExitCode.Should().Be(-46);
 
-            CleanupWorkspace(ticket);
+            await CleanupWorkspace(ticket, CancellationToken.None);
         }
 
         [Test]
@@ -380,7 +380,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             response.ExitCode.Should().Be(-46);
 
-            CleanupWorkspace(ticket);
+            await CleanupWorkspace(ticket, CancellationToken.None);
         }
 
         [Test]
@@ -472,10 +472,10 @@ namespace Octopus.Tentacle.Tests.Integration
             return stateWorkspace;
         }
 
-        private void CleanupWorkspace(ScriptTicket ticket)
+        private async Task CleanupWorkspace(ScriptTicket ticket, CancellationToken cancellationToken)
         {
             var workspace = workspaceFactory.GetWorkspace(ticket);
-            workspace.Delete();
+            await workspace.Delete(cancellationToken);
         }
 
         (StartScriptCommandV2 StartScriptCommand, FileInfo FileScriptWillCreate) GetStartScriptCommandForScriptThatCreatesAFile(ScriptTicket scriptTicket, int? scriptDelayInSeconds = null)

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV3AlphaFixture.cs
@@ -362,7 +362,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             response.ExitCode.Should().Be(-46);
 
-            CleanupWorkspace(ticket);
+            await CleanupWorkspace(ticket, CancellationToken.None);
         }
 
         [Test]
@@ -376,7 +376,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             response.ExitCode.Should().Be(-46);
 
-            CleanupWorkspace(ticket);
+            await CleanupWorkspace(ticket, CancellationToken.None);
         }
 
         [Test]
@@ -468,10 +468,10 @@ namespace Octopus.Tentacle.Tests.Integration
             return stateWorkspace;
         }
 
-        private void CleanupWorkspace(ScriptTicket ticket)
+        private async Task CleanupWorkspace(ScriptTicket ticket, CancellationToken cancellationToken)
         {
             var workspace = workspaceFactory.GetWorkspace(ticket);
-            workspace.Delete();
+            await workspace.Delete(cancellationToken);
         }
 
         (StartScriptCommandV3Alpha StartScriptCommand, FileInfo FileScriptWillCreate) GetStartScriptCommandForScriptThatCreatesAFile(ScriptTicket scriptTicket, int? scriptDelayInSeconds = null)

--- a/source/Octopus.Tentacle/Scripts/IScriptWorkspace.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptWorkspace.cs
@@ -17,7 +17,6 @@ namespace Octopus.Tentacle.Scripts
         string? ScriptMutexName { get; set; }
         void BootstrapScript(string scriptBody);
         string ResolvePath(string fileName);
-        void Delete();
         Task Delete(CancellationToken cancellationToken);
         IScriptLog CreateLog();
         string LogFilePath { get; }

--- a/source/Octopus.Tentacle/Scripts/ScriptWorkspace.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptWorkspace.cs
@@ -82,11 +82,6 @@ namespace Octopus.Tentacle.Scripts
             return path;
         }
 
-        public void Delete()
-        {
-            FileSystem.DeleteDirectory(WorkingDirectory, DeletionOptions.TryThreeTimesIgnoreFailure);
-        }
-
         public async Task Delete(CancellationToken cancellationToken)
         {
             await FileSystem.DeleteDirectory(WorkingDirectory, cancellationToken, DeletionOptions.TryThreeTimesIgnoreFailure);

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
@@ -76,7 +76,7 @@ namespace Octopus.Tentacle.Services.Scripts
             cancellationTokens.TryRemove(command.Ticket.TaskId, out _);
             var response = GetResponse(command.Ticket, script, command.LastLogSequence);
             var workspace = workspaceFactory.GetWorkspace(command.Ticket);
-            workspace.Delete();
+            await workspace.Delete(cancellationToken);
             return response;
         }
 

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
@@ -121,7 +121,7 @@ namespace Octopus.Tentacle.Services.Scripts
             }
 
             var workspace = workspaceFactory.GetWorkspace(command.Ticket);
-            workspace.Delete();
+            await workspace.Delete(cancellationToken);
         }
 
         RunningScript LaunchShell(ScriptTicket ticket, string serverTaskId, IScriptWorkspace workspace, IScriptStateStore stateStore, CancellationToken cancellationToken)


### PR DESCRIPTION
# Background

Adding some more logging to a flakey test `WhenScriptServiceIsRunning_ThenWorkspaceIsNotDeleted` e.g. https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacleNet48_SensibleDefaultsChainFullChain/10569176?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildTestsSection=true&expandBuildProblemsSection=true&expandBuildDeploymentsSection=false

Removed a sync call that then did a Wait on an async call as well can be fully async now.

[sc-66742]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.