### PR TITLE
Fix the LegacyClientAndTentacleBuilder not using a custom Machine configuration home directory

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +14,6 @@ using Octopus.Tentacle.Contracts.Observability;
 using Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers;
 using Octopus.Tentacle.Tests.Integration.Util;
 using Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers;
-using Octopus.Tentacle.Variables;
 using Octopus.TestPortForwarder;
 using Serilog;
 
@@ -209,14 +207,17 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 var pollingTentacleBuilder = new PollingTentacleBuilder(portForwarder?.ListeningPort ?? serverListeningPort, Certificates.ServerPublicThumbprint)
                     .WithTentacleExe(tentacleExe);
 
+                if (!useCustomMachineConfigurationHomeDirectory)
+                {
+                    pollingTentacleBuilder.UseDefaultMachineConfigurationHomeDirectory();
+                }
+
                 tentacleBuilderAction?.Invoke(pollingTentacleBuilder);
 
                 if (installAsAService)
                 { 
                     pollingTentacleBuilder.InstallAsAService();
                 }
-
-                ConfigureTentacleMachineConfigurationHomeDirectory(pollingTentacleBuilder, temporaryDirectory);
 
                 runningTentacle = await pollingTentacleBuilder.Build(logger, cancellationToken);
 
@@ -227,14 +228,17 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 var listeningTentacleBuilder = new ListeningTentacleBuilder(Certificates.ServerPublicThumbprint)
                     .WithTentacleExe(tentacleExe);
 
+                if (!useCustomMachineConfigurationHomeDirectory)
+                {
+                    listeningTentacleBuilder.UseDefaultMachineConfigurationHomeDirectory();
+                }
+
                 tentacleBuilderAction?.Invoke(listeningTentacleBuilder);
                 
                 if (installAsAService)
                 { 
                     listeningTentacleBuilder.InstallAsAService();
                 }
-
-                ConfigureTentacleMachineConfigurationHomeDirectory(listeningTentacleBuilder, temporaryDirectory);
 
                 runningTentacle = await listeningTentacleBuilder.Build(logger, cancellationToken);
 
@@ -273,16 +277,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 tentacleServiceDecorator);
 
             return new ClientAndTentacle(server.ServerHalibutRuntime, tentacleEndPoint, server, portForwarder, runningTentacle, tentacleClient, temporaryDirectory, retrySettings, logger);
