### PR TITLE
Move Octopus.Configuration interfaces and enum into tentacle and update references

### DIFF
--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManager/TentacleManagerModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManager/TentacleManagerModel.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
-using Octopus.Configuration;
 using Octopus.Manager.Tentacle.Controls;
 using Octopus.Manager.Tentacle.Infrastructure;
 using Octopus.Manager.Tentacle.Util;

--- a/source/Octopus.Tentacle.Tests/Commands/DeregisterMachineCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/DeregisterMachineCommandFixture.cs
@@ -6,7 +6,6 @@ using NSubstitute;
 using NUnit.Framework;
 using Octopus.Client;
 using Octopus.Client.Model;
-using Octopus.Configuration;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Certificates;
 using Octopus.Tentacle.Commands;

--- a/source/Octopus.Tentacle.Tests/Commands/DeregisterWorkerCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/DeregisterWorkerCommandFixture.cs
@@ -6,7 +6,6 @@ using NSubstitute;
 using NUnit.Framework;
 using Octopus.Client;
 using Octopus.Client.Model;
-using Octopus.Configuration;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Certificates;
 using Octopus.Tentacle.Commands;

--- a/source/Octopus.Tentacle.Tests/Configuration/ApplicationInstanceSelectorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Configuration/ApplicationInstanceSelectorFixture.cs
@@ -3,7 +3,6 @@ using FluentAssertions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
-using Octopus.Configuration;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Configuration.Instances;

--- a/source/Octopus.Tentacle.Tests/Configuration/CurrentRoundTripTestBase.cs
+++ b/source/Octopus.Tentacle.Tests/Configuration/CurrentRoundTripTestBase.cs
@@ -1,7 +1,7 @@
 using System;
 using FluentAssertions;
 using NUnit.Framework;
