### PR TITLE
The linux configure-tentacle.sh script now supports setting comms ports other than 10943.

### DIFF
--- a/linux-packages/content/configure-tentacle.sh
+++ b/linux-packages/content/configure-tentacle.sh
@@ -100,6 +100,7 @@ function setupPollingTentacle {
     rolesstring=""
     workerpoolsstring=""
     machinetype=1
+    servercommsport=10943
 
     read -p "Where would you like Tentacle to store log files? ($logpath):" inputlogpath
     logpath=$(assignNonEmptyValue "$inputlogpath" $logpath)
@@ -149,6 +150,9 @@ function setupPollingTentacle {
     read -p "What name would you like to register this Tentacle with? ($displayname): " displaynameinput
     displayname=$(assignNonEmptyValue "$displaynameinput" $displayname)
 
+    read -p "What port is the Octopus Server comms port? ($servercommsport): " servercommsportinput
+    servercommsport=$(assignNonEmptyValue "$servercommsportinput" $servercommsport)
+
     case $machinetype in
         2 | worker)
             #Get worker pools
@@ -181,9 +185,9 @@ function setupPollingTentacle {
     echo -e "sudo /opt/octopus/tentacle/Tentacle configure --instance \"$instancename\" --app \"$applicationpath\" --noListen \"True\" --reset-trust"
 
     if [ $machinetype = 2 ] || [ $machinetype = "worker" ]; then
-        echo -e "sudo /opt/octopus/tentacle/Tentacle register-worker --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" --server-comms-port \"10943\" $displayauth --space \"$space\" $workerpoolsstring"
+        echo -e "sudo /opt/octopus/tentacle/Tentacle register-worker --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" --server-comms-port \"$servercommsport\" $displayauth --space \"$space\" $workerpoolsstring"
     else
-        echo -e "sudo /opt/octopus/tentacle/Tentacle register-with --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" --server-comms-port \"10943\" $displayauth --space \"$space\" $envstring $rolesstring"
+        echo -e "sudo /opt/octopus/tentacle/Tentacle register-with --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" --server-comms-port \"$servercommsport\" $displayauth --space \"$space\" $envstring $rolesstring"
     fi
 
     echo -e "sudo /opt/octopus/tentacle/Tentacle service --install --start --instance \"$instancename\"${NC}"
@@ -200,9 +204,9 @@ function setupPollingTentacle {
     exitIfCommandFailed 
 
     if [ $machinetype = 2 ] || [ $machinetype = "worker" ]; then
-        eval sudo /opt/octopus/tentacle/Tentacle register-worker --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" --server-comms-port \"10943\" $auth --space \"$space\" $workerpoolsstring
+        eval sudo /opt/octopus/tentacle/Tentacle register-worker --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" --server-comms-port \"$servercommsport\" $auth --space \"$space\" $workerpoolsstring
     else
-        eval sudo /opt/octopus/tentacle/Tentacle register-with --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" --server-comms-port \"10943\" $auth --space \"$space\" $envstring $rolesstring
+        eval sudo /opt/octopus/tentacle/Tentacle register-with --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" --server-comms-port \"$servercommsport\" $auth --space \"$space\" $envstring $rolesstring
     fi
 
     exitIfCommandFailed


### PR DESCRIPTION
# Background

[SC-68270]

Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/793

Related to: https://github.com/OctopusDeploy/OctopusTentacle/issues/527



# Results

## Before

The script would always assume `10943` as the comms port.
## After
It now asks if the comms port is at the same or different address:

```
Is the comms port on the same domain as the Octopus Server : 1) Yes or 2) No (default 1): 2
What is the Octopus Server comms address including port e.g. 'https://polling.<yoururl>.octopus.app:443' ?: https://127.0.0.1:11943
```

which results in:
```
sudo /opt/octopus/tentacle/Tentacle register-with --instance "Tentacle" --server "http://127.0.0.1:8066" --name "aero2" --comms-style "TentacleActive" --server-comms-address "https://127.0.0.1:11943" --apiKey "API-XXXXXXXXXXXXXXXXXXXXXXXXXX" --space "Default" --environment "bready"  --role "roll" 
```

If the address is the same we also ask what port:

```
Is the comms port on the same domain as the Octopus Server : 1) Yes or 2) No (default 1): 
What port is the Octopus Server comms port? (10943): 11943
```
and the resulting command:
```
sudo /opt/octopus/tentacle/Tentacle register-with --instance "aa-luke-2" --server "http://127.0.0.1:8066" --name "aero4" --comms-style "TentacleActive" --server-comms-port "11943" --apiKey "API-XXXXXXXXXXXXXXXXXXXXXXXXXX" --space "Default" --environment "Dev"  --role "bread" 
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.