### PR TITLE
Possible fix for Execution Timeout issues seen on Build Server

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
@@ -397,7 +397,11 @@ namespace Octopus.Tentacle.Tests.Integration
             Func<Task<(ScriptExecutionResult, List<ProcessOutput>)>> action = async () => await executeScriptTask;
 
             Logger.Information("Waiting for the RPC Call to start");
-            await Wait.For(() => rpcCallHasStarted.Value, CancellationToken);
+            await Wait.For(
+                () => rpcCallHasStarted.Value, 
+                TimeSpan.FromSeconds(30),
+                () => throw new Exception("RPC call did not start")
+                ,CancellationToken);
             Logger.Information("RPC Call has start");
 
             await Task.Delay(TimeSpan.FromSeconds(6), CancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
@@ -494,7 +494,10 @@ namespace Octopus.Tentacle.Tests.Integration
                 cancelExecutionCancellationTokenSource.Token);
 
             Logger.Information("Waiting for the RPC Call to start");
-            await Wait.For(() => rpcCallHasStarted.Value, CancellationToken);
+            await Wait.For(() => rpcCallHasStarted.Value, 
+                TimeSpan.FromSeconds(30),
+                () => throw new Exception("RPC call did not start"),
+                CancellationToken);
             Logger.Information("RPC Call has start");
 
             var cancellationDuration = new Stopwatch();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -52,7 +52,10 @@ namespace Octopus.Tentacle.Tests.Integration
                 CancellationToken);
 
             // Wait for the script to start.
-            await Wait.For(() => File.Exists(scriptHasStartFile), CancellationToken);
+            await Wait.For(() => File.Exists(scriptHasStartFile), 
+                TimeSpan.FromSeconds(30),
+                () => throw new Exception("Script did not start"),
+                CancellationToken);
 
             // Now it has started, kill active connections killing the start script request.
             clientTentacle.PortForwarder.CloseExistingConnections();
@@ -111,7 +114,10 @@ namespace Octopus.Tentacle.Tests.Integration
                 async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog),
                 CancellationToken);
 
-            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).LastException != null, CancellationToken);
+            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).LastException != null, 
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("GetStatus did not error"),
+                CancellationToken);
 
             // Let the script finish.
             File.WriteAllText(waitForFile, "");
@@ -194,7 +200,10 @@ namespace Octopus.Tentacle.Tests.Integration
                         nameof(IAsyncClientScriptServiceV2.GetStatusAsync),
                         async (_, _) =>
                         {
-                            await Wait.For(() => File.Exists(scriptIsRunningFlag), CancellationToken);
+                            await Wait.For(() => File.Exists(scriptIsRunningFlag), 
+                                TimeSpan.FromSeconds(30),
+                                () => throw new Exception("Script did not start"),
+                                CancellationToken);
                             cts.Cancel();
                         })
                     .HookServiceMethod(tentacleConfigurationTestCase,

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
@@ -50,13 +50,19 @@ namespace Octopus.Tentacle.Tests.Integration
             var firstScriptExecution = Task.Run(async () => await tentacleClient.ExecuteScript(firstStartScriptCommand, CancellationToken));
 
             // Wait for the first script to start running
-            await Wait.For(() => File.Exists(firstScriptStartFile), CancellationToken);
+            await Wait.For(() => File.Exists(firstScriptStartFile), 
+                TimeSpan.FromSeconds(30),
+                () => throw new Exception("Script did not start"),
+                CancellationToken);
             Logger.Information("First script is now running");
 
             var secondScriptExecution = Task.Run(async () => await tentacleClient.ExecuteScript(secondStartScriptCommand, CancellationToken));
 
             // Wait for the second script start script RPC call to return.
-            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.StartScriptAsync)).Completed == 2, CancellationToken);
+            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.StartScriptAsync)).Completed == 2, 
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("Second execute script call did not complete"),
+                CancellationToken);
 
             // Give Tentacle some more time to run the script (although it should not).
             await Task.Delay(TimeSpan.FromSeconds(2));
@@ -104,12 +110,18 @@ namespace Octopus.Tentacle.Tests.Integration
             var firstScriptExecution = Task.Run(async () => await tentacleClient.ExecuteScript(firstStartScriptCommand, CancellationToken));
 
             // Wait for the first script to start running
-            await Wait.For(() => File.Exists(firstScriptStartFile), CancellationToken);
+            await Wait.For(() => File.Exists(firstScriptStartFile), 
+                TimeSpan.FromSeconds(30),
+                () => throw new Exception("Script did not start running"),
+                CancellationToken);
 
             var secondScriptExecution = Task.Run(async () => await tentacleClient.ExecuteScript(secondStartScriptCommand, CancellationToken));
 
             // Wait for the second script to start
