### PR TITLE
Format kubernetes console logs with log level and timestamp

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -81,6 +81,9 @@
 		<Content Include="Tentacle.exe.manifest">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
+		<None Update="Tentacle.exe.k8s.nlog">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
 		<RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />

--- a/source/Octopus.Tentacle/Startup/OctopusProgram.cs
+++ b/source/Octopus.Tentacle/Startup/OctopusProgram.cs
@@ -308,17 +308,14 @@ namespace Octopus.Tentacle.Startup
                 Target.Register<NullLogTarget>("EventLog");
 #endif
 #if REQUIRES_EXPLICIT_LOG_CONFIG
-            var nLogFile = Path.ChangeExtension(GetType().Assembly.Location, "exe.nlog");
+            var nLogFileExtension = !PlatformDetection.Kubernetes.IsRunningInKubernetes
+                ? "exe.nlog"
+                : "exe.k8s.nlog";
+
+            var nLogFile = Path.ChangeExtension(GetType().Assembly.Location, nLogFileExtension);
             LogManager.ThrowConfigExceptions = true;
             LogManager.Configuration = new XmlLoggingConfiguration(nLogFile);
 #endif
-            //if we are running in kubernetes, make the console log more helpful
-            if (PlatformDetection.Kubernetes.IsRunningInKubernetes)
-            {
-                var consoleLayout = new SimpleLayout("${longdate}  ${uppercase:${level}:padding=5}  ${message}${onexception:${newline}${exception:format=ToString}}");
-                LogManager.Configuration.FindTargetByName<ColoredConsoleTarget>("stdout").Layout = consoleLayout;
-                LogManager.Configuration.FindTargetByName<ColoredConsoleTarget>("stderr").Layout = consoleLayout;
-            }
 
             SystemLog.Appenders.Add(new NLogAppender());
 

--- a/source/Octopus.Tentacle/Tentacle.exe.k8s.nlog
+++ b/source/Octopus.Tentacle/Tentacle.exe.k8s.nlog
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog
+  xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  autoReload="true"
+  throwExceptions="false"
+  internalLogLevel="Fatal"
+  internalLogToConsole="true">
+
+  <extensions>
+    <add assembly="Tentacle"/>
+  </extensions>
+
+  <variable name="appName" value="Octopus Tentacle" />
+  <variable name="messageLayout" value="${longdate} | ${uppercase:${level}:padding=5} | ${message}${onexception:${newline}${exception:format=ToString}}"/>
+  <variable name="normalLayout" value="${longdate}  ${processid:padding=5}  ${threadid:padding=5} ${uppercase:${level}:padding=5}  ${messageLayout}"/>
+  <variable name="logLevel" value="Info" />
+
+  <targets async="false">
+    <target xsi:type="ColoredConsole" name="stdout" layout="${messageLayout}" />
+    <target xsi:type="ColoredConsole" name="stderr" stdErr="true" layout="${messageLayout}" />
+    <target name="octopus-log-file" xsi:type="File"
+        layout="${normalLayout}"
+        fileName="${octopusLogsDirectory}/OctopusTentacle.txt"
+        archiveFileName="${octopusLogsDirectory}/OctopusTentacle.{#}.txt"
+        archiveEvery="Day"
+        archiveNumbering="Rolling"
+        maxArchiveFiles="7"
+        concurrentWrites="true"
+        keepFileOpen="false" />
+    <target xsi:type="EventLog" name="eventlog" source="${appName}" layout="${normalLayout}" />
+  </targets>
+
+  <rules>
+    <logger name="LogFileOnlyLogger" writeTo="octopus-log-file" final="true" />
+    <logger name="*" minlevel="${var:logLevel}" maxLevel="Warn" writeTo="stdout" />
+    <logger name="*" minlevel="Error" writeTo="stderr" />
+    <logger name="*" minlevel="${var:logLevel}" writeTo="octopus-log-file" />
+    <logger name="*" minlevel="Fatal" writeTo="eventlog" />
+</rules>
+</nlog>


### PR DESCRIPTION
# Background

We are correctly logging system logs to the Kubernetes pod logs, however they don't have some useful information like timestamp or log level, making it hard to correlate with other logs for timings etc.

# Results

This PR changes the target layout for the `stdout` and `stderr` targets, but only when running in Kubernetes.

## After

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/332730/eaf54c71-97ff-4452-bac2-94b01dfc483c)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.