### PR TITLE
Adds a TentacleBackwardsCompatibility test category

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
@@ -173,7 +173,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                         }
                         #endif
                         
-                        if (item is not TentacleConfigurationTestCase {Version: null} version)
+                        if (item is not TentacleConfigurationTestCase {Version: null})
                         {
                             parms.Properties.Add(PropertyNames.Category, TentacleBackwardsCompatibility);
                         }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
@@ -44,6 +44,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         private readonly NUnitTestCaseBuilder _builder = new();
         
         public const string Net60ClientNet48Service = nameof(Net60ClientNet48Service);
+        
+        /// <summary>
+        /// Tests which are testing against a previous version of tentacle, e.g. testing tentacle client
+        /// with version 5.0.12 of tentacle.
+        /// </summary>
+        public const string TentacleBackwardsCompatibility = nameof(TentacleBackwardsCompatibility);
 
         /// <summary>
         /// Construct with a Type and name
@@ -166,6 +172,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                             parms.Properties.Add(PropertyNames.Category, Net60ClientNet48Service);
                         }
                         #endif
+                        
+                        if (item is not TentacleConfigurationTestCase {Version: null} version)
+                        {
+                            parms.Properties.Add(PropertyNames.Category, TentacleBackwardsCompatibility);
+                        }
 
                         data.Add(parms);
                     }


### PR DESCRIPTION
# Background

Integration tests which test with an older version of tentacle are now categorised with `TentacleBackwardsCompatibility`.

Doing so will make it possible to not test this category on some teamcity OS VM agents.

[SC-65861]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.