### PR TITLE
Add standard metadata to all created Kubernetes objects

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -4,11 +4,16 @@ namespace Octopus.Tentacle.Kubernetes
 {
     public static class KubernetesConfig
     {
-        public static string Namespace => GetRequiredEnvVar("OCTOPUS__K8STENTACLE__NAMESPACE", "Unable to determine Kubernetes namespace.");
-        public static string JobServiceAccountName => GetRequiredEnvVar("OCTOPUS__K8STENTACLE__JOBSERVICEACCOUNTNAME", "Unable to determine Kubernetes Job service account name.");
-        public static string JobVolumeYaml => GetRequiredEnvVar("OCTOPUS__K8STENTACLE__JOBVOLUMEYAML", "Unable to determine Kubernetes Job volume yaml.");
-        public static bool UseJobs => bool.TryParse(Environment.GetEnvironmentVariable("OCTOPUS__K8STENTACLE__USEJOBS"), out var useJobs) && useJobs;
-        public static int JobTtlSeconds => int.TryParse(Environment.GetEnvironmentVariable("OCTOPUS__K8STENTACLE__JOBTTL"), out var jobTtl) ? jobTtl : 60; //Default 1min
+        const string EnvVarPrefix = "OCTOPUS__K8STENTACLE";
+
+        public static string Namespace => GetRequiredEnvVar($"{EnvVarPrefix}__NAMESPACE", "Unable to determine Kubernetes namespace.");
+        public static string JobServiceAccountName => GetRequiredEnvVar($"{EnvVarPrefix}__JOBSERVICEACCOUNTNAME", "Unable to determine Kubernetes Job service account name.");
+        public static string JobVolumeYaml => GetRequiredEnvVar($"{EnvVarPrefix}__JOBVOLUMEYAML", "Unable to determine Kubernetes Job volume yaml.");
+        public static bool UseJobs => bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__USEJOBS"), out var useJobs) && useJobs;
+        public static int JobTtlSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__JOBTTL"), out var jobTtl) ? jobTtl : 60; //Default 1min
+
+        public static string HelmReleaseName => GetRequiredEnvVar($"{EnvVarPrefix}__HELMRELEASENAME", "Unable to determine Helm release name.");
+        public static string HelmChartVersion => GetRequiredEnvVar($"{EnvVarPrefix}__HELMCHARTVERSION", "Unable to determine Helm chart version.");
 
         static string GetRequiredEnvVar(string variable, string errorMessage)
             => Environment.GetEnvironmentVariable(variable)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobService.cs
@@ -67,7 +67,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         public async Task CreateJob(V1Job job, CancellationToken cancellationToken)
         {
-            AddStandardMetadata(job.Metadata);
+            AddStandardMetadata(job);
             await Client.CreateNamespacedJobAsync(job, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
         }
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobService.cs
@@ -65,7 +65,11 @@ namespace Octopus.Tentacle.Kubernetes
 
         public string BuildJobName(ScriptTicket scriptTicket) => $"octopus-job-{scriptTicket.TaskId}".ToLowerInvariant();
 
-        public async Task CreateJob(V1Job job, CancellationToken cancellationToken) => await Client.CreateNamespacedJobAsync(job, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
+        public async Task CreateJob(V1Job job, CancellationToken cancellationToken)
+        {
+            AddStandardMetadata(job.Metadata);
+            await Client.CreateNamespacedJobAsync(job, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
+        }
 
         public async Task Delete(ScriptTicket scriptTicket, CancellationToken cancellationToken) => await Client.DeleteNamespacedJobAsync(BuildJobName(scriptTicket), KubernetesConfig.Namespace, cancellationToken: cancellationToken);
     }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesSecretService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesSecretService.cs
@@ -38,7 +38,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         public async Task CreateSecretAsync(V1Secret secret, CancellationToken cancellationToken)
         {
-            AddStandardMetadata(secret.Metadata);
+            AddStandardMetadata(secret);
             await Client.CreateNamespacedSecretAsync(secret, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
         }
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesSecretService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesSecretService.cs
@@ -37,7 +37,10 @@ namespace Octopus.Tentacle.Kubernetes
         }
 
         public async Task CreateSecretAsync(V1Secret secret, CancellationToken cancellationToken)
-            => await Client.CreateNamespacedSecretAsync(secret, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
+        {
+            AddStandardMetadata(secret.Metadata);
+            await Client.CreateNamespacedSecretAsync(secret, KubernetesConfig.Namespace, cancellationToken: cancellationToken);
+        }
 
         public async Task UpdateSecretDataAsync(string secretName, Dictionary<string, byte[]> secretData, CancellationToken cancellationToken)
         {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesService.cs
@@ -1,4 +1,6 @@
-﻿using k8sClient = k8s.Kubernetes;
+﻿using k8s;
+using k8s.Models;
+using k8sClient = k8s.Kubernetes;
 
 namespace Octopus.Tentacle.Kubernetes
 {
@@ -9,6 +11,21 @@ namespace Octopus.Tentacle.Kubernetes
         protected KubernetesService(IKubernetesClientConfigProvider configProvider)
         {
             Client = new k8sClient(configProvider.Get());
+        }
+
+        /// <summary>
+        /// Adds standard metadata to this <see cref="IKubernetesObject{TMetadata}"/>
+        /// </summary>
+        /// <param name="k8sObject">The Kubernetes object to add the metadata to.</param>
+        protected void AddStandardMetadata(IKubernetesObject<V1ObjectMeta> k8sObject)
+        {
+            //Everything should be in the main namespace
+            k8sObject.Metadata.NamespaceProperty = KubernetesConfig.Namespace;
+
+            //Add helm specific metadata so it's w
+            k8sObject.Metadata.Annotations["meta.helm.sh/release-name"] = KubernetesConfig.HelmReleaseName;
+            k8sObject.Metadata.Annotations["meta.helm.sh/release-namespace"] = KubernetesConfig.Namespace;
+            k8sObject.Metadata.Labels["app.kubernetes.io/managed-by"] = "Helm";
         }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesService.cs
@@ -22,7 +22,7 @@ namespace Octopus.Tentacle.Kubernetes
             //Everything should be in the main namespace
             k8sObject.Metadata.NamespaceProperty = KubernetesConfig.Namespace;
 
-            //Add helm specific metadata so it's w
+            //Add helm specific metadata so it's removed if the helm release is uninstalled
             k8sObject.Metadata.Annotations["meta.helm.sh/release-name"] = KubernetesConfig.HelmReleaseName;
             k8sObject.Metadata.Annotations["meta.helm.sh/release-namespace"] = KubernetesConfig.Namespace;
             k8sObject.Metadata.Labels["app.kubernetes.io/managed-by"] = "Helm";


### PR DESCRIPTION
# Background

Let's make sure that all Kubernetes objects created have the correct namespace set as well as has metadata so that it's included in the helm release (so we don't have left over resources when the helm chart is uninstalled)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.