### PR TITLE
Fix TC build for project Octopus.Manager.Tentacle.Tests

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -1,4 +1,4 @@
-// ReSharper disable RedundantUsingDirective
+﻿// ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -273,9 +273,7 @@ partial class Build
         var octopusTentacleManagerTestsDirectory = BuildDirectory / "Octopus.Manager.Tentacle.Tests" / testFramework / testRuntime;
         var testAssembliesPath = octopusTentacleTestsDirectory.GlobFiles("*.Tests.dll")
             .Union(octopusTentacleClientTestsDirectory.GlobFiles("*.Tests.dll"))
-            .Union(octopusTentacleManagerTestsDirectory.GlobFiles("*.Tests.dll")).ToArray();
-        
-        Log.Warning(string.Join(Environment.NewLine, testAssembliesPath.Select(z => z.ToString())));
+            .Union(octopusTentacleManagerTestsDirectory.GlobFiles("*.Tests.dll"));
         
         try
         {

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable RedundantUsingDirective
+// ReSharper disable RedundantUsingDirective
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -273,7 +273,9 @@ partial class Build
         var octopusTentacleManagerTestsDirectory = BuildDirectory / "Octopus.Manager.Tentacle.Tests" / testFramework / testRuntime;
         var testAssembliesPath = octopusTentacleTestsDirectory.GlobFiles("*.Tests.dll")
             .Union(octopusTentacleClientTestsDirectory.GlobFiles("*.Tests.dll"))
-            .Union(octopusTentacleManagerTestsDirectory.GlobFiles("*.Tests.dll"));
+            .Union(octopusTentacleManagerTestsDirectory.GlobFiles("*.Tests.dll")).ToArray();
+        
+        Log.Warning(string.Join(Environment.NewLine, testAssembliesPath.Select(z => z.ToString())));
         
         try
         {

--- a/source/Octopus.Manager.Tentacle.Tests/ApplicationStartupSanityCheckFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/ApplicationStartupSanityCheckFixture.cs
@@ -4,7 +4,9 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using Autofac;
 using NUnit.Framework;
+using Octopus.Manager.Tentacle.TentacleConfiguration.TentacleManager;
 
 namespace Octopus.Manager.Tentacle.Tests
 {
@@ -12,6 +14,16 @@ namespace Octopus.Manager.Tentacle.Tests
     public class ApplicationStartupSanityCheckFixture
     {
         [Test]
+        public void TentacleManagerModelCanBeResolved()
+        {
+            // If we can resolve the main view model without errors,
+            // then we can safely assume all the necessary components
+            // have been correctly registered in the IoC container
+            var container = App.ConfigureContainer();
+            _ = container.Resolve<TentacleManagerModel>();
+        }
+        
+        [Ignore("Run in local enviroment only")]
         public void ApplicationCanStartWithoutCrashing()
         { 
             Exception threadException = null;

--- a/source/Octopus.Manager.Tentacle.Tests/ApplicationStartupSanityCheckFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/ApplicationStartupSanityCheckFixture.cs
@@ -23,7 +23,8 @@ namespace Octopus.Manager.Tentacle.Tests
             _ = container.Resolve<TentacleManagerModel>();
         }
         
-        [Ignore("Run in local enviroment only")]
+        [Test]
+        [Ignore("Run in local environment only")]
         public void ApplicationCanStartWithoutCrashing()
         { 
             Exception threadException = null;

--- a/source/Octopus.Manager.Tentacle.Tests/ApplicationStartupSanityCheckFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/ApplicationStartupSanityCheckFixture.cs
@@ -24,7 +24,7 @@ namespace Octopus.Manager.Tentacle.Tests
         }
         
         [Test]
-        [Ignore("Run in local environment only")]
+        [Ignore("Run in local environment only. Programmatically starting WPF app will crash TeamCity host.")]
         public void ApplicationCanStartWithoutCrashing()
         { 
             Exception threadException = null;

--- a/source/Octopus.Manager.Tentacle/App.xaml.cs
+++ b/source/Octopus.Manager.Tentacle/App.xaml.cs
@@ -53,6 +53,9 @@ namespace Octopus.Manager.Tentacle
             ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
             var container = ConfigureContainer();
+            
+            if (!HasPrerequisites(new TentaclePrerequisiteProfile()))
+                Environment.Exit(0);
 
             if (reconfigure)
             {
@@ -67,7 +70,7 @@ namespace Octopus.Manager.Tentacle
             CreateAndShowShell(container);
         }
 
-        static IContainer ConfigureContainer()
+        public static IContainer ConfigureContainer()
         {
             var builder = new ContainerBuilder();
 
@@ -76,9 +79,6 @@ namespace Octopus.Manager.Tentacle
             builder.RegisterModule(new OctopusFileSystemModule());
             builder.RegisterType<CertificateGenerator>().As<ICertificateGenerator>();
             builder.RegisterModule(new ManagerConfigurationModule(ApplicationName.Tentacle));
-
-            if (!HasPrerequisites(new TentaclePrerequisiteProfile()))
-                Environment.Exit(0);
 
             builder.RegisterModule(new TentacleConfigurationModule());
             builder.RegisterModule(new TentacleModule());

--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -1,5 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
+    <AssemblyName>Octopus.Manager.Tentacle</AssemblyName>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <RootNamespace>Octopus.Manager.Tentacle</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPublishable>false</IsPublishable>
     <OutputPath>bin</OutputPath>

--- a/source/Tentacle.sln
+++ b/source/Tentacle.sln
@@ -47,6 +47,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octopus.Tentacle.Client.Tests", "Octopus.Tentacle.Client.Tests\Octopus.Tentacle.Client.Tests.csproj", "{48C4D03B-F044-4089-942E-20DF102059F0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octopus.Manager.Tentacle.Tests", "Octopus.Manager.Tentacle.Tests\Octopus.Manager.Tentacle.Tests.csproj", "{20B8E669-D121-426B-97C9-84A866430635}"
+  ProjectSection(ProjectDependencies) = postProject
+  		{A9E01394-4A21-418F-9ACC-D5A164E8491B} = {A9E01394-4A21-418F-9ACC-D5A164E8491B}
+  EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/source/Tentacle.sln
+++ b/source/Tentacle.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33627.172
@@ -260,8 +260,11 @@ Global
 		{20B8E669-D121-426B-97C9-84A866430635}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{20B8E669-D121-426B-97C9-84A866430635}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20B8E669-D121-426B-97C9-84A866430635}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{20B8E669-D121-426B-97C9-84A866430635}.Release|Any CPU.Build.0 = Release|Any CPU
 		{20B8E669-D121-426B-97C9-84A866430635}.Release-net48-win|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release-net6.0-win-x64|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release-net48-win|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/Tentacle.sln
+++ b/source/Tentacle.sln
@@ -48,7 +48,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octopus.Tentacle.Client.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octopus.Manager.Tentacle.Tests", "Octopus.Manager.Tentacle.Tests\Octopus.Manager.Tentacle.Tests.csproj", "{20B8E669-D121-426B-97C9-84A866430635}"
   ProjectSection(ProjectDependencies) = postProject
-  		{A9E01394-4A21-418F-9ACC-D5A164E8491B} = {A9E01394-4A21-418F-9ACC-D5A164E8491B}
+    {A9E01394-4A21-418F-9ACC-D5A164E8491B} = {A9E01394-4A21-418F-9ACC-D5A164E8491B}
   EndProjectSection
 EndProject
 Global

--- a/source/Tentacle.sln
+++ b/source/Tentacle.sln
@@ -268,6 +268,12 @@ Global
 		{20B8E669-D121-426B-97C9-84A866430635}.Release-net6.0-win-x86|Any CPU.ActiveCfg = Debug|Any CPU
 		{20B8E669-D121-426B-97C9-84A866430635}.Release|Any CPU.Build.0 = Release|Any CPU
 		{20B8E669-D121-426B-97C9-84A866430635}.Release-net48-win|Any CPU.Build.0 = Debug|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release-net6.0-linux-arm|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release-net6.0-linux-arm64|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release-net6.0-linux-musl-x64|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release-net6.0-linux-x64|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release-net6.0-osx-arm64|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B8E669-D121-426B-97C9-84A866430635}.Release-net6.0-osx-x64|Any CPU.ActiveCfg = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Background

The newly added project `Octopus.Manager.Tentacle.Tests` isn't built in TeamCity due to the project default's configuration settings. Therefore, the tests added in this project don't run in TC either.

This PR changes the project configuration settings so that `Octopus.Manager.Tentacle.Tests` will be built with `Release-net48-win` config. Additionally, a dependency section is also added to `Tentacle.sln` to ensure MSBuild builds the projects in the right order.

[sc-70950]

The test to programmatically start the WPF application caused the TC host to crash. Thus, I inverted it back to our original approach which resolves the `TentacleManagerModel`.

# Result

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/79076870/43376626-0d9c-4690-8028-1d105cdd0694)

Tests in `Octopus.Manager.Tentacle.Tests` are run as part of the MSBuild command `TestWindows`.

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/79076870/2b908a4a-401e-4b6b-806e-fd73a499d845)

Tentacle Manager tests are now run in TeamCity build.

# How to review this PR


Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.