### PR TITLE
Add encryption to configmap store

### DIFF
--- a/source/Octopus.Tentacle.Tests/Configuration/ApplicationInstanceSelectorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Configuration/ApplicationInstanceSelectorFixture.cs
@@ -5,6 +5,7 @@ using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Configuration.Crypto;
 using Octopus.Tentacle.Configuration.Instances;
 using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Util;
@@ -189,7 +190,7 @@ namespace Octopus.Tentacle.Tests.Configuration
                 applicationInstanceStore,
                 instanceRequest ?? new StartUpDynamicInstanceRequest(),
                 additionalConfigurations ?? new IApplicationConfigurationContributor[0],
-                new Lazy<ConfigMapKeyValueStore>(() => new ConfigMapKeyValueStore(Substitute.For<IKubernetesConfigMapService>())),
+                new Lazy<ConfigMapKeyValueStore>(() => new ConfigMapKeyValueStore(Substitute.For<IKubernetesConfigMapService>(), Substitute.For<IKubernetesMachineKeyEncryptor>())),
                 octopusFileSystem,
                 log);
         }

--- a/source/Octopus.Tentacle/Configuration/ConfigurationModule.cs
+++ b/source/Octopus.Tentacle/Configuration/ConfigurationModule.cs
@@ -1,5 +1,6 @@
 using System;
 using Autofac;
+using Octopus.Tentacle.Configuration.Crypto;
 using Octopus.Tentacle.Configuration.EnvironmentVariableMappings;
 using Octopus.Tentacle.Configuration.Instances;
 using Octopus.Tentacle.Startup;
@@ -55,6 +56,7 @@ namespace Octopus.Tentacle.Configuration
                 .As<IApplicationInstanceSelector>()
                 .SingleInstance();
 
+            builder.RegisterType<KubernetesMachineKeyEncryptor>().As<IKubernetesMachineKeyEncryptor>().SingleInstance();
             builder.RegisterType<ConfigMapKeyValueStore>().SingleInstance();
 
             builder.RegisterType<WindowsLocalAdminRightsChecker>()

--- a/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
@@ -20,7 +20,7 @@ public class KubernetesMachineKeyEncryptor : IKubernetesMachineKeyEncryptor
 
         readonly byte[]? machineKey;
         readonly byte[]? machineIv;
