### PR TITLE
Add back non generic test decorators

### DIFF
--- a/source/Octopus.Tentacle.Client/ITentacleServiceDecoratorFactory.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleServiceDecoratorFactory.cs
@@ -2,7 +2,7 @@ using Octopus.Tentacle.Contracts.ClientServices;
 
 namespace Octopus.Tentacle.Client
 {
-    public interface ITentacleServiceDecoratorFactory
+    interface ITentacleServiceDecoratorFactory
     {
         public IAsyncClientScriptService Decorate(IAsyncClientScriptService scriptService);
         

--- a/source/Octopus.Tentacle.Client/ITentacleServiceDecoratorFactory.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleServiceDecoratorFactory.cs
@@ -2,7 +2,7 @@ using Octopus.Tentacle.Contracts.ClientServices;
 
 namespace Octopus.Tentacle.Client
 {
-    interface ITentacleServiceDecoratorFactory
+    public interface ITentacleServiceDecoratorFactory
     {
         public IAsyncClientScriptService Decorate(IAsyncClientScriptService scriptService);
         

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TestDecoratorsAreCalledInTheCorrectOrder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TestDecoratorsAreCalledInTheCorrectOrder.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using NUnit.Framework;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators.Proxies;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public class TestDecoratorsAreCalledInTheCorrectOrder
+    {
+        [Test]
+        public async Task MethodDecoratorsAreCalledInTheOrderTheyAreDefined()
+        {
+            var list = new List<int>();
+            var decorator = new TentacleServiceDecoratorBuilder()
+                .DecorateScriptServiceV2With(b => b.BeforeCompleteScript(async (_, _, _) =>
+                {
+                    list.Add(1);
+                    await Task.CompletedTask;
+                }))
+                .DecorateScriptServiceV2With(b => b.BeforeCompleteScript(async (_, _, _) =>
+                {
+                    list.Add(2);
+                    await Task.CompletedTask;
+                }))
+                .DecorateScriptServiceV2With(b => b.DecorateCompleteScriptWith(async (inner, command, options) =>
+                {
+                    await Task.CompletedTask;
+                    await inner.CompleteScriptAsync(command, options);
+                    list.Add(3);
+                }))
+                .DecorateScriptServiceV2With(b => b.DecorateCompleteScriptWith(async (inner, command, options) =>
+                {
+                    await Task.CompletedTask;
+                    await inner.CompleteScriptAsync(command, options);
+                    list.Add(4);
+                }))
+                .Build();
+
+            await decorator.Decorate(new NoOPClientScriptService()).CompleteScriptAsync(SomeCompleteScriptCommandV2(), SomeHalibutProxyRequestOptions());
+
+            list.Should().BeEquivalentTo(new List<int> {1, 2, 3, 4});
+        }
+
+        [Test]
+        public void ProxyGeneratedDecoratorsAreFirst()
+        {
+            var list = new List<int>();
+            IRecordedMethodUsages recordedUsages = new MethodUsages();
+            long startedCountInCall = 0;
+            var decorator = new TentacleServiceDecoratorBuilder()
+                .DecorateScriptServiceV2With(b => b.BeforeCompleteScript(async (_, _, _) =>
+                    {
+                        await Task.CompletedTask;
+                        // We should find that the proxy decorator has already counted this call.
+                        startedCountInCall = recordedUsages.ForAll().Started;
+                        // If the proxy decorator after this then throwing an exception here would result in calls not being counted.
+                        throw new Exception();
+                    })
+                    .Build())
+                .RecordMethodUsages<IAsyncClientScriptServiceV2>(out recordedUsages)
+                .Build();
+
+            Assert.ThrowsAsync<Exception>(async () => await decorator.Decorate(new NoOPClientScriptService()).CompleteScriptAsync(SomeCompleteScriptCommandV2(), SomeHalibutProxyRequestOptions()));
+
+            var usage = recordedUsages.ForAll();
+
+            usage.LastException.Should().NotBeNull();
+            usage.Started.Should().Be(1);
+            startedCountInCall.Should().Be(1, "Because the proxy decorator which count calls should happen before any method specific decorators.");
+        }
+
+        static CompleteScriptCommandV2 SomeCompleteScriptCommandV2()
+        {
+            return new CompleteScriptCommandV2(new ScriptTicket("a"));
+        }
+
+        static HalibutProxyRequestOptions SomeHalibutProxyRequestOptions()
+        {
+            return new HalibutProxyRequestOptions(CancellationToken.None);
+        }
+
+        class NoOPClientScriptService : IAsyncClientScriptServiceV2
+        {
+            public Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request, HalibutProxyRequestOptions proxyRequestOptions)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions)
+            {
+                throw new NotImplementedException();
+            }
+
+            public async Task CompleteScriptAsync(CompleteScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions)
+            {
+                await Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CapabilitiesServiceV2DecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CapabilitiesServiceV2DecoratorBuilder.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
+{
+    public class CapabilitiesServiceV2DecoratorBuilder
+    {
+        public delegate Task<CapabilitiesResponseV2> GetCapabilitiesClientDecorator(IAsyncClientCapabilitiesServiceV2 inner, HalibutProxyRequestOptions halibutProxyRequestOptions);
+
+        private GetCapabilitiesClientDecorator getCapabilitiesFunc = async (inner, options) => await inner.GetCapabilitiesAsync(options);
+
+        public CapabilitiesServiceV2DecoratorBuilder BeforeGetCapabilities(Func<Task> beforeGetCapabilities)
+        {
+            return BeforeGetCapabilities(async inner => await beforeGetCapabilities());
+        }
+
+        public CapabilitiesServiceV2DecoratorBuilder BeforeGetCapabilities(Func<IAsyncClientCapabilitiesServiceV2, Task> beforeGetCapabilities)
+        {
+            return DecorateGetCapabilitiesWith(async (inner, options) =>
+            {
+                await beforeGetCapabilities(inner);
+                return await inner.GetCapabilitiesAsync(options);
+            });
+        }
+
+        public CapabilitiesServiceV2DecoratorBuilder AfterGetCapabilities(Func<CapabilitiesResponseV2, Task> afterGetCapabilities)
+        {
+            return DecorateGetCapabilitiesWith(async (inner, options) =>
+            {
+                var response = await inner.GetCapabilitiesAsync(options);
+                await afterGetCapabilities(response);
+                return response;
+            });
+        }
+
+        public CapabilitiesServiceV2DecoratorBuilder DecorateGetCapabilitiesWith(GetCapabilitiesClientDecorator getCapabilitiesFunc)
+        {
+            this.getCapabilitiesFunc = getCapabilitiesFunc;
+            return this;
+        }
+
+        public Decorator<IAsyncClientCapabilitiesServiceV2> Build()
+        {
+            return inner => new FuncCapabilitiesServiceV2Decorator(inner, getCapabilitiesFunc);
+        }
+
+        private class FuncCapabilitiesServiceV2Decorator : IAsyncClientCapabilitiesServiceV2
+        {
+            private readonly IAsyncClientCapabilitiesServiceV2 inner;
+            private readonly GetCapabilitiesClientDecorator getCapabilitiesFunc;
+
+            public FuncCapabilitiesServiceV2Decorator(IAsyncClientCapabilitiesServiceV2 inner, GetCapabilitiesClientDecorator getCapabilitiesFunc)
+            {
+                this.inner = inner;
+                this.getCapabilitiesFunc = getCapabilitiesFunc;
+            }
+
+            public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(HalibutProxyRequestOptions options)
+            {
+                return await getCapabilitiesFunc(inner, options);
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CombiningTentacleServiceDecoratorFactory.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CombiningTentacleServiceDecoratorFactory.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using Octopus.Tentacle.Client;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
+{
+    public class CombiningTentacleServiceDecoratorFactory : ITentacleServiceDecoratorFactory
+    {
+        readonly List<ITentacleServiceDecoratorFactory> decoratorsInReverse;
+
+        public CombiningTentacleServiceDecoratorFactory(List<ITentacleServiceDecoratorFactory> decorators)
+        {
+            // Reversing the decorators means the first decorator in the given list will be called first.
+            decoratorsInReverse = new List<ITentacleServiceDecoratorFactory>(decorators);
+            decoratorsInReverse.Reverse();
+        }
+
+        public IAsyncClientScriptService Decorate(IAsyncClientScriptService service)
+        {
+            foreach (var decoratorFactory in decoratorsInReverse)
+            {
+                service = decoratorFactory.Decorate(service);
+            }
+
+            return service;
+        }
+
+        public IAsyncClientScriptServiceV2 Decorate(IAsyncClientScriptServiceV2 service)
+        {
+            foreach (var decoratorFactory in decoratorsInReverse)
+            {
+                service = decoratorFactory.Decorate(service);
+            }
+            return service;
+        }
+
+        public IAsyncClientFileTransferService Decorate(IAsyncClientFileTransferService service)
+        {
+            foreach (var decoratorFactory in decoratorsInReverse)
+            {
+                service = decoratorFactory.Decorate(service);
+            }
+            return service;
+        }
+
+        public IAsyncClientCapabilitiesServiceV2 Decorate(IAsyncClientCapabilitiesServiceV2 service)
+        {
+            foreach (var decoratorFactory in decoratorsInReverse)
+            {
+                service = decoratorFactory.Decorate(service);
+            }
+            return service;
+        }
+
+        public IAsyncClientScriptServiceV3Alpha Decorate(IAsyncClientScriptServiceV3Alpha service)
+        {
+            foreach (var decoratorFactory in decoratorsInReverse)
+            {
+                service = decoratorFactory.Decorate(service);
+            }
+            return service;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CombiningTentacleServiceDecoratorFactory.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/CombiningTentacleServiceDecoratorFactory.cs
@@ -9,7 +9,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
     {
         readonly List<ITentacleServiceDecoratorFactory> decoratorsInReverse;
 
-        public CombiningTentacleServiceDecoratorFactory(List<ITentacleServiceDecoratorFactory> decorators)
+        internal CombiningTentacleServiceDecoratorFactory(List<ITentacleServiceDecoratorFactory> decorators)
         {
             // Reversing the decorators means the first decorator in the given list will be called first.
             decoratorsInReverse = new List<ITentacleServiceDecoratorFactory>(decorators);

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/FileTransferServiceDecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/FileTransferServiceDecoratorBuilder.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Threading.Tasks;
+using Halibut;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
+{
+    public class FileTransferServiceDecoratorBuilder
+    {
+        public delegate Task<UploadResult> UploadFileClientDecorator(IAsyncClientFileTransferService inner, string remotePath, DataStream upload, HalibutProxyRequestOptions proxyRequestOptions); 
+        public delegate Task<DataStream> DownloadFileClientDecorator(IAsyncClientFileTransferService inner, string remotePath, HalibutProxyRequestOptions proxyRequestOptions);
+        
+        private UploadFileClientDecorator uploadFileFunc = async (inner, remotePath, upload, options) => await inner.UploadFileAsync(remotePath, upload, options);
+        private DownloadFileClientDecorator downloadFileFunc = async (inner, remotePath, options) => await inner.DownloadFileAsync(remotePath, options);
+
+        public FileTransferServiceDecoratorBuilder BeforeUploadFile(Func<Task>beforeUploadFile)
+        {
+            return DecorateUploadFileWith(async (inner, remotePath, upload, options) =>
+            {
+                await beforeUploadFile();
+                return await inner.UploadFileAsync(remotePath, upload, options);
+            });
+        }
+
+        public FileTransferServiceDecoratorBuilder BeforeUploadFile(Func<IAsyncClientFileTransferService, string, DataStream, Task> beforeUploadFile)
+        {
+            return DecorateUploadFileWith(async (inner, remotePath, upload, options) =>
+            {
+                await beforeUploadFile(inner, remotePath, upload);
+                return await inner.UploadFileAsync(remotePath, upload, options);
+            });
+        }
+
+        public FileTransferServiceDecoratorBuilder DecorateUploadFileWith(UploadFileClientDecorator uploadFileFunc)
+        {
+            this.uploadFileFunc = uploadFileFunc;
+            return this;
+        }
+
+        public FileTransferServiceDecoratorBuilder BeforeDownloadFile(Func<Task> beforeDownloadFile)
+        {
+            return DecorateDownloadFileWith(async (inner, remotePath, options) =>
+            {
+                await beforeDownloadFile();
+                return await inner.DownloadFileAsync(remotePath, options);
+            });
+        }
+
+        public FileTransferServiceDecoratorBuilder BeforeDownloadFile(Func<IAsyncClientFileTransferService, string, Task> beforeDownloadFile)
+        {
+            return DecorateDownloadFileWith(async (inner, remotePath, options) =>
+            {
+                await beforeDownloadFile(inner, remotePath);
+                return await inner.DownloadFileAsync(remotePath, options);
+            });
+        }
+
+        public FileTransferServiceDecoratorBuilder DecorateDownloadFileWith(DownloadFileClientDecorator downloadFileFunc)
+        {
+            this.downloadFileFunc = downloadFileFunc;
+            return this;
+        }
+
+        public Decorator<IAsyncClientFileTransferService> Build()
+        {
+            return inner =>
+            {
+                return new FuncDecoratingFileTransferService(inner,
+                    uploadFileFunc,
+                    downloadFileFunc);
+            };
+        }
+
+
+        private class FuncDecoratingFileTransferService : IAsyncClientFileTransferService
+        {
+            private IAsyncClientFileTransferService inner;
+            private UploadFileClientDecorator uploadFileFunc;
+            private DownloadFileClientDecorator downloadFileFunc;
+
+            public FuncDecoratingFileTransferService(
+                IAsyncClientFileTransferService inner,
+                UploadFileClientDecorator uploadFileFunc,
+                DownloadFileClientDecorator downloadFileFunc)
+            {
+                this.inner = inner;
+                this.uploadFileFunc = uploadFileFunc;
+                this.downloadFileFunc = downloadFileFunc;
+            }
+
+            public async Task<UploadResult> UploadFileAsync(string remotePath, DataStream upload, HalibutProxyRequestOptions options)
+            {
+                return await uploadFileFunc(inner, remotePath, upload, options);
+            }
+
+            public async Task<DataStream> DownloadFileAsync(string remotePath, HalibutProxyRequestOptions options)
+            {
+                return await downloadFileFunc(inner, remotePath, options);
+            }
+        }
+    }
+
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceDecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceDecoratorBuilder.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
+{
+    public class ScriptServiceDecoratorBuilder
+    {
+        public delegate Task<ScriptTicket> StartScriptClientDecorator(IAsyncClientScriptService inner, StartScriptCommand command, HalibutProxyRequestOptions options);
+        public delegate Task<ScriptStatusResponse> GetStatusClientDecorator(IAsyncClientScriptService inner, ScriptStatusRequest request, HalibutProxyRequestOptions options);
+        public delegate Task<ScriptStatusResponse> CancelScriptClientDecorator(IAsyncClientScriptService inner, CancelScriptCommand command, HalibutProxyRequestOptions options);
+        public delegate Task<ScriptStatusResponse> CompleteScriptClientDecorator(IAsyncClientScriptService inner, CompleteScriptCommand command, HalibutProxyRequestOptions options);
+        
+        private StartScriptClientDecorator startScriptFunc = async (inner, command, options) => await inner.StartScriptAsync(command, options);
+        private GetStatusClientDecorator getStatusFunc = async (inner, command, options) => await inner.GetStatusAsync(command, options);
+        private CancelScriptClientDecorator cancelScriptFunc = async (inner, command, options) => await inner.CancelScriptAsync(command, options);
+        private CompleteScriptClientDecorator completeScriptAction = async (inner, command, options) => await inner.CompleteScriptAsync(command, options);
+
+        public ScriptServiceDecoratorBuilder BeforeStartScript(Func<Task> beforeGetStatus)
+        {
+            return DecorateStartScriptWith(async (inner, scriptStatusRequest, options) =>
+            {
+                await beforeGetStatus();
+                return await inner.StartScriptAsync(scriptStatusRequest, options);
+            });
+        }
+        
+        public ScriptServiceDecoratorBuilder DecorateStartScriptWith(StartScriptClientDecorator startScriptFunc)
+        {
+            this.startScriptFunc = startScriptFunc;
+            return this;
+        }
+
+        public ScriptServiceDecoratorBuilder DecorateGetStatusWith(GetStatusClientDecorator getStatusFunc)
+        {
+            this.getStatusFunc = getStatusFunc;
+            return this;
+        }
+
+        public ScriptServiceDecoratorBuilder BeforeGetStatus(Func<Task> beforeGetStatus)
+        {
+            return BeforeGetStatus(async (_, _) => await beforeGetStatus());
+        }
+        
+        public ScriptServiceDecoratorBuilder BeforeGetStatus(Func<IAsyncClientScriptService, ScriptStatusRequest, Task> beforeGetStatus)
+        {
+            return DecorateGetStatusWith(async (inner, scriptStatusRequest, options) =>
+            {
+                await beforeGetStatus(inner, scriptStatusRequest);
+                return await inner.GetStatusAsync(scriptStatusRequest, options);
+            });
+        }
+
+        public ScriptServiceDecoratorBuilder DecorateCancelScriptWith(CancelScriptClientDecorator cancelScriptFunc)
+        {
+            this.cancelScriptFunc = cancelScriptFunc;
+            return this;
+        }
+
+        public ScriptServiceDecoratorBuilder BeforeCancelScript(Func<Task> beforeCancelScript)
+        {
+            return DecorateCancelScriptWith(async (inner, command, options) =>
+            {
+                await beforeCancelScript();
+                return await inner.CancelScriptAsync(command, options);
+            });
+        }
+
+        public ScriptServiceDecoratorBuilder BeforeCancelScript(Func<IAsyncClientScriptService, CancelScriptCommand, Task> beforeCancelScript)
+        {
+            return DecorateCancelScriptWith(async (inner, command, options) =>
+            {
+                await beforeCancelScript(inner, command);
+                return await inner.CancelScriptAsync(command, options);
+            });
+        }
+
+        public ScriptServiceDecoratorBuilder DecorateCompleteScriptWith(CompleteScriptClientDecorator completeScriptAction)
+        {
+            this.completeScriptAction = completeScriptAction;
+            return this;
+        }
+
+        public ScriptServiceDecoratorBuilder BeforeCompleteScript(Func<Task> beforeCompleteScript)
+        {
+            return DecorateCompleteScriptWith(async (inner, command, options) =>
+            {
+                await beforeCompleteScript();
+                return await inner.CompleteScriptAsync(command, options);
+            });
+        }
+
+        public Decorator<IAsyncClientScriptService> Build()
+        {
+            return inner =>
+            {
+                return new FuncDecoratingScriptService(inner,
+                    startScriptFunc,
+                    getStatusFunc,
+                    cancelScriptFunc,
+                    completeScriptAction);
+            };
+        }
+
+        private class FuncDecoratingScriptService : IAsyncClientScriptService
+        {
+            private readonly IAsyncClientScriptService inner;
+            private readonly StartScriptClientDecorator startScriptFunc;
+            private readonly GetStatusClientDecorator getStatusFunc;
+            private readonly CancelScriptClientDecorator cancelScriptFunc;
+            private readonly CompleteScriptClientDecorator completeScriptAction;
+
+            public FuncDecoratingScriptService(
+                IAsyncClientScriptService inner, StartScriptClientDecorator startScriptFunc, GetStatusClientDecorator getStatusFunc, CancelScriptClientDecorator cancelScriptFunc, CompleteScriptClientDecorator completeScriptAction)
+            {
+                this.inner = inner;
+                this.startScriptFunc = startScriptFunc;
+                this.getStatusFunc = getStatusFunc;
+                this.cancelScriptFunc = cancelScriptFunc;
+                this.completeScriptAction = completeScriptAction;
+            }
+
+            public async Task<ScriptTicket> StartScriptAsync(StartScriptCommand command, HalibutProxyRequestOptions options)
+            {
+                return await startScriptFunc(inner, command, options);
+            }
+
+            public async Task<ScriptStatusResponse> GetStatusAsync(ScriptStatusRequest request, HalibutProxyRequestOptions options)
+            {
+                return await getStatusFunc(inner, request, options);
+            }
+
+            public async Task<ScriptStatusResponse> CancelScriptAsync(CancelScriptCommand command, HalibutProxyRequestOptions options)
+            {
+                return await cancelScriptFunc(inner, command, options);
+            }
+
+            public async Task<ScriptStatusResponse> CompleteScriptAsync(CompleteScriptCommand command, HalibutProxyRequestOptions options)
+            {
+                return await completeScriptAction(inner, command, options);
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceV2DecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceV2DecoratorBuilder.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
+{
+    public class ScriptServiceV2DecoratorBuilder
+    {
+        public delegate Task<ScriptStatusResponseV2> StartScriptClientDecorator(IAsyncClientScriptServiceV2 inner,StartScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions);
+        public delegate Task<ScriptStatusResponseV2> GetStatusClientDecorator(IAsyncClientScriptServiceV2 inner,ScriptStatusRequestV2 request, HalibutProxyRequestOptions proxyRequestOptions);
+        public delegate Task<ScriptStatusResponseV2> CancelScriptClientDecorator(IAsyncClientScriptServiceV2 inner,CancelScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions);
+        public delegate Task CompleteScriptClientDecorator(IAsyncClientScriptServiceV2 inner,CompleteScriptCommandV2 command, HalibutProxyRequestOptions proxyRequestOptions);
+        
+        private StartScriptClientDecorator startScriptFunc = async (inner, command, options) => await inner.StartScriptAsync(command, options);
+        private GetStatusClientDecorator getStatusFunc = async (inner, command, options) => await inner.GetStatusAsync(command, options);
+        private CancelScriptClientDecorator cancelScriptFunc = async (inner, command, options) => await inner.CancelScriptAsync(command, options);
+        private CompleteScriptClientDecorator completeScriptAction = async (inner, command, options) => { await Task.CompletedTask; };
+
+        public ScriptServiceV2DecoratorBuilder BeforeStartScript(Func<Task> beforeStartScript)
+        {
+            return BeforeStartScript(async (_, _) => await beforeStartScript());
+        }
+
+        public ScriptServiceV2DecoratorBuilder BeforeStartScript(Func<IAsyncClientScriptServiceV2, StartScriptCommandV2, Task> beforeStartScript)
+        {
+            return DecorateStartScriptWith(async (inner, scriptStatusRequestV2, options) =>
+            {
+                await beforeStartScript(inner, scriptStatusRequestV2);
+                return await inner.StartScriptAsync(scriptStatusRequestV2, options);
+            });
+        }
+
+        public ScriptServiceV2DecoratorBuilder DecorateStartScriptWith(StartScriptClientDecorator startScriptFunc)
+        {
+            this.startScriptFunc = startScriptFunc;
+            return this;
+        }
+
+        public ScriptServiceV2DecoratorBuilder DecorateGetStatusWith(GetStatusClientDecorator getStatusFunc)
+        {
+            this.getStatusFunc = getStatusFunc;
+            return this;
+        }
+
+        public ScriptServiceV2DecoratorBuilder BeforeGetStatus(Func<Task> beforeGetStatus)
+        {
+
+            return BeforeGetStatus(async (_, _) => await beforeGetStatus());
+        }
+
+        public ScriptServiceV2DecoratorBuilder BeforeGetStatus(Func<IAsyncClientScriptServiceV2, ScriptStatusRequestV2, Task> beforeGetStatus)
+        {
+            return DecorateGetStatusWith(async (inner, scriptStatusRequestV2, options) =>
+            {
+                await beforeGetStatus(inner, scriptStatusRequestV2);
+                return await inner.GetStatusAsync(scriptStatusRequestV2, options);
+            });
+        }
+
+        public ScriptServiceV2DecoratorBuilder DecorateCancelScriptWith(CancelScriptClientDecorator cancelScriptFunc)
+        {
+            this.cancelScriptFunc = cancelScriptFunc;
+            return this;
+        }
+
+        public ScriptServiceV2DecoratorBuilder BeforeCancelScript(Func<Task> beforeCancelScript)
+        {
+            return BeforeCancelScript(async (_, _) => await beforeCancelScript());
+        }
+
+        public ScriptServiceV2DecoratorBuilder BeforeCancelScript(Func<IAsyncClientScriptServiceV2, CancelScriptCommandV2, Task> beforeCancelScript)
+        {
+            return DecorateCancelScriptWith(async (inner, command, options) =>
+            {
+                await beforeCancelScript(inner, command);
+                return await inner.CancelScriptAsync(command, options);
+            });
+        }
+
+        public ScriptServiceV2DecoratorBuilder DecorateCompleteScriptWith(CompleteScriptClientDecorator completeScriptAction)
+        {
+            this.completeScriptAction = completeScriptAction;
+            return this;
+        }
+
+        public ScriptServiceV2DecoratorBuilder BeforeCompleteScript(Func<Task> beforeCompleteScript)
+        {
+            return BeforeCompleteScript(async (_, _) => await beforeCompleteScript());
+        }
+
+        public ScriptServiceV2DecoratorBuilder BeforeCompleteScript(Func<IAsyncClientScriptServiceV2, CompleteScriptCommandV2, Task> beforeCompleteScript)
+        {
+            return DecorateCompleteScriptWith(async (inner, command, options) =>
+            {
+                await beforeCompleteScript(inner, command);
+                await inner.CompleteScriptAsync(command, options);
+            });
+        }
+
+        public Decorator<IAsyncClientScriptServiceV2> Build()
+        {
+            return inner => new FuncDecoratingScriptServiceV2(inner,
+                startScriptFunc,
+                getStatusFunc,
+                cancelScriptFunc,
+                completeScriptAction);
+        }
+
+
+        private class FuncDecoratingScriptServiceV2 : IAsyncClientScriptServiceV2
+        {
+            private IAsyncClientScriptServiceV2 inner;
+            private StartScriptClientDecorator startScriptFunc;
+            private GetStatusClientDecorator getStatusFunc;
+            private CancelScriptClientDecorator cancelScriptFunc;
+            private CompleteScriptClientDecorator completeScriptAction;
+
+            public FuncDecoratingScriptServiceV2(
+                IAsyncClientScriptServiceV2 inner,
+                StartScriptClientDecorator startScriptFunc,
+                GetStatusClientDecorator getStatusFunc,
+                CancelScriptClientDecorator cancelScriptFunc,
+                CompleteScriptClientDecorator completeScriptAction)
+            {
+                this.inner = inner;
+                this.startScriptFunc = startScriptFunc;
+                this.getStatusFunc = getStatusFunc;
+                this.cancelScriptFunc = cancelScriptFunc;
+                this.completeScriptAction = completeScriptAction;
+            }
+
+            public async Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, HalibutProxyRequestOptions options)
+            {
+                return await startScriptFunc(inner, command, options);
+            }
+
+            public async Task<ScriptStatusResponseV2> GetStatusAsync(ScriptStatusRequestV2 request, HalibutProxyRequestOptions options)
+            {
+                return await getStatusFunc(inner, request, options);
+            }
+
+            public async Task<ScriptStatusResponseV2> CancelScriptAsync(CancelScriptCommandV2 command, HalibutProxyRequestOptions options)
+            {
+                return await cancelScriptFunc(inner, command, options);
+            }
+
+            public async Task CompleteScriptAsync(CompleteScriptCommandV2 command, HalibutProxyRequestOptions options)
+            {
+                await completeScriptAction(inner, command, options);
+            }
+        }
+
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceV2DecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceV2DecoratorBuilder.cs
@@ -16,18 +16,18 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         private StartScriptClientDecorator startScriptFunc = async (inner, command, options) => await inner.StartScriptAsync(command, options);
         private GetStatusClientDecorator getStatusFunc = async (inner, command, options) => await inner.GetStatusAsync(command, options);
         private CancelScriptClientDecorator cancelScriptFunc = async (inner, command, options) => await inner.CancelScriptAsync(command, options);
-        private CompleteScriptClientDecorator completeScriptAction = async (inner, command, options) => { await Task.CompletedTask; };
+        private CompleteScriptClientDecorator completeScriptAction = async (inner, command, options) => { await inner.CompleteScriptAsync(command, options); };
 
         public ScriptServiceV2DecoratorBuilder BeforeStartScript(Func<Task> beforeStartScript)
         {
-            return BeforeStartScript(async (_, _) => await beforeStartScript());
+            return BeforeStartScript(async (_, _, _) => await beforeStartScript());
         }
 
-        public ScriptServiceV2DecoratorBuilder BeforeStartScript(Func<IAsyncClientScriptServiceV2, StartScriptCommandV2, Task> beforeStartScript)
+        public ScriptServiceV2DecoratorBuilder BeforeStartScript(Func<IAsyncClientScriptServiceV2, StartScriptCommandV2, HalibutProxyRequestOptions, Task> beforeStartScript)
         {
             return DecorateStartScriptWith(async (inner, scriptStatusRequestV2, options) =>
             {
-                await beforeStartScript(inner, scriptStatusRequestV2);
+                await beforeStartScript(inner, scriptStatusRequestV2, options);
                 return await inner.StartScriptAsync(scriptStatusRequestV2, options);
             });
         }
@@ -47,14 +47,14 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         public ScriptServiceV2DecoratorBuilder BeforeGetStatus(Func<Task> beforeGetStatus)
         {
 
-            return BeforeGetStatus(async (_, _) => await beforeGetStatus());
+            return BeforeGetStatus(async (_, _, _) => await beforeGetStatus());
         }
 
-        public ScriptServiceV2DecoratorBuilder BeforeGetStatus(Func<IAsyncClientScriptServiceV2, ScriptStatusRequestV2, Task> beforeGetStatus)
+        public ScriptServiceV2DecoratorBuilder BeforeGetStatus(Func<IAsyncClientScriptServiceV2, ScriptStatusRequestV2, HalibutProxyRequestOptions, Task> beforeGetStatus)
         {
             return DecorateGetStatusWith(async (inner, scriptStatusRequestV2, options) =>
             {
-                await beforeGetStatus(inner, scriptStatusRequestV2);
+                await beforeGetStatus(inner, scriptStatusRequestV2, options);
                 return await inner.GetStatusAsync(scriptStatusRequestV2, options);
             });
         }
@@ -67,14 +67,14 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 
         public ScriptServiceV2DecoratorBuilder BeforeCancelScript(Func<Task> beforeCancelScript)
         {
-            return BeforeCancelScript(async (_, _) => await beforeCancelScript());
+            return BeforeCancelScript(async (_, _, _) => await beforeCancelScript());
         }
 
-        public ScriptServiceV2DecoratorBuilder BeforeCancelScript(Func<IAsyncClientScriptServiceV2, CancelScriptCommandV2, Task> beforeCancelScript)
+        public ScriptServiceV2DecoratorBuilder BeforeCancelScript(Func<IAsyncClientScriptServiceV2, CancelScriptCommandV2, HalibutProxyRequestOptions, Task> beforeCancelScript)
         {
             return DecorateCancelScriptWith(async (inner, command, options) =>
             {
-                await beforeCancelScript(inner, command);
+                await beforeCancelScript(inner, command, options);
                 return await inner.CancelScriptAsync(command, options);
             });
         }
@@ -87,14 +87,14 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 
         public ScriptServiceV2DecoratorBuilder BeforeCompleteScript(Func<Task> beforeCompleteScript)
         {
-            return BeforeCompleteScript(async (_, _) => await beforeCompleteScript());
+            return BeforeCompleteScript(async (_, _, _) => await beforeCompleteScript());
         }
 
-        public ScriptServiceV2DecoratorBuilder BeforeCompleteScript(Func<IAsyncClientScriptServiceV2, CompleteScriptCommandV2, Task> beforeCompleteScript)
+        public ScriptServiceV2DecoratorBuilder BeforeCompleteScript(Func<IAsyncClientScriptServiceV2, CompleteScriptCommandV2, HalibutProxyRequestOptions, Task> beforeCompleteScript)
         {
             return DecorateCompleteScriptWith(async (inner, command, options) =>
             {
-                await beforeCompleteScript(inner, command);
+                await beforeCompleteScript(inner, command, options);
                 await inner.CompleteScriptAsync(command, options);
             });
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
@@ -12,10 +12,133 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 
     public class TentacleServiceDecoratorBuilder
     {
+        private readonly List<Decorator<IAsyncClientScriptService>> scriptServiceDecorator = new ();
+        private readonly List<Decorator<IAsyncClientScriptServiceV2>> scriptServiceV2Decorator = new ();
+        private readonly List<Decorator<IAsyncClientFileTransferService>> fileTransferServiceDecorator = new ();
+        private readonly List<Decorator<IAsyncClientCapabilitiesServiceV2>> capabilitiesServiceV2Decorator = new ();
+
         readonly Dictionary<Type, List<ProxyDecoratorFactory>> registeredProxyDecorators = new();
 
+        public TentacleServiceDecoratorBuilder DecorateScriptServiceWith(Decorator<IAsyncClientScriptService> scriptServiceDecorator)
+        {
+            this.scriptServiceDecorator.Add(scriptServiceDecorator);
+            return this;
+        }
+
+        public TentacleServiceDecoratorBuilder DecorateScriptServiceV2With(Decorator<IAsyncClientScriptServiceV2> scriptServiceV2Decorator)
+        {
+            this.scriptServiceV2Decorator.Add(scriptServiceV2Decorator);
+            return this;
+        }
+
+        public TentacleServiceDecoratorBuilder DecorateScriptServiceV2With(Action<ScriptServiceV2DecoratorBuilder> scriptServiceV2Decorator)
+        {
+            var b = new ScriptServiceV2DecoratorBuilder();
+            scriptServiceV2Decorator(b);
+            this.DecorateScriptServiceV2With(b.Build());
+            return this;
+        }
+
+        public TentacleServiceDecoratorBuilder DecorateFileTransferServiceWith(Decorator<IAsyncClientFileTransferService> fileTransferServiceDecorator)
+        {
+            this.fileTransferServiceDecorator.Add(fileTransferServiceDecorator);
+            return this;
+        }
+
+        public TentacleServiceDecoratorBuilder DecorateFileTransferServiceWith(Action<FileTransferServiceDecoratorBuilder> fileTransferServiceDecorator)
+        {
+            var b = new FileTransferServiceDecoratorBuilder();
+            fileTransferServiceDecorator(b);
+            this.DecorateFileTransferServiceWith(b.Build());
+            return this;
+        }
+
+        public TentacleServiceDecoratorBuilder DecorateCapabilitiesServiceV2With(Decorator<IAsyncClientCapabilitiesServiceV2> capabilitiesServiceV2Decorator)
+        {
+            this.capabilitiesServiceV2Decorator.Add(capabilitiesServiceV2Decorator);
+            return this;
+        }
+
+        public TentacleServiceDecoratorBuilder DecorateCapabilitiesServiceV2With(Action<CapabilitiesServiceV2DecoratorBuilder> capabilitiesServiceDecorator)
+        {
+            var b = new CapabilitiesServiceV2DecoratorBuilder();
+            capabilitiesServiceDecorator(b);
+            this.DecorateCapabilitiesServiceV2With(b.Build());
+            return this;
+        }
+
         internal ITentacleServiceDecoratorFactory Build()
-            => new ProxyTentacleServiceDecoratorFactory(registeredProxyDecorators);
+        {
+            // Eventually the proxy tentacle service decorator will only work on all methods
+            // e.g. for logging or counting. It will always make sense for this decorator to be called first.
+            var genericDecorators = new ProxyTentacleServiceDecoratorFactory(registeredProxyDecorators);
+
+            var perMethodDecorators = new CombinePerServiceTentacleServiceDecoratorFactory(Combine(scriptServiceDecorator), Combine(scriptServiceV2Decorator), Combine(fileTransferServiceDecorator), Combine(capabilitiesServiceV2Decorator));
+
+            return new CombiningTentacleServiceDecoratorFactory(new List<ITentacleServiceDecoratorFactory>(){genericDecorators, perMethodDecorators});
+        }
+
+        static Decorator<T> Combine<T>(List<Decorator<T>> chain) where T : class
+        {
+
+            return t =>
+            {
+                var reverseChain = new List<Decorator<T>>(chain);
+                reverseChain.Reverse();
+
+                foreach (var func in reverseChain)
+                {
+                    t = func(t);
+                }
+
+                return t;
+            };
+        }
+
+        class CombinePerServiceTentacleServiceDecoratorFactory : ITentacleServiceDecoratorFactory
+        {
+            readonly Decorator<IAsyncClientScriptService> scriptServiceDecorator;
+            readonly Decorator<IAsyncClientScriptServiceV2> scriptServiceV2Decorator;
+            readonly Decorator<IAsyncClientFileTransferService> fileTransferServiceDecorator;
+            readonly Decorator<IAsyncClientCapabilitiesServiceV2> capabilitiesServiceV2Decorator;
+
+            public CombinePerServiceTentacleServiceDecoratorFactory(
+                Decorator<IAsyncClientScriptService> scriptServiceDecorator,
+                Decorator<IAsyncClientScriptServiceV2> scriptServiceV2Decorator,
+                Decorator<IAsyncClientFileTransferService> fileTransferServiceDecorator,
+                Decorator<IAsyncClientCapabilitiesServiceV2> capabilitiesServiceV2Decorator)
+            {
+                this.scriptServiceDecorator = scriptServiceDecorator;
+                this.scriptServiceV2Decorator = scriptServiceV2Decorator;
+                this.fileTransferServiceDecorator = fileTransferServiceDecorator;
+                this.capabilitiesServiceV2Decorator = capabilitiesServiceV2Decorator;
+            }
+
+            public IAsyncClientScriptService Decorate(IAsyncClientScriptService scriptService)
+            {
+                return scriptServiceDecorator(scriptService);
+            }
+
+            public IAsyncClientScriptServiceV2 Decorate(IAsyncClientScriptServiceV2 scriptService)
+            {
+                return scriptServiceV2Decorator(scriptService);
+            }
+
+            public IAsyncClientFileTransferService Decorate(IAsyncClientFileTransferService service)
+            {
+                return fileTransferServiceDecorator(service);
+            }
+
+            public IAsyncClientCapabilitiesServiceV2 Decorate(IAsyncClientCapabilitiesServiceV2 service)
+            {
+                return capabilitiesServiceV2Decorator(service);
+            }
+
+            public IAsyncClientScriptServiceV3Alpha Decorate(IAsyncClientScriptServiceV3Alpha service)
+            {
+                return service;
+            }
+        }
 
         public TentacleServiceDecoratorBuilder RegisterProxyDecorator<TService>(Func<TService, TService> proxyDecoratorFactory) where TService : class
         {


### PR DESCRIPTION
# Background

https://github.com/OctopusDeploy/OctopusTentacle/pull/663 replaced all decorators with a generic proxy decorator. That works great for things like logging ALL calls or counting ALL calls. However it is very difficult to use when the test needs to do something special with one call because:
* The proxy decorator has no autocompletion making it hard to tab your way through.
* The proxy decorator has no type safety.
* The proxy decorator assumes each RPC has exactly one parameter.

The change here is to add back some of the original test decorators, specifically it adds back the decorators that allow of doing something before/after a specific method. The result is:
* Decorations that want to apply to all calls is automatically done through the proxy decorator.
* Decorations that want to apply to just one call is easier to do in, since autocompletion and type safety is enforced. Users (ie test writers) can tab complete their way to glory.

This PR doesn't stop the proxy decorator from being used as something that overrides a single call, a future PR will need to be done to do that. For now we need this PR to unblock https://github.com/OctopusDeploy/OctopusTentacle/pull/769


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.