### PR TITLE
Set resource requests on Kubernetes Jobs

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
@@ -354,7 +354,7 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
                                         Requests = new Dictionary<string, ResourceQuantity>
                                         {
                                             ["cpu"] = new("25m"),
-                                            ["memory"] = new ("50Mi")
+                                            ["memory"] = new ("100Mi")
                                         }
                                     }
                                 }

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
@@ -345,8 +345,17 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
                                         new(EnvironmentVariables.TentacleVersion, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleVersion)),
                                         new(EnvironmentVariables.TentacleCertificateSignatureAlgorithm, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleCertificateSignatureAlgorithm)),
                                         new("OCTOPUS_RUNNING_IN_CONTAINER", "Y")
-                                        
+
                                         //We intentionally exclude setting "TentacleJournal" since it doesn't make sense to keep a Deployment Journal for Kubernetes deployments
+                                    },
+                                    Resources = new V1ResourceRequirements
+                                    {
+                                        //set resource requests to be quite low for now as the jobs tend to run fairly quickly
+                                        Requests = new Dictionary<string, ResourceQuantity>
+                                        {
+                                            ["cpu"] = new("25m"),
+                                            ["memory"] = new ("50Mi")
+                                        }
                                     }
                                 }
                             },


### PR DESCRIPTION
# Background

Related to: https://github.com/OctopusDeploy/helm-charts/pull/57

To be good Kubernetes citizens, we should set resource requests on our job containers.

# Results

Based on testing on an AKS cluster, these requests seem quite reasonable. They are fairly lightweight and barely use any memory/CPU

Shortcut story: [sc-70554]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.