### PR TITLE
Add new timeout for job watch api call

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -11,6 +11,7 @@ namespace Octopus.Tentacle.Kubernetes
         public static string JobVolumeYaml => GetRequiredEnvVar($"{EnvVarPrefix}__JOBVOLUMEYAML", "Unable to determine Kubernetes Job volume yaml.");
         public static bool UseJobs => bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__USEJOBS"), out var useJobs) && useJobs;
         public static int JobTtlSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__JOBTTL"), out var jobTtl) ? jobTtl : 60; //Default 1min
+        public static int JobMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__JOBMONITORTIMEOUT"), out var jobMonitorTimeout) ? jobMonitorTimeout : 1800; //30min
 
         public static string HelmReleaseName => GetRequiredEnvVar($"{EnvVarPrefix}__HELMRELEASENAME", "Unable to determine Helm release name.");
         public static string HelmChartVersion => GetRequiredEnvVar($"{EnvVarPrefix}__HELMCHARTVERSION", "Unable to determine Helm chart version.");

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobService.cs
@@ -47,7 +47,7 @@ namespace Octopus.Tentacle.Kubernetes
                 //only list this job
                 fieldSelector: $"metadata.name=={jobName}",
                 watch: true,
-                timeoutSeconds: KubernetesConfig.JobTtlSeconds,
+                timeoutSeconds: KubernetesConfig.JobMonitorTimeoutSeconds,
                 cancellationToken: cancellationToken);
 
             await foreach (var (type, job) in response.WatchAsync<V1Job, V1JobList>(onError, cancellationToken: cancellationToken))


### PR DESCRIPTION
# Background

We identified an issue where if the job took longer to run than the job TTL (default 60s), then the `jobService.Watch` call would timeout, which would "complete" the job and no longer record any logs.

This would happen most obviously the first time you acquire an execution image and the job would complete in the octopus UI before the job would execute.

# Results

Introduces a new environment variable `OCTOPUS__K8STENTACLE__JOBMONITORTIMEOUT` for adjusting the timeout of this watch call. Default's to 30min if not specified.

The watch still finishes when signalled or when the job has been deleted.

Shortcut story: [sc-70357]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.