### PR TITLE
Try and make ScriptWorkspace.Delete more reliable

### DIFF
--- a/source/Octopus.Tentacle/Scripts/ScriptWorkspace.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptWorkspace.cs
@@ -85,6 +85,20 @@ namespace Octopus.Tentacle.Scripts
         public async Task Delete(CancellationToken cancellationToken)
         {
             await FileSystem.DeleteDirectory(WorkingDirectory, cancellationToken, DeletionOptions.TryThreeTimesIgnoreFailure);
+
+            // It appears that the FileSystem.DeleteDirectory method can fail to delete the directory in cases where Directory.Delete(recursive: true) can be successful.
+            // Leaving the existing code as we would need to understand more about the intent of the logic before changing it but adding in another best effort attempt to delete the directory.
+            if (Directory.Exists(WorkingDirectory))
+            {
+                try
+                {
+                    Directory.Delete(WorkingDirectory, true);
+                }
+                catch
+                {
+                    // Best effort cleanup so don't throw
+                }
+            }
         }
 
         public IScriptLog CreateLog()


### PR DESCRIPTION
# Background

Try and make ScriptWorkspace.Delete more reliable

It appears that the FileSystem.DeleteDirectory method can fail to delete the directory in cases where Directory.Delete(recursive: true) can be successful.

Leaving the existing code as we would need to understand more about the intent of the logic before changing it but adding in another best effort attempt to delete the directory.

This has been observed in Workspace Cleaner tests

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/547e935e-0dd2-4893-9e2e-fb2d6159e250)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.