### PR TITLE
Improve support for running integration tests on ARM 

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -143,6 +143,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             }
 #endif
 
+            versions.RemoveWhere(v => TentacleVersions.VersionsToSkip.Contains(v));
+
             var testCases =
                 from tentacleType in tentacleTypes
                 from runtime in runtimes

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleConfigurationsAttribute.cs
@@ -143,7 +143,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             }
 #endif
 
-            versions.RemoveWhere(v => TentacleVersions.VersionsToSkip.Contains(v));
+            versions.RemoveWhere(v => TentacleVersions.VersionsUnsupportedByCurrentOperatingSystemAndArchitecture.Contains(v));
 
             var testCases =
                 from tentacleType in tentacleTypes

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Tentacle.Util;
@@ -16,7 +17,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             this.logger = logger;
         }
 
-        static string LinuxDownloadUrlForVersion(string versionString) => $"https://download.octopusdeploy.com/linux-tentacle/tentacle-{versionString}-linux_x64.tar.gz";
+        static string LinuxDownloadUrlForVersion(string versionString)
+        {
+            var architecture = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : "x64";
+            return $"https://download.octopusdeploy.com/linux-tentacle/tentacle-{versionString}-linux_{architecture}.tar.gz";
+        }
 
         public async Task<string> GetTentacleVersion(string downloadPath, Version version, TentacleRuntime _, CancellationToken cancellationToken)
         {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/NugetTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/NugetTentacleFetcher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,7 +43,19 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             ZipFile.ExtractToDirectory(downloadFilePath, extractionDirectory);
 
             // This is the path to the runtime-specific artifact
-            var tentacleArtifact = Path.Combine(extractionDirectory, TentacleArtifactName(runtime));
+            var tentacleArtifacts = TentacleArtifactNames(runtime)
+                .Select(name => Path.Combine(extractionDirectory, name))
+                .ToArray();
+            var tentacleArtifact = tentacleArtifacts.FirstOrDefault(File.Exists);
+            if (tentacleArtifact == null)
+            {
+                var artifactNamesList = string.Join(Environment.NewLine, tentacleArtifacts
+                    .Select(Path.GetFileName)
+                    .Select(a => $"- {a}")
+                );
+                throw new FileNotFoundException($"Could not find any of the expected tentacle artifacts in {extractionDirectory}.{Environment.NewLine}{artifactNamesList}");
+            }
+            logger.Information($"Extracting tentacle from {tentacleArtifact}");
 
             var tentacleFolder = Path.Combine(directoryPath, "tentacle");
             if (tentacleArtifact.EndsWith(".tar.gz"))
@@ -57,39 +70,71 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             return Path.Combine(tentacleFolder, "tentacle", "Tentacle");
         }
 
-        public string TentacleArtifactName(TentacleRuntime runtime)
+        public string[] TentacleArtifactNames(TentacleRuntime runtime)
         {
             if (PlatformDetection.IsRunningOnWindows)
             {
-                var net48ArtifactName = "tentacle-net48-win.zip";
-                var net60ArtifactName = $"tentacle-{RuntimeDetection.GetCurrentRuntime()}-win-{Architecture()}.zip";
+                var net48ArtifactNames = new[] {"tentacle-net48-win.zip"};
+                var net60ArtifactNames = Architectures()
+                    .Select(a => $"tentacle-{RuntimeDetection.GetCurrentRuntime()}-win-{a}.zip")
+                    .ToArray();
 
-                var name = runtime switch
+                var names = runtime switch
                 {
-                    TentacleRuntime.DotNet6 => net60ArtifactName,
-                    TentacleRuntime.Framework48 => net48ArtifactName,
+                    TentacleRuntime.DotNet6 => net60ArtifactNames,
+                    TentacleRuntime.Framework48 => net48ArtifactNames,
                     _ => throw new ArgumentOutOfRangeException(nameof(runtime), runtime, null)
                 };
 
-                return name;
+                return names;
             }
 
             if (PlatformDetection.IsRunningOnMac)
             {
-                return $"tentacle-{RuntimeDetection.GetCurrentRuntime()}-osx-{Architecture()}.tar.gz";
+                return Architectures()
+                    .Select(a => $"tentacle-{RuntimeDetection.GetCurrentRuntime()}-osx-{a}.tar.gz")
+                    .ToArray();
             }
 
             if (PlatformDetection.IsRunningOnNix)
             {
-                return $"tentacle-{RuntimeDetection.GetCurrentRuntime()}-linux-{Architecture()}.tar.gz";
+                return Architectures()
+                    .Select(a => $"tentacle-{RuntimeDetection.GetCurrentRuntime()}-linux-{a}.tar.gz")
+                    .ToArray();
             }
 
             throw new Exception("Wow this is one fancy OS that tentacle probably can't run on");
         }
 