-        public KubernetesMachineKeyEncryptor(IKubernetesV1SecretService kubernetesSecretService, ISystemLog log)
+        public KubernetesMachineKeyEncryptor(IKubernetesSecretService kubernetesSecretService, ISystemLog log)
         {
             var secret = kubernetesSecretService.TryGet(SecretName, CancellationToken.None).GetAwaiter().GetResult() ?? throw new InvalidOperationException($"Unable to retrieve MachineKey from secret for namespace {KubernetesConfig.Namespace}");
 

--- a/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
@@ -20,11 +20,12 @@ public class KubernetesMachineKeyEncryptor : IKubernetesMachineKeyEncryptor
 
         readonly byte[]? machineKey;
         readonly byte[]? machineIv;
-        public KubernetesMachineKeyEncryptor(IKubernetesV1SecretService kubernetesSecretService, ILog log)
+        public KubernetesMachineKeyEncryptor(IKubernetesV1SecretService kubernetesSecretService, ISystemLog log)
         {
             var secret = kubernetesSecretService.TryGet(SecretName, CancellationToken.None).GetAwaiter().GetResult() ?? throw new InvalidOperationException($"Unable to retrieve MachineKey from secret for namespace {KubernetesConfig.Namespace}");
 
-            if (!secret.Data.TryGetValue(MachineKeyName, out machineKey) ||
+            if (secret.Data is null ||
+                !secret.Data.TryGetValue(MachineKeyName, out machineKey) ||
                 !secret.Data.TryGetValue(MachineIvName, out machineIv))
             {
                 var (key, iv) = GenerateMachineKey(log);

--- a/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Configuration.Crypto
     {
     }
 
-public class KubernetesMachineKeyEncryptor : IKubernetesMachineKeyEncryptor
+    public class KubernetesMachineKeyEncryptor : IKubernetesMachineKeyEncryptor
     {
         const string SecretName = "tentacle-secret";
         const string MachineKeyName = "machine-key";

--- a/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
@@ -52,7 +52,7 @@ namespace Octopus.Tentacle.Configuration.Crypto
         }
         V1Secret GetSecret()
         {
-            return kubernetesSecretService.TryGet(SecretName, CancellationToken.None).GetAwaiter().GetResult() ?? throw new InvalidOperationException($"Unable to retrieve MachineKey from secret for namespace {KubernetesConfig.Namespace}");
+            return kubernetesSecretService.TryGetSecretAsync(SecretName, CancellationToken.None).GetAwaiter().GetResult() ?? throw new InvalidOperationException($"Unable to retrieve MachineKey from secret for namespace {KubernetesConfig.Namespace}");
         }
 
         (byte[] key, byte[] iv) GetMachineKey()
@@ -65,7 +65,7 @@ namespace Octopus.Tentacle.Configuration.Crypto
                 (key, iv) = GenerateMachineKey(log);
                 data = new Dictionary<string, byte[]> { { MachineKeyName, key }, { MachineIvName, iv } };
 
-                kubernetesSecretService.Patch(SecretName, data, CancellationToken.None).GetAwaiter().GetResult();
+                kubernetesSecretService.UpdateSecretDataAsync(SecretName, data, CancellationToken.None).GetAwaiter().GetResult();
             }
 
             if (key == null || iv == null)

--- a/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/KubernetesMachineKeyEncryptor.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using k8s;
+using k8s.Models;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Kubernetes;
+
+namespace Octopus.Tentacle.Configuration.Crypto
+{
+    public class KubernetesMachineKeyEncryptor : IMachineKeyEncryptor
+    {
+        const string SecretName = "tentacle-secret";
+        const string MachineKeyName = "machine-key";
+        const string MachineIvName = "machine-iv";
+
+        readonly byte[]? machineKey;
+        readonly byte[]? machineIv;
+        public KubernetesMachineKeyEncryptor(ILog log)
+        {
+            var @namespace = KubernetesConfig.Namespace;
+            var kubeConfig = KubernetesClientConfiguration.InClusterConfig();
+            var client = new k8s.Kubernetes(kubeConfig);
+
+            var secret = CreateSecret(@namespace, client, log);
+
+            if (!secret.Data.TryGetValue(MachineKeyName, out machineKey) ||
+                !secret.Data.TryGetValue(MachineIvName, out machineIv))
+            {
+                var (key, iv) = GenerateMachineKey(log);
+                secret.Data[MachineKeyName] = machineKey = key;
+                secret.Data[MachineIvName] = machineIv = iv;
+
+                client.CoreV1.ReplaceNamespacedSecret(secret, SecretName, @namespace);
+            }
+
+            if (machineKey == null || machineIv == null)
+            {
+                throw new InvalidOperationException("Unable to retrieve or create a machine key for encryption.");
+            }
+        }
+
+        public string Encrypt(string raw)
+        {
+            using var aes = Aes.Create();
+            using var enc = aes.CreateEncryptor(machineKey!, machineIv);
+            var inBlock = Encoding.UTF8.GetBytes(raw);
+            var trans = enc.TransformFinalBlock(inBlock, 0, inBlock.Length);
+            return Convert.ToBase64String(trans);
+        }
+
+        public string Decrypt(string encrypted)
+        {
+            using var aes = Aes.Create();
+            using var dec = aes.CreateDecryptor(machineKey!, machineIv);
+            var fromBase = Convert.FromBase64String(encrypted);
+            var asd = dec.TransformFinalBlock(fromBase, 0, fromBase.Length);
+            return Encoding.UTF8.GetString(asd);
+        }
+
+        static (byte[] key, byte[] iv) GenerateMachineKey(ILog log)
+        {
+            log.Info("Machine key file does not yet exist. Generating key that will be used to encrypt data for this tentacle.");
+            var aes = Aes.Create();
+            aes.GenerateIV();
+            aes.GenerateKey();
+            return (aes.Key, aes.IV);
+        }
+
+        static V1Secret CreateSecret(string @namespace, AbstractKubernetes client, ILog log)
+        {
+            V1Secret? secret;
+            try
+            {
+                secret = client.CoreV1.ReadNamespacedSecret(SecretName, @namespace);
+            }
+            catch
+            {
+                log.Info($"Secret for Tentacle Configuration not found for namespace {@namespace}, creating new Secret.");
+                secret = null;
+            }
+
+            if (secret is not null)
+                return secret;
+
+            var (key, iv) = GenerateMachineKey(log);
+            return client.CoreV1.CreateNamespacedSecret(
+                new V1Secret
+                {
+                    Metadata = new V1ObjectMeta { Name = SecretName, NamespaceProperty = @namespace },
+                    Data = new Dictionary<string, byte[]> { { MachineKeyName, key }, {MachineIvName, iv} }
+                }, @namespace);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Configuration/Crypto/MachineKeyEncryptor.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/MachineKeyEncryptor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Configuration.Crypto
@@ -10,7 +11,18 @@ namespace Octopus.Tentacle.Configuration.Crypto
 
         static MachineKeyEncryptor()
         {
-            Current = PlatformDetection.IsRunningOnWindows ? new WindowsMachineKeyEncryptor() : LinuxEncryptor();
+            if (KubernetesConfig.IsRunningInKubernetesCluster)
+            {
+                Current = new KubernetesMachineKeyEncryptor(new SystemLog());
+            }
+            else if (PlatformDetection.IsRunningOnWindows)
+            {
+                Current = new WindowsMachineKeyEncryptor();
+            }
+            else
+            {
+                Current = LinuxEncryptor();
+            }
         }
 
         static IMachineKeyEncryptor LinuxEncryptor()

--- a/source/Octopus.Tentacle/Configuration/Crypto/MachineKeyEncryptor.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/MachineKeyEncryptor.cs
@@ -11,11 +11,7 @@ namespace Octopus.Tentacle.Configuration.Crypto
 
         static MachineKeyEncryptor()
         {
-            if (KubernetesConfig.IsRunningInKubernetesCluster)
-            {
-                Current = new KubernetesMachineKeyEncryptor(new SystemLog());
-            }
-            else if (PlatformDetection.IsRunningOnWindows)
+            if (PlatformDetection.IsRunningOnWindows)
             {
                 Current = new WindowsMachineKeyEncryptor();
             }

--- a/source/Octopus.Tentacle/Configuration/Instances/ConfigMapKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ConfigMapKeyValueStore.cs
@@ -86,15 +86,13 @@ namespace Octopus.Tentacle.Configuration.Instances
             return true;
         }
 
-        string EncryptIfRequired(string? input, ProtectionLevel protectionLevel)
+        string EncryptIfRequired(string input, ProtectionLevel protectionLevel)
         {
-            input ??= string.Empty;
             return protectionLevel == ProtectionLevel.MachineKey ? encryptor.Encrypt(input) : input;
         }
 
-        string DecryptIfRequired(string? input, ProtectionLevel protectionLevel)
+        string DecryptIfRequired(string input, ProtectionLevel protectionLevel)
         {
-            input ??= string.Empty;
             return protectionLevel == ProtectionLevel.MachineKey ? encryptor.Decrypt(input) : input;
         }
     }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesSecretService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesSecretService.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Kubernetes
     {
         Task<V1Secret?> TryGetSecretAsync(string name, CancellationToken cancellationToken);
         Task CreateSecretAsync(V1Secret secret, CancellationToken cancellationToken);
-        Task UpdateSecretDataAsync(string secretName, Dictionary<string, byte[]> secretData, CancellationToken cancellationToken);
+        Task UpdateSecretDataAsync(string secretName, IDictionary<string, byte[]> secretData, CancellationToken cancellationToken);
     }
 
     public class KubernetesSecretService : KubernetesService, IKubernetesSecretService
@@ -42,7 +42,7 @@ namespace Octopus.Tentacle.Kubernetes
             await Client.CreateNamespacedSecretAsync(secret, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
         }
 
-        public async Task UpdateSecretDataAsync(string secretName, Dictionary<string, byte[]> secretData, CancellationToken cancellationToken)
+        public async Task UpdateSecretDataAsync(string secretName, IDictionary<string, byte[]> secretData, CancellationToken cancellationToken)
         {
             var patchSecret = new V1Secret
             {


### PR DESCRIPTION
# Background

Part of #project-k8s-agent

In the recent PR #674 I updated tentacle to allow it to store it's configuraiton in a kubernetes configmap instead of a file. This bypassed any machine key encryption which is what this PR adds.

# Results

We need to encrypt certain items that are added to the configuration store using a machine key which is generated when the tentacle is first configured.

We're adding the `KubernetesSecretService` 🕵️ to provide access to kubernetes secrets so we can store the machine key there.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.