### PR TITLE
Add Namespace env var to k8s jobs

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -6,7 +6,8 @@ namespace Octopus.Tentacle.Kubernetes
     {
         const string EnvVarPrefix = "OCTOPUS__K8STENTACLE";
 
-        public static string Namespace => GetRequiredEnvVar($"{EnvVarPrefix}__NAMESPACE", "Unable to determine Kubernetes namespace.");
+        public static string NamespaceVariableName => $"{EnvVarPrefix}__NAMESPACE";
+        public static string Namespace => GetRequiredEnvVar(NamespaceVariableName, "Unable to determine Kubernetes namespace.");
         public static string JobServiceAccountName => GetRequiredEnvVar($"{EnvVarPrefix}__JOBSERVICEACCOUNTNAME", "Unable to determine Kubernetes Job service account name.");
         public static string JobVolumeYaml => GetRequiredEnvVar($"{EnvVarPrefix}__JOBVOLUMEYAML", "Unable to determine Kubernetes Job volume yaml.");
         public static bool UseJobs => bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__USEJOBS"), out var useJobs) && useJobs;

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
@@ -341,6 +341,7 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
                                     },
                                     Env = new List<V1EnvVar>
                                     {
+                                        new(KubernetesConfig.NamespaceVariableName, KubernetesConfig.Namespace),
                                         new(KubernetesConfig.HelmReleaseNameVariableName, KubernetesConfig.HelmReleaseName),
                                         new(KubernetesConfig.HelmChartVersionVariableName, KubernetesConfig.HelmChartVersion),
                                         new(EnvironmentVariables.TentacleHome, $"/octopus"),


### PR DESCRIPTION
# Background

#project-k8s-agent

I realised while spiking out the server-driven updates that we didn't know what the namespace was for the agent but we need to know when running the helm upgrade command.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.