### PR TITLE
Fix chmod for dev-scripts

### DIFF
--- a/docker/kubernetes-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-tentacle/dev/Dockerfile
@@ -36,6 +36,6 @@ COPY docker/kubernetes-tentacle/scripts/* /scripts/
 RUN chmod +x /scripts/*.sh
 
 COPY docker/kubernetes-tentacle/dev/scripts/* /dev-scripts/
-RUN chmod +x /scripts/*.sh
+RUN chmod +x /dev-scripts/*.sh
 
 CMD /dev-scripts/bootstrap.sh


### PR DESCRIPTION
# Background

This Dockerfile is for creating a debuggable kubernetes tentacle image.

We realised this was a copy paste error when looking into another issue so just a quick fix up.

# Results

Now the dev scripts have execution set correctly

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.