### PR TITLE
Halibut no longer has PollingRequestMaximumMessageProcessingTimeout

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.535-pull-595" />
+    <PackageReference Include="Halibut" Version="7.0.539" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.465" />
+    <PackageReference Include="Halibut" Version="7.0.535-pull-595" />
     <PackageReference Include="Octopus.Diagnostics" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -145,7 +145,6 @@ namespace Octopus.Tentacle.Tests.Integration
                 .WithServiceEndpointModifier(serviceEndpoint =>
                 {
                     serviceEndpoint.PollingRequestQueueTimeout = TimeSpan.FromSeconds(10);
-                    serviceEndpoint.PollingRequestMaximumMessageProcessingTimeout = TimeSpan.FromSeconds(10);
                     serviceEndpoint.RetryCountLimit = 1;
                 })
                 .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()

--- a/source/Octopus.Tentacle.Tests.Integration/Support/PendingRequestQueueFactories/CancelWhenRequestQueuedPendingRequestQueueFactory.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/PendingRequestQueueFactories/CancelWhenRequestQueuedPendingRequestQueueFactory.cs
@@ -63,6 +63,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support.PendingRequestQueueFactorie
 
                 return await queueAndWait;
             }
+
+            public ValueTask DisposeAsync()
+            {
+                return inner.DisposeAsync();
+            }
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationTokenObservingPendingRequestQueueDecorator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationTokenObservingPendingRequestQueueDecorator.cs
@@ -34,5 +34,9 @@ namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
 
         public bool IsEmpty => pendingRequestQueue.IsEmpty;
         public int Count => pendingRequestQueue.Count;
+        public ValueTask DisposeAsync()
+        {
+            return pendingRequestQueue.DisposeAsync();
+        }
     }
 }


### PR DESCRIPTION
# Background


[SC-67117]

Bumps tentacle to using a recent version of Halibut which removes the `pollingRequestMaximumMessageProcessingTimeout`.

See  https://github.com/OctopusDeploy/Halibut/pull/595

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.