### PR TITLE
Don't run Tentacle Compatibility tests with VMs

### DIFF
--- a/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
+++ b/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
@@ -17,7 +17,7 @@ itdll=`pwd`/build/outputs/integrationtests/net6.0/linux-x64/Octopus.Tentacle.Tes
 
 
 if [ "$TENTACLE_IT_WITH_SUDO" = "1" ]; then
-sudo -i dotnet vstest $itdll /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
+sudo -i dotnet vstest $itdll "/testcasefilter:TestCategory!=TentacleBackwardsCompatibility" /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 else
 dotnet vstest $itdll "/testcasefilter:TestCategory!=RequiresSudoOnLinux&TestCategory!=TentacleBackwardsCompatibility" /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 fi

--- a/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
+++ b/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
@@ -19,6 +19,6 @@ itdll=`pwd`/build/outputs/integrationtests/net6.0/linux-x64/Octopus.Tentacle.Tes
 if [ "$TENTACLE_IT_WITH_SUDO" = "1" ]; then
 sudo -i dotnet vstest $itdll /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 else
-dotnet vstest $itdll /testcasefilter:TestCategory!=RequiresSudoOnLinux /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
+dotnet vstest $itdll "/testcasefilter:TestCategory!=RequiresSudoOnLinux&TestCategory!=TentacleBackwardsCompatibility" /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 fi
 


### PR DESCRIPTION
# Background

[SC-65861]

To avoid needing VMs to have old ssl libs installed, this stops testing on VMs only that compatibility with old tentacles is maintained.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.