-        string Architecture()
+        string[] Architectures()
         {
-            return RuntimeInformation.ProcessArchitecture.ToString().ToLower();
+            if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                if (PlatformDetection.IsRunningOnMac)
+                {
+                    // Mac automatically emulates for x64 processes on ARM and the ARM version of
+                    // Tentacle from the bundle does not currently run.
+                    return new[]
+                    {
+                        Architecture.X64.ToString().ToLower()
+                    };
+                }
+
+                if (PlatformDetection.IsRunningOnWindows)
+                {
+                    // Windows automatically emulates for x64 processes on ARM, so we can fallback
+                    // to the x64 Tentacle if an ARM version is unavailable.
+                    return new[]
+                    {
+                        RuntimeInformation.ProcessArchitecture.ToString().ToLower(),
+                        Architecture.X64.ToString().ToLower()
+                    };
+                }
+            }
+            return new []
+            {
+                RuntimeInformation.ProcessArchitecture.ToString().ToLower()
+            };
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleFetcher.cs
@@ -13,10 +13,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
         {
             if (!TentacleVersions.AllTestedVersionsToDownload.Any(v => v.Equals(version)))
             {
-                if (TentacleVersions.VersionsToSkip.Any(v => v.Equals(version)))
-                {
-                    throw new IgnoreException($"Skipping test for version {version} as it is not supported");
-                }
                 throw new Exception($"Version {version} must be added to {nameof(TentacleVersions)}.{nameof(TentacleVersions.AllTestedVersionsToDownload)}");
             }
             return await new TentacleFetcherFactory().Create(logger).GetTentacleVersion(downloadPath, version, runtime, cancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/TentacleFetcher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using Serilog;
 
 namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
@@ -12,6 +13,10 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
         {
             if (!TentacleVersions.AllTestedVersionsToDownload.Any(v => v.Equals(version)))
             {
+                if (TentacleVersions.VersionsToSkip.Any(v => v.Equals(version)))
+                {
+                    throw new IgnoreException($"Skipping test for version {version} as it is not supported");
+                }
                 throw new Exception($"Version {version} must be added to {nameof(TentacleVersions)}.{nameof(TentacleVersions.AllTestedVersionsToDownload)}");
             }
             return await new TentacleFetcherFactory().Create(logger).GetTentacleVersion(downloadPath, version, runtime, cancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Octopus.Tentacle.CommonTestUtils;
 
 namespace Octopus.Tentacle.Tests.Integration.Support
 {
@@ -29,16 +33,43 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         // The version compiled from the current source
         public static readonly Version? Current = null;
 
-        public static Version[] AllTestedVersionsToDownload =
+        public static Version[] AllTestedVersionsToDownload = GetAllTestedVersionsToDownload();
+
+        public static Version[] VersionsToSkip = GetVersionsToSkip();
+
+        static Version[] GetVersionsToSkip()
         {
-            v5_0_4_FirstLinuxRelease,
-            v5_0_12_AutofacServiceFactoryIsInShared,
-            v5_0_15_LastOfVersion5,
-            v6_3_417_LastWithScriptServiceV1Only,
-            v6_3_451_NoCapabilitiesService,
-            v7_1_189_SyncHalibutAndScriptServiceV2,
-            v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha
-        };
+            if (!PlatformDetection.IsRunningOnMac && RuntimeInformation.ProcessArchitecture != Architecture.Arm64) return Array.Empty<Version>();
+
+            if (PlatformDetection.IsRunningOnWindows) return Array.Empty<Version>(); 
+
+            // These versions are not available on MacOS or ARM
+            return new []
+            {
+                v5_0_4_FirstLinuxRelease,
+                v5_0_12_AutofacServiceFactoryIsInShared,
+                v5_0_15_LastOfVersion5
+            };
+        }
+        static Version[] GetAllTestedVersionsToDownload()
+        {
+            var versions = new List<Version>();
+
+            if (PlatformDetection.IsRunningOnWindows || (!PlatformDetection.IsRunningOnMac && RuntimeInformation.ProcessArchitecture != Architecture.Arm64))
+            {
+                // These versions are not available on MacOS or ARM
+                versions.Add(v5_0_4_FirstLinuxRelease);
+                versions.Add(v5_0_12_AutofacServiceFactoryIsInShared);
+                versions.Add(v5_0_15_LastOfVersion5);
+            }
+
+            versions.Add(v6_3_417_LastWithScriptServiceV1Only);
+            versions.Add(v6_3_451_NoCapabilitiesService);
+            versions.Add(v7_1_189_SyncHalibutAndScriptServiceV2);
+            versions.Add(v8_0_81_AsyncHalibutAndLastWithoutScriptServiceV3Alpha);
+
+            return versions.ToArray();
+        }
     }
 
     public static class VersionExtensionMethods

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleVersions.cs
@@ -35,9 +35,9 @@ namespace Octopus.Tentacle.Tests.Integration.Support
 
         public static Version[] AllTestedVersionsToDownload = GetAllTestedVersionsToDownload();
 
-        public static Version[] VersionsToSkip = GetVersionsToSkip();
+        public static readonly Version[] VersionsUnsupportedByCurrentOperatingSystemAndArchitecture = GetVersionsUnsupportedByCurrentOperatingSystemAndArchitecture();
 
-        static Version[] GetVersionsToSkip()
+        static Version[] GetVersionsUnsupportedByCurrentOperatingSystemAndArchitecture()
         {
             if (!PlatformDetection.IsRunningOnMac && RuntimeInformation.ProcessArchitecture != Architecture.Arm64) return Array.Empty<Version>();
 


### PR DESCRIPTION
# Background

As more engineers are migrating to ARM based development environments, it is necessary to be able to run the Tentacle integration tests locally or on ARM based VMs. This also unlocks the capability to execute integration tests for ARM based Linux platforms.

This requires that an appropriate version of the Tentacle be downloaded as part of the tests.

# Results

<!-- Describe the result of the change -->

## Before

Tests would fail to run on ARM platforms

## After

Tests run on ARM platforms

# How to review this PR

- Review that the version selections are reasonable
- Quality :heavy_check_mark:

I have run these tests on Windows, Linux and Mac OS X on ARM.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.