### PR TITLE
Create debug container with Rider debugging tools

### DIFF
--- a/build-k8s-docker-local.ps1
+++ b/build-k8s-docker-local.ps1
@@ -1,21 +1,26 @@
 param (    
-    [Parameter()]
     [string]
     $BuildArch = "amd64",
     
-    [Parameter()]
     [string]
     $LocalRegistryDomain = "localhost:5500",
 
-    [Parameter()]
     [switch]
-    $NonMinikubeRegistry = $false
+    $NonMinikubeRegistry = $false,
+
+    [switch]
+    $BuildDebugImage,
+
+    [switch]
+    $SkipBuild
 )
 
 $runtimeToBuild = "linux-$BuildArch".Replace("amd", "x")
 
 #First we pack the unsigned builds
-& .\build.ps1 -Target "PackLinuxUnsigned" -RuntimeId $runtimeToBuild
+if (!$SkipBuild) {
+    & .\build.ps1 -Target "PackLinuxUnsigned" -RuntimeId $runtimeToBuild
+}
 
 #Now find the latest package version
 $package = Get-ChildItem -Path "$PSScriptRoot/_artifacts/deb" -Filter "tentacle_*_$BuildArch.deb"
@@ -28,9 +33,35 @@ $env:BUILD_NUMBER = $buildNumber
 $env:BUILD_DATE = Get-Date -Format "yyyy-MM-dd"
 $env:BUILD_ARCH = $BuildArch
 
+$baseTag = "$buildNumber-linux-$BuildArch"
+$tag = $baseTag
+
+$artifactoryImage = "docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle"
+$localImage = "$LocalRegistryDomain/kubernetes-tentacle"
+
+Write-Output "Building image"
+
 & docker compose -f docker-compose.build.yml -v build --pull octopusdeploy-kubernetes-tentacle-linux
 
