### PR TITLE
Disable journalling on Kubernetes Agent scripts - there's no need for it

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
@@ -339,7 +339,7 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
                                         new("/octopus", "tentacle-home"),
                                     },
                                     Env = new List<V1EnvVar>
-                                    {                                        
+                                    {
                                         new(EnvironmentVariables.TentacleHome, $"/octopus"),
                                         new(EnvironmentVariables.TentacleInstanceName, instanceName),
                                         new(EnvironmentVariables.TentacleVersion, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleVersion)),

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
@@ -339,12 +339,14 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
                                         new("/octopus", "tentacle-home"),
                                     },
                                     Env = new List<V1EnvVar>
-                                    {
+                                    {                                        
                                         new(EnvironmentVariables.TentacleHome, $"/octopus"),
                                         new(EnvironmentVariables.TentacleInstanceName, instanceName),
                                         new(EnvironmentVariables.TentacleVersion, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleVersion)),
                                         new(EnvironmentVariables.TentacleCertificateSignatureAlgorithm, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleCertificateSignatureAlgorithm)),
                                         new("OCTOPUS_RUNNING_IN_CONTAINER", "Y")
+                                        
+                                        //We intentionally exclude setting "TentacleJournal" since it doesn't make sense to keep a Deployment Journal for Kubernetes deployments
                                     }
                                 }
                             },

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
@@ -341,7 +341,6 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
                                     Env = new List<V1EnvVar>
                                     {
                                         new(EnvironmentVariables.TentacleHome, $"/octopus"),
-                                        new(EnvironmentVariables.TentacleJournal, $"/octopus/DeploymentJournal.xml"),
                                         new(EnvironmentVariables.TentacleInstanceName, instanceName),
                                         new(EnvironmentVariables.TentacleVersion, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleVersion)),
                                         new(EnvironmentVariables.TentacleCertificateSignatureAlgorithm, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleCertificateSignatureAlgorithm)),


### PR DESCRIPTION
# Background
[sc-70260]
<!-- Why does this PR exist? -->

The agent doesn't need to keep a journal, since the journal is intended for long-lived extracted files that are used externally AFTER deployment has completed.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.