### PR TITLE
Add EnableWindowsTargeting to Octopus.Manager.Tentacle.Tests.csproj

### DIFF
--- a/source/Octopus.Manager.Tentacle.Tests/Octopus.Manager.Tentacle.Tests.csproj
+++ b/source/Octopus.Manager.Tentacle.Tests/Octopus.Manager.Tentacle.Tests.csproj
@@ -8,6 +8,7 @@
     <PublishDir>../../_build/$(AssemblyName)/$(TargetFramework)/$(RuntimeIdentifier)</PublishDir>
     <RootNamespace>Octopus.Manager.Tentacle.Tests</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <LangVersion>9</LangVersion>
     <Nullable>annotations</Nullable>
     <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>

--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -11,7 +11,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>   
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
     <!-- 
       Suppressing those validations error due to validation bugs in .NET 6.


### PR DESCRIPTION
# Background

I noticed that this project doesn't build on mac (and I presume other *nix flavours). Adding this property makes it build again. Note: this does not allow you to run the built .dll on mac or linux.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.