### PR TITLE
Monitor pod status via long-running watch task

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
@@ -10,6 +10,7 @@ using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Configuration.Instances;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Startup;
 using Octopus.Tentacle.Util;
 using Octopus.Time;
@@ -26,6 +27,7 @@ namespace Octopus.Tentacle.Tests.Commands
         IHomeConfiguration home = null!;
         IApplicationInstanceSelector selector = null!;
         IWorkspaceCleanerTask workspaceCleanerTask = null!;
+        IKubernetesPodMonitorTask kubernetesPodMonitorTask = null!;
 
         [SetUp]
         public override void SetUp()
@@ -39,6 +41,7 @@ namespace Octopus.Tentacle.Tests.Commands
             home = Substitute.For<IHomeConfiguration>();
             sleep = Substitute.For<ISleep>();
             workspaceCleanerTask = Substitute.For<IWorkspaceCleanerTask>();
+            kubernetesPodMonitorTask = Substitute.For<IKubernetesPodMonitorTask>();
 
             Command = new RunAgentCommand(
                 new Lazy<IHalibutInitializer>(() => halibut),
@@ -52,7 +55,8 @@ namespace Octopus.Tentacle.Tests.Commands
                 Substitute.For<IWindowsLocalAdminRightsChecker>(),
                 new AppVersion(GetType().Assembly),
                 Substitute.For<ILogFileOnlyLogger>(),
-                new Lazy<IWorkspaceCleanerTask>(() => workspaceCleanerTask));
+                new Lazy<IWorkspaceCleanerTask>(() => workspaceCleanerTask),
+                new Lazy<IKubernetesPodMonitorTask>(() => kubernetesPodMonitorTask));
 
             selector.Current.Returns(new ApplicationInstanceConfiguration("MyTentacle", null, null, null));
         }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using k8s;
