### PR TITLE
Run Integration Tests Script for VMs supports sudo

### DIFF
--- a/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
+++ b/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
@@ -14,4 +14,11 @@ $SCRIPT_DIR/setup-vm-agent.sh
 source $SCRIPT_DIR/set-dotnet-envvars.sh
 
 itdll=`pwd`/build/outputs/integrationtests/net6.0/linux-x64/Octopus.Tentacle.Tests.Integration.dll
+
+
+if [ "$TENTACLE_IT_WITH_SUDO" = "1" ]; then
+sudo dotnet vstest $itdll /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
+else
 dotnet vstest $itdll /testcasefilter:TestCategory!=RequiresSudoOnLinux /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
+fi
+

--- a/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
+++ b/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
@@ -17,7 +17,7 @@ itdll=`pwd`/build/outputs/integrationtests/net6.0/linux-x64/Octopus.Tentacle.Tes
 
 
 if [ "$TENTACLE_IT_WITH_SUDO" = "1" ]; then
-sudo dotnet vstest $itdll /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
+sudo -i dotnet vstest $itdll /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 else
 dotnet vstest $itdll /testcasefilter:TestCategory!=RequiresSudoOnLinux /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 fi


### PR DESCRIPTION
# Background

[SC-65861]

The integration test scripts for VMs now supports running tests with sudo, since some VMs have users with sudo access. This means we can run Integration tests that require sudo in those cases.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.