### PR TITLE
Monitor all jobs status via long-running monitor

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
@@ -10,6 +10,7 @@ using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Configuration.Instances;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Startup;
 using Octopus.Tentacle.Util;
 using Octopus.Time;
@@ -26,6 +27,7 @@ namespace Octopus.Tentacle.Tests.Commands
         IHomeConfiguration home = null!;
         IApplicationInstanceSelector selector = null!;
         IWorkspaceCleanerTask workspaceCleanerTask = null!;
+        IKubernetesJobMonitorTask kubernetesJobMonitorTask = null!;
 
         [SetUp]
         public override void SetUp()
@@ -39,6 +41,7 @@ namespace Octopus.Tentacle.Tests.Commands
             home = Substitute.For<IHomeConfiguration>();
             sleep = Substitute.For<ISleep>();
             workspaceCleanerTask = Substitute.For<IWorkspaceCleanerTask>();
+            kubernetesJobMonitorTask = Substitute.For<IKubernetesJobMonitorTask>();
 
             Command = new RunAgentCommand(
                 new Lazy<IHalibutInitializer>(() => halibut),
@@ -52,7 +55,8 @@ namespace Octopus.Tentacle.Tests.Commands
                 Substitute.For<IWindowsLocalAdminRightsChecker>(),
                 new AppVersion(GetType().Assembly),
                 Substitute.For<ILogFileOnlyLogger>(),
-                new Lazy<IWorkspaceCleanerTask>(() => workspaceCleanerTask));
+                new Lazy<IWorkspaceCleanerTask>(() => workspaceCleanerTask),
+                new Lazy<IKubernetesJobMonitorTask>(() => kubernetesJobMonitorTask));
 
             selector.Current.Returns(new ApplicationInstanceConfiguration("MyTentacle", null, null, null));
         }

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -7,6 +7,7 @@ using Octopus.Diagnostics;
 using Octopus.Tentacle.Communications;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Maintenance;
 using Octopus.Tentacle.Startup;
 using Octopus.Tentacle.Util;
@@ -26,6 +27,7 @@ namespace Octopus.Tentacle.Commands
         readonly Lazy<IProxyConfiguration> proxyConfiguration;
         readonly Lazy<IProxyInitializer> proxyInitializer;
         readonly Lazy<IWorkspaceCleanerTask> workspaceCleanerTask;
+        readonly Lazy<IKubernetesJobMonitorTask> kubernetesJobMonitorTask;
 
         readonly ISleep sleep;
         readonly ISystemLog log;
@@ -35,6 +37,7 @@ namespace Octopus.Tentacle.Commands
         int wait;
         bool halibutHasStarted;
         bool workspaceCleanerHasStarted;
+        bool kubernetesJobMonitorHasStarted;
 
         public override bool CanRunAsService => true;
 
@@ -50,7 +53,8 @@ namespace Octopus.Tentacle.Commands
             IWindowsLocalAdminRightsChecker windowsLocalAdminRightsChecker,
             AppVersion appVersion,
             ILogFileOnlyLogger logFileOnlyLogger,
