### PR TITLE
Cancel ScriptExecution without calling CancelScript when the StartScript request has never been transferred to Tentacle

### DIFF
--- a/source/Octopus.Tentacle.Client/ExceptionExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Client/ExceptionExtensionMethods.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Halibut;
+using Halibut.Exceptions;
+using Halibut.Transport;
+
+namespace Octopus.Tentacle.Client
+{
+    public static class ExceptionExtensionMethods
+    {
+        public static bool IsConnectionException(this Exception exception)
+        {
+            return exception is ConnectingRequestCancelledException 
+                || exception is HalibutClientException {ConnectionState: ConnectionState.Connecting};
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Orchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Orchestrator.cs
@@ -85,8 +85,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 void OnErrorAction(Exception ex)
                 {
                     // If we can guarantee that the call to StartScript has not connected to the Service then we can decrement the count
-                    if (ex is ConnectingRequestCancelledException || 
-                        ex is HalibutClientException { ConnectionState: ConnectionState.Connecting })
+                    if (ex.IsConnectionException())
                     {
                         --startScriptCallsConnectedCount;
                     }
@@ -109,7 +108,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
                 // We determine if the call was connecting when cancelled, then assume it's transferring if it is not connecting.
                 // This is the safest option as it will default to the CancelScript CompleteScript path if we are unsure
-                var startScriptCallIsConnecting = ex is ConnectingRequestCancelledException;
+                var startScriptCallIsConnecting = ex.IsConnectionException();
 
                 if (!startScriptCallIsConnecting || startScriptCallIsBeingRetried)
                 {

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
@@ -73,8 +73,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 void OnErrorAction(Exception ex)
                 {
                     // If we can guarantee that the call to StartScript has not connected to the Service then we can decrement the count
-                    if (ex is ConnectingRequestCancelledException || 
-                        ex is HalibutClientException { ConnectionState: ConnectionState.Connecting })
+                    if (ex.IsConnectionException())
                     {
                         --startScriptCallsConnectedCount;
                     }
@@ -97,7 +96,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
                 // We determine if the call was connecting when cancelled, then assume it's transferring if it is not connecting.
                 // This is the safest option as it will default to the CancelScript CompleteScript path if we are unsure
-                var startScriptCallIsConnecting = ex is ConnectingRequestCancelledException;
+                var startScriptCallIsConnecting = ex.IsConnectionException();
 
                 if (!startScriptCallIsConnecting || startScriptCallIsBeingRetried)
                 {

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.459" />
+    <PackageReference Include="Halibut" Version="7.0.465" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -38,6 +38,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         TcpConnectionUtilities? tcpConnectionUtilities;
         bool installAsAService = false;
         bool useDefaultMachineConfigurationHomeDirectory = false;
+        HalibutTimeoutsAndLimits? halibutTimeoutsAndLimits;
 
         public ClientAndTentacleBuilder(TentacleType tentacleType)
         {
@@ -157,6 +158,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             return this;
         }
 
+        public ClientAndTentacleBuilder WithHalibutTimeoutsAndLimits(HalibutTimeoutsAndLimits halibutTimeoutsAndLimits)
+        {
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
+            return this;
+        }
+
         PortForwarder? BuildPortForwarder(int localPort, int? listeningPort)
         {
             if (portForwarderModifiers.Count == 0) return null;
@@ -175,7 +182,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             // Server
             var serverHalibutRuntimeBuilder = new HalibutRuntimeBuilder()
                 .WithServerCertificate(Certificates.Server)
-                .WithHalibutTimeoutsAndLimits(HalibutTimeoutsAndLimits.RecommendedValues())
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits ?? HalibutTimeoutsAndLimits.RecommendedValues())
                 .WithLegacyContractSupport();
             
             if (queueFactory != null)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PendingRequestQueueFactories/CancelWhenRequestQueuedPendingRequestQueueFactory.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PendingRequestQueueFactories/CancelWhenRequestQueuedPendingRequestQueueFactory.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Halibut;
+using Halibut.Diagnostics;
+using Halibut.ServiceModel;
+using Halibut.Transport.Protocol;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.PendingRequestQueueFactories
+{
+    /// <summary>
+    /// CancelWhenRequestQueuedPendingRequestQueueFactory cancels the cancellation token source when a request is queued
+    /// </summary>
+    public class CancelWhenRequestQueuedPendingRequestQueueFactory : IPendingRequestQueueFactory
+    {
+        readonly CancellationTokenSource cancellationTokenSource;
+        readonly HalibutTimeoutsAndLimits halibutTimeoutsAndLimits;
+        readonly Func<Task<bool>> shouldCancel;
+
+        public CancelWhenRequestQueuedPendingRequestQueueFactory(CancellationTokenSource cancellationTokenSource, HalibutTimeoutsAndLimits halibutTimeoutsAndLimits,  Func<Task<bool>> shouldCancel)
+        {
+            this.cancellationTokenSource = cancellationTokenSource;
+            this.halibutTimeoutsAndLimits = halibutTimeoutsAndLimits;
+            this.shouldCancel = shouldCancel;
+        }
+
+        public IPendingRequestQueue CreateQueue(Uri endpoint)
+        {
+            return new Decorator(new PendingRequestQueueAsync(halibutTimeoutsAndLimits, new LogFactory().ForEndpoint(endpoint)), cancellationTokenSource, shouldCancel);
+        }
+
+        class Decorator : IPendingRequestQueue
+        {
+            readonly CancellationTokenSource cancellationTokenSource;
+            readonly Func<Task<bool>> shouldCancel;
+            readonly IPendingRequestQueue inner;
+
+            public Decorator(IPendingRequestQueue inner, CancellationTokenSource cancellationTokenSource, Func<Task<bool>>? shouldCancel)
+            {
+                this.inner = inner;
+                this.cancellationTokenSource = cancellationTokenSource;
+                this.shouldCancel = shouldCancel;
+            }
+
+            public bool IsEmpty => inner.IsEmpty;
+            public int Count => inner.Count;
+            public async Task ApplyResponse(ResponseMessage response, ServiceEndPoint destination) => await inner.ApplyResponse(response, destination);
+            public async Task<RequestMessageWithCancellationToken?> DequeueAsync(CancellationToken cancellationToken) => await inner.DequeueAsync(cancellationToken);
+
+            public async Task<ResponseMessage> QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationTokens)
+            {
+                var queueAndWait = inner.QueueAndWaitAsync(request, cancellationTokens);
+                var cancel = Task.Run(async () =>
+                {
+                    if (await shouldCancel())
+                    {
+                        // Allow the PendingRRequest to be queued
+                        cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(1));
+                    }
+                });
+
+                await Task.WhenAll(queueAndWait, cancel);
+
+                return await queueAndWait;
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -79,6 +79,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 tentacleTypes.Add(TentacleType.Listening);
             }
 
+            if (!tentacleTypes.Any())
+            {
+                throw new ArgumentException("At least one tentacle type to test must be specified");
+            }
+
             List<Version?> versions = new();
 
             if (testCommonVersions)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -15,13 +15,23 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             bool testScriptIsolationLevelVersions = false,
             bool testDefaultTentacleRuntimeOnly = false,
             ScriptServiceVersionToTest scriptServiceToTest = ScriptServiceVersionToTest.TentacleSupported,
+            bool testPolling = true,
+            bool testListening = true,
             params object[] additionalParameterTypes)
             : base(
                 typeof(TentacleConfigurationTestCases),
                 nameof(TentacleConfigurationTestCases.GetEnumerator),
                 new object[]
                 {
-                    testCommonVersions, testCapabilitiesServiceVersions, testNoCapabilitiesServiceVersions, testScriptIsolationLevelVersions, testDefaultTentacleRuntimeOnly, scriptServiceToTest, additionalParameterTypes
+                    testCommonVersions, 
+                    testCapabilitiesServiceVersions,
+                    testNoCapabilitiesServiceVersions, 
+                    testScriptIsolationLevelVersions, 
+                    testDefaultTentacleRuntimeOnly, 
+                    scriptServiceToTest, 
+                    testPolling,
+                    testListening,
+                    additionalParameterTypes
                 })
         {
         }
@@ -53,9 +63,22 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             bool testScriptIsolationLevel,
             bool testDefaultTentacleRuntimeOnly,
             ScriptServiceVersionToTest scriptServiceToTest,
+            bool testPolling,
+            bool testListening,
             object[] additionalParameterTypes)
         {
-            var tentacleTypes = new[] { TentacleType.Listening, TentacleType.Polling };
+            var tentacleTypes = new List<TentacleType>();
+
+            if (testPolling)
+            {
+                tentacleTypes.Add(TentacleType.Polling);
+            }
+
+            if (testListening)
+            {
+                tentacleTypes.Add(TentacleType.Listening);
+            }
+
             List<Version?> versions = new();
 
             if (testCommonVersions)

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/Proxies/MethodUsages.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/Proxies/MethodUsages.cs
@@ -21,6 +21,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.Proxies
             });
         }
 
+        public void Reset()
+        {
+            trackedMethods.Clear();
+        }
+
         public void RecordCallStart(MethodInfo targetMethod)
         {
             var stats = GetMethodStats(targetMethod);
@@ -47,6 +52,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.Proxies
     {
         IRecordedMethodUsage For(string methodName);
         IRecordedMethodUsage ForAll();
+        void Reset();
     }
 
     public class MethodUsage : IRecordedMethodUsage


### PR DESCRIPTION
# Background

Related to: https://github.com/OctopusDeploy/Issues/issues/8535

Given ScriptExecution has started for a Polling Tentacle that has recently gone offline
And the GetCapabilities response is cached
And RPC retries have started for the StartScript Call 
When the ScriptExecution is cancelled
Then TentacleClient will try and cancel script execution on Tentacle by calling CancelScript

In this scenario, we can guarantee that StartScript has never been transferred to Tentacle so the script is definitely not running.
Tentacle Client should be able to cancel any queued request and immediately return.

## Before

Cancelling ScriptExecution would start trying to cancel the script on Tentacle by calling CancelScript

## After

Cancelling ScriptExecution does not try and call CancelScript on Tentacle and instead cancels the queued request and stops ScriptExecution immediately.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.