### PR TITLE
Fix building debug Kubernetes image

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -30,6 +30,12 @@
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
         },
+        "DockerBuilder": {
+          "type": "string"
+        },
+        "DockerPlatform": {
+          "type": "string"
+        },
         "Help": {
           "type": "boolean",
           "description": "Shows the help text for this build assembly"
@@ -98,6 +104,7 @@
             "type": "string",
             "enum": [
               "BuildAll",
+              "BuildAndLoadLocalDebugKubernetesTentacleContainerImage",
               "BuildAndLoadLocallyKubernetesTentacleContainerImage",
               "BuildAndPushKubernetesTentacleContainerImage",
               "BuildLinux",
@@ -145,6 +152,7 @@
             "type": "string",
             "enum": [
               "BuildAll",
+              "BuildAndLoadLocalDebugKubernetesTentacleContainerImage",
               "BuildAndLoadLocallyKubernetesTentacleContainerImage",
               "BuildAndPushKubernetesTentacleContainerImage",
               "BuildLinux",

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -23,8 +23,13 @@ partial class Build
     //We don't sign linux packages when building locally
     readonly bool SignLinuxPackages = !IsLocalBuild;
 
-    [Parameter(Name = "DockerBuilder")] string? DockerBuildxBuilder;
-    [Parameter(Name = "DockerPlatform")] string DockerPlatform = "linux/arm64,linux/amd64";
+    [Parameter("Used to set a custom docker builder when executing DockerBuildxBuild tasks",
+        Name = "DockerBuilder")]
+    string? DockerBuildxBuilder;
+
+    [Parameter("Specifies the platforms to build the docker images in. Multiple platforms must be comma-separated. Defaults to 'linux/arm64,linux/amd64'.",
+        Name = "DockerPlatform")]
+    string DockerPlatform = "linux/arm64,linux/amd64";
 
     [PublicAPI]
     Target PackOsxTarballs => _ => _
@@ -156,7 +161,7 @@ partial class Build
         .DependsOn(PackDebianPackage)
         .Executes(() =>
         {
-            BuildAndPushOrLoadKubernetesTentacleContainerImage(push: false, load: true, includeDebugger:true);
+            BuildAndPushOrLoadKubernetesTentacleContainerImage(push: false, load: true, includeDebugger: true);
         });
 
     [PublicAPI]
@@ -539,13 +544,13 @@ partial class Build
         var dockerDir = ArtifactsDirectory / "docker";
         FileSystemTasks.EnsureExistingDirectory(dockerDir);
 
-        FileSystemTasks.CopyFile( packageFilePath, dockerDir / $"tentacle_{FullSemVer}_linux-{dockerArch}.deb");
+        FileSystemTasks.CopyFile(packageFilePath, dockerDir / $"tentacle_{FullSemVer}_linux-{dockerArch}.deb");
     }
 
     static IReadOnlyDictionary<string, (string deb, string docker)> DebDockerMap { get; } = new Dictionary<string, (string deb, string docker)>
     {
-        {"linux-x64", ("amd64", "amd64")},
-        {"linux-arm64", ("arm64", "arm64")},
-        {"linux-arm", ("armhf", "armv7")}
+        { "linux-x64", ("amd64", "amd64") },
+        { "linux-arm64", ("arm64", "arm64") },
+        { "linux-arm", ("armhf", "armv7") }
     };
 }

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -23,6 +23,9 @@ partial class Build
     //We don't sign linux packages when building locally
     readonly bool SignLinuxPackages = !IsLocalBuild;
 
+    [Parameter(Name = "DockerBuilder")] string? DockerBuildxBuilder;
+    [Parameter(Name = "DockerPlatform")] string DockerPlatform = "linux/arm64,linux/amd64";
+
     [PublicAPI]
     Target PackOsxTarballs => _ => _
         .Description("Packs the OS/X tarballs containing the published binaries.")
@@ -144,6 +147,16 @@ partial class Build
         .Executes(() =>
         {
             BuildAndPushOrLoadKubernetesTentacleContainerImage(push: false, load: true);
+        });
+
+    [PublicAPI]
+    Target BuildAndLoadLocalDebugKubernetesTentacleContainerImage => _ => _
+        .Description("Builds and loads locally the kubernetes tentacle multi-arch container image")
+        .OnlyWhenStatic(() => IsLocalBuild)
+        .DependsOn(PackDebianPackage)
+        .Executes(() =>
+        {
+            BuildAndPushOrLoadKubernetesTentacleContainerImage(push: false, load: true, includeDebugger:true);
         });
 
     [PublicAPI]
@@ -477,17 +490,42 @@ partial class Build
             $"tentacle-{FullSemVer}-{NetCore}-{runtimeId}.tar.gz");
     }
 