-            await Wait.For(() => File.Exists(secondScriptStart), CancellationToken);
+            await Wait.For(() => File.Exists(secondScriptStart), 
+                TimeSpan.FromSeconds(30),
+                () => throw new Exception("Second script did not start"),
+                CancellationToken);
             // Both scripts are now running in parallel
 
             // Let the first script finish.

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -452,7 +452,10 @@ namespace Octopus.Tentacle.Tests.Integration
                 null,
                 inMemoryLog);
             
-            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).Completed > 0, CancellationToken);
+            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).Completed > 0, 
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("Script execution did not complete"),
+                CancellationToken);
 
             // We cancel script execution via the cancellation token. This should trigger the CancelScript RPC call to be made
             testCancellationTokenSource.Cancel();
@@ -519,7 +522,11 @@ namespace Octopus.Tentacle.Tests.Integration
                 inMemoryLog);
 
             Func<Task> action = async () => await executeScriptTask;
-            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).Completed > 0, CancellationToken);
+            await Wait.For(
+                () => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).Completed > 0, 
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("Script Execution did not complete"),
+                CancellationToken);
 
             // We cancel script execution via the cancellation token. This should trigger the CancelScript RPC call to be made
             testCancellationTokenSource.Cancel();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
@@ -123,8 +123,11 @@ namespace Octopus.Tentacle.Tests.Integration
             File.WriteAllText(waitForFile, "");
             var legacyTentacleClient = clientTentacle.LegacyTentacleClientBuilder().Build();
 
-            await Wait.For(async () => (await legacyTentacleClient.ScriptService.GetStatusAsync(scriptStatusRequest, new(CancellationToken)))
-                .State == ProcessState.Complete, CancellationToken);
+            await Wait.For(
+                async () => (await legacyTentacleClient.ScriptService.GetStatusAsync(scriptStatusRequest, new(CancellationToken))).State == ProcessState.Complete, 
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("Script Execution did not complete"),
+                CancellationToken);
 
             var allLogs = logs.JoinLogs();
 
@@ -198,8 +201,11 @@ namespace Octopus.Tentacle.Tests.Integration
             File.WriteAllText(waitForFile, "");
             var legacyTentacleClient = clientTentacle.LegacyTentacleClientBuilder().Build();
 
-            await Wait.For(async () => (await legacyTentacleClient.ScriptService.GetStatusAsync(scriptStatusRequest, new(CancellationToken)))
-                .State == ProcessState.Complete, CancellationToken);
+            await Wait.For(
+                async () => (await legacyTentacleClient.ScriptService.GetStatusAsync(scriptStatusRequest, new(CancellationToken))).State == ProcessState.Complete, 
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("Script Execution did not complete"),
+                CancellationToken);
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Wait.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Wait.cs
@@ -7,7 +7,22 @@ namespace Octopus.Tentacle.Tests.Integration.Util
 {
     public static class Wait
     {
-        public static async Task For(Func<bool> toBeTrue, CancellationToken cancellationToken)
+        public static async Task For(Func<bool> toBeTrue, TimeSpan timeout, Action onTimeoutOrCancellation, CancellationToken cancellationToken)
+        {
+            using var timeoutCancellationTokenSource = new CancellationTokenSource(timeout);
+            using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
+
+            try
+            {
+                await For(toBeTrue, linkedCancellationTokenSource.Token);
+            }
+            catch (OperationCanceledException) when (linkedCancellationTokenSource.IsCancellationRequested)
+            {
+                onTimeoutOrCancellation();
+            }
+        }
+
+        static async Task For(Func<bool> toBeTrue, CancellationToken cancellationToken)
         {
             while (true)
             {
@@ -19,7 +34,22 @@ namespace Octopus.Tentacle.Tests.Integration.Util
             }
         }
 
-        public static async Task For(Func<Task<bool>> toBeTrue, CancellationToken cancellationToken)
+        public static async Task For(Func<Task<bool>> toBeTrue, TimeSpan timeout, Action onTimeoutOrCancellation, CancellationToken cancellationToken)
+        {
+            using var timeoutCancellationTokenSource = new CancellationTokenSource(timeout);
+            using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
+
+            try
+            {
+                await For(toBeTrue, linkedCancellationTokenSource.Token);
+            }
+            catch (OperationCanceledException) when (linkedCancellationTokenSource.IsCancellationRequested)
+            {
+                onTimeoutOrCancellation();
+            }
+        }
+
+        static async Task For(Func<Task<bool>> toBeTrue, CancellationToken cancellationToken)
         {
             while (true)
             {


### PR DESCRIPTION
# Background

Possible fix for Execution Timeout issues seen on Build Server

- Wait.For now requires a specific timeout to avoid waiting for too long / never finishing the wait if the CancellationToken fails to be cancelled
- IntegrationTest will now attempt to cancel the cancellation token just before the test times out. Nunit does not call TearDown on the test if it times out through the `TimeoutAttribute` so we end up in a state where the CancellationToken used for test cleanup is not cancelled and things can keep running.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.