-& docker tag "docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:$buildNumber-linux-$BuildArch" "$LocalRegistryDomain/kubernetes-tentacle:$buildNumber-linux-$BuildArch"
+$builtImage = "$($artifactoryImage):$tag"
+$builtLocalImage = "$($localImage):$tag"
+
+if ($BuildDebugImage) {
+    Write-Output "Building debug image"
+    
+    $env:IMAGE_TAG = $tag
+    $env:DEBUGGER_ARCH = $runtimeToBuild
+
+    & docker compose -f docker-compose.build-dev.yml -v build octopusdeploy-kubernetes-tentacle-linux
+    
+    $tag = "$tag-debug"    
+    $builtImage = "$($artifactoryImage):$tag"
+    $builtLocalImage = "$($localImage):$tag"
+}
+
+
+& docker tag $builtImage $builtLocalImage
+
 
 if (!$NonMinikubeRegistry) {
     $registryPort = ($LocalRegistryDomain -split ":")[-1]
@@ -42,7 +73,6 @@ if (!$NonMinikubeRegistry) {
     $portForwardProcess = Start-Process kubectl -ArgumentList "port-forward --namespace kube-system service/registry $($registryPort):80" -NoNewWindow -PassThru
     
     Write-Output "Running network forwarding docker container"
-    $minikubeIP = & minikube ip
     $containerId = & docker run --rm -d --network=host alpine/socat "tcp-listen:$registryPort,reuseaddr,fork" "tcp-connect:host.docker.internal:$registryPort"
 
     $isRunning = $false
@@ -58,13 +88,12 @@ if (!$NonMinikubeRegistry) {
     Write-Output "Network forwarding docker container running"
 }
 
-$imageName = "$LocalRegistryDomain/kubernetes-tentacle:$buildNumber-linux-$BuildArch"
+Write-Output "Pushing $builtLocalImage"
 
-Write-Output "Pushing $imageName"
+& docker push $builtLocalImage
 
-& docker push $imageName
+Write-Output "Pushed $builtLocalImage"
 
-Write-Output "Pushed $imageName"
 
 if (!$NonMinikubeRegistry) {
     Write-Output "Stopping network forwarding docker container"
@@ -72,3 +101,17 @@ if (!$NonMinikubeRegistry) {
     Write-Output "Stopping minikube port forwarding"
     Stop-Process -Id $portForwardProcess.Id -ErrorAction SilentlyContinue
 }
+
+Write-Output "---------"
+
+if ($BuildDebugImage) {
+    Write-Output "Base Image: $($artifactoryImage):$baseTag"
+}
+Write-Output "Built Image: $builtImage"
+Write-Output "Built Local Image: $builtLocalImage"
+Write-Output "Built Tag: $tag"
+if (!$NonMinikubeRegistry) {
+    Write-Output "Minikube Image: $($builtLocalImage.Replace($LocalRegistryDomain, "localhost:5000"))"
+}
+
+Write-Output "---------"

--- a/docker-compose.build-dev.yml
+++ b/docker-compose.build-dev.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+
+    octopusdeploy-kubernetes-tentacle-linux:
+        platform: "linux/${BUILD_ARCH:?err}"
+        build:
+            context: .
+            dockerfile: ./docker/kubernetes-tentacle/dev/Dockerfile
+            args:
+                IMAGE_TAG: ${IMAGE_TAG:?err}
+                DEBUGGER_ARCH: ${DEBUGGER_ARCH:?err}
+        image: docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:${BUILD_NUMBER?err}-linux-${BUILD_ARCH:?err}-debug

--- a/docker/kubernetes-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-tentacle/dev/Dockerfile
@@ -1,0 +1,41 @@
+ARG IMAGE_TAG
+FROM docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:$IMAGE_TAG
+
+RUN apt-get update && apt-get install -y curl p7zip-full
+
+ARG DEBUGGER_ARCH=linux-x64
+
+RUN \
+    curl -L "https://download.jetbrains.com/rider/ssh-remote-debugging/${DEBUGGER_ARCH}/jetbrains_debugger_agent_20230319.24.0" \
+    -o /usr/local/bin/debugger && \
+    chmod +x /usr/local/bin/debugger
+
+# This installs the required tools, but there are versioning issues and it isn't working as expected
+
+#ARG DEBUGGER_TOOLS_ARCH=linux64
+#ARG DEBUGGER_TOOLS_VERSION=2023.3.2
+
+# RUN mkdir ~/.local && \
+#     mkdir ~/.local/share && \
+#     mkdir ~/.local/share/JetBrains && \
+#     mkdir ~/.local/share/JetBrains/RiderRemoteDebugger && \
+#     mkdir ~/.local/share/JetBrains/RiderRemoteDebugger/${DEBUGGER_TOOLS_VERSION}
+
+# RUN \
+#     curl -L "https://data.services.jetbrains.com/products/download?code=RRD&platform=${DEBUGGER_TOOLS_ARCH}" \
+#     -o  ~/.local/share/JetBrains/RiderRemoteDebugger/${DEBUGGER_TOOLS_VERSION}/debug_tools.zip
+
+# RUN \
+#     cd ~/.local/share/JetBrains/RiderRemoteDebugger/${DEBUGGER_TOOLS_VERSION} \
+#     7z x debug_tools.zip
+
+# debugging port
+EXPOSE 7777
+
+COPY docker/kubernetes-tentacle/scripts/* /scripts/
+RUN chmod +x /scripts/*.sh
+
+COPY docker/kubernetes-tentacle/dev/scripts/* /dev-scripts/
+RUN chmod +x /scripts/*.sh
+
+CMD /dev-scripts/bootstrap.sh

--- a/docker/kubernetes-tentacle/dev/scripts/bootstrap.sh
+++ b/docker/kubernetes-tentacle/dev/scripts/bootstrap.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+./dev-scripts/start-debugger.sh &
+
+(./scripts/configure-tentacle.sh && /scripts/run-tentacle.sh)
+
+wait -n
+
+exit $?

--- a/docker/kubernetes-tentacle/dev/scripts/start-debugger.sh
+++ b/docker/kubernetes-tentacle/dev/scripts/start-debugger.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/local/bin/debugger -port 7777


### PR DESCRIPTION
# Background

Updates the `build-k8s-docker-local.ps1` script with a new parameter to create a version of the Kubernetes Tentacle container with the Rider SSH debugging tools installed. https://www.jetbrains.com/help/rider/SSH_Remote_Debugging.html

# Results

There is also a new `-SkipBuild` parameter for skipping the dotnet build if you are just making revisions on the container (and don't need to build the code each time)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.