### PR TITLE
increased the timeout for completion phase

### DIFF
--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -94,7 +94,7 @@ namespace Octopus.Tentacle.Client
             rpcCallExecutor = RpcCallExecutorFactory.Create(this.clientOptions.RpcRetrySettings.RetryDuration, this.tentacleClientObserver);
         }
 
-        public TimeSpan OnCancellationAbandonCompleteScriptAfter { get; set; } = TimeSpan.FromMinutes(1);
+        public TimeSpan OnCancellationAbandonCompleteScriptAfter { get; set; } = TimeSpan.FromMinutes(5);
 
         public async Task<UploadResult> UploadFile(string fileName, string path, DataStream package, ILog logger, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
[sc-68281]

# Background

The completion phase was recently [changed](https://github.com/OctopusDeploy/OctopusTentacle/commit/be322a02d8b267c42fbedfcc79b96191f6cf0943#diff-cc31b0e7a7349a8280a9d04aa2f689706d3543aad6d0ecf6e5775ef492a75983) to be async with a cancellation token.
The default time on the cancellation token is 1 minute, which in some cases was being hit when the size of the workspace was very large or had many files.

[Customer reported](https://octopus.zendesk.com/agent/tickets/167317) that this problem only started occurring after upgrading to Tentacle version 8.1.558. Previous versions did not have this issue.

# Results

## Before

The timestamps in the below task log clearly show a 1 minute gap between the end of the task execution and the timeout of the cancellation token.
```
15:53:30   Verbose  |       Process C:\Windows\system32\WindowsPowershell\v1.0\PowerShell.exe in C:\Octopus\OctopusCloud-Tentacle\Work\DGCCBsHs606XsqM5b9FLA exited with code 0
15:54:30   Warning  |       Failed to cleanup the script working directory on Tentacle
15:54:30   Verbose  |       The task was canceled
                    |       The Request was cancelled while Transferring.
                    |       Halibut.Exceptions.TransferringRequestCancelledException: The Request was cancelled while Transferring.
                    |       ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
                    |       at Halibut.ServiceModel.PendingRequestQueueAsync.PendingRequest.WaitForResponseToBeSet(Nullable`1 timeout, Boolean cancelTheRequestWhenTransferHasBegun, CancellationToken cancellationToken)
                    |       --- End of inner exception stack trace ---
                    |       at Halibut.ServiceModel.PendingRequestQueueAsync.PendingRequest.WaitForResponseToBeSet(Nullable`1 timeout, Boolean cancelTheRequestWhenTransferHasBegun, CancellationToken cancellationToken)
                    |       at Halibut.ServiceModel.PendingRequestQueueAsync.PendingRequest.WaitUntilComplete(CancellationToken cancellationToken)
                    |       at Halibut.ServiceModel.PendingRequestQueueAsync.QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
                    |       at Halibut.ServiceModel.PendingRequestQueueAsync.QueueAndWaitAsync(RequestMessage request, CancellationToken cancellationToken)
                    |       at Halibut.HalibutRuntime.SendOutgoingPollingRequestAsync(RequestMessage request, CancellationToken cancellationToken)
                    |       at Halibut.HalibutRuntime.SendOutgoingRequestAsync(RequestMessage request, MethodInfo methodInfo, CancellationToken cancellationToken)
                    |       at Halibut.ServiceModel.HalibutProxyWithAsync.MakeRpcCall(MethodInfo asyncMethod, Object[] args)
                    |       at Halibut.ServiceModel.HalibutProxyWithAsync.InvokeAsync(MethodInfo asyncMethod, Object[] args)
                    |       at System.Reflection.AsyncDispatchProxyGenerator.InvokeAsync(Object[] args)
                    |       at Octopus.Tentacle.Client.Scripts.ScriptServiceV2Orchestrator.<>c__DisplayClass13_0.<<Finish>b__0>d.MoveNext()
                    |       --- End of stack trace from previous location ---
                    |       at Octopus.Tentacle.Client.Execution.RpcCallExecutor.ExecuteWithNoRetries(RpcCall rpcCall, Func`2 action, ILog logger, ClientOperationMetricsBuilder clientOperationMetricsBuilder, CancellationToken cancellationToken)
                    |       at Octopus.Tentacle.Client.Scripts.ScriptServiceV2Orchestrator.Finish(ScriptStatusResponseV2 lastStatusResponse, CancellationToken scriptExecutionCancellationToken)
                    |       Octopus.Server version 2024.1.6809 (2024.1.6809)
```

## After

<!-- Consider adding a log excerpt or screen capture. -->


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.