-    void BuildAndPushOrLoadKubernetesTentacleContainerImage(bool push, bool load, string? host = null)
+    void BuildAndPushOrLoadKubernetesTentacleContainerImage(bool push, bool load, string? host = null, bool includeDebugger = false)
     {
         var hostPrefix = host is not null ? $"{host}/" : string.Empty;
         DockerTasks.DockerBuildxBuild(settings =>
-            settings.AddBuildArg($"BUILD_NUMBER={FullSemVer}", $"BUILD_DATE={DateTime.UtcNow:O}")
-                .SetPlatform("linux/arm64,linux/amd64")
-                .SetTag($"{hostPrefix}octopusdeploy/kubernetes-tentacle:{FullSemVer}")
-                .SetFile("./docker/kubernetes-tentacle/Dockerfile")
+        {
+            if (includeDebugger && DockerPlatform.Contains(','))
+                throw new InvalidOperationException("Only a single DockerPlatform can be defined when build the docker image with the debugger");
+
+            if (DockerBuildxBuilder is not null)
+                settings = settings.SetBuilder(DockerBuildxBuilder);
+
+            var dockerfile = !includeDebugger
+                ? "./docker/kubernetes-tentacle/Dockerfile"
+                : "./docker/kubernetes-tentacle/dev/Dockerfile";
+
+            var tag = $"{hostPrefix}octopusdeploy/kubernetes-tentacle:{FullSemVer}";
+            if (includeDebugger)
+                tag += "-debug";
+
+            settings = settings
+                .AddBuildArg($"BUILD_NUMBER={FullSemVer}", $"BUILD_DATE={DateTime.UtcNow:O}")
+                .SetPlatform(DockerPlatform)
+                .SetTag(tag)
+                .SetFile(dockerfile)
                 .SetPath(RootDirectory)
                 .SetPush(push)
-                .SetLoad(load));
+                .SetLoad(load);
+
+            if (includeDebugger)
+            {
+                var debuggerArch = DockerPlatform.Replace("/", "-").Replace("amd", "x");
+                settings = settings.AddBuildArg($"DEBUGGER_ARCH={debuggerArch}");
+            }
+
+            return settings;
+        });
     }
 
     void CopyDebianPackageToDockerFolder(string runtimeId)

--- a/docker/kubernetes-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-tentacle/dev/Dockerfile
@@ -1,14 +1,81 @@
-ARG IMAGE_TAG
-FROM docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:$IMAGE_TAG
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0
 
-RUN apt-get update && apt-get install -y curl p7zip-full
-
+ARG BUILD_NUMBER
+ARG BUILD_DATE
+ARG TARGETARCH
+ARG TARGETOS
+ARG TARGETVARIANT
 ARG DEBUGGER_ARCH=linux-x64