+using k8s.Models;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Kubernetes;
+using Octopus.Tentacle.Tests.Support;
+
+namespace Octopus.Tentacle.Tests.Kubernetes
+{
+    [TestFixture]
+    public class KubernetesPodMonitorTests
+    {
+        IKubernetesPodService podService;
+        ISystemLog log;
+        KubernetesPodMonitor monitor;
+        ScriptTicket scriptTicket;
+
+        [SetUp]
+        public void SetUp()
+        {
+            podService = Substitute.For<IKubernetesPodService>();
+            log = new InMemoryLog();
+            monitor = new KubernetesPodMonitor(podService, log);
+
+            scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
+        }
+
+        [Test]
+        public async Task NewlyAddedPodIsAddedToTracking()
+        {
+            // Arrange
+            const WatchEventType type = WatchEventType.Added;
+            var pod = new V1Pod
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        [OctopusLabels.ScriptTicketId] = scriptTicket.TaskId
+                    }
+                }
+            };
+
+            //Act
+            await monitor.OnNewEvent(type, pod);
+
+            //Assert
+            var status = ((IKubernetesPodStatusProvider)monitor).TryGetPodStatus(scriptTicket);
+            status.Should().NotBeNull();
+
+            status.Should().Match<PodStatus>(status =>
+                status.ScriptTicket == scriptTicket &&
+                status.State == PodState.Running &&
+                status.ExitCode == null
+            );
+        }
+
+        [Test]
+        public async Task ExistingPodIsUpdatedWhenCompleted()
+        {
+            // Arrange
+            const WatchEventType type = WatchEventType.Modified;
+            var pod = new V1Pod
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        [OctopusLabels.ScriptTicketId] = scriptTicket.TaskId
+                    }
+                }
+            };
+
+            podService.ListAllPodsAsync(Arg.Any<CancellationToken>())
+                .Returns(new V1PodList
+                {
+                    Items = new List<V1Pod>
+                    {
+                        pod
+                    }
+                });
+
+            //Act
+
+            //preload the pod
+            await monitor.InitialLoadAsync(CancellationToken.None);
+
+            //Update the pod
+            pod.Status = new V1PodStatus
+            {
+                Phase = "Succeeded"
+            };
+            await monitor.OnNewEvent(type, pod);
+
+            //Assert
+            var status = ((IKubernetesPodStatusProvider)monitor).TryGetPodStatus(scriptTicket);
+            status.Should().NotBeNull();
+
+            status.Should().Match<PodStatus>(status =>
+                status.ScriptTicket == scriptTicket &&
+                status.State == PodState.Succeeded &&
+                status.ExitCode == 0
+            );
+        }
+
+        [Test]
+        public async Task ExistingPodIsUpdatedWhenFailed()
+        {
+            // Arrange
+            const WatchEventType type = WatchEventType.Modified;
+            var pod = new V1Pod
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        [OctopusLabels.ScriptTicketId] = scriptTicket.TaskId
+                    }
+                }
+            };
+
+            podService.ListAllPodsAsync(Arg.Any<CancellationToken>())
+                .Returns(new V1PodList
+                {
+                    Items = new List<V1Pod>
+                    {
+                        pod
+                    }
+                });
+
+            //Act
+
+            //preload the pod
+            await monitor.InitialLoadAsync(CancellationToken.None);
+
+            //Update the pod
+            pod.Status = new V1PodStatus
+            {
+                Phase = "Failed",
+                ContainerStatuses = new List<V1ContainerStatus>
+                {
+                    new()
+                    {
+                        State = new V1ContainerState
+                        {
+                            Terminated = new V1ContainerStateTerminated
+                            {
+                                ExitCode = -99
+                            }
+                        }
+                    }
+                }
+            };
+            await monitor.OnNewEvent(type, pod);
+
+            //Assert
+            var status = ((IKubernetesPodStatusProvider)monitor).TryGetPodStatus(scriptTicket);
+            status.Should().NotBeNull();
+
+            status.Should().Match<PodStatus>(status =>
+                status.ScriptTicket == scriptTicket &&
+                status.State == PodState.Failed &&
+                status.ExitCode == -99
+            );
+        }
+
+        [Test]
+        public async Task StopTrackingPodWhenDeleted()
+        {
+            // Arrange
+            const WatchEventType type = WatchEventType.Deleted;
+            var pod = new V1Pod
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        [OctopusLabels.ScriptTicketId] = scriptTicket.TaskId
+                    }
+                }
+            };
+
+            podService.ListAllPodsAsync(Arg.Any<CancellationToken>())
+                .Returns(new V1PodList
+                {
+                    Items = new List<V1Pod>
+                    {
+                        pod
+                    }
+                });
+
+            //Act
+
+            //preload the pod
+            await monitor.InitialLoadAsync(CancellationToken.None);
+
+            //Update the pod
+            await monitor.OnNewEvent(type, pod);
+
+            //Assert
+            var status = ((IKubernetesPodStatusProvider)monitor).TryGetPodStatus(scriptTicket);
+            status.Should().BeNull();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Octopus.Tentacle.Kubernetes.Scripts;
 
 namespace Octopus.Tentacle.Kubernetes
 {
@@ -11,6 +12,10 @@ namespace Octopus.Tentacle.Kubernetes
             builder.RegisterType<KubernetesPodContainerResolver>().As<IKubernetesPodContainerResolver>().SingleInstance();
             builder.RegisterType<KubernetesConfigMapService>().As<IKubernetesConfigMapService>().SingleInstance();
             builder.RegisterType<KubernetesSecretService>().As<IKubernetesSecretService>().SingleInstance();
+            builder.RegisterType<RunningKubernetesPod>().InstancePerLifetimeScope();
+
+            builder.RegisterType<KubernetesPodMonitorTask>().As<IKubernetesPodMonitorTask>().SingleInstance();
+            builder.RegisterType<KubernetesPodMonitor>().As<IKubernetesPodMonitor>().As<IKubernetesPodStatusProvider>().SingleInstance();
 
 #if DEBUG
             builder.RegisterType<LocalMachineKubernetesClientConfigProvider>().As<IKubernetesClientConfigProvider>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -12,7 +12,9 @@ namespace Octopus.Tentacle.Kubernetes
             builder.RegisterType<KubernetesPodContainerResolver>().As<IKubernetesPodContainerResolver>().SingleInstance();
             builder.RegisterType<KubernetesConfigMapService>().As<IKubernetesConfigMapService>().SingleInstance();
             builder.RegisterType<KubernetesSecretService>().As<IKubernetesSecretService>().SingleInstance();
-            builder.RegisterType<RunningKubernetesPod>().InstancePerLifetimeScope();
+
+            // this needs to be per-dependency, otherwise it re-uses the RunningKubernetesPod
+            builder.RegisterType<RunningKubernetesPod>().InstancePerDependency();
 
             builder.RegisterType<KubernetesPodMonitorTask>().As<IKubernetesPodMonitorTask>().SingleInstance();
             builder.RegisterType<KubernetesPodMonitor>().As<IKubernetesPodMonitor>().As<IKubernetesPodStatusProvider>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s;
+using k8s.Models;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesPodMonitor
+    {
+        Task StartAsync(CancellationToken token);
+    }
+
+    public interface IKubernetesPodStatusProvider
+    {
+        PodStatus? TryGetPodStatus(ScriptTicket scriptTicket);
+    }
+
+    public class KubernetesPodMonitor : IKubernetesPodMonitor, IKubernetesPodStatusProvider
+    {
+        readonly IKubernetesPodService podService;
+        readonly ISystemLog log;
+        readonly Dictionary<ScriptTicket, PodStatus> podStatusLookup = new();
+
+        public KubernetesPodMonitor(IKubernetesPodService podService, ISystemLog log)
+        {
+            this.podService = podService;
+            this.log = log;
+        }
+
+        async Task IKubernetesPodMonitor.StartAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                //initially load all the pods and their status's
+                var initialResourceVersion = await InitialLoadAsync(cancellationToken);
+
+                //we start the watch from the resource version we initially loaded. This means we receive w
+                await podService.WatchAllPods(initialResourceVersion,async (type, pod) =>
+                    {
+                        await Task.CompletedTask;
+
+                        try
+                        {
+                            log.Verbose($"Received {type} event for pod {pod.Name()}");
+
+                            var scriptTicket = pod.GetScriptTicket();
+
+                            switch (type)
+                            {
+                                case WatchEventType.Added or WatchEventType.Modified:
+                                {
+                                    if (!podStatusLookup.TryGetValue(scriptTicket, out var status))
+                                    {
+                                        status = new PodStatus(pod.GetScriptTicket());
+                                        podStatusLookup[scriptTicket] = status;
+                                    }
+
+                                    status.Update(pod);
+                                    log.Verbose($"Updated pod {pod.Name()} status. {status}");
+
+                                    break;
+                                }
+                                case WatchEventType.Deleted:
+                                    log.Verbose($"Removed {type} pod {pod.Name()} status");
+
+                                    //if the pod is deleted, remove it
+                                    podStatusLookup.Remove(scriptTicket);
+                                    break;
+                                default:
+                                    log.Warn($"Received watch event type {type} for pod {pod.Name()}. Ignoring as we don't need it");
+                                    break;
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            log.Error(e, $"Failed to process event {type} for pod {pod.Name()}.");
+                        }
+                    }, ex =>
+                    {
+                        log.Error(ex, "An unhandled error occured in monitoring the pods");
+                    }, cancellationToken
+                );
+            }
+        }
+
+        async Task<string> InitialLoadAsync(CancellationToken cancellationToken)
+        {
+            log.Verbose("Preloading pod statuses");
+            //clear the status'
+            podStatusLookup.Clear();
+
+            var allPods = await podService.ListAllPodsAsync(cancellationToken);
+            foreach (var pod in allPods.Items)
+            {
+                var status = new PodStatus(pod.GetScriptTicket());
+                status.Update(pod);
+
+                log.Verbose($"Preloaded pod {pod.Name()}. {status}");
+                podStatusLookup[status.ScriptTicket] = status;
+            }
+
+            log.Verbose($"Preloaded {allPods.Items.Count} pod statuses. ResourceVersion: {allPods.ResourceVersion()}");
+
+            //this is the resource version for the list. We use this to start the watch at this particular point
+            return allPods.ResourceVersion();
+        }
+
+        PodStatus? IKubernetesPodStatusProvider.TryGetPodStatus(ScriptTicket scriptTicket)
+            => podStatusLookup.TryGetValue(scriptTicket, out var status) ? status : null;
+    }
+
+    public class PodStatus
+    {
+        public ScriptTicket ScriptTicket { get; }
+
+        public bool Success { get; private set; }
+
+        public bool Failed { get; private set; }
+
+        public int? ExitCode { get; private set; }
+
+        public PodStatus(ScriptTicket ticket)
+        {
+            ScriptTicket = ticket;
+        }
+
+        public void Update(V1Pod pod)
+        {
+            switch (pod.Status?.Phase)
+            {
+                case "Succeeded":
+                    Success = true;
+                    Failed = false;
+                    ExitCode = 0;
+                    break;
+                case "Failed":
+                    Success = false;
+                    Failed = true;
+
+                    //find the status for the container
+                    //we we can't determine the exit code from the pod container, just return 1
+                    ExitCode = pod.Status?.ContainerStatuses?.FirstOrDefault()?.State?.Terminated?.ExitCode ?? 1;
+
+                    break;
+            }
+        }
+
+        public override string ToString()
+            => $"ScriptTicket: {ScriptTicket}, Success: {Success}, Failed: {Failed}, ExitCode: {ExitCode}";
+    }
+
+    public static class V1PodExtensions
+    {
+        public static ScriptTicket GetScriptTicket(this V1Pod pod) => new(pod.GetLabel(OctopusLabels.ScriptTicketId));
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -118,15 +118,14 @@ namespace Octopus.Tentacle.Kubernetes
     {
         public ScriptTicket ScriptTicket { get; }
 
-        public bool Success { get; private set; }
-
-        public bool Failed { get; private set; }
+        public PodState State { get; private set; }
 
         public int? ExitCode { get; private set; }
 
         public PodStatus(ScriptTicket ticket)
         {
             ScriptTicket = ticket;
+            State = PodState.Running;
         }
 
         public void Update(V1Pod pod)
@@ -134,13 +133,11 @@ namespace Octopus.Tentacle.Kubernetes
             switch (pod.Status?.Phase)
             {
                 case "Succeeded":
-                    Success = true;
-                    Failed = false;
+                    State = PodState.Succeeded;
                     ExitCode = 0;
                     break;
                 case "Failed":
-                    Success = false;
-                    Failed = true;
+                    State = PodState.Failed;
 
                     //find the status for the container
                     //we we can't determine the exit code from the pod container, just return 1
@@ -151,7 +148,14 @@ namespace Octopus.Tentacle.Kubernetes
         }
 
         public override string ToString()
-            => $"ScriptTicket: {ScriptTicket}, Success: {Success}, Failed: {Failed}, ExitCode: {ExitCode}";
+            => $"ScriptTicket: {ScriptTicket}, State: {State}, ExitCode: {ExitCode}";
+    }
+
+    public enum PodState
+    {
+        Running,
+        Succeeded,
+        Failed
     }
 
     public static class V1PodExtensions

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -39,8 +39,9 @@ namespace Octopus.Tentacle.Kubernetes
                 //initially load all the pods and their status's
                 var initialResourceVersion = await InitialLoadAsync(cancellationToken);
 
-                //we start the watch from the resource version we initially loaded. This means we receive w
-                await podService.WatchAllPods(initialResourceVersion,async (type, pod) =>
+                // We start the watch from the resource version we initially loaded.
+                // This means we only receive events that occur after the resource version
+                await podService.WatchAllPods(initialResourceVersion, async (type, pod) =>
                     {
                         await Task.CompletedTask;
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitorTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitorTask.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Diagnostics;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesPodMonitorTask
+    {
+        void Start();
+        void Stop();
+    }
+
+    public class KubernetesPodMonitorTask: IKubernetesPodMonitorTask, IDisposable
+    {
+        readonly IKubernetesPodMonitor podMonitor;
+        readonly ISystemLog log;
+        readonly CancellationTokenSource cancellationTokenSource = new ();
+
+        static readonly object LockObj = new();
+
+        Task? monitorTask;
+
+        public KubernetesPodMonitorTask(IKubernetesPodMonitor podMonitor, ISystemLog log)
+        {
+            this.podMonitor = podMonitor;
+            this.log = log;
+        }
+
+        public void Start()
+        {
+            lock (LockObj)
+            {
+                if (monitorTask is not null)
+                {
+                    log.Error("Kubernetes Pod Monitor task already running.");
+                    return;
+                }
+
+                log.Info("Starting Kubernetes Pod Monitor");
+                monitorTask = Task.Run(() => podMonitor.StartAsync(cancellationTokenSource.Token));
+            }
+        }
+
+        public void Stop()
+        {
+            lock (LockObj)
+            {
+                if (monitorTask is null) return;
+
+                try
+                {
+                    log.Info("Stopping Kubernetes Pod Monitor");
+                    cancellationTokenSource.Cancel();
+
+                    monitorTask.Wait();
+                }
+                catch (Exception e)
+                {
+                    log.Error(e, "Could not stop Kubernetes Pod Monitor cleaner");
+                }
+                finally
+                {
+                    log.Info("Stopped Kubernetes Pod Monitor");
+                    monitorTask = null;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            log.Info("Disposing of Kubernetes Pod Monitor");
+            Stop();
+            cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitorTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitorTask.cs
@@ -53,7 +53,8 @@ namespace Octopus.Tentacle.Kubernetes
                     log.Info("Stopping Kubernetes Pod Monitor");
                     cancellationTokenSource.Cancel();
 
-                    monitorTask.Wait();
+                    // give the monitor 30 to gracefully shutdown
+                    monitorTask.Wait(TimeSpan.FromSeconds(30));
                 }
                 catch (Exception e)
                 {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitorTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitorTask.cs
@@ -17,7 +17,7 @@ namespace Octopus.Tentacle.Kubernetes
         readonly ISystemLog log;
         readonly CancellationTokenSource cancellationTokenSource = new ();
 
-        static readonly object LockObj = new();
+        readonly object LockObj = new();
 
         Task? monitorTask;
 
@@ -57,7 +57,7 @@ namespace Octopus.Tentacle.Kubernetes
                 }
                 catch (Exception e)
                 {
-                    log.Error(e, "Could not stop Kubernetes Pod Monitor cleaner");
+                    log.Error(e, "Could not stop Kubernetes Pod Monitor");
                 }
                 finally
                 {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
@@ -9,9 +9,11 @@ namespace Octopus.Tentacle.Kubernetes
 {
     public interface IKubernetesPodService
     {
+        Task<V1Pod?> TryGetPod(ScriptTicket scriptTicket, CancellationToken cancellationToken);
+        Task<V1PodList> ListAllPodsAsync(CancellationToken cancellationToken);
+        Task WatchAllPods(string initialResourceVersion, Func<WatchEventType, V1Pod, Task> onChange, Action<Exception> onError, CancellationToken cancellationToken);
         Task Create(V1Pod pod, CancellationToken cancellationToken);
         Task Delete(ScriptTicket scriptTicket, CancellationToken cancellationToken);
-        Task Watch(ScriptTicket scriptTicket, Func<V1Pod, bool> onChange, Action<Exception> onError, CancellationToken cancellationToken);
     }
 
     public class KubernetesPodService : KubernetesService, IKubernetesPodService
@@ -21,29 +23,41 @@ namespace Octopus.Tentacle.Kubernetes
         {
         }
 
-        public async Task Watch(ScriptTicket scriptTicket, Func<V1Pod, bool> onChange, Action<Exception> onError, CancellationToken cancellationToken)
+        public async Task<V1Pod?> TryGetPod(ScriptTicket scriptTicket, CancellationToken cancellationToken) =>
+            await TryGetAsync(() => Client.ReadNamespacedPodAsync(scriptTicket.ToKubernetesScriptPobName(), KubernetesConfig.Namespace, cancellationToken: cancellationToken));
+
+        public async Task<V1PodList> ListAllPodsAsync(CancellationToken cancellationToken)
+        {
+            return await Client.ListNamespacedPodAsync(KubernetesConfig.Namespace,
+                labelSelector: OctopusLabels.ScriptTicketId,
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task WatchAllPods(string initialResourceVersion, Func<WatchEventType, V1Pod, Task> onChange, Action<Exception> onError, CancellationToken cancellationToken)
         {
             using var response = Client.CoreV1.ListNamespacedPodWithHttpMessagesAsync(
                 KubernetesConfig.Namespace,
-                //only list this pod
-                fieldSelector: $"metadata.name=={scriptTicket.ToKubernetesScriptPobName()}",
+                labelSelector: OctopusLabels.ScriptTicketId,
+                resourceVersion: initialResourceVersion,
                 watch: true,
-                timeoutSeconds: KubernetesConfig.PodMonitorTimeoutSeconds,
                 cancellationToken: cancellationToken);
 
-            await foreach (var (type, pod) in response.WatchAsync<V1Pod, V1PodList>(onError, cancellationToken: cancellationToken))
-            {
-                //watch for modifications and deletions
-                if (type is not (WatchEventType.Modified or WatchEventType.Deleted))
-                    continue;
+            var watchErrorCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-                var stopWatching = onChange(pod);
-                //we stop watching when told to or if this is deleted
-                if (stopWatching || type is WatchEventType.Deleted)
-                    break;
+            Action<Exception> internalOnError = ex =>
+            {
+                //We cancel the watch explicitly (so it can be restarted)
+                watchErrorCancellationTokenSource.Cancel();
+
+                //notify there was an error
+                onError(ex);
+            };
+
+            await foreach (var (type, pod) in response.WatchAsync<V1Pod, V1PodList>(internalOnError, cancellationToken: watchErrorCancellationTokenSource.Token))
+            {
+                await onChange(type, pod);
             }
         }
-
         public async Task Create(V1Pod pod, CancellationToken cancellationToken)
         {
             AddStandardMetadata(pod);

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesService.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
 using k8s;
+using k8s.Autorest;
 using k8s.Models;
 using k8sClient = k8s.Kubernetes;
 
@@ -30,6 +34,19 @@ namespace Octopus.Tentacle.Kubernetes
 
             k8sObject.Metadata.Labels ??= new Dictionary<string, string>();
             k8sObject.Metadata.Labels["app.kubernetes.io/managed-by"] = "Helm";
+        }
+
+        protected async Task<T?> TryGetAsync<T>(Func<Task<T>> loadAction) where T: class
+        {
+            try
+            {
+                return await loadAction();
+            }
+            catch (HttpOperationException opException)
+                when (opException.Response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
         }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/OctopusLabels.cs
+++ b/source/Octopus.Tentacle/Kubernetes/OctopusLabels.cs
@@ -1,0 +1,7 @@
+﻿namespace Octopus.Tentacle.Kubernetes
+{
+    public static class OctopusLabels
+    {
+        public const string ScriptTicketId = "octopus.com/scriptTicketId";
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesPod.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesPod.cs
@@ -66,7 +66,7 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
             IScriptStateStore stateStore,
             KubernetesAgentScriptExecutionContext executionContext,
             CancellationToken scriptCancellationToken,
-            ILog log,
+            ISystemLog log,
             IKubernetesPodService podService,
             IKubernetesPodStatusProvider podStatusProvider,
             IKubernetesSecretService secretService,
@@ -196,18 +196,18 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
 
         async Task<int> CheckIfPodHasCompleted(CancellationTokenSource podCompletionCancellationTokenSource)
         {
-            var resultStatusCode = 0;
+            var resultStatusCode = ScriptExitCodes.UnknownScriptExitCode;
             PodStatus? status = null;
             while (!scriptCancellationToken.IsCancellationRequested)
             {
                 status = podStatusProvider.TryGetPodStatus(scriptTicket);
-                if (status is not null && status.Success)
+                if (status is not null && status.State == PodState.Succeeded)
                 {
                     resultStatusCode = 0;
                     break;
                 }
 
-                if (status is not null && status.Failed)
+                if (status is not null && status.State == PodState.Failed)
                 {
                     resultStatusCode = status.ExitCode!.Value;
                     break;

--- a/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesPod.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Scripts/RunningKubernetesPod.cs
@@ -31,8 +31,6 @@ namespace Octopus.Tentacle.Kubernetes.Scripts
             KubernetesAgentScriptExecutionContext executionContext,
             CancellationToken scriptCancellationToken);
 
-
-
         static readonly AsyncLazy<string> BootstrapRunnerScript = new(async () =>
         {
             using var stream = typeof(RunningKubernetesPod).Assembly.GetManifestResourceStream("Octopus.Tentacle.Kubernetes.bootstrapRunner.sh");


### PR DESCRIPTION
# Background

Superceeds #818 

In preparation for making Tentacle when running in Kubernetes a much more stateless application, we need to change how we monitor the status of jobs.

Currently, when a script is started, it spawns a `RunningKubernetesPod` which runs it's `Execute` in a background thread. In this `Execute`, it creates the pod and starts monitoring the logs & pod status. This means that if the Tentacle is torn-down or evicted etc, then we lose all that state.

This PR starts this improvement by introducing a long-running `KubernetesPodMonitorTask` which is used to watch changes to _all_ pods in the Tentacle namespace. This is then used in the `RunningKubenetesPod` to get the status. Eventually, this would be done directly in the `GetScriptStatus` RPC call, but that will come in later PR's.

# Results

Introduces a the new `KubernetesPodMonitorTask` and `KubernetesPodMonitor` class which is started in the `RunAgentCommand` (much like the `WorkspaceCleanerTask`).

The `KubernetesPodMonitor` first loads the current state of all the pods and stores them in a local dictionary. It then starts a watch from the `resourceVersion` returned from the initial list call. This is considered best practice and is recommended in the Kubernetes documentation under [Efficient detection of changes](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes).

We then access the pod monitor (via a different interface) in the `RunningKubernetesPod` and use the resolved status to determine if it's finished.

I have done testing and verified that this correctly monitors successful and failed pods and deployments are completed successfully in Octopus Server.

Shortcut story: [sc-71688]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.