### PR TITLE
Update comment to reflect correct container

### DIFF
--- a/scripts/deploy/test-linux-package-from-feed.sh
+++ b/scripts/deploy/test-linux-package-from-feed.sh
@@ -12,7 +12,7 @@ if [[ "$OSRELID" == "rhel" && ( -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHA
   exit 1
 fi
 
-# Install the packages from our package feed (with any needed docker config, system registration) using a script from 'linux-package-feeds'.
+# Install the packages from our package feed (with any needed docker config, system registration) using the script from 'tool-linux-packages'.
 export PKG_NAMES="octopuscli tentacle"
 bash install-linux-feed-package.sh || exit
 


### PR DESCRIPTION
# Background

In https://github.com/OctopusDeploy/OctopusTentacle/pull/231, the packaging was changed to no longer use the `linux-pacakge-feeds` docker container, and use the `tool-linux-packages` container instead.

A comment referring to the old container was left behind. 

# Results

That comment is now updated.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.