### PR TITLE
Add RequiresAdminOnWindows Attribute, and dont make test users when we don't need to.

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Startup/WindowsServiceConfiguratorFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/WindowsServiceConfiguratorFixture.cs
@@ -23,6 +23,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
     public class WindowsServiceConfiguratorFixture
     {
         [Test]
+        [RequiresAdminOnWindows]
         public void CanInstallWindowsService()
         {
             const string serviceName = "OctopusShared.ServiceHelperTest";
@@ -70,6 +71,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
         }
 
         [Test]
+        [RequiresAdminOnWindows]
         public void ThrowsOnBadServiceDependency()
         {
             const string serviceName = "OctopusShared.ServiceHelperTest";

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TestAttributes/RequiresAdminOnWindowsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TestAttributes/RequiresAdminOnWindowsAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class RequiresAdminOnWindowsAttribute : CategoryAttribute
+    { }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
@@ -27,7 +27,6 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         IScriptWorkspace workspace;
         TestScriptLog scriptLog;
         RunningScript runningScript;
-        TestUserPrincipal user;
 
         [SetUp]
         public void SetUpLocal()
@@ -39,7 +38,6 @@ namespace Octopus.Tentacle.Tests.Integration.Util
             {
                 testRootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), $"OctopusTest-{nameof(RunningScriptFixture)}");
                 shell = new PowerShell();
-                user = new TestUserPrincipal("test-runningscript");
             }
             else
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
@@ -14,7 +14,6 @@ namespace Octopus.Tentacle.Tests.Integration.Util
     {
         const int SIG_TERM = 143;
         const int SIG_KILL = 137;
-        TestUserPrincipal user;
         string command;
         string commandParam;
 
@@ -23,7 +22,6 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         {
             if (PlatformDetection.IsRunningOnWindows)
             {
-                user = new TestUserPrincipal("test-silentprocess");
                 command = "cmd.exe";
                 commandParam = "/c";
             }


### PR DESCRIPTION
# Background

Removes the creation of a windows user from some tests since, it wasn't required.

Adds a `[RequiresAdminOnWindows]` test attribute for integration tests which require admin on windows.

Doing this means the windows build can be run in containers and the windows VM builds wont need to run with old versions of tentacles.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.