### PR TITLE
Add job container for Kubernetes 1.29

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobContainerRegistry.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobContainerRegistry.cs
@@ -24,6 +24,7 @@ namespace Octopus.Tentacle.Kubernetes
             new(1, 26, 3),
             new(1, 27, 3),
             new(1, 28, 2),
+            new(1, 29, 1),
         };
 
         public async Task<string> GetContainerImageForCluster()


### PR DESCRIPTION
# Background

If customers are running a v1.29 Kubernetes cluster, we need to use the correct `octopuslabs/k8s-workertools` tag

https://hub.docker.com/layers/octopuslabs/k8s-workertools/1.29.1/images/sha256-977619da8d8b9f2c74392f9fca0072e7a4047b2ed6a40b26fcb05389683d77fa?context=explore

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.