### PR TITLE
Support locally building unsigned Linux packages

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -81,6 +81,9 @@
           "type": "string",
           "description": "Root directory during build execution"
         },
+        "RuntimeId": {
+          "type": "string"
+        },
         "signing_certificate_password": {
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
@@ -112,6 +115,7 @@
               "PackLinux",
               "PackLinuxPackagesLegacy",
               "PackLinuxTarballs",
+              "PackLinuxUnsigned",
               "PackOsx",
               "PackOsxTarballs",
               "PackRedHatPackage",
@@ -156,6 +160,7 @@
               "PackLinux",
               "PackLinuxPackagesLegacy",
               "PackLinuxTarballs",
+              "PackLinuxUnsigned",
               "PackOsx",
               "PackOsxTarballs",
               "PackRedHatPackage",

--- a/build-k8s-docker-local.ps1
+++ b/build-k8s-docker-local.ps1
@@ -1,24 +1,72 @@
-param (
-    [Parameter(Mandatory=$True)]
-    [string]
-    $BuildNumber,
-    
+param (    
     [Parameter()]
     [string]
     $BuildArch = "amd64",
-
     
     [Parameter()]
     [string]
-    $LocalRegistryDomain = "localhost:5500"
+    $LocalRegistryDomain = "localhost:5500",
+
+    [Parameter()]
+    [switch]
+    $NonMinikubeRegistry = $false
 )
 
-$env:BUILD_NUMBER=$BuildNumber
-$env:BUILD_DATE= Get-Date -Format "yyyy-MM-dd"
-$env:BUILD_ARCH=$BuildArch
+$runtimeToBuild = "linux-$BuildArch".Replace("amd", "x")
+
+#First we pack the unsigned builds
+& .\build.ps1 -Target "PackLinuxUnsigned" -RuntimeId $runtimeToBuild
+
+#Now find the latest package version
+$package = Get-ChildItem -Path "$PSScriptRoot/_artifacts/deb" -Filter "tentacle_*_$BuildArch.deb"
+$packageNameParts = $package.Name -Split "_"
+$buildNumber = $packageNameParts[1]
+
+Write-Output "Using package $($package.Name)"
+
+$env:BUILD_NUMBER = $buildNumber
+$env:BUILD_DATE = Get-Date -Format "yyyy-MM-dd"
+$env:BUILD_ARCH = $BuildArch
 
 & docker compose -f docker-compose.build.yml -v build --pull octopusdeploy-kubernetes-tentacle-linux
 
-& docker tag "docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:$BuildNumber-linux-$BuildArch" "$LocalRegistryDomain/kubernetes-tentacle:$BuildNumber-linux-$BuildArch"
+& docker tag "docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:$buildNumber-linux-$BuildArch" "$LocalRegistryDomain/kubernetes-tentacle:$buildNumber-linux-$BuildArch"
 
-& docker push "$LocalRegistryDomain/kubernetes-tentacle:$BuildNumber-linux-$BuildArch"
+if (!$NonMinikubeRegistry) {
+    $registryPort = ($LocalRegistryDomain -split ":")[-1]
+
+    Write-Output "Setting kubectl context to 'minikube'"
+    & kubectl config use-context minikube
+
+    Write-Output "Forwarding minikube registry on port $registryPort"
+    $portForwardProcess = Start-Process kubectl -ArgumentList "port-forward --namespace kube-system service/registry $($registryPort):80" -NoNewWindow -PassThru
+    
+    Write-Output "Running network forwarding docker container"
+    $minikubeIP = & minikube ip
+    $containerId = & docker run --rm -d --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:$registryPort,reuseaddr,fork TCP:$($minikubeIP):$registryPort"
+
+    $isRunning = $false
+    Write-Output "Waiting for network forwarding docker container to be running"
+    while ($isRunning -ne $true) {
+        $runningValue = & docker inspect -f "{{.State.Running}}" $containerId
+        $isRunning = $runningValue -eq "true"
+
+        if ($isRunning -eq $false) {
+            Start-Sleep -Milliseconds 250
+        }
+    }
+    Write-Output "Network forwarding docker container running"
+}
+
+$imageName = "$LocalRegistryDomain/kubernetes-tentacle:$buildNumber-linux-$BuildArch"
+
+Write-Output "Pushing $imageName"
+
+& docker push $imageName
+
+if (!$NonMinikubeRegistry) {
+    Write-Output "Stopping network forwarding docker container"
+    & docker stop $containerId | Out-Null
+    Write-Output "Stopping minikube port forwarding"
+    Stop-Process -Id $portForwardProcess.Id
+}

--- a/build-k8s-docker-local.ps1
+++ b/build-k8s-docker-local.ps1
@@ -43,7 +43,7 @@ if (!$NonMinikubeRegistry) {
     
     Write-Output "Running network forwarding docker container"
     $minikubeIP = & minikube ip
-    $containerId = & docker run -rm -d --network=host alpine/socat "tcp-listen:$registryPort,reuseaddr,fork" "tcp-connect:host.docker.internal:$registryPort"
+    $containerId = & docker run --rm -d --network=host alpine/socat "tcp-listen:$registryPort,reuseaddr,fork" "tcp-connect:host.docker.internal:$registryPort"
 
     $isRunning = $false
     Write-Output "Waiting for network forwarding docker container to be running"
@@ -70,5 +70,5 @@ if (!$NonMinikubeRegistry) {
     Write-Output "Stopping network forwarding docker container"
     & docker stop $containerId | Out-Null
     Write-Output "Stopping minikube port forwarding"
-    Stop-Process -Id $portForwardProcess.Id
+    Stop-Process -Id $portForwardProcess.Id -ErrorAction SilentlyContinue
 }

--- a/build-k8s-docker-local.ps1
+++ b/build-k8s-docker-local.ps1
@@ -43,7 +43,7 @@ if (!$NonMinikubeRegistry) {
     
     Write-Output "Running network forwarding docker container"
     $minikubeIP = & minikube ip
-    $containerId = & docker run --rm -d --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:$registryPort,reuseaddr,fork TCP:$($minikubeIP):$registryPort"
+    $containerId = & docker run -rm -d --network=host alpine/socat "tcp-listen:$registryPort,reuseaddr,fork" "tcp-connect:host.docker.internal:$registryPort"
 
     $isRunning = $false
     Write-Output "Waiting for network forwarding docker container to be running"
@@ -63,6 +63,8 @@ $imageName = "$LocalRegistryDomain/kubernetes-tentacle:$buildNumber-linux-$Build
 Write-Output "Pushing $imageName"
 
 & docker push $imageName
+
+Write-Output "Pushed $imageName"
 
 if (!$NonMinikubeRegistry) {
     Write-Output "Stopping network forwarding docker container"

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -137,6 +137,7 @@ partial class Build
         .Description("Packages all the Linux targets without signing the packages.")
         .DependsOn(PackDebianPackage)
         .DependsOn(PackRedHatPackage)
+        .OnlyWhenStatic(() => IsLocalBuild)
         .OnlyWhenStatic(() => !SignLinuxPackages);
 
     [PublicAPI]

--- a/linux-packages/packaging-scripts/unsigned/create-linux-packages.sh
+++ b/linux-packages/packaging-scripts/unsigned/create-linux-packages.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Package files from INPUT_PATH, with executable permission and a /usr/bin symlink, into .deb and .rpm packages in OUTPUT_PATH.
+
+# NOTE: This file has been lifted wholesale from
+# https://github.com/OctopusDeploy/tool-containers/blob/main/tool-linux-packages/linux/scripts/create-linux-packages.sh
+# with almost no modification. It still leeds a lot of re-work.
+
+SIGN_TIMEOUT_SECONDS=240 # Signing aborts after this long. Healthy operation takes 15-45 seconds
+if [[ -z "$VERSION" ]]; then
+  echo 'This script requires the environment variable VERSION - the version being packaged.' >&2
+  exit 1
+fi
+if [[ -z "$INPUT_PATH" ]]; then
+  echo 'This script requires the environment variable INPUT_PATH - the path containing binaries and related files to package.' >&2
+  exit 1
+fi
+if [[ -z "$COMMAND_FILE" ]]; then
+  echo 'This script requires the environment variable COMMAND_FILE - the path of a command (relative to INPUT_PATH) to symlink in /usr/bin/.' >&2
+  exit 1
+fi
+if [[ -z "$INSTALL_PATH" ]]; then
+  echo 'This script requires the environment variable INSTALL_PATH - the path the packages will install to.' >&2
+  exit 1
+fi
+if [[ -z "$OUTPUT_PATH" ]]; then
+  echo 'This script requires the environment variable OUTPUT_PATH - the path where packages should be written.' >&2
+  exit 1
+fi
+# Set the array FPM_OPTS to supply additional options to fpm.
+# Set the array FPM_DEB_OPTS to supply additional options to fpm when building the .deb package.
+# Set the array FPM_RPM_OPTS to supply additional options to fpm when building the .rpm package.
+
+which fpm >/dev/null || {
+  echo 'This script requires fpm and related tools, and is intended to be run in the container "octopusdeploy/package-linux-docker".' >&2
+  exit 1
+}
+which gpg1 >/dev/null || {
+  echo 'This script requires gpg1, and is intended to be run in the container "octopusdeploy/package-linux-docker".' >&2
+  exit 1
+}
+list_descendent_pids() {
+  local CHPIDS="$(ps --format pid= --ppid "$1")"
+  echo -n "$1,"
+  for PID in $CHPIDS; do
+    list_descendent_pids "$PID"
+  done
+}
+
+
+echo "Preparing files to package."
+
+# Remove existing packages, fpm doesnt like to overwrite
+rm -f *.{deb,rpm} || exit
+
+# Remove build files
+if [[ -d tmp_usr_bin ]]; then
+  rm -rf tmp_usr_bin || exit
+fi
+
+# Create executable symlink to include in package
+mkdir tmp_usr_bin && ln -s "$INSTALL_PATH/$COMMAND_FILE" tmp_usr_bin/ || exit
+
+# Make sure the command has execute permissions
+chmod a+x "$INPUT_PATH/$COMMAND_FILE" || exit
+
+echo "Creating .deb package."
+set -ex
+fpm --version "$VERSION" \
+  --name "$PACKAGE_NAME" \
+  --input-type dir \
+  --output-type deb \
+  --maintainer '<support@octopus.com>' \
+  --vendor 'Octopus Deploy' \
+  --url 'https://octopus.com/' \
+  --description "$PACKAGE_DESC" \
+  --deb-no-default-config-files \
+  "${FPM_DEB_OPTS[@]}" \
+  "${FPM_OPTS[@]}" \
+  "$INPUT_PATH/=$INSTALL_PATH/" \
+  tmp_usr_bin/=/usr/bin/
+set +ex
+
+echo "Creating .rpm package."
+set -ex
+fpm --version "$VERSION" \
+  --name "$PACKAGE_NAME" \
+  --input-type dir \
+  --output-type rpm \
+  --maintainer '<support@octopus.com>' \
+  --vendor 'Octopus Deploy' \
+  --url 'https://octopus.com/' \
+  --description "$PACKAGE_DESC" \
+  --verbose \
+  --rpm-rpmbuild-define "_build_id_links none" \
+  "${FPM_RPM_OPTS[@]}" \
+  "${FPM_OPTS[@]}" \
+  "$INPUT_PATH/=$INSTALL_PATH/" \
+  tmp_usr_bin/=/usr/bin/
+set +ex
+
+# Remove build files
+if [[ -d tmp_usr_bin ]]; then
+  rm -rf tmp_usr_bin || exit
+fi
+
+# Move to output path
+mv -f *.{deb,rpm} "$OUTPUT_PATH" || exit

--- a/linux-packages/packaging-scripts/unsigned/package.sh
+++ b/linux-packages/packaging-scripts/unsigned/package.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -eux
+
+# Get the directory of the cucrrently-executing script so that we can call its siblings later.
+# fpm appears to be sensitive to working directories so we don't want to just cd to anywhere.
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+# Package tentacle from INPUT_PATH, with executable permission into .deb and .rpm packages (with a /usr/bin symlink)
+# and a .tar.gz archive, placed in OUTPUT_PATH.
+
+echo Package versions will be $VERSION
+echo Will pack content from $INPUT_PATH
+echo Will write artifacts to $OUTPUT_PATH
+
+find $INPUT_PATH
+
+# Ensure that all the scripts in the input path have the correct attributes
+find $INPUT_PATH -name "*.sh" -type f -exec chmod +x {} \;
+
+# Ensure that the output path exists
+mkdir -p "$OUTPUT_PATH"
+
+set +ex
+
+# Prepare arguments to invoke the package-creation script. The script is from our tool container
+# and actually creates the packages for us.
+
+architecture=$1
+if [ $architecture == "linux-arm64" ] ; then
+  DEB_PACKAGE_ARCHITECTURE="arm64";
+  RPM_PACKAGE_ARCHITECTURE="aarch64";
+elif [ $architecture == "linux-arm" ] ; then
+  DEB_PACKAGE_ARCHITECTURE="armhf"
+  RPM_PACKAGE_ARCHITECTURE="armv7hl"
+elif [ $architecture == "linux-x64" ] ; then
+  DEB_PACKAGE_ARCHITECTURE="x86_64";
+  RPM_PACKAGE_ARCHITECTURE="x86_64";
+elif [ $architecture == "linux-musl-x64" ] ; then
+  DEB_PACKAGE_ARCHITECTURE="x86_64";
+  RPM_PACKAGE_ARCHITECTURE="x86_64";
+fi
+COMMAND_FILE=Tentacle
+INSTALL_PATH=/opt/octopus/tentacle
+PACKAGE_NAME="tentacle"
+PACKAGE_DESC='Octopus Tentacle package'
+FPM_OPTS=(
+  --after-install "$INPUT_PATH/after-install.sh"
+  --before-remove "$INPUT_PATH/before-uninstall.sh"
+)
+FPM_DEB_OPTS=(
+  --depends 'libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3'
+  --architecture "$DEB_PACKAGE_ARCHITECTURE"
+)
+FPM_RPM_OPTS=(
+  --depends 'openssl-libs'
+  --architecture "$RPM_PACKAGE_ARCHITECTURE"
+)
+
+# The script has interstitial errors so we can't use set -e here.
+source $SCRIPT_DIR/create-linux-packages.sh || exit 1


### PR DESCRIPTION
# Background

Because the Kubernetes Tentacle has to run in a container, we need to update the local build process to build unsigned linux artifacts and create the container using them

# Results

I duplicated the linux build scripts into a new `unsigned` subfolder and just removed all the signing logic.

I also added a new parameter `RuntimeId` to the build process so you can specific a specific runtime to build (rather than all of them).

I also updated the `build-k8s-docker-loca.ps1` script to run the nuke build, then use the correct artifact to create the container. It also contains logic to automatically push the container to the minikube registry if it's enabled. (based on https://minikube.sigs.k8s.io/docs/handbook/registry/)

```Setting kubectl context to 'minikube'
Switched to context "minikube".
Forwarding minikube registry on port 5500
Running network forwarding docker container
Forwarding from 127.0.0.1:5500 -> 5000
Forwarding from [::1]:5500 -> 5000
Waiting for network forwarding docker container to be running
Network forwarding docker container running
Pushing localhost:5500/kubernetes-tentacle:8.1.503-ap-local-build-linux-without-signing-20231221130059-linux-amd64
The push refers to repository [localhost:5500/kubernetes-tentacle]
Get "http://localhost:5500/v2/": dial tcp [::1]:5500: connect: connection refused
Stopping network forwarding docker container
Stopping minikube port forwarding```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.