### PR TITLE
Remove the patch version from job container tags

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobContainerRegistry.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobContainerRegistry.cs
@@ -21,10 +21,10 @@ namespace Octopus.Tentacle.Kubernetes
 
         static readonly List<Version> KnownLatestContainerTags = new()
         {
-            new(1, 26, 3),
-            new(1, 27, 3),
-            new(1, 28, 2),
-            new(1, 29, 1),
+            new(1, 26),
+            new(1, 27),
+            new(1, 28),
+            new(1, 29),
         };
 
         public async Task<string> GetContainerImageForCluster()
@@ -34,7 +34,7 @@ namespace Octopus.Tentacle.Kubernetes
             //find the highest tag for this cluster version
             var tagVersion = KnownLatestContainerTags.FirstOrDefault(tag => tag.Major == clusterVersion.Major && tag.Minor == clusterVersion.Minor);
 
-            var tag = tagVersion?.ToString(3) ?? "latest";
+            var tag = tagVersion?.ToString(2) ?? "latest";
 
             return $"octopuslabs/k8s-workertools:{tag}";
         }


### PR DESCRIPTION

# Background

For #project-k8s-agent

Now that the octopuslabs/k8s-workertools image is being published with `major.minor` tags, we can clean up this code a bit so that we get workertools images with the latest patches for a minor version.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.