### PR TITLE
vstest exit code should not cause the build to fail

### DIFF
--- a/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
+++ b/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
@@ -16,6 +16,8 @@ source $SCRIPT_DIR/set-dotnet-envvars.sh
 itdll=`pwd`/build/outputs/integrationtests/net6.0/linux-x64/Octopus.Tentacle.Tests.Integration.dll
 
 
+# We don't care about the exit code of dotnet test and instead depend on tests passing.
+set +e
 if [ "$TENTACLE_IT_WITH_SUDO" = "1" ]; then
 sudo -E env PATH=$PATH dotnet vstest $itdll "/testcasefilter:TestCategory!=TentacleBackwardsCompatibility" /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 else


### PR DESCRIPTION
# Background

We are seeing builds fail where no tests have failed e.g.:

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/7076477/ca0788c2-8838-476a-89d3-ad1134f245c9)

this is probably caused because we recently changed the build script to return exit 1 when vstest has a failed test. Previously we ignored the exit code of the vstest command.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.