### PR TITLE
Work around an issue where Tentacle configuration, startup and removal cannot be isolated in integration tests for Tentacle < 8.1.284

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -204,7 +204,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             {
                 portForwarder = BuildPortForwarder(serverListeningPort, null);
 
-                var pollingTentacleBuilder = new PollingTentacleBuilder(portForwarder?.ListeningPort ?? serverListeningPort, Certificates.ServerPublicThumbprint)
+                var pollingTentacleBuilder = new PollingTentacleBuilder(portForwarder?.ListeningPort ?? serverListeningPort, Certificates.ServerPublicThumbprint, tentacleVersion)
                     .WithTentacleExe(tentacleExe);
 
                 if (useDefaultMachineConfigurationHomeDirectory)
@@ -225,7 +225,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             }
             else
             {
-                var listeningTentacleBuilder = new ListeningTentacleBuilder(Certificates.ServerPublicThumbprint)
+                var listeningTentacleBuilder = new ListeningTentacleBuilder(Certificates.ServerPublicThumbprint, tentacleVersion)
                     .WithTentacleExe(tentacleExe);
 
                 if (useDefaultMachineConfigurationHomeDirectory)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
@@ -77,7 +77,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
             {
                 portForwarder = PortForwarderBuilder.ForwardingToLocalPort(serverListeningPort, new SerilogLoggerBuilder().Build()).Build();
 
-                runningTentacle = await new PollingTentacleBuilder(portForwarder.ListeningPort, Certificates.ServerPublicThumbprint)
+                runningTentacle = await new PollingTentacleBuilder(portForwarder.ListeningPort, Certificates.ServerPublicThumbprint, tentacleVersion)
                     .WithTentacleExe(tentacleExe)
                     .Build(logger, cancellationToken);
 
@@ -85,7 +85,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
             }
             else
             {
-                runningTentacle = await new ListeningTentacleBuilder(Certificates.ServerPublicThumbprint)
+                runningTentacle = await new ListeningTentacleBuilder(Certificates.ServerPublicThumbprint, tentacleVersion)
                     .WithTentacleExe(tentacleExe)
                     .Build(logger, cancellationToken);
 


### PR DESCRIPTION
# Background

Work around an issue where Tentacle configuration, startup and removal cannot be isolated in integration tests for Tentacle < 8.1.284

This can lead to tests colliding and failing due to misconfiguration or incorrect startup/failure of Tentacle.

## Timings before the change

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/2f74869c-5c91-4f8a-bf88-7779a7c071b4)

## Timings after the change 

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/86938706/38f38557-08ac-4c85-a649-c73e62e06df1)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.