### PR TITLE
Force DockerTasks to run with image platform amd64 when running on arm64 arch

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO.Compression;
 using System.Linq;
+using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using Nuke.Common;
 using Nuke.Common.IO;
@@ -76,9 +77,11 @@ partial class Build
                     .ForEach(x => FileSystemTasks.CopyFileToDirectory(x, debBuildDir / "scripts"));
 
                 DockerTasks.DockerPull(settings => settings
+                    .When(RuntimeInformation.OSArchitecture == Architecture.Arm64, _ => _.SetPlatform("linux/amd64").SetQuiet(true))
                     .SetName(dockerToolsContainerImage));
 
                 DockerTasks.DockerRun(settings => settings
+                    .When(RuntimeInformation.OSArchitecture == Architecture.Arm64, _ => _.SetPlatform("linux/amd64"))
                     .EnableRm()
                     .EnableTty()
                     .SetEnv(

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -77,7 +77,7 @@ partial class Build
                     .ForEach(x => FileSystemTasks.CopyFileToDirectory(x, debBuildDir / "scripts"));
 
                 DockerTasks.DockerPull(settings => settings
-                    .When(RuntimeInformation.OSArchitecture == Architecture.Arm64, _ => _.SetPlatform("linux/amd64").SetQuiet(true))
+                    .When(RuntimeInformation.OSArchitecture == Architecture.Arm64, _ => _.SetPlatform("linux/amd64"))
                     .SetName(dockerToolsContainerImage));
 
                 DockerTasks.DockerRun(settings => settings


### PR DESCRIPTION
# Background

The nuke build doesn't work correctly on M1 macs because the DockerTasks try and pull an arm64 version of the container which doesn't exist. This change just forces the DockerTasks to use an amd64 version of the container which runs via Rosetta 2 and works correctly.

# Results

This only affects builds on machines running on arm64 architecture and all it does is set the `platform` option to `amd64`.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.