### PR TITLE
Support using custom container for Kubernetes Job

### DIFF
--- a/source/Octopus.Tentacle.Contracts/ScriptServiceV3Alpha/KubernetesJobScriptExecutionContext.cs
+++ b/source/Octopus.Tentacle.Contracts/ScriptServiceV3Alpha/KubernetesJobScriptExecutionContext.cs
@@ -1,6 +1,28 @@
-﻿
+﻿using Newtonsoft.Json;
+
 namespace Octopus.Tentacle.Contracts.ScriptServiceV3Alpha
 {
     public class KubernetesJobScriptExecutionContext : IScriptExecutionContext
-    { }
+    {
+        [JsonConstructor]
+        public KubernetesJobScriptExecutionContext(string image, string feedUrl, string feedUsername, string feedPassword)
+        {
+            Image = image;
+            FeedUrl = feedUrl;
+            FeedUsername = feedUsername;
+            FeedPassword = feedPassword;
+        }
+
+        public KubernetesJobScriptExecutionContext()
+        {
+        }
+
+        public string? Image { get; }
+
+        public string? FeedUrl { get; }
+
+        public string? FeedUsername { get; }
+
+        public string? FeedPassword { get; }
+    }
 }

--- a/source/Octopus.Tentacle.Contracts/ScriptServiceV3Alpha/KubernetesJobScriptExecutionContext.cs
+++ b/source/Octopus.Tentacle.Contracts/ScriptServiceV3Alpha/KubernetesJobScriptExecutionContext.cs
@@ -5,7 +5,7 @@ namespace Octopus.Tentacle.Contracts.ScriptServiceV3Alpha
     public class KubernetesJobScriptExecutionContext : IScriptExecutionContext
     {
         [JsonConstructor]
-        public KubernetesJobScriptExecutionContext(string image, string feedUrl, string feedUsername, string feedPassword)
+        public KubernetesJobScriptExecutionContext(string image, string? feedUrl, string? feedUsername, string? feedPassword)
         {
             Image = image;
             FeedUrl = feedUrl;

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -9,6 +9,7 @@ namespace Octopus.Tentacle.Kubernetes
             builder.RegisterType<KubernetesJobService>().As<IKubernetesJobService>().SingleInstance();
             builder.RegisterType<KubernetesClusterService>().As<IKubernetesClusterService>().SingleInstance();
             builder.RegisterType<KubernetesJobContainerResolver>().As<IKubernetesJobContainerResolver>().SingleInstance();
+            builder.RegisterType<KubernetesSecretService>().As<IKubernetesSecretService>().SingleInstance();
 
 #if DEBUG
             builder.RegisterType<LocalMachineKubernetesClientConfigProvider>().As<IKubernetesClientConfigProvider>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesSecretService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesSecretService.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesSecretService
+    {
+        Task<V1Secret?> TryGetSecretAsync(string name, CancellationToken cancellationToken);
+        Task CreateSecretAsync(V1Secret secret, CancellationToken cancellationToken);
+        Task UpdateSecretDataAsync(string secretName, Dictionary<string, byte[]> secretData, CancellationToken cancellationToken);
+    }
+
+    public class KubernetesSecretService : KubernetesService, IKubernetesSecretService
+    {
+        public KubernetesSecretService(IKubernetesClientConfigProvider configProvider)
+            : base(configProvider)
+        {
+        }
+
+        public async Task<V1Secret?> TryGetSecretAsync(string name, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await Client.ReadNamespacedSecretAsync(name, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
+            }
+            catch (HttpOperationException opException)
+                when (opException.Response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
+
+        public async Task CreateSecretAsync(V1Secret secret, CancellationToken cancellationToken)
+            => await Client.CreateNamespacedSecretAsync(secret, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
+
+        public async Task UpdateSecretDataAsync(string secretName, Dictionary<string, byte[]> secretData, CancellationToken cancellationToken)
+        {
+            var patchSecret = new V1Secret
+            {
+                Data = secretData
+            };
+
+            var patchYaml = KubernetesJson.Serialize(patchSecret);
+
+            await Client.PatchNamespacedSecretAsync(new V1Patch(patchYaml, V1Patch.PatchType.MergePatch), secretName, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/KubernetesJobScriptExecutor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/KubernetesJobScriptExecutor.cs
@@ -11,13 +11,15 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
     public class KubernetesJobScriptExecutor : IScriptExecutor
     {
         readonly IKubernetesJobService jobService;
+        readonly IKubernetesSecretService secretService;
         readonly IKubernetesJobContainerResolver containerResolver;
         readonly IApplicationInstanceSelector appInstanceSelector;
         readonly ISystemLog log;
 
-        public KubernetesJobScriptExecutor(IKubernetesJobService jobService, IKubernetesJobContainerResolver containerResolver, IApplicationInstanceSelector appInstanceSelector, ISystemLog log)
+        public KubernetesJobScriptExecutor(IKubernetesJobService jobService, IKubernetesSecretService secretService, IKubernetesJobContainerResolver containerResolver, IApplicationInstanceSelector appInstanceSelector, ISystemLog log)
         {
             this.jobService = jobService;
+            this.secretService = secretService;
             this.containerResolver = containerResolver;
             this.appInstanceSelector = appInstanceSelector;
             this.log = log;
@@ -27,7 +29,18 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
 
         public IRunningScript ExecuteOnBackgroundThread(StartScriptCommandV3Alpha command, IScriptWorkspace workspace, ScriptStateStore scriptStateStore, CancellationToken cancellationToken)
         {
-            var runningScript = new RunningKubernetesJob(workspace, workspace.CreateLog(), command.ScriptTicket, command.TaskId, log, scriptStateStore, jobService, containerResolver, appInstanceSelector, cancellationToken);
+            var runningScript = new RunningKubernetesJob(
+                workspace,
+                workspace.CreateLog(),
+                command.ScriptTicket,
+                command.TaskId, log,
+                scriptStateStore,
+                jobService,
+                secretService,
+                containerResolver,
+                appInstanceSelector,
+                (KubernetesJobScriptExecutionContext)command.ExecutionContext,
+                cancellationToken);
 
             Task.Run(() => runningScript.Execute(), cancellationToken);
 

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
@@ -276,7 +276,7 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
         {
             //The secret name is the domain of the feed & the username in a hash
             //We use MD5 because we want a small hash (as a secrets name is max 253 chars) and we aren't hashing secure data
-            using var sha1 = MD5.Create();
+            using var sha1 = SHA1.Create();
             var feedUri = new Uri(feedUrl);
 
             var hash = Convert.ToBase64String(sha1.ComputeHash(Encoding.UTF8.GetBytes($"{feedUri.DnsSafeHost}:{username}")));
@@ -323,7 +323,6 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
                                 {
                                     Name = jobName,
                                     Image = await containerResolver.GetContainerImageForCluster(),
-
                                     Command = new List<string> { "bash" },
                                     Args = new List<string>
                                         {


### PR DESCRIPTION
# Background

For certain steps (namely the Kubernetes Script Step), the customer needs to provide a Execution/Action Container to run the script in.

Server provides this information as part of the `KubernetesJobScriptExecutionContext`, which can then be used.

# Results

Kubernetes needs a secret in a specific docker config format to pull from private registries. If the user has provided a feed url & feed username, we create a secret with a unique name (which is a hash of the url domain & username) and create the correct data format.

We then use this in the `ImagePullSecrets` item in the job spec.

Shortcut story: [sc-67356]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.`