### PR TITLE
Fix Tests that start Tentacle as a Service

### DIFF
--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceStore.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceStore.cs
@@ -37,9 +37,11 @@ namespace Octopus.Tentacle.Configuration.Instances
             else
             {
                 machineConfigurationHomeDirectory = PlatformDetection.IsRunningOnWindows ? 
-                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Octopus") : 
-                    "/etc/octopus";
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Octopus") :
+                "/etc/octopus";
             }
+
+            log.Info("Machine configuration home directory is " + machineConfigurationHomeDirectory);
         }
 
         public ApplicationInstanceRecord LoadInstanceDetails(string? instanceName)

--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceStore.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceStore.cs
@@ -41,7 +41,7 @@ namespace Octopus.Tentacle.Configuration.Instances
                 "/etc/octopus";
             }
 
-            log.Info("Machine configuration home directory is " + machineConfigurationHomeDirectory);
+            log.Verbose("Machine configuration home directory is " + machineConfigurationHomeDirectory);
         }
 
         public ApplicationInstanceRecord LoadInstanceDetails(string? instanceName)


### PR DESCRIPTION
# Background

Set Environment variables for the Windows and Linux Service so it behaves like running Tentacle via the console in tests.

The tests were already flakey and then broken with https://github.com/OctopusDeploy/OctopusTentacle/pull/738 

No muted tests with the last run of this PR so looking like it has solved the main issues

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/66cfab7b-5090-4fc8-955d-bbafe5be7e50)

I can still get failures on Ubuntu locally if I run to failure, so it's not 100% reliable but it shifts the issue on to the restart `--stop --start` performed during the test, rather than the failure occurring when trying to setup and start the service initally.
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.