### PR TITLE
Fix BuildAndLoadLocallyKubernetesTentacleContainerImage build target

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -98,6 +98,8 @@
             "type": "string",
             "enum": [
               "BuildAll",
+              "BuildAndLoadLocallyKubernetesTentacleContainerImage",
+              "BuildAndPushKubernetesTentacleContainerImage",
               "BuildLinux",
               "BuildOsx",
               "BuildWindows",
@@ -143,6 +145,8 @@
             "type": "string",
             "enum": [
               "BuildAll",
+              "BuildAndLoadLocallyKubernetesTentacleContainerImage",
+              "BuildAndPushKubernetesTentacleContainerImage",
               "BuildLinux",
               "BuildOsx",
               "BuildWindows",

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -479,11 +479,11 @@ partial class Build
 
     void BuildAndPushOrLoadKubernetesTentacleContainerImage(bool push, bool load, string? host = null)
     {
-        host = host is not null ? $"{host}/" : null;
+        var hostPrefix = host is not null ? $"{host}/" : string.Empty;
         DockerTasks.DockerBuildxBuild(settings =>
             settings.AddBuildArg($"BUILD_NUMBER={FullSemVer}", $"BUILD_DATE={DateTime.UtcNow:O}")
                 .SetPlatform("linux/arm64,linux/amd64")
-                .SetTag($"{host}octopusdeploy/kubernetes-tentacle:{FullSemVer}")
+                .SetTag($"{hostPrefix}octopusdeploy/kubernetes-tentacle:{FullSemVer}")
                 .SetFile("./docker/kubernetes-tentacle/Dockerfile")
                 .SetPath(RootDirectory)
                 .SetPush(push)

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -133,7 +133,7 @@ partial class Build
         .Description("Builds and pushes the kubernetes tentacle multi-arch container image")
         .Executes(() =>
         {
-            BuildAndPushOrLoadKubernetesTentacleContainerImage(push: true, load: false);
+            BuildAndPushOrLoadKubernetesTentacleContainerImage(push: true, load: false, "docker.packages.octopushq.com");
         });
 
     [PublicAPI]
@@ -477,12 +477,13 @@ partial class Build
             $"tentacle-{FullSemVer}-{NetCore}-{runtimeId}.tar.gz");
     }
 
-    void BuildAndPushOrLoadKubernetesTentacleContainerImage(bool push, bool load)
+    void BuildAndPushOrLoadKubernetesTentacleContainerImage(bool push, bool load, string? host = null)
     {
+        host = host is not null ? $"{host}/" : null;
         DockerTasks.DockerBuildxBuild(settings =>
             settings.AddBuildArg($"BUILD_NUMBER={FullSemVer}", $"BUILD_DATE={DateTime.UtcNow:O}")
                 .SetPlatform("linux/arm64,linux/amd64")
-                .SetTag($"docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:{FullSemVer}")
+                .SetTag($"{host}octopusdeploy/kubernetes-tentacle:{FullSemVer}")
                 .SetFile("./docker/kubernetes-tentacle/Dockerfile")
                 .SetPath(RootDirectory)
                 .SetPush(push)


### PR DESCRIPTION
# Background

Now that the helm chart defaults to the docker registry for tentacle, we can build locally with the tag without the artifactory repo host name.

# Results

I've updated it so that the "Push" version still pushes to artifactory, but the build and load locally option doesn't add the hostname.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.