+
+EXPOSE 10933
+
+# debugging port
+EXPOSE 7777
+
+COPY docker/kubernetes-tentacle/scripts/* /scripts/
+RUN chmod +x /scripts/*.sh
+
+COPY docker/kubernetes-tentacle/dev/scripts/* /dev-scripts/
+RUN chmod +x /dev-scripts/*.sh
+
+WORKDIR /tmp
+
+# Install Tentacle
+COPY _artifacts/docker/tentacle_${BUILD_NUMBER}_${TARGETOS}-${TARGETARCH}${TARGETVARIANT}.deb /tmp/tentacle.deb
+RUN apt-get update
+RUN apt install ./tentacle.deb -y
+RUN apt-get clean
+RUN apt install curl p7zip-full -y
+RUN rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
 
 RUN \
     curl -L "https://download.jetbrains.com/rider/ssh-remote-debugging/${DEBUGGER_ARCH}/jetbrains_debugger_agent_20230319.24.0" \
     -o /usr/local/bin/debugger && \
-    chmod +x /usr/local/bin/debugger
+    chmod +x /usr/local/bin/debugger 
+
+# We know this won't reduce the image size at all. It's just to make the filesystem a little tidier.
+RUN rm -rf /tmp/*
+
+ENV OCTOPUS_RUNNING_IN_CONTAINER=Y
+ENV ACCEPT_EULA=N
+ENV CustomPublicHostName=""
+ENV ListeningPort=""
+ENV MachinePolicy="Default Machine Policy"
+ENV PublicHostNameConfiguration="ComputerName"
+ENV ServerApiKey=""
+ENV ServerPassword=""
+ENV ServerUsername=""
+ENV ServerCommsAddress=""
+ENV ServerPort=""
+ENV ServerUrl=""
+ENV Space="Default"
+ENV TargetEnvironment=""
+ENV TargetName=""
+ENV TargetRole=""
+ENV TargetTenant=""
+ENV TargetTenantTag=""
+ENV TargetTenantedDeploymentParticipation=""
+ENV OCTOPUS__K8STENTACLE__NAMESPACE=""
+ENV OCTOPUS__K8STENTACLE__USEJOBS="True"
+ENV OCTOPUS__K8STENTACLE__JOBSERVICEACCOUNTNAME=""
+ENV OCTOPUS__K8STENTACLE__JOBVOLUMEYAML=""
+ENV TentacleHome=""
+ENV TentacleApplications=""
+
+CMD /dev-scripts/bootstrap.sh
+
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.name="Octopus Deploy Kubernetes Tentacle" \
+    org.label-schema.vendor="Octopus Deploy" \
+    org.label-schema.url="https://octopus.com" \
+    org.label-schema.vcs-url="https://github.com/OctopusDeploy/OctopusTentacle" \
+    org.label-schema.license="Apache"  \
+    org.label-schema.description="Octopus Kubernetes Tentacle instance with auto-registration to Octopus Server" \
+    org.label-schema.version=${BUILD_NUMBER} \
+    org.label-schema.build-date=${BUILD_DATE}
 
 # This installs the required tools, but there are versioning issues and it isn't working as expected
 
@@ -28,14 +95,3 @@ RUN \
 # RUN \
 #     cd ~/.local/share/JetBrains/RiderRemoteDebugger/${DEBUGGER_TOOLS_VERSION} \
 #     7z x debug_tools.zip
-
-# debugging port
-EXPOSE 7777
-
-COPY docker/kubernetes-tentacle/scripts/* /scripts/
-RUN chmod +x /scripts/*.sh
-
-COPY docker/kubernetes-tentacle/dev/scripts/* /dev-scripts/
-RUN chmod +x /dev-scripts/*.sh
-
-CMD /dev-scripts/bootstrap.sh


### PR DESCRIPTION
# Background

Debugging Tentacle running in a Kubernetes cluster is challenging as you can't just hook up the debugger and go. 

To do this via Rider, we have a custom docker image that includes the Rider Remote Debugging Tools. This PR fixes the build since it was moved to `buildx` and the multi-arch images.

# Results

One key point is that this can only build a single architecture image as the rider tools are only single arch. To do this, I added a new Nuke parameter called `DockerPlatform` which allows for changing the default multi-arch platforms. Also, I added a `DockerBuilder` parameter so you can specify a custom docker build if you haven't swapped to buildx for all builds.

There is a new Nuke target to build and load the debug image. It's essentially the same, just sources a different docker file

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.