-            Lazy<IWorkspaceCleanerTask> workspaceCleanerTask) : base(selector, log, logFileOnlyLogger)
+            Lazy<IWorkspaceCleanerTask> workspaceCleanerTask,
+            Lazy<IKubernetesJobMonitorTask> kubernetesJobMonitorTask) : base(selector, log, logFileOnlyLogger)
         {
             this.halibut = halibut;
             this.configuration = configuration;
@@ -63,6 +67,7 @@ namespace Octopus.Tentacle.Commands
             this.windowsLocalAdminRightsChecker = windowsLocalAdminRightsChecker;
             this.appVersion = appVersion;
             this.workspaceCleanerTask = workspaceCleanerTask;
+            this.kubernetesJobMonitorTask = kubernetesJobMonitorTask;
 
             Options.Add("wait=", "Delay (ms) before starting", arg => wait = int.Parse(arg));
             Options.Add("console", "Don't attempt to run as a service, even if the user is non-interactive", v =>
@@ -129,6 +134,12 @@ namespace Octopus.Tentacle.Commands
             workspaceCleanerTask.Value.Start();
             workspaceCleanerHasStarted = true;
 
+            if (PlatformDetection.Kubernetes.IsRunningInKubernetes)
+            {
+                kubernetesJobMonitorTask.Value.Start();
+                kubernetesJobMonitorHasStarted = true;
+            }
+
             Runtime.WaitForUserToExit();
         }
 
@@ -154,6 +165,11 @@ namespace Octopus.Tentacle.Commands
             if (workspaceCleanerHasStarted)
             {
                 workspaceCleanerTask.Value.Stop();
+            }
+
+            if (kubernetesJobMonitorHasStarted)
+            {
+                kubernetesJobMonitorTask.Value.Stop();
             }
         }
     }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -11,7 +11,7 @@ namespace Octopus.Tentacle.Kubernetes
         public static string JobServiceAccountName => GetRequiredEnvVar($"{EnvVarPrefix}__JOBSERVICEACCOUNTNAME", "Unable to determine Kubernetes Job service account name.");
         public static string JobVolumeYaml => GetRequiredEnvVar($"{EnvVarPrefix}__JOBVOLUMEYAML", "Unable to determine Kubernetes Job volume yaml.");
         public static bool UseJobs => bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__USEJOBS"), out var useJobs) && useJobs;
-        public static int JobTtlSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__JOBTTL"), out var jobTtl) ? jobTtl : 60; //Default 1min
+        public static int JobTtlSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__JOBTTL"), out var jobTtl) ? jobTtl : 1800; //30min
         public static int JobMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__JOBMONITORTIMEOUT"), out var jobMonitorTimeout) ? jobMonitorTimeout : 1800; //30min
 
         public static string HelmReleaseNameVariableName => $"{EnvVarPrefix}__HELMRELEASENAME";

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitor.cs
@@ -105,7 +105,7 @@ namespace Octopus.Tentacle.Kubernetes
                 jobStatusLookup[status.ScriptTicket] = status;
             }
 
-            log.Verbose($"Preloaded job statuses. ResourceVersion: {allJobs.ResourceVersion()}");
+            log.Verbose($"Preloaded {allJobs.Items.Count} job statuses. ResourceVersion: {allJobs.ResourceVersion()}");
 
             //this is the resource version for the list. We use this to start the watch at this particular point
             return allJobs.ResourceVersion();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitor.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s;