-        }
-
-        void ConfigureTentacleMachineConfigurationHomeDirectory(ITentacleBuilder tentacleBuilder, TemporaryDirectory temporaryDirectory)
-        {
-            if (useCustomMachineConfigurationHomeDirectory)
-            {
-                var directory = Path.Combine(temporaryDirectory.DirectoryPath, "Octopus", "Tentacle", "Instances");
-
-                tentacleBuilder.WithRunTentacleEnvironmentVariable(EnvironmentVariables.TentacleMachineConfigurationHomeDirectory, directory);
-            }
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -37,7 +37,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         Action<TentacleClientOptions>? configureClientOptions;
         TcpConnectionUtilities? tcpConnectionUtilities;
         bool installAsAService = false;
-        bool useCustomMachineConfigurationHomeDirectory = true;
+        bool useDefaultMachineConfigurationHomeDirectory = false;
 
         public ClientAndTentacleBuilder(TentacleType tentacleType)
         {
@@ -152,7 +152,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         public ClientAndTentacleBuilder UseDefaultMachineConfigurationHomeDirectory()
         {
-            useCustomMachineConfigurationHomeDirectory = false;
+            useDefaultMachineConfigurationHomeDirectory = true;
 
             return this;
         }
@@ -207,7 +207,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 var pollingTentacleBuilder = new PollingTentacleBuilder(portForwarder?.ListeningPort ?? serverListeningPort, Certificates.ServerPublicThumbprint)
                     .WithTentacleExe(tentacleExe);
 
-                if (!useCustomMachineConfigurationHomeDirectory)
+                if (useDefaultMachineConfigurationHomeDirectory)
                 {
                     pollingTentacleBuilder.UseDefaultMachineConfigurationHomeDirectory();
                 }
@@ -228,7 +228,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 var listeningTentacleBuilder = new ListeningTentacleBuilder(Certificates.ServerPublicThumbprint)
                     .WithTentacleExe(tentacleExe);
 
-                if (!useCustomMachineConfigurationHomeDirectory)
+                if (useDefaultMachineConfigurationHomeDirectory)
                 {
                     listeningTentacleBuilder.UseDefaultMachineConfigurationHomeDirectory();
                 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ListeningTentacleBuilder.cs
@@ -23,6 +23,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var logger = log.ForContext<ListeningTentacleBuilder>();
             logger.Information($"Tentacle.exe location: {tentacleExe}");
 
+            ConfigureTentacleMachineConfigurationHomeDirectory();
             await CreateInstance(tentacleExe, configFilePath, instanceName, HomeDirectory, logger, cancellationToken);
             await AddCertificateToTentacle(tentacleExe, instanceName, CertificatePfxPath, HomeDirectory, logger, cancellationToken);
             var applicationDirectory = Path.Combine(HomeDirectory.DirectoryPath, "appdir");

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PollingTentacleBuilder.cs
@@ -30,6 +30,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var logger = log.ForContext<PollingTentacleBuilder>();
             logger.Information($"Tentacle.exe location: {tentacleExe}");
 
+            ConfigureTentacleMachineConfigurationHomeDirectory();
             await CreateInstance(tentacleExe, configFilePath, instanceName, HomeDirectory, logger, cancellationToken);
             var applicationDirectory = Path.Combine(HomeDirectory.DirectoryPath, "appdir");
             ConfigureTentacleToPollOctopusServer(configFilePath, subscriptionId, applicationDirectory);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -15,6 +15,7 @@ using NUnit.Framework;
 using Octopus.Tentacle.CommonTestUtils;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Tests.Integration.Util;
+using Octopus.Tentacle.Variables;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
@@ -33,6 +34,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         protected string CertificatePfxPath = Certificates.TentaclePfxPath;
         protected string TentacleThumbprint = Certificates.TentaclePublicThumbprint;
         bool installAsService = false;
+        bool useCustomMachineConfigurationHomeDirectory = true;
 
         static readonly Regex ListeningPortRegex = new (@"listen:\/\/.+:(\d+)\/");
         readonly Dictionary<string, string> runTentacleEnvironmentVariables = new();
@@ -47,7 +49,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 return homeDirectory;
             }
         }
-
+        
         public ITentacleBuilder WithHomeDirectory(TemporaryDirectory homeDirectory)
         {
             this.homeDirectory = homeDirectory;
@@ -88,6 +90,13 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public ITentacleBuilder InstallAsAService()
         {
             installAsService = true;
+
+            return this;
+        }
+
+        public ITentacleBuilder UseDefaultMachineConfigurationHomeDirectory()
+        {
+            useCustomMachineConfigurationHomeDirectory = false;
 
             return this;
         }
@@ -263,6 +272,16 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             }
 
             return (runningTentacle, serviceUri);
+        }
+
+        protected void ConfigureTentacleMachineConfigurationHomeDirectory()
+        {
+            if (useCustomMachineConfigurationHomeDirectory)
+            {
+                var directory = Path.Combine(HomeDirectory.DirectoryPath, "Octopus", "Tentacle", "Instances");
+
+                WithRunTentacleEnvironmentVariable(EnvironmentVariables.TentacleMachineConfigurationHomeDirectory, directory);
+            }
         }
 
         async Task SetEnvironmentVariablesForService(string instanceName, TemporaryDirectory tempDirectory, ILogger logger, CancellationToken cancellationToken)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -34,7 +34,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         protected string CertificatePfxPath = Certificates.TentaclePfxPath;
         protected string TentacleThumbprint = Certificates.TentaclePublicThumbprint;
         bool installAsService = false;
-        bool useCustomMachineConfigurationHomeDirectory = true;
+        bool useDefaultMachineConfigurationHomeDirectory = false;
 
         static readonly Regex ListeningPortRegex = new (@"listen:\/\/.+:(\d+)\/");
         readonly Dictionary<string, string> runTentacleEnvironmentVariables = new();
@@ -96,7 +96,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         public ITentacleBuilder UseDefaultMachineConfigurationHomeDirectory()
         {
-            useCustomMachineConfigurationHomeDirectory = false;
+            useDefaultMachineConfigurationHomeDirectory = true;
 
             return this;
         }
@@ -276,7 +276,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         protected void ConfigureTentacleMachineConfigurationHomeDirectory()
         {
-            if (useCustomMachineConfigurationHomeDirectory)
+            if (!useDefaultMachineConfigurationHomeDirectory)
             {
                 var directory = Path.Combine(HomeDirectory.DirectoryPath, "Octopus", "Tentacle", "Instances");
 


### PR DESCRIPTION
# Background

Fix the LegacyClientAndTentacleBuilder not using a custom Machine configuration home directory

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.