-using Octopus.Configuration;
+using Octopus.Tentacle.Configuration;
 
 namespace Octopus.Tentacle.Tests.Configuration
 {

--- a/source/Octopus.Tentacle.Tests/Configuration/InMemoryKeyValueStoreFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Configuration/InMemoryKeyValueStoreFixture.cs
@@ -6,7 +6,6 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using NSubstitute;
 using NUnit.Framework;
-using Octopus.Configuration;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Configuration.EnvironmentVariableMappings;
 

--- a/source/Octopus.Tentacle.Tests/Configuration/RoundTripTestBaseFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Configuration/RoundTripTestBaseFixture.cs
@@ -3,8 +3,8 @@ using System.IO;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
-using Octopus.Configuration;
 using Octopus.Diagnostics;
+using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Tests.Configuration

--- a/source/Octopus.Tentacle.Tests/Configuration/XmlFileKeyValueStoreFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Configuration/XmlFileKeyValueStoreFixture.cs
@@ -11,7 +11,6 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using NSubstitute;
 using NUnit.Framework;
-using Octopus.Configuration;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Configuration.Crypto;

--- a/source/Octopus.Tentacle/Commands/ShowConfigurationCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ShowConfigurationCommand.cs
@@ -6,7 +6,6 @@ using Octopus.Client;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
-using Octopus.Configuration;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Commands.OptionSets;
 using Octopus.Tentacle.Configuration;

--- a/source/Octopus.Tentacle/Configuration/ConfigurationModule.cs
+++ b/source/Octopus.Tentacle/Configuration/ConfigurationModule.cs
@@ -1,6 +1,5 @@
 using System;
 using Autofac;
-using Octopus.Configuration;
 using Octopus.Tentacle.Configuration.EnvironmentVariableMappings;
 using Octopus.Tentacle.Configuration.Instances;
 using Octopus.Tentacle.Startup;

--- a/source/Octopus.Tentacle/Configuration/FlatDictionaryKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/FlatDictionaryKeyValueStore.cs
@@ -1,6 +1,5 @@
 using System;
 using Newtonsoft.Json;
-using Octopus.Configuration;
 using Octopus.Tentacle.Configuration.Crypto;
 using Octopus.Tentacle.Configuration.Instances;
 

--- a/source/Octopus.Tentacle/Configuration/HierarchicalDictionaryKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/HierarchicalDictionaryKeyValueStore.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Newtonsoft.Json;
-using Octopus.Configuration;
 using Octopus.Tentacle.Configuration.Crypto;
 
 namespace Octopus.Tentacle.Configuration

--- a/source/Octopus.Tentacle/Configuration/HomeConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/HomeConfiguration.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using Octopus.Configuration;
 using Octopus.Tentacle.Configuration.Instances;
 
 namespace Octopus.Tentacle.Configuration

--- a/source/Octopus.Tentacle/Configuration/IKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/IKeyValueStore.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Octopus.Tentacle.Configuration
+{
+    public interface IKeyValueStore
+    {
+        string? Get(string name, ProtectionLevel protectionLevel = ProtectionLevel.None);
+
+        [return: NotNullIfNotNull("defaultValue")]
+        TData? Get<TData>(string name, TData? defaultValue = default, ProtectionLevel protectionLevel = ProtectionLevel.None);
+    }
+}

--- a/source/Octopus.Tentacle/Configuration/IWritableKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/IWritableKeyValueStore.cs
@@ -1,0 +1,13 @@
+namespace Octopus.Tentacle.Configuration
+{
+    public interface IWritableKeyValueStore : IKeyValueStore
+    {
+        bool Set(string name, string? value, ProtectionLevel protectionLevel = ProtectionLevel.None);
+
+        bool Set<TData>(string name, TData value, ProtectionLevel protectionLevel = ProtectionLevel.None);
+
+        bool Remove(string name);
+
+        bool Save();
+    }
+}

--- a/source/Octopus.Tentacle/Configuration/InMemoryKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/InMemoryKeyValueStore.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Newtonsoft.Json;
-using Octopus.Configuration;
 using Octopus.Tentacle.Configuration.EnvironmentVariableMappings;
 using Octopus.Tentacle.Configuration.Instances;
 

--- a/source/Octopus.Tentacle/Configuration/Instances/AggregatedKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/AggregatedKeyValueStore.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Octopus.Configuration;
 
 namespace Octopus.Tentacle.Configuration.Instances
 {

--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceConfiguration.cs
@@ -1,5 +1,4 @@
 using System;
-using Octopus.Configuration;
 
 namespace Octopus.Tentacle.Configuration.Instances
 {

--- a/source/Octopus.Tentacle/Configuration/Instances/IAggregatableKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/IAggregatableKeyValueStore.cs
@@ -1,5 +1,4 @@
 using System;
-using Octopus.Configuration;
 
 namespace Octopus.Tentacle.Configuration.Instances
 {

--- a/source/Octopus.Tentacle/Configuration/JsonHierarchicalConsoleKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/JsonHierarchicalConsoleKeyValueStore.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Octopus.Configuration;
 
 namespace Octopus.Tentacle.Configuration
 {

--- a/source/Octopus.Tentacle/Configuration/KeyValueStoreBase.cs
+++ b/source/Octopus.Tentacle/Configuration/KeyValueStoreBase.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using Octopus.Configuration;
 
 namespace Octopus.Tentacle.Configuration
 {

--- a/source/Octopus.Tentacle/Configuration/PollingProxyConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/PollingProxyConfiguration.cs
@@ -1,6 +1,7 @@
+#nullable enable
 namespace Octopus.Tentacle.Configuration
 {
-    class PollingProxyConfiguration : IPollingProxyConfiguration
+    internal class PollingProxyConfiguration : IPollingProxyConfiguration
     {
         public const string UseDefaultProxySettingName = "Octopus.Server.Proxy.UseDefaultProxy";
         public const string ProxyUsernameSettingName = "Octopus.Server.Proxy.ProxyUsername";

--- a/source/Octopus.Tentacle/Configuration/PollingProxyConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/PollingProxyConfiguration.cs
@@ -1,9 +1,6 @@
-#nullable enable
-using Octopus.Configuration;
-
 namespace Octopus.Tentacle.Configuration
 {
-    internal class PollingProxyConfiguration : IPollingProxyConfiguration
+    class PollingProxyConfiguration : IPollingProxyConfiguration
     {
         public const string UseDefaultProxySettingName = "Octopus.Server.Proxy.UseDefaultProxy";
         public const string ProxyUsernameSettingName = "Octopus.Server.Proxy.ProxyUsername";

--- a/source/Octopus.Tentacle/Configuration/ProtectionLevel.cs
+++ b/source/Octopus.Tentacle/Configuration/ProtectionLevel.cs
@@ -1,0 +1,8 @@
+namespace Octopus.Tentacle.Configuration
+{
+    public enum ProtectionLevel
+    {
+        None,
+        MachineKey,
+    }
+}

--- a/source/Octopus.Tentacle/Configuration/ProxyConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ProxyConfiguration.cs
@@ -1,5 +1,4 @@
 using System;
-using Octopus.Configuration;
 
 namespace Octopus.Tentacle.Configuration
 {

--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -7,7 +6,6 @@ using System.Security.Cryptography.X509Certificates;
 using Newtonsoft.Json;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
-using Octopus.Configuration;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Certificates;
 using Octopus.Tentacle.Security;

--- a/source/Octopus.Tentacle/Configuration/XmlFileKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/XmlFileKeyValueStore.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Octopus.Configuration;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Configuration

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -57,7 +57,6 @@
 		<PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
 		<PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
 		<PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-		<PackageReference Include="Octopus.Configuration" Version="4.1.0" />
 		<PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
 		<PackageReference Include="Octopus.Time" Version="1.1.339" />
 		<PackageReference Include="Polly" Version="7.2.2" />


### PR DESCRIPTION
# Background

As part of #project-k8s-agent, I was adding the ability for Tentacle to save and source configuration from a configmap. During this work, I found that the `Octopus.Configuration` project has been merged back into `Octopus.Server` and the repo in github has been archived.

# Results

 This PR just removes the now defunct nuget package and moves the two interfaces and one enum into Tentacle. It's a relatively simple change, but it touches quite a few files to remove the old namespace.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.