+using k8s.Models;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesJobMonitor
+    {
+        Task StartAsync(CancellationToken token);
+    }
+
+    public interface IKubernetesJobStatusProvider
+    {
+        JobStatus? TryGetJobStatus(ScriptTicket scriptTicket);
+    }
+
+    public class KubernetesJobMonitor : IKubernetesJobMonitor, IKubernetesJobStatusProvider
+    {
+        readonly IKubernetesJobService jobService;
+        readonly IKubernetesPodService podService;
+        readonly ISystemLog log;
+        readonly Dictionary<ScriptTicket, JobStatus> jobStatusLookup = new();
+
+        public KubernetesJobMonitor(IKubernetesJobService jobService, IKubernetesPodService podService, ISystemLog log)
+        {
+            this.jobService = jobService;
+            this.podService = podService;
+            this.log = log;
+        }
+
+        async Task IKubernetesJobMonitor.StartAsync(CancellationToken cancellationToken)
+        {
+            //initially load all the jobs and their status's
+            await InitialLoadAsync(cancellationToken);
+
+            await jobService.WatchAllJobsAsync(async (type, job) =>
+                {
+                    await Task.CompletedTask;
+
+                    var scriptTicket = job.GetScriptTicket();
+
+                    switch (type)
+                    {
+                        case WatchEventType.Added or WatchEventType.Modified:
+                        {
+                            if (!jobStatusLookup.TryGetValue(scriptTicket, out var status))
+                            {
+                                status = new JobStatus(job.GetScriptTicket());
+                                jobStatusLookup[scriptTicket] = status;
+                            }
+
+                            await status.UpdateAsync(job, podService, cancellationToken);
+
+                            break;
+                        }
+                        case WatchEventType.Deleted:
+                            //if the job is deleted, remove it
+                            jobStatusLookup.Remove(scriptTicket);
+                            break;
+                        default:
+                            log.Warn($"Received watch event type {type} for job {job.Name()}. Ignoring");
+                            break;
+                    }
+                }, ex =>
+                {
+                    log.Error(ex, "An unhandled error occured in monitoring the jobs");
+                }, cancellationToken
+            );
+        }
+
+        JobStatus? IKubernetesJobStatusProvider.TryGetJobStatus(ScriptTicket scriptTicket)
+            => jobStatusLookup.TryGetValue(scriptTicket, out var status) ? status : null;
+
+        async Task InitialLoadAsync(CancellationToken cancellationToken)
+        {
+            var allJobs = await jobService.ListAllJobsAsync(cancellationToken);
+            foreach (var job in allJobs.Items)
+            {
+                var status = new JobStatus(job.GetScriptTicket());
+                await status.UpdateAsync(job, podService, cancellationToken);
+
+                jobStatusLookup[status.ScriptTicket] = status;
+            }
+        }
+    }
+
+    public class JobStatus
+    {
+        public ScriptTicket ScriptTicket { get; }
+
+        public bool Success { get; private set; }
+
+        public bool Failed { get; private set; }
+
+        public int? ExitCode { get; private set; }
+
+        public JobStatus(ScriptTicket ticket)
+        {
+            ScriptTicket = ticket;
+        }
+
+        public async Task UpdateAsync(V1Job job, IKubernetesPodService podService, CancellationToken cancellationToken)
+        {
+            var firstCondition = job.Status?.Conditions?.FirstOrDefault();
+            switch (firstCondition)
+            {
+                case { Status: "True", Type: "Complete" }:
+                    Success = true;
+                    Failed = false;
+                    ExitCode = 0;
+                    break;
+                case { Status: "True", Type: "Failed" }:
+                    Success = false;
+                    Failed = true;
+
+                    var pod = await podService.TryGetPodForJob(ScriptTicket, cancellationToken);
+
+                    //find the status for the container
+                    //we we can't determine the exit code from the pod container, just return 1
+                    ExitCode = pod?.Status?.ContainerStatuses?.FirstOrDefault()?.State?.Terminated?.ExitCode ?? 1;
+
+                    break;
+            }
+        }
+    }
+
+    public static class V1JobExtensions
+    {
+        public static ScriptTicket GetScriptTicket(this V1Job job) => new(job.GetLabel(OctopusLabels.ScriptTicketId));
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitorTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitorTask.cs
@@ -37,6 +37,7 @@ namespace Octopus.Tentacle.Kubernetes
                     return;
                 }
 
+                log.Info("Starting Kubernetes Job Monitor");
                 monitorTask = Task.Run(() => jobMonitor.StartAsync(cancellationTokenSource.Token));
             }
         }
@@ -45,11 +46,11 @@ namespace Octopus.Tentacle.Kubernetes
         {
             lock (LockObj)
             {
-
                 if (monitorTask is null) return;
 
                 try
                 {
+                    log.Info("Stopping Kubernetes Job Monitor");
                     cancellationTokenSource.Cancel();
 
                     monitorTask.Wait();
@@ -60,6 +61,7 @@ namespace Octopus.Tentacle.Kubernetes
                 }
                 finally
                 {
+                    log.Info("Stopped Kubernetes Job Monitor");
                     monitorTask = null;
                 }
             }
@@ -67,6 +69,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         public void Dispose()
         {
+            log.Info("Disposing of Kubernetes Job Monitor");
             Stop();
             cancellationTokenSource.Dispose();
         }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitorTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitorTask.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Diagnostics;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesJobMonitorTask
+    {
+        void Start();
+        void Stop();
+    }
+
+    public class KubernetesJobMonitorTask: IKubernetesJobMonitorTask, IDisposable
+    {
+        readonly IKubernetesJobMonitor jobMonitor;
+        readonly ISystemLog log;
+        readonly CancellationTokenSource cancellationTokenSource = new ();
+
+        static readonly object LockObj = new();
+
+        Task? monitorTask;
+
+        public KubernetesJobMonitorTask(IKubernetesJobMonitor jobMonitor, ISystemLog log)
+        {
+            this.jobMonitor = jobMonitor;
+            this.log = log;
+        }
+
+        public void Start()
+        {
+            lock (LockObj)
+            {
+                if (monitorTask is not null)
+                {
+                    log.Error("Kubernetes Job Monitor task already running.");
+                    return;
+                }
+
+                monitorTask = jobMonitor.StartAsync(cancellationTokenSource.Token);
+            }
+        }
+
+        public void Stop()
+        {
+            lock (LockObj)
+            {
+
+                if (monitorTask is null) return;
+
+                try
+                {
+                    cancellationTokenSource.Cancel();
+
+                    monitorTask.Wait();
+                }
+                catch (Exception e)
+                {
+                    log.Error(e, "Could not stop Kubernetes Job Monitor cleaner");
+                }
+                finally
+                {
+                    monitorTask = null;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Stop();
+            cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitorTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobMonitorTask.cs
@@ -37,7 +37,7 @@ namespace Octopus.Tentacle.Kubernetes
                     return;
                 }
 
-                monitorTask = jobMonitor.StartAsync(cancellationTokenSource.Token);
+                monitorTask = Task.Run(() => jobMonitor.StartAsync(cancellationTokenSource.Token));
             }
         }
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesJobNameExtensions.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesJobNameExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public static class KubernetesJobNameExtensions
+    {
+        public static string ToKubernetesJobName(this ScriptTicket scriptTicket) => $"octopus-job-{scriptTicket.TaskId}".ToLowerInvariant();
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -11,6 +11,10 @@ namespace Octopus.Tentacle.Kubernetes
             builder.RegisterType<KubernetesJobContainerResolver>().As<IKubernetesJobContainerResolver>().SingleInstance();
             builder.RegisterType<KubernetesConfigMapService>().As<IKubernetesConfigMapService>().SingleInstance();
             builder.RegisterType<KubernetesSecretService>().As<IKubernetesSecretService>().SingleInstance();
+            builder.RegisterType<KubernetesPodService>().As<IKubernetesPodService>().SingleInstance();
+
+            builder.RegisterType<KubernetesJobMonitorTask>().As<IKubernetesJobMonitorTask>().SingleInstance();
+            builder.RegisterType<KubernetesJobMonitor>().As<IKubernetesJobMonitor>().As<IKubernetesJobStatusProvider>().SingleInstance();
 
 #if DEBUG
             builder.RegisterType<LocalMachineKubernetesClientConfigProvider>().As<IKubernetesClientConfigProvider>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s;
+using k8s.Models;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesPodService
+    {
+        Task<V1Pod?> TryGetPodForJob(ScriptTicket scriptTicket, CancellationToken cancellationToken);
+    }
+
+    public class KubernetesPodService : KubernetesService, IKubernetesPodService
+    {
+        public KubernetesPodService(IKubernetesClientConfigProvider configProvider)
+            : base(configProvider)
+        {
+        }
+
+        public async Task<V1Pod?> TryGetPodForJob(ScriptTicket scriptTicket, CancellationToken cancellationToken)
+        {
+            var jobPods = await Client.ListNamespacedPodAsync(
+                KubernetesConfig.Namespace,
+                labelSelector:$"job-name={scriptTicket.ToKubernetesJobName()}",
+                //we limit to 2 so we can error if there is more than 2 (see below)
+                limit: 2,
+                cancellationToken: cancellationToken);
+
+            //there should only ever be one pod, so let's error if there isn't
+            return jobPods.Items.SingleOrDefault();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/OctopusLabels.cs
+++ b/source/Octopus.Tentacle/Kubernetes/OctopusLabels.cs
@@ -1,0 +1,7 @@
+﻿namespace Octopus.Tentacle.Kubernetes
+{
+    public static class OctopusLabels
+    {
+        public const string ScriptTicketId = "octopus.com/scriptTicketId";
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/KubernetesJobScriptExecutor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/KubernetesJobScriptExecutor.cs
@@ -14,14 +14,16 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
         readonly IKubernetesSecretService secretService;
         readonly IKubernetesJobContainerResolver containerResolver;
         readonly IApplicationInstanceSelector appInstanceSelector;
+        readonly IKubernetesJobStatusProvider jobsStatusProvider;
         readonly ISystemLog log;
 
-        public KubernetesJobScriptExecutor(IKubernetesJobService jobService, IKubernetesSecretService secretService, IKubernetesJobContainerResolver containerResolver, IApplicationInstanceSelector appInstanceSelector, ISystemLog log)
+        public KubernetesJobScriptExecutor(IKubernetesJobService jobService, IKubernetesSecretService secretService, IKubernetesJobContainerResolver containerResolver, IApplicationInstanceSelector appInstanceSelector, IKubernetesJobStatusProvider jobsStatusProvider, ISystemLog log)
         {
             this.jobService = jobService;
             this.secretService = secretService;
             this.containerResolver = containerResolver;
             this.appInstanceSelector = appInstanceSelector;
+            this.jobsStatusProvider = jobsStatusProvider;
             this.log = log;
         }
 
@@ -36,6 +38,7 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
                 command.TaskId, log,
                 scriptStateStore,
                 jobService,
+                jobsStatusProvider,
                 secretService,
                 containerResolver,
                 appInstanceSelector,

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
@@ -187,9 +187,10 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
         async Task<int> CheckIfJobHasCompleted(CancellationTokenSource jobCompletionCancellationTokenSource)
         {
             var resultStatusCode = 0;
+            JobStatus? status = null;
             while (!scriptCancellationToken.IsCancellationRequested)
             {
-                var status = jobStatusProvider.TryGetJobStatus(scriptTicket);
+                status = jobStatusProvider.TryGetJobStatus(scriptTicket);
                 if (status is not null && status.Success)
                 {
                     resultStatusCode = 0;
@@ -212,6 +213,8 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
             }
 
             jobCompletionCancellationTokenSource.Cancel();
+
+            log.Verbose($"Job {jobName} completed. Status: {status}");
 
             return resultStatusCode;
         }

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesJob.cs
@@ -214,7 +214,7 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
 
             jobCompletionCancellationTokenSource.Cancel();
 
-            log.Verbose($"Job {jobName} completed. Status: {status}");
+            log.Verbose($"Job {jobName} completed.{status}");
 
             return resultStatusCode;
         }


### PR DESCRIPTION
Note: There are changes here that have been abstracted out into 2 other PRs #821  and #822. I'll update the PR when they are approved and merged

# Background

In preparation for making Tentacle when running in Kubernetes a much more stateless application, we need to change how we monitor the status of jobs.

Currently, when a script is started, it spawns a `RunningKubernetesJob` which runs it's `Execute` in a background thread. In this `Execute`, it creates the job and starts monitoring the logs & job status. This means that if the Tentacle is torn-down or evicted etc, then we lose all that state.

This PR starts this improvement by introducing a long-running `KubernetesJobMonitorTask` which is used to watch changes to _all_ jobs in the Tentacle namespace. This is then used in the `RunningKubenetesJob` to monitor the status. Eventually, this would be done directly in the `GetScriptStatus` RPC call, but that will come in later PR's.

# Results

Introduces a the new `KubernetesJobMonitorTask` and `KubernetesJobMonitor` class which is started in the `RunAgentCommand` (much like the `WorkspaceCleanerTask`).

The `KubernetesJobMonitor` first loads the current state of all the jobs and stores them in a local dictionary. It then starts a watch from the `resourceVersion` returned from the initial list call. This is considered best practice and is recommended in the Kubernetes documentation under [Efficient detection of changes](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes).

We then access the job monitor (via a different interface) in the `RunningKubernetesJob` and use the resolved status to determine if it's finished.

I have done testing and verified that this correctly monitors successful and failed jobs and deployments are completed successfully in Octopus Server.

This also increases the default Job TTL to 30min

**Note:** This will require an update to the Helm Chart as the Tentacle service account will need read access to `pods` to retrieve the exit code in case of failure

Shortcut story: [sc-71688]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.