### PR TITLE
Client should wait for script cleanup call

### DIFF
--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Orchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Orchestrator.cs
@@ -200,7 +200,10 @@ namespace Octopus.Tentacle.Client.Scripts
             {
                 // Finish performs a best effort cleanup of the Workspace on Tentacle
                 // If we are cancelling script execution we abandon a call to complete script after a period of time
-                using var completeScriptCancellationTokenSource = new CancellationTokenSource(onCancellationAbandonCompleteScriptAfter);
+                
+                using var completeScriptCancellationTokenSource = new CancellationTokenSource();
+
+                await using var _ = scriptExecutionCancellationToken.Register(() => completeScriptCancellationTokenSource.CancelAfter(onCancellationAbandonCompleteScriptAfter));
 
                 await rpcCallExecutor.ExecuteWithNoRetries(
                         RpcCall.Create<IScriptServiceV2>(nameof(IScriptServiceV2.CompleteScript)),

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
@@ -188,7 +188,9 @@ namespace Octopus.Tentacle.Client.Scripts
             {
                 // Finish performs a best effort cleanup of the Workspace on Tentacle
                 // If we are cancelling script execution we abandon a call to complete script after a period of time
-                using var completeScriptCancellationTokenSource = new CancellationTokenSource(onCancellationAbandonCompleteScriptAfter);
+                using var completeScriptCancellationTokenSource = new CancellationTokenSource();
+
+                await using var _ = scriptExecutionCancellationToken.Register(() => completeScriptCancellationTokenSource.CancelAfter(onCancellationAbandonCompleteScriptAfter));
 
                 await rpcCallExecutor.ExecuteWithNoRetries(
                         RpcCall.Create<IScriptServiceV3Alpha>(nameof(IScriptServiceV3Alpha.CompleteScript)),

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
@@ -180,5 +180,38 @@ namespace Octopus.Tentacle.Tests.Integration
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CompleteScriptAsync)).Started.Should().Be(1);
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).Started.Should().BeGreaterThanOrEqualTo(1);
         }
+        
+        [Test]
+        [TentacleConfigurations(scriptServiceToTest: ScriptServiceVersionToTest.Version2)]
+        public async Task WhenOnCompleteTakesLongerThan_OnCancellationAbandonCompleteScriptAfter_AndTheExecutionIsNotCancelled_TheOrchestratorWaitsForCleanUpToComplete(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            bool calledWithNonCancelledCT = false;
+            
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var recordedUsages)
+                    .DecorateScriptServiceV2With(b => b
+                        .BeforeCompleteScript(async (_, _, halibutProxyRequestOptions) =>
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken);
+                            calledWithNonCancelledCT = !halibutProxyRequestOptions.RequestCancellationToken.IsCancellationRequested;
+                        })
+                        .Build())
+                    .Build())
+                .Build(CancellationToken);
+
+            var scriptCommand = new LatestStartScriptCommandBuilder()
+                .WithScriptBody(b => b.Print("Hello"))
+                .Build();
+
+            var tentacleClient = clientTentacle.TentacleClient;
+
+            tentacleClient.OnCancellationAbandonCompleteScriptAfter = TimeSpan.FromMilliseconds(1);
+
+            await tentacleClient.ExecuteScript(scriptCommand, CancellationToken);
+
+
+            calledWithNonCancelledCT.Should().Be(true);
+        }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceV3DecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceV3DecoratorBuilder.cs
@@ -8,26 +8,29 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 {
     public class ScriptServiceV3AlphaDecoratorBuilder
     {
-        public delegate Task<ScriptStatusResponseV3Alpha> StartScriptClientDecorator(IAsyncClientScriptServiceV3Alpha inner,StartScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
-        public delegate Task<ScriptStatusResponseV3Alpha> GetStatusClientDecorator(IAsyncClientScriptServiceV3Alpha inner,ScriptStatusRequestV3Alpha request, HalibutProxyRequestOptions proxyRequestOptions);
-        public delegate Task<ScriptStatusResponseV3Alpha> CancelScriptClientDecorator(IAsyncClientScriptServiceV3Alpha inner,CancelScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
-        public delegate Task CompleteScriptClientDecorator(IAsyncClientScriptServiceV3Alpha inner,CompleteScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
-        
+        public delegate Task<ScriptStatusResponseV3Alpha> StartScriptClientDecorator(IAsyncClientScriptServiceV3Alpha inner, StartScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
+
+        public delegate Task<ScriptStatusResponseV3Alpha> GetStatusClientDecorator(IAsyncClientScriptServiceV3Alpha inner, ScriptStatusRequestV3Alpha request, HalibutProxyRequestOptions proxyRequestOptions);
+
+        public delegate Task<ScriptStatusResponseV3Alpha> CancelScriptClientDecorator(IAsyncClientScriptServiceV3Alpha inner, CancelScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
+
+        public delegate Task CompleteScriptClientDecorator(IAsyncClientScriptServiceV3Alpha inner, CompleteScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
+
         private StartScriptClientDecorator startScriptFunc = async (inner, command, options) => await inner.StartScriptAsync(command, options);
         private GetStatusClientDecorator getStatusFunc = async (inner, command, options) => await inner.GetStatusAsync(command, options);
         private CancelScriptClientDecorator cancelScriptFunc = async (inner, command, options) => await inner.CancelScriptAsync(command, options);
-        private CompleteScriptClientDecorator completeScriptAction = async (inner, command, options) => { await Task.CompletedTask; };
+        private CompleteScriptClientDecorator completeScriptAction = async (inner, command, options) => await inner.CompleteScriptAsync(command, options);
 
         public ScriptServiceV3AlphaDecoratorBuilder BeforeStartScript(Func<Task> beforeStartScript)
         {
-            return BeforeStartScript(async (_, _) => await beforeStartScript());
+            return BeforeStartScript(async (_, _, _) => await beforeStartScript());
         }
 
-        public ScriptServiceV3AlphaDecoratorBuilder BeforeStartScript(Func<IAsyncClientScriptServiceV3Alpha, StartScriptCommandV3Alpha, Task> beforeStartScript)
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeStartScript(Func<IAsyncClientScriptServiceV3Alpha, StartScriptCommandV3Alpha, HalibutProxyRequestOptions, Task> beforeStartScript)
         {
             return DecorateStartScriptWith(async (inner, scriptStatusRequestV3Alpha, options) =>
             {
-                await beforeStartScript(inner, scriptStatusRequestV3Alpha);
+                await beforeStartScript(inner, scriptStatusRequestV3Alpha, options);
                 return await inner.StartScriptAsync(scriptStatusRequestV3Alpha, options);
             });
         }
@@ -46,15 +49,14 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 
         public ScriptServiceV3AlphaDecoratorBuilder BeforeGetStatus(Func<Task> beforeGetStatus)
         {
-
-            return BeforeGetStatus(async (_, _) => await beforeGetStatus());
+            return BeforeGetStatus(async (_, _, _) => await beforeGetStatus());
         }
 
-        public ScriptServiceV3AlphaDecoratorBuilder BeforeGetStatus(Func<IAsyncClientScriptServiceV3Alpha, ScriptStatusRequestV3Alpha, Task> beforeGetStatus)
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeGetStatus(Func<IAsyncClientScriptServiceV3Alpha, ScriptStatusRequestV3Alpha, HalibutProxyRequestOptions, Task> beforeGetStatus)
         {
             return DecorateGetStatusWith(async (inner, scriptStatusRequestV3Alpha, options) =>
             {
-                await beforeGetStatus(inner, scriptStatusRequestV3Alpha);
+                await beforeGetStatus(inner, scriptStatusRequestV3Alpha, options);
                 return await inner.GetStatusAsync(scriptStatusRequestV3Alpha, options);
             });
         }
@@ -67,14 +69,14 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 
         public ScriptServiceV3AlphaDecoratorBuilder BeforeCancelScript(Func<Task> beforeCancelScript)
         {
-            return BeforeCancelScript(async (_, _) => await beforeCancelScript());
+            return BeforeCancelScript(async (_, _, _) => await beforeCancelScript());
         }
 
-        public ScriptServiceV3AlphaDecoratorBuilder BeforeCancelScript(Func<IAsyncClientScriptServiceV3Alpha, CancelScriptCommandV3Alpha, Task> beforeCancelScript)
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeCancelScript(Func<IAsyncClientScriptServiceV3Alpha, CancelScriptCommandV3Alpha, HalibutProxyRequestOptions, Task> beforeCancelScript)
         {
             return DecorateCancelScriptWith(async (inner, command, options) =>
             {
-                await beforeCancelScript(inner, command);
+                await beforeCancelScript(inner, command, options);
                 return await inner.CancelScriptAsync(command, options);
             });
         }
@@ -108,14 +110,13 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
                 completeScriptAction);
         }
 
-
         private class FuncDecoratingScriptServiceV3Alpha : IAsyncClientScriptServiceV3Alpha
         {
-            private IAsyncClientScriptServiceV3Alpha inner;
-            private StartScriptClientDecorator startScriptFunc;
-            private GetStatusClientDecorator getStatusFunc;
-            private CancelScriptClientDecorator cancelScriptFunc;
-            private CompleteScriptClientDecorator completeScriptAction;
+            private readonly IAsyncClientScriptServiceV3Alpha inner;
+            private readonly StartScriptClientDecorator startScriptFunc;
+            private readonly GetStatusClientDecorator getStatusFunc;
+            private readonly CancelScriptClientDecorator cancelScriptFunc;
+            private readonly CompleteScriptClientDecorator completeScriptAction;
 
             public FuncDecoratingScriptServiceV3Alpha(
                 IAsyncClientScriptServiceV3Alpha inner,
@@ -151,6 +152,5 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
                 await completeScriptAction(inner, command, options);
             }
         }
-
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceV3DecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/ScriptServiceV3DecoratorBuilder.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+
+namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
+{
+    public class ScriptServiceV3AlphaDecoratorBuilder
+    {
+        public delegate Task<ScriptStatusResponseV3Alpha> StartScriptClientDecorator(IAsyncClientScriptServiceV3Alpha inner,StartScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
+        public delegate Task<ScriptStatusResponseV3Alpha> GetStatusClientDecorator(IAsyncClientScriptServiceV3Alpha inner,ScriptStatusRequestV3Alpha request, HalibutProxyRequestOptions proxyRequestOptions);
+        public delegate Task<ScriptStatusResponseV3Alpha> CancelScriptClientDecorator(IAsyncClientScriptServiceV3Alpha inner,CancelScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
+        public delegate Task CompleteScriptClientDecorator(IAsyncClientScriptServiceV3Alpha inner,CompleteScriptCommandV3Alpha command, HalibutProxyRequestOptions proxyRequestOptions);
+        
+        private StartScriptClientDecorator startScriptFunc = async (inner, command, options) => await inner.StartScriptAsync(command, options);
+        private GetStatusClientDecorator getStatusFunc = async (inner, command, options) => await inner.GetStatusAsync(command, options);
+        private CancelScriptClientDecorator cancelScriptFunc = async (inner, command, options) => await inner.CancelScriptAsync(command, options);
+        private CompleteScriptClientDecorator completeScriptAction = async (inner, command, options) => { await Task.CompletedTask; };
+
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeStartScript(Func<Task> beforeStartScript)
+        {
+            return BeforeStartScript(async (_, _) => await beforeStartScript());
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeStartScript(Func<IAsyncClientScriptServiceV3Alpha, StartScriptCommandV3Alpha, Task> beforeStartScript)
+        {
+            return DecorateStartScriptWith(async (inner, scriptStatusRequestV3Alpha, options) =>
+            {
+                await beforeStartScript(inner, scriptStatusRequestV3Alpha);
+                return await inner.StartScriptAsync(scriptStatusRequestV3Alpha, options);
+            });
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder DecorateStartScriptWith(StartScriptClientDecorator startScriptFunc)
+        {
+            this.startScriptFunc = startScriptFunc;
+            return this;
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder DecorateGetStatusWith(GetStatusClientDecorator getStatusFunc)
+        {
+            this.getStatusFunc = getStatusFunc;
+            return this;
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeGetStatus(Func<Task> beforeGetStatus)
+        {
+
+            return BeforeGetStatus(async (_, _) => await beforeGetStatus());
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeGetStatus(Func<IAsyncClientScriptServiceV3Alpha, ScriptStatusRequestV3Alpha, Task> beforeGetStatus)
+        {
+            return DecorateGetStatusWith(async (inner, scriptStatusRequestV3Alpha, options) =>
+            {
+                await beforeGetStatus(inner, scriptStatusRequestV3Alpha);
+                return await inner.GetStatusAsync(scriptStatusRequestV3Alpha, options);
+            });
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder DecorateCancelScriptWith(CancelScriptClientDecorator cancelScriptFunc)
+        {
+            this.cancelScriptFunc = cancelScriptFunc;
+            return this;
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeCancelScript(Func<Task> beforeCancelScript)
+        {
+            return BeforeCancelScript(async (_, _) => await beforeCancelScript());
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeCancelScript(Func<IAsyncClientScriptServiceV3Alpha, CancelScriptCommandV3Alpha, Task> beforeCancelScript)
+        {
+            return DecorateCancelScriptWith(async (inner, command, options) =>
+            {
+                await beforeCancelScript(inner, command);
+                return await inner.CancelScriptAsync(command, options);
+            });
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder DecorateCompleteScriptWith(CompleteScriptClientDecorator completeScriptAction)
+        {
+            this.completeScriptAction = completeScriptAction;
+            return this;
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeCompleteScript(Func<Task> beforeCompleteScript)
+        {
+            return BeforeCompleteScript(async (_, _, _) => await beforeCompleteScript());
+        }
+
+        public ScriptServiceV3AlphaDecoratorBuilder BeforeCompleteScript(Func<IAsyncClientScriptServiceV3Alpha, CompleteScriptCommandV3Alpha, HalibutProxyRequestOptions, Task> beforeCompleteScript)
+        {
+            return DecorateCompleteScriptWith(async (inner, command, options) =>
+            {
+                await beforeCompleteScript(inner, command, options);
+                await inner.CompleteScriptAsync(command, options);
+            });
+        }
+
+        public Decorator<IAsyncClientScriptServiceV3Alpha> Build()
+        {
+            return inner => new FuncDecoratingScriptServiceV3Alpha(inner,
+                startScriptFunc,
+                getStatusFunc,
+                cancelScriptFunc,
+                completeScriptAction);
+        }
+
+
+        private class FuncDecoratingScriptServiceV3Alpha : IAsyncClientScriptServiceV3Alpha
+        {
+            private IAsyncClientScriptServiceV3Alpha inner;
+            private StartScriptClientDecorator startScriptFunc;
+            private GetStatusClientDecorator getStatusFunc;
+            private CancelScriptClientDecorator cancelScriptFunc;
+            private CompleteScriptClientDecorator completeScriptAction;
+
+            public FuncDecoratingScriptServiceV3Alpha(
+                IAsyncClientScriptServiceV3Alpha inner,
+                StartScriptClientDecorator startScriptFunc,
+                GetStatusClientDecorator getStatusFunc,
+                CancelScriptClientDecorator cancelScriptFunc,
+                CompleteScriptClientDecorator completeScriptAction)
+            {
+                this.inner = inner;
+                this.startScriptFunc = startScriptFunc;
+                this.getStatusFunc = getStatusFunc;
+                this.cancelScriptFunc = cancelScriptFunc;
+                this.completeScriptAction = completeScriptAction;
+            }
+
+            public async Task<ScriptStatusResponseV3Alpha> StartScriptAsync(StartScriptCommandV3Alpha command, HalibutProxyRequestOptions options)
+            {
+                return await startScriptFunc(inner, command, options);
+            }
+
+            public async Task<ScriptStatusResponseV3Alpha> GetStatusAsync(ScriptStatusRequestV3Alpha request, HalibutProxyRequestOptions options)
+            {
+                return await getStatusFunc(inner, request, options);
+            }
+
+            public async Task<ScriptStatusResponseV3Alpha> CancelScriptAsync(CancelScriptCommandV3Alpha command, HalibutProxyRequestOptions options)
+            {
+                return await cancelScriptFunc(inner, command, options);
+            }
+
+            public async Task CompleteScriptAsync(CompleteScriptCommandV3Alpha command, HalibutProxyRequestOptions options)
+            {
+                await completeScriptAction(inner, command, options);
+            }
+        }
+
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/Decorators/TentacleServiceDecoratorBuilder.cs
@@ -14,6 +14,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
     {
         private readonly List<Decorator<IAsyncClientScriptService>> scriptServiceDecorator = new ();
         private readonly List<Decorator<IAsyncClientScriptServiceV2>> scriptServiceV2Decorator = new ();
+        private readonly List<Decorator<IAsyncClientScriptServiceV3Alpha>> scriptServiceV3AlphaDecorator = new ();
         private readonly List<Decorator<IAsyncClientFileTransferService>> fileTransferServiceDecorator = new ();
         private readonly List<Decorator<IAsyncClientCapabilitiesServiceV2>> capabilitiesServiceV2Decorator = new ();
 
@@ -30,12 +31,26 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             this.scriptServiceV2Decorator.Add(scriptServiceV2Decorator);
             return this;
         }
+        
+        public TentacleServiceDecoratorBuilder DecorateScriptServiceV3AlphaWith(Decorator<IAsyncClientScriptServiceV3Alpha> scriptServiceV3AlphaDecorator)
+        {
+            this.scriptServiceV3AlphaDecorator.Add(scriptServiceV3AlphaDecorator);
+            return this;
+        }
 
         public TentacleServiceDecoratorBuilder DecorateScriptServiceV2With(Action<ScriptServiceV2DecoratorBuilder> scriptServiceV2Decorator)
         {
             var b = new ScriptServiceV2DecoratorBuilder();
             scriptServiceV2Decorator(b);
             this.DecorateScriptServiceV2With(b.Build());
+            return this;
+        }
+        
+        public TentacleServiceDecoratorBuilder DecorateScriptServiceV3AlphaWith(Action<ScriptServiceV3AlphaDecoratorBuilder> scriptServiceV3AlphaDecorator)
+        {
+            var b = new ScriptServiceV3AlphaDecoratorBuilder();
+            scriptServiceV3AlphaDecorator(b);
+            this.DecorateScriptServiceV3AlphaWith(b.Build());
             return this;
         }
 
@@ -73,7 +88,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
             // e.g. for logging or counting. It will always make sense for this decorator to be called first.
             var genericDecorators = new ProxyTentacleServiceDecoratorFactory(registeredProxyDecorators);
 
-            var perMethodDecorators = new CombinePerServiceTentacleServiceDecoratorFactory(Combine(scriptServiceDecorator), Combine(scriptServiceV2Decorator), Combine(fileTransferServiceDecorator), Combine(capabilitiesServiceV2Decorator));
+            var perMethodDecorators = new CombinePerServiceTentacleServiceDecoratorFactory(Combine(scriptServiceDecorator), Combine(scriptServiceV2Decorator), Combine(scriptServiceV3AlphaDecorator), Combine(fileTransferServiceDecorator), Combine(capabilitiesServiceV2Decorator));
 
             return new CombiningTentacleServiceDecoratorFactory(new List<ITentacleServiceDecoratorFactory>(){genericDecorators, perMethodDecorators});
         }
@@ -99,12 +114,14 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
         {
             readonly Decorator<IAsyncClientScriptService> scriptServiceDecorator;
             readonly Decorator<IAsyncClientScriptServiceV2> scriptServiceV2Decorator;
+            readonly Decorator<IAsyncClientScriptServiceV3Alpha> scriptServiceV3AlphaDecorator;
             readonly Decorator<IAsyncClientFileTransferService> fileTransferServiceDecorator;
             readonly Decorator<IAsyncClientCapabilitiesServiceV2> capabilitiesServiceV2Decorator;
 
             public CombinePerServiceTentacleServiceDecoratorFactory(
                 Decorator<IAsyncClientScriptService> scriptServiceDecorator,
                 Decorator<IAsyncClientScriptServiceV2> scriptServiceV2Decorator,
+                Decorator<IAsyncClientScriptServiceV3Alpha> scriptServiceV3AlphaDecorator,
                 Decorator<IAsyncClientFileTransferService> fileTransferServiceDecorator,
                 Decorator<IAsyncClientCapabilitiesServiceV2> capabilitiesServiceV2Decorator)
             {
@@ -112,6 +129,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
                 this.scriptServiceV2Decorator = scriptServiceV2Decorator;
                 this.fileTransferServiceDecorator = fileTransferServiceDecorator;
                 this.capabilitiesServiceV2Decorator = capabilitiesServiceV2Decorator;
+                this.scriptServiceV3AlphaDecorator = scriptServiceV3AlphaDecorator;
             }
 
             public IAsyncClientScriptService Decorate(IAsyncClientScriptService scriptService)
@@ -136,7 +154,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators
 
             public IAsyncClientScriptServiceV3Alpha Decorate(IAsyncClientScriptServiceV3Alpha service)
             {
-                return service;
+                return scriptServiceV3AlphaDecorator(service);
             }
         }
 


### PR DESCRIPTION
# Background

[SC-68685]

The tentacle client had a bug in which it would not wait longer than 1 min to wait for the response to `CompleteScriptAsync`. This meant that although Tentacle would (assuming no errors occure on tentacle itself) complete the clean up. The tentacle client would report that the cleanup was failed to be cleaned up.


Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/770

Relates to: https://github.com/OctopusDeploy/OctopusTentacle/pull/767
# Results

We now don't set a 1 min timeout when waiting for the `CompleteScriptAsync` to complete, instead the normal Halibut timeouts will apply.

Now when a call to `CompleteScriptAsync` takes a couple of minutes, we will wait for the RPC and we will NOT report it failed (unless it actually did).

This fixes both v2 and v3Alpha Script orchestrators in the Tentacle Client.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.