### PR TITLE
Remove race condition in WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
@@ -55,7 +55,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 {
                                     // Kill the port forwarder so the next requests are in the connecting state when retries timeout
                                     Logger.Information("Killing PortForwarder");
-                                    portForwarder!.Dispose();
+                                    portForwarder!.EnterKillNewAndExistingConnectionsMode();
                                 }
                                 else
                                 {


### PR DESCRIPTION
# Background

This test was failing by somehow successfully as far as the caller is concerned, uploading the file to tentacle.

Looking at the logs we see on the second attempt to upload the file:
```
00:00:04.4086383 [TentacleClient] [WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(Listening,Latest,True)] Info "Beginning upload of UploadFile.txt to Tentacle"
12/16/2023 5:33:18 AM 228 Info Beginning upload of UploadFile.txt to Tentacle
00:00:04.4087075 [MethodLoggingProxyDecorator] [WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(Listening,Latest,True)] IAsyncClientFileTransferService.UploadFileAsync() started
00:00:04.4087428 [ClientFileTransferRetriesTimeout] [WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(Listening,Latest,True)] Killing PortForwarder
00:00:04.4087496 [PortForwarder] [WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(Listening,Latest,True)] Start Dispose Pumps
00:00:04.4087550 [PortForwarder] [WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(Listening,Latest,True)] Fisinshed Dispose Pumps
00:00:05.4244475 [MethodLoggingProxyDecorator] [WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(Listening,Latest,True)] IAsyncClientFileTransferService.UploadFileAsync() completed
00:00:05.4244686 [TentacleClient] [WhenRpcRetriesTimeOut_DuringUploadFile_TheRpcCallIsCancelled(Listening,Latest,True)] Info "Upload complete"
12/16/2023 5:33:19 AM 248 Info Upload complete
```

Its interesting to see that the port forwarder doesn't see any data flowing which suggests:
* halibut started talking to some other tentacle on the same port
* halibut is lying about uploading the file.

This PR preserves the port forwarder listen port, and instead just moves the port forwarder into a mode in which new and existing connections are killed. This will remove any chance we are talking to the wrong tentacle.

[SC-67413]


Another test suggests this is happening as well see this error:
```
Halibut.HalibutClientException: An error occurred when sending a request to 'https://localhost:37903/', after the 
request began: The server at https://localhost:37903/ presented an unexpected security certificate. We expected the 
server to present a certificate with the thumbprint '36F35047CE8B000CF4C671819A2DD1AFCDE3403D'. Instead, it 
presented a certificate with a thumbprint of '76225C0717A16C1D0BA4A7FFA76519D286D8A248' and subject 
'C="CN=Halibut Bob", O="CN=Halibut Bob", CN="CN=Halibut Bob", E=""'. This usually happens when the client has 
been configured to expect the server to have the wrong certificate, or when the certificate on the server has been 
regenerated and the client has not been updated. It may also happen if someone is performing a man-in-the-middle 
attack on the remote machine, or if a proxy server is intercepting requests. Please check the certificate used on the 
server, and verify that the client has been configured correctly.

```

that was the error when uploading the second time after we disposed of the port forwarder. What is happening is that it is talking to a server (client) and so seeing the (server/client) certificate! So it does appear to be the case that something else can quickly stand up and take the port.
# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.