### PR TITLE
Remove unecessary references to NuGet fork in Octopus.Manager.Tentacle

### DIFF
--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -124,12 +124,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="NLog" Version="5.0.4" />
-    <PackageReference Include="NuGet.Common" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Frameworks" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Packaging" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />


### PR DESCRIPTION
Looking at bringing back to life the work to upgrade\deprecate our NuGet fork. Looking around I found that we are referencing the assemblies in `Octopus.Manager.Tentacle` which I can't imagine why it would be needed.