### PR TITLE
Allow server communication port to be overriden in Tentacle Manager

### DIFF
--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
@@ -811,6 +811,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
             validator.RuleSet("TentacleActive", delegate
             {
                 validator.RuleFor(m => m.OctopusServerUrl).Must(BeAValidUrl).WithMessage("Please enter a valid Octopus Server URL");
+                validator.RuleFor(m => m.ServerCommsPort).Matches("^[0-9]+$").WithMessage("Please enter a TCP port for Tentacle to communicate with the Octopus Server");
                 validator.RuleFor(m => m.ApiKey).Cascade(CascadeMode.StopOnFirstFailure).NotEmpty().WithMessage("Please enter your API key").When(t => t.AuthMode == AuthMode.APIKey)
                     .Must(s => s.StartsWith("API-")).WithMessage("The API key you provided doesn't start with \"API-\" as expected. It's possible you've copied the wrong thing from the Octopus Portal.").When(t => t.AuthMode == AuthMode.APIKey);
                 validator.RuleFor(m => m.Username).NotEmpty().WithMessage("Please enter your username").When(t => t.AuthMode == AuthMode.UsernamePassword);

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/Views/OctopusServerConnectionTab.xaml
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/Views/OctopusServerConnectionTab.xaml
@@ -33,6 +33,7 @@
                     <StackPanel Width="400" HorizontalAlignment="Left">
 
                         <TextBox Text="{Binding Path=OctopusServerUrl, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" Name="OctopusServerUrlTextBox" Margin="0,10,0,20" materialDesign:ValidationAssist.Background="Transparent" materialDesign:HintAssist.Hint="Octopus Server URL"/>
+                        <TextBox Text="{Binding Path=ServerCommsPort, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" Name="ServerCommsPortTextBox" Margin="0,10,0,20" materialDesign:ValidationAssist.Background="Transparent" materialDesign:HintAssist.Hint="Server Communications Port"/>
 
 
                         <ComboBox


### PR DESCRIPTION
# Background

Customers can configure the communication port for the server and need to be able to easily configure the tentacle to use that port.

Recently the [Linux tentacle installation script was updated to support configuring a custom port](https://github.com/OctopusDeploy/OctopusTentacle/pull/792). This change exposes the same configurability in the Tentacle Manager.

# Results

The tentacle's server communication port can now be configured in Tentacle Manager.

[SC-68270]

## Before

<img width="1087" alt="image" src="https://github.com/OctopusDeploy/OctopusTentacle/assets/112689/261f7eaa-5246-4e5e-8ecf-1c23711d033a">


## After

<img width="1091" alt="image" src="https://github.com/OctopusDeploy/OctopusTentacle/assets/112689/ad367a4a-4082-4a5f-8f59-0e8b4a480475">

With validation error:

<img width="1085" alt="image" src="https://github.com/OctopusDeploy/OctopusTentacle/assets/112689/0147ef25-6b11-4fee-9d7b-ab07775ded65">


# How to review this PR

- Confirm that the UI positioning makes sense
- Uses existing property for binding.

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.