### PR TITLE
Add telemetry to Tentacle Manager

### DIFF
--- a/source/Octopus.Manager.Tentacle.Tests/Builders/SetupTentacleWizardModelBuilder.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/Builders/SetupTentacleWizardModelBuilder.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using NSubstitute;
+using Octopus.Diagnostics;
+using Octopus.Manager.Tentacle.Shell;
+using Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard;
+using Octopus.Manager.Tentacle.Util;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Manager.Tentacle.Tests.Builders
+{
+    public class SetupTentacleWizardModelBuilder
+    {
+        InstanceSelectionModel instanceSelectionModel;
+        ITentacleManagerInstanceIdentifierService tentacleManagerInstanceIdentifierService;
+        ICommandLineRunner commandLineRunner;
+        ITelemetryService? telemetryService;
+
+        public SetupTentacleWizardModelBuilder()
+        {
+            var instanceStore = Substitute.For<IApplicationInstanceStore>();
+            instanceSelectionModel = new InstanceSelectionModel(ApplicationName.Tentacle, instanceStore);
+            const string tentacleInstanceName = "TestInstance";
+            instanceSelectionModel.New(tentacleInstanceName);
+
+            tentacleManagerInstanceIdentifierService = Substitute.For<ITentacleManagerInstanceIdentifierService>();
+            tentacleManagerInstanceIdentifierService.GetIdentifier().Returns(_ => Guid.NewGuid().ToString("N"));
+
+            commandLineRunner = Substitute.For<ICommandLineRunner>();
+            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>(), Arg.Any<ILog>()).Returns(true);
+            commandLineRunner.Execute(Arg.Any<IEnumerable<CommandLineInvocation>>(), Arg.Any<ILog>()).Returns(true);
+        }
+
+        public SetupTentacleWizardModelBuilder WithTelemetryService(ITelemetryService telemetryService)
+        {
+            this.telemetryService = telemetryService;
+            return this;
+        }
+
+        public SetupTentacleWizardModel Build()
+        {
+            var model = new SetupTentacleWizardModel(
+                instanceSelectionModel,
+                tentacleManagerInstanceIdentifierService,
+                commandLineRunner,
+                telemetryService ?? new TelemetryServiceBuilder().Build()
+            );
+            
+            // TODO: Model should take logger in constructor
+            model.ReviewAndRunScriptTabViewModel.SetLogger(new SystemLog());
+            
+            return model;
+        }
+    }
+}

--- a/source/Octopus.Manager.Tentacle.Tests/Builders/TelemetryServiceBuilder.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/Builders/TelemetryServiceBuilder.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using NSubstitute;
+using Octopus.Manager.Tentacle.Infrastructure;
+using Octopus.Manager.Tentacle.Util;
+
+namespace Octopus.Manager.Tentacle.Tests.Builders
+{
+    public class TelemetryServiceBuilder
+    {
+        bool sendingResult = true;
+
+        public TelemetryServiceBuilder WithSendingResult(bool result)
+        {
+            sendingResult = result;
+            return this;
+        }
+
+        public ITelemetryService Build()
+        {
+            var telemetryService = Substitute.For<ITelemetryService>();
+            telemetryService.SendTelemetryEvent(Arg.Any<Uri>(), Arg.Any<TelemetryEvent>()).Returns(sendingResult);
+            return telemetryService;
+        }
+    }
+}

--- a/source/Octopus.Manager.Tentacle.Tests/Builders/TelemetryServiceBuilder.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/Builders/TelemetryServiceBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using NSubstitute;
 using Octopus.Manager.Tentacle.Infrastructure;
 using Octopus.Manager.Tentacle.Util;
@@ -18,7 +19,7 @@ namespace Octopus.Manager.Tentacle.Tests.Builders
         public ITelemetryService Build()
         {
             var telemetryService = Substitute.For<ITelemetryService>();
-            telemetryService.SendTelemetryEvent(Arg.Any<Uri>(), Arg.Any<TelemetryEvent>()).Returns(sendingResult);
+            telemetryService.SendTelemetryEvent(Arg.Any<Uri>(), Arg.Any<TelemetryEvent>(), Arg.Any<IWebProxy>()).Returns(sendingResult);
             return telemetryService;
         }
     }

--- a/source/Octopus.Manager.Tentacle.Tests/Utils/TentacleManagerInstanceIdentifierServiceFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/Utils/TentacleManagerInstanceIdentifierServiceFixture.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Halibut.Util;
 using NUnit.Framework;
 using Octopus.Manager.Tentacle.Util;
 
@@ -9,74 +10,85 @@ namespace Octopus.Manager.Tentacle.Tests.Utils
 {
     public class TentacleManagerInstanceIdentifierServiceFixture
     {
-        readonly string identifierLocation = Path.GetTempPath();
-        
         [Test]
         public async Task Given_ThereIsNoExistingIdentifier_When_AnIdentifierIsRequested_Then_ANewIdentifierIsGeneratedAndReturned()
         {
-            // Arrange: Ensure there is no current identifier
-            var identifierFullPath = Path.Combine(identifierLocation, TentacleManagerInstanceIdentifierService.IdentifierFileName);
-            File.Delete(identifierFullPath);
-            Assert.False(File.Exists(identifierFullPath));
+            var identifierFullPath = Path.GetTempFileName();
+            try
+            {
+                // Arrange: Ensure there is no current identifier
+                File.Delete(identifierFullPath);
+                Assert.False(File.Exists(identifierFullPath));
 
-            // Act: Get the identifier
-            var sut = new TentacleManagerInstanceIdentifierService(new DirectoryInfo(identifierLocation));
-            var identifierValue = await sut.GetIdentifier();
-            
-            // Assert: The identifier returned should match the contents of the file we expect to be created
-            Assert.True(File.Exists(identifierFullPath));
-            var identifierFileContents = File.ReadAllLines(identifierFullPath);
-            Assert.AreEqual(1, identifierFileContents.Length);
-            Assert.AreEqual(identifierValue, identifierFileContents.Single());
+                // Act: Get the identifier
+                var sut = new TentacleManagerInstanceIdentifierService(identifierFullPath);
+                var identifierValue = await sut.GetIdentifier();
+
+                // Assert: The identifier returned should match the contents of the file we expect to be created
+                Assert.IsNotNull(identifierValue);
+                Assert.IsNotEmpty(identifierValue);
+                Assert.True(File.Exists(identifierFullPath));
+                var identifierFileContents = File.ReadAllLines(identifierFullPath);
+                Assert.AreEqual(1, identifierFileContents.Length);
+                Assert.AreEqual(identifierValue, identifierFileContents.Single());
+            }
+            finally
+            {
+                File.Delete(identifierFullPath);
+            }
         }
 
         [Test]
         public async Task Given_ThereIsAnExistingIdentifier_When_AnIdentifierIsRequested_Then_TheExistingIdentifierIsReturned()
         {
-            // Arrange: Ensure there is an existing identifier
-            var identifierFullPath = Path.Combine(identifierLocation, TentacleManagerInstanceIdentifierService.IdentifierFileName);
-            var identifier = Guid.NewGuid().ToString("N");
-            // ReSharper disable once ConvertToUsingDeclaration
-            using (var streamWriter = File.CreateText(identifierFullPath))
+            var identifierFullPath = Path.GetTempFileName();
+            try
             {
-                await streamWriter.WriteLineAsync(identifier);
-            }
+                // Arrange: Ensure there is an existing identifier
+                var identifier = Guid.NewGuid().ToString("N");
+                File.WriteAllLines(identifierFullPath, new[] {identifier});
 
-            // Act: Get the identifier
-            var sut = new TentacleManagerInstanceIdentifierService(new DirectoryInfo(identifierLocation));
-            var identifierValue = await sut.GetIdentifier();
-            
-            // Assert: The identifier returned should match the contents of the pre-existing file
-            Assert.AreEqual(identifier, identifierValue);
+                // Act: Get the identifier
+                var sut = new TentacleManagerInstanceIdentifierService(identifierFullPath);
+                var identifierValue = await sut.GetIdentifier();
+
+                // Assert: The identifier returned should match the contents of the pre-existing file
+                Assert.AreEqual(identifier, identifierValue);
+            }
+            finally
+            {
+                File.Delete(identifierFullPath);
+            }
         }
 
         [Test]
         public async Task Given_ThereIsAnExistingInvalidIdentifier_When_AnIdentifierIsRequested_Then_ANewIdentifierIsGeneratedAndReturned()
         {
-            // Arrange: Ensure there is an existing but invalid identifier file
-            var identifierFullPath = Path.Combine(identifierLocation, TentacleManagerInstanceIdentifierService.IdentifierFileName);
-            var invalidLine1 = "This is not a valid ID string";
-            var invalidLine2 = "This contains multiple lines";
-            // ReSharper disable once ConvertToUsingDeclaration
-            using (var streamWriter = File.CreateText(identifierFullPath))
+            var identifierFullPath = Path.GetTempFileName();
+            try
             {
-                await streamWriter.WriteLineAsync(invalidLine1);
-                await streamWriter.WriteLineAsync(invalidLine2);
+                // Arrange: Ensure there is an existing but invalid identifier file
+                var invalidLine1 = "This is not a valid ID string";
+                var invalidLine2 = "This contains multiple lines";
+                File.WriteAllLines(identifierFullPath, new[] {invalidLine1, invalidLine2});
+
+                // Act: Get the identifier
+                var sut = new TentacleManagerInstanceIdentifierService(identifierFullPath);
+                var identifierValue = await sut.GetIdentifier();
+
+                // Assert: The identifier returned should be a valid ID
+                Assert.DoesNotThrow(() => Guid.Parse(identifierValue));
+                // Assert: The identifier file should not contain the original invalid value(s)
+                var identifierFileContents = File.ReadAllLines(identifierFullPath);
+                Assert.AreEqual(1, identifierFileContents.Length);
+                var identifierFileContentsLine = identifierFileContents.Single();
+                Assert.IsFalse(identifierFileContentsLine.Contains(invalidLine1));
+                Assert.IsFalse(identifierFileContentsLine.Contains(invalidLine2));
             }
-            
-            // Act: Get the identifier
-            var sut = new TentacleManagerInstanceIdentifierService(new DirectoryInfo(identifierLocation));
-            var identifierValue = await sut.GetIdentifier();
-            
-            // Assert: The identifier returned should be a valid ID
-            Assert.DoesNotThrow(() => Guid.Parse(identifierValue));
-            // Assert: The identifier file should not contain the original invalid value(s)
-            var identifierFileContents = File.ReadAllLines(identifierFullPath);
-            Assert.AreEqual(1, identifierFileContents.Length);
-            var identifierFileContentsLine = identifierFileContents.Single();
-            Assert.IsFalse(identifierFileContentsLine.Contains(invalidLine1));
-            Assert.IsFalse(identifierFileContentsLine.Contains(invalidLine2));
-            
+            finally
+            {
+                File.Delete(identifierFullPath);
+            }
         }
     }
 }

--- a/source/Octopus.Manager.Tentacle.Tests/Utils/TentacleManagerInstanceIdentifierServiceFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/Utils/TentacleManagerInstanceIdentifierServiceFixture.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Octopus.Manager.Tentacle.Util;
+
+namespace Octopus.Manager.Tentacle.Tests.Utils
+{
+    public class TentacleManagerInstanceIdentifierServiceFixture
+    {
+        readonly string identifierLocation = Path.GetTempPath();
+        
+        [Test]
+        public async Task Given_ThereIsNoExistingIdentifier_When_AnIdentifierIsRequested_Then_ANewIdentifierIsGeneratedAndReturned()
+        {
+            // Arrange: Ensure there is no current identifier
+            var identifierFullPath = Path.Combine(identifierLocation, TentacleManagerInstanceIdentifierService.IdentifierFileName);
+            File.Delete(identifierFullPath);
+            Assert.False(File.Exists(identifierFullPath));
+
+            // Act: Get the identifier
+            var sut = new TentacleManagerInstanceIdentifierService(new DirectoryInfo(identifierLocation));
+            var identifierValue = await sut.GetIdentifier();
+            
+            // Assert: The identifier returned should match the contents of the file we expect to be created
+            Assert.True(File.Exists(identifierFullPath));
+            var identifierFileContents = File.ReadAllLines(identifierFullPath);
+            Assert.AreEqual(1, identifierFileContents.Length);
+            Assert.AreEqual(identifierValue, identifierFileContents.Single());
+        }
+
+        [Test]
+        public async Task Given_ThereIsAnExistingIdentifier_When_AnIdentifierIsRequested_Then_TheExistingIdentifierIsReturned()
+        {
+            // Arrange: Ensure there is an existing identifier
+            var identifierFullPath = Path.Combine(identifierLocation, TentacleManagerInstanceIdentifierService.IdentifierFileName);
+            var identifier = Guid.NewGuid().ToString("N");
+            // ReSharper disable once ConvertToUsingDeclaration
+            using (var streamWriter = File.CreateText(identifierFullPath))
+            {
+                await streamWriter.WriteLineAsync(identifier);
+            }
+
+            // Act: Get the identifier
+            var sut = new TentacleManagerInstanceIdentifierService(new DirectoryInfo(identifierLocation));
+            var identifierValue = await sut.GetIdentifier();
+            
+            // Assert: The identifier returned should match the contents of the pre-existing file
+            Assert.AreEqual(identifier, identifierValue);
+        }
+
+        [Test]
+        public async Task Given_ThereIsAnExistingInvalidIdentifier_When_AnIdentifierIsRequested_Then_ANewIdentifierIsGeneratedAndReturned()
+        {
+            // Arrange: Ensure there is an existing but invalid identifier file
+            var identifierFullPath = Path.Combine(identifierLocation, TentacleManagerInstanceIdentifierService.IdentifierFileName);
+            var invalidLine1 = "This is not a valid ID string";
+            var invalidLine2 = "This contains multiple lines";
+            // ReSharper disable once ConvertToUsingDeclaration
+            using (var streamWriter = File.CreateText(identifierFullPath))
+            {
+                await streamWriter.WriteLineAsync(invalidLine1);
+                await streamWriter.WriteLineAsync(invalidLine2);
+            }
+            
+            // Act: Get the identifier
+            var sut = new TentacleManagerInstanceIdentifierService(new DirectoryInfo(identifierLocation));
+            var identifierValue = await sut.GetIdentifier();
+            
+            // Assert: The identifier returned should be a valid ID
+            Assert.DoesNotThrow(() => Guid.Parse(identifierValue));
+            // Assert: The identifier file should not contain the original invalid value(s)
+            var identifierFileContents = File.ReadAllLines(identifierFullPath);
+            Assert.AreEqual(1, identifierFileContents.Length);
+            var identifierFileContentsLine = identifierFileContents.Single();
+            Assert.IsFalse(identifierFileContentsLine.Contains(invalidLine1));
+            Assert.IsFalse(identifierFileContentsLine.Contains(invalidLine2));
+            
+        }
+    }
+}

--- a/source/Octopus.Manager.Tentacle.Tests/WizardFixtures/SetupTentacleWizardFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/WizardFixtures/SetupTentacleWizardFixture.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
@@ -30,14 +32,17 @@ namespace Octopus.Manager.Tentacle.Tests.WizardFixtures
 
             // Assert
             var pathToTentacleExe = $"\"{model.PathToTentacleExe ?? CommandLine.PathToTentacleExe()}\"";
-            var expectedOutput = $"{pathToTentacleExe} create-instance --instance \"{model.InstanceName}\" --config \"C:\\Octopus\\{model.InstanceName}\\Tentacle-{model.InstanceName}.config\"" +
-                Environment.NewLine + $"{pathToTentacleExe} new-certificate --instance \"{model.InstanceName}\" --if-blank" +
-                Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --reset-trust" +
-                Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --app \"C:\\Octopus\\Applications\\{model.InstanceName}\" --port \"{model.ListenPort}\" --noListen \"False\"" +
-                Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --trust \"{model.OctopusThumbprint}\"" +
-                Environment.NewLine + $"\"netsh\" advfirewall firewall add rule \"name=Octopus Deploy Tentacle\" dir=in action=allow protocol=TCP localport={model.ListenPort}" +
-                Environment.NewLine + $"{pathToTentacleExe} service --instance \"{model.InstanceName}\" --install --stop --start";
-            script.Should().Be(expectedOutput);
+
+            StringBuilder expectedOutput = new StringBuilder();
+            expectedOutput.AppendLine($"{pathToTentacleExe} create-instance --instance \"{model.InstanceName}\" --config \"C:\\Octopus\\{model.InstanceName}\\Tentacle-{model.InstanceName}.config\"");
+            expectedOutput.AppendLine($"{pathToTentacleExe} new-certificate --instance \"{model.InstanceName}\" --if-blank");
+            expectedOutput.AppendLine($"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --reset-trust");
+            expectedOutput.AppendLine($"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --app \"C:\\Octopus\\Applications\\{model.InstanceName}\" --port \"{model.ListenPort}\" --noListen \"False\"");
+            expectedOutput.AppendLine($"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --trust \"{model.OctopusThumbprint}\"");
+            expectedOutput.AppendLine($"\"netsh\" advfirewall firewall add rule \"name=Octopus Deploy Tentacle\" dir=in action=allow protocol=TCP localport={model.ListenPort}");
+            expectedOutput.Append($"{pathToTentacleExe} service --instance \"{model.InstanceName}\" --install --stop --start");
+            
+            script.Should().Be(expectedOutput.ToString());
         }
 
         [Test]
@@ -60,14 +65,17 @@ namespace Octopus.Manager.Tentacle.Tests.WizardFixtures
 
             // Assert
             var pathToTentacleExe = $"\"{model.PathToTentacleExe ?? CommandLine.PathToTentacleExe()}\"";
-            var expectedOutput = $"{pathToTentacleExe} create-instance --instance \"{model.InstanceName}\" --config \"C:\\Octopus\\{model.InstanceName}\\Tentacle-{model.InstanceName}.config\"" +
-                Environment.NewLine + $"{pathToTentacleExe} new-certificate --instance \"{model.InstanceName}\" --if-blank" +
-                Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --reset-trust" +
-                Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --app \"C:\\Octopus\\Applications\\{model.InstanceName}\" --port \"{model.ListenPort}\" --noListen \"True\"" +
-                Environment.NewLine + $"{pathToTentacleExe} polling-proxy --instance \"{model.InstanceName}\" --proxyEnable \"False\" --proxyUsername \"\" --proxyPassword \"\" --proxyHost \"\" --proxyPort \"\"" +
-                Environment.NewLine + $"{pathToTentacleExe} register-with --instance \"{model.InstanceName}\" --server \"{model.OctopusServerUrl}\" --name \"{model.MachineName}\" --comms-style \"TentacleActive\" --server-comms-port \"{model.ServerCommsPort}\" --apiKey \"{model.ApiKey}\" --policy \"{model.SelectedMachinePolicy}\"" +
-                Environment.NewLine + $"{pathToTentacleExe} service --instance \"{model.InstanceName}\" --install --stop --start";
-            script.Should().Be(expectedOutput);
+            
+            StringBuilder expectedOutput = new StringBuilder();
+            expectedOutput.AppendLine($"{pathToTentacleExe} create-instance --instance \"{model.InstanceName}\" --config \"C:\\Octopus\\{model.InstanceName}\\Tentacle-{model.InstanceName}.config\"");
+            expectedOutput.AppendLine($"{pathToTentacleExe} new-certificate --instance \"{model.InstanceName}\" --if-blank");
+            expectedOutput.AppendLine($"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --reset-trust");
+            expectedOutput.AppendLine($"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --app \"C:\\Octopus\\Applications\\{model.InstanceName}\" --port \"{model.ListenPort}\" --noListen \"True\"");
+            expectedOutput.AppendLine($"{pathToTentacleExe} polling-proxy --instance \"{model.InstanceName}\" --proxyEnable \"False\" --proxyUsername \"\" --proxyPassword \"\" --proxyHost \"\" --proxyPort \"\"");
+            expectedOutput.AppendLine($"{pathToTentacleExe} register-with --instance \"{model.InstanceName}\" --server \"{model.OctopusServerUrl}\" --name \"{model.MachineName}\" --comms-style \"TentacleActive\" --server-comms-port \"{model.ServerCommsPort}\" --apiKey \"{model.ApiKey}\" --policy \"{model.SelectedMachinePolicy}\"");
+            expectedOutput.Append($"{pathToTentacleExe} service --instance \"{model.InstanceName}\" --install --stop --start");
+            
+            script.Should().Be(expectedOutput.ToString());
         }
 
         [Test]

--- a/source/Octopus.Manager.Tentacle.Tests/WizardFixtures/SetupTentacleWizardFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/WizardFixtures/SetupTentacleWizardFixture.cs
@@ -1,14 +1,14 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Client.Model;
-using Octopus.Manager.Tentacle.Shell;
+using Octopus.Manager.Tentacle.Infrastructure;
 using Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard;
+using Octopus.Manager.Tentacle.Tests.Builders;
 using Octopus.Manager.Tentacle.Tests.Utils;
 using Octopus.Manager.Tentacle.Util;
-using Octopus.Tentacle.Configuration;
-using Octopus.Tentacle.Configuration.Instances;
 
 namespace Octopus.Manager.Tentacle.Tests.WizardFixtures
 {
@@ -18,7 +18,7 @@ namespace Octopus.Manager.Tentacle.Tests.WizardFixtures
         public void WhenSettingUpListeningTentacle_ScriptShouldBeCorrectlyGenerated()
         {
             // Arrange
-            var model = CreateTestSetupTentacleWizardModel();
+            var model = new SetupTentacleWizardModelBuilder().Build();
             model.CommunicationStyle = CommunicationStyle.TentaclePassive;
             model.ListenPort = "10933";
             model.OctopusThumbprint = "TestThumbprint";
@@ -31,20 +31,20 @@ namespace Octopus.Manager.Tentacle.Tests.WizardFixtures
             // Assert
             var pathToTentacleExe = $"\"{model.PathToTentacleExe ?? CommandLine.PathToTentacleExe()}\"";
             var expectedOutput = $"{pathToTentacleExe} create-instance --instance \"{model.InstanceName}\" --config \"C:\\Octopus\\{model.InstanceName}\\Tentacle-{model.InstanceName}.config\"" +
-                    Environment.NewLine + $"{pathToTentacleExe} new-certificate --instance \"{model.InstanceName}\" --if-blank" +
-                    Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --reset-trust" +
-                    Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --app \"C:\\Octopus\\Applications\\{model.InstanceName}\" --port \"{model.ListenPort}\" --noListen \"False\"" +
-                    Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --trust \"{model.OctopusThumbprint}\"" +
-                    Environment.NewLine + $"\"netsh\" advfirewall firewall add rule \"name=Octopus Deploy Tentacle\" dir=in action=allow protocol=TCP localport={model.ListenPort}" +
-                    Environment.NewLine + $"{pathToTentacleExe} service --instance \"{model.InstanceName}\" --install --stop --start";
+                Environment.NewLine + $"{pathToTentacleExe} new-certificate --instance \"{model.InstanceName}\" --if-blank" +
+                Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --reset-trust" +
+                Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --app \"C:\\Octopus\\Applications\\{model.InstanceName}\" --port \"{model.ListenPort}\" --noListen \"False\"" +
+                Environment.NewLine + $"{pathToTentacleExe} configure --instance \"{model.InstanceName}\" --trust \"{model.OctopusThumbprint}\"" +
+                Environment.NewLine + $"\"netsh\" advfirewall firewall add rule \"name=Octopus Deploy Tentacle\" dir=in action=allow protocol=TCP localport={model.ListenPort}" +
+                Environment.NewLine + $"{pathToTentacleExe} service --instance \"{model.InstanceName}\" --install --stop --start";
             script.Should().Be(expectedOutput);
         }
-        
+
         [Test]
         public void WhenSettingUpPollingTentacle_ScriptShouldBeCorrectlyGenerated()
         {
             // Arrange
-            var model = CreateTestSetupTentacleWizardModel();
+            var model = new SetupTentacleWizardModelBuilder().Build();
             model.CommunicationStyle = CommunicationStyle.TentacleActive;
             model.OctopusServerUrl = "localhost";
             model.AuthMode = AuthMode.APIKey;
@@ -69,17 +69,32 @@ namespace Octopus.Manager.Tentacle.Tests.WizardFixtures
                 Environment.NewLine + $"{pathToTentacleExe} service --instance \"{model.InstanceName}\" --install --stop --start";
             script.Should().Be(expectedOutput);
         }
-        
-        static SetupTentacleWizardModel CreateTestSetupTentacleWizardModel()
-        {
-            var instanceStore = Substitute.For<IApplicationInstanceStore>();
-            var instanceSelectionModel = new InstanceSelectionModel(ApplicationName.Tentacle, instanceStore);
-            const string tentacleInstanceName = "TestInstance";
-            instanceSelectionModel.New(tentacleInstanceName);
 
-            var model = new SetupTentacleWizardModel(instanceSelectionModel);
-            
-            return model;
+        [Test]
+        public async Task WhenSettingUpPollingTentacle_TelemetryEventShouldBeSent()
+        {
+            var telemetryService = new TelemetryServiceBuilder().Build();
+
+            var model = new SetupTentacleWizardModelBuilder()
+                .WithTelemetryService(telemetryService)
+                .Build();
+
+            model.OctopusServerUrl = "http://localhost";
+            model.CommunicationStyle = CommunicationStyle.TentacleActive;
+            model.MachineType = MachineType.DeploymentTarget;
+
+            _ = await model.ReviewAndRunScriptTabViewModel.GenerateAndExecuteScript();
+
+            // TODO: Replace with a less ugly assertion
+            await telemetryService
+                .Received(1)
+                .SendTelemetryEvent(
+                    new Uri("http://localhost"),
+                    Arg.Is<TelemetryEvent>(t =>
+                        t.EventProperties.ContainsKey("Communication Style") &&
+                        t.EventProperties["Communication Style"] == CommunicationStyle.TentacleActive.ToString() &&
+                        t.EventProperties.ContainsKey("Machine Type") &&
+                        t.EventProperties["Machine Type"] == MachineType.DeploymentTarget.ToString()));
         }
     }
 }

--- a/source/Octopus.Manager.Tentacle.Tests/WizardFixtures/SetupTentacleWizardFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/WizardFixtures/SetupTentacleWizardFixture.cs
@@ -96,5 +96,23 @@ namespace Octopus.Manager.Tentacle.Tests.WizardFixtures
                         t.EventProperties.ContainsKey("Machine Type") &&
                         t.EventProperties["Machine Type"] == MachineType.DeploymentTarget.ToString()));
         }
+
+        [Test]
+        public async Task WhenSettingUpAListeningTentacle_TelemetryEventShouldNotBeSent()
+        {
+            var telemetryService = new TelemetryServiceBuilder().Build();
+
+            var model = new SetupTentacleWizardModelBuilder()
+                .WithTelemetryService(telemetryService)
+                .Build();
+
+            model.CommunicationStyle = CommunicationStyle.TentaclePassive;
+
+            _ = await model.ReviewAndRunScriptTabViewModel.GenerateAndExecuteScript();
+
+            await telemetryService
+                .Received(0)
+                .SendTelemetryEvent(Arg.Any<Uri>(), Arg.Any<TelemetryEvent>());
+        }
     }
 }

--- a/source/Octopus.Manager.Tentacle.Tests/WizardFixtures/SetupTentacleWizardFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/WizardFixtures/SetupTentacleWizardFixture.cs
@@ -94,7 +94,8 @@ namespace Octopus.Manager.Tentacle.Tests.WizardFixtures
                         t.EventProperties.ContainsKey("Communication Style") &&
                         t.EventProperties["Communication Style"] == CommunicationStyle.TentacleActive.ToString() &&
                         t.EventProperties.ContainsKey("Machine Type") &&
-                        t.EventProperties["Machine Type"] == MachineType.DeploymentTarget.ToString()));
+                        t.EventProperties["Machine Type"] == MachineType.DeploymentTarget.ToString()),
+                    Arg.Any<IWebProxy>());
         }
 
         [Test]
@@ -111,8 +112,8 @@ namespace Octopus.Manager.Tentacle.Tests.WizardFixtures
             _ = await model.ReviewAndRunScriptTabViewModel.GenerateAndExecuteScript();
 
             await telemetryService
-                .Received(0)
-                .SendTelemetryEvent(Arg.Any<Uri>(), Arg.Any<TelemetryEvent>());
+                .DidNotReceiveWithAnyArgs()
+                .SendTelemetryEvent(null, null, null);
         }
     }
 }

--- a/source/Octopus.Manager.Tentacle/App.xaml.cs
+++ b/source/Octopus.Manager.Tentacle/App.xaml.cs
@@ -84,7 +84,7 @@ namespace Octopus.Manager.Tentacle
             builder.RegisterModule(new ManagerConfigurationModule(ApplicationName.Tentacle));
 
             builder.RegisterModule(new TentacleConfigurationModule());
-            builder.RegisterModule(new TentacleModule());
+            builder.RegisterModule(new TentacleManagerModule());
             return builder.Build();
         }
 

--- a/source/Octopus.Manager.Tentacle/Infrastructure/TelemetryEvent.cs
+++ b/source/Octopus.Manager.Tentacle/Infrastructure/TelemetryEvent.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Octopus.Manager.Tentacle.Infrastructure
+{
+    public abstract class TelemetryEvent
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        
+        [JsonProperty("user_id")]
+        public string UserId { get; set; }
+
+        [JsonProperty("device_id")]
+        public string DeviceId { get; set;  }
+        
+        [JsonProperty("event_type")]
+        public string EventType { get; }
+
+        [JsonProperty("event_properties")]
+        public IDictionary<string, string> EventProperties = new Dictionary<string, string>();
+
+        protected TelemetryEvent(string eventType, string userId, string deviceId)
+        {
+            EventType = eventType;
+            UserId = userId;
+            DeviceId = deviceId;
+        }
+    }
+}

--- a/source/Octopus.Manager.Tentacle/Infrastructure/TelemetryEventBatch.cs
+++ b/source/Octopus.Manager.Tentacle/Infrastructure/TelemetryEventBatch.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Octopus.Manager.Tentacle.Infrastructure
+{
+    public class TelemetryEventBatch
+    {
+        [JsonProperty("client_upload_time")]
+        public long Timestamp { get; } = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        [JsonProperty("events")]
+        public IEnumerable<TelemetryEvent> Events { get; }
+
+        public TelemetryEventBatch(TelemetryEvent eventObj)
+        {
+            Events = new List<TelemetryEvent> { eventObj };
+        }
+    }
+}

--- a/source/Octopus.Manager.Tentacle/Infrastructure/TentacleManagerScriptExecuted.cs
+++ b/source/Octopus.Manager.Tentacle/Infrastructure/TentacleManagerScriptExecuted.cs
@@ -1,0 +1,22 @@
+using System;
+using Octopus.Client.Model;
+using Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard;
+
+namespace Octopus.Manager.Tentacle.Infrastructure
+{
+    public class TentacleManagerScriptExecuted : TelemetryEvent
+    {
+        public TentacleManagerScriptExecuted(
+            string userId,
+            string deviceId,
+            string description,
+            MachineType machineType,
+            CommunicationStyle communicationStyle)
+            : base("Tentacle Manager script executed", userId, deviceId)
+        {
+            EventProperties.Add("Description", description);
+            EventProperties.Add("Machine Type", machineType.ToString());
+            EventProperties.Add("Communication Style", communicationStyle.ToString());
+        }
+    }
+}

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/ReviewAndRunScriptTabViewModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/ReviewAndRunScriptTabViewModel.cs
@@ -5,6 +5,7 @@ using FluentValidation;
 using Octopus.Diagnostics;
 using Octopus.Manager.Tentacle.Infrastructure;
 using Octopus.Manager.Tentacle.Util;
+using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
@@ -15,7 +16,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
         readonly Func<Task> onScriptSucceeded;
         readonly Func<Task> onScriptFailed;
         readonly IScriptableViewModel wizardModel;
-        TextBoxLogger logger;
+        SystemLog logger;
 
         public ReviewAndRunScriptTabViewModel(
             IScriptableViewModel wizardModel,
@@ -108,7 +109,12 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
             return validator;
         }
 
-        public void SetLogger(TextBoxLogger newLogger)
+        // TODO: Remove this workaround
+        // This only exists so that a TextBoxLogger, a UI component,
+        // can be set from the view.
+        // We should change this so that the model doesn't depend
+        // on a UI component.
+        public void SetLogger(SystemLog newLogger)
         {
             logger = newLogger;
         }

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
@@ -969,6 +969,13 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
 
         async Task SendTentacleInstalledTelemetryEvent()
         {
+            // Do not try to send telemetry if we are installing a 
+            // listening Tentacle
+            if (CommunicationStyle == CommunicationStyle.TentaclePassive)
+            {
+                return;
+            }
+            
             var deviceId = await tentacleManagerInstanceIdentifierService.GetIdentifier();
 
             var eventObj = new TentacleManagerScriptExecuted(

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManager/TentacleManagerView.xaml.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManager/TentacleManagerView.xaml.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Data;
-using Autofac;
 using MaterialDesignThemes.Wpf;
 using Octopus.Manager.Tentacle.DeleteWizard;
 using Octopus.Manager.Tentacle.DeleteWizard.Views;
@@ -104,13 +103,11 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.TentacleManager
             wizard.AddTab(new MachineType(setupTentacleWizardModel));
             wizard.AddTab(new TentacleActiveDetailsTab(setupTentacleWizardModel));
             wizard.AddTab(new TentaclePassiveTab(setupTentacleWizardModel));
-            wizard.AddTab(
-                new ReviewAndRunScriptTabView(new ReviewAndRunScriptTabViewModel(setupTentacleWizardModel, model.CommandLineRunner))
-                {
-                    ReadyMessage = "You're ready to install an Octopus Tentacle.",
-                    SuccessMessage = "Installation complete!"
-                }
-            );
+            wizard.AddTab(new ReviewAndRunScriptTabView(setupTentacleWizardModel.ReviewAndRunScriptTabViewModel)
+            {
+                ReadyMessage = "You're ready to install an Octopus Tentacle.",
+                SuccessMessage = "Installation complete!"
+            });
 
             var shell = new ShellView("Tentacle Setup Wizard", setupTentacleWizardModel)
             {

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManagerModule.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManagerModule.cs
@@ -44,7 +44,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration
             builder.RegisterType<TentacleManagerInstanceIdentifierService>()
                 .As<ITentacleManagerInstanceIdentifierService>()
                 .SingleInstance()
-                .WithParameter("identifierLocation", new DirectoryInfo(processExecutableLocation));
+                .WithParameter("identifierFilePath", Path.Combine(processExecutableLocation, "TentacleManagerInstanceID"));
         }
     }
 }

--- a/source/Octopus.Manager.Tentacle/Util/TelemetryService.cs
+++ b/source/Octopus.Manager.Tentacle/Util/TelemetryService.cs
@@ -23,8 +23,15 @@ namespace Octopus.Manager.Tentacle.Util
                 var eventBatch = new TelemetryEventBatch(eventObj);
                 var stringPayload = JsonConvert.SerializeObject(eventBatch);
 
-                var response = await httpClient.PostAsync("api/telemetry/process", new StringContent(stringPayload, Encoding.UTF8, "application/json"));
-                return response.IsSuccessStatusCode;
+                try
+                {
+                    var response = await httpClient.PostAsync("api/telemetry/process", new StringContent(stringPayload, Encoding.UTF8, "application/json"));
+                    return response.IsSuccessStatusCode;
+                }
+                catch
+                {
+                    return false;
+                }
             }
         }
     }

--- a/source/Octopus.Manager.Tentacle/Util/TelemetryService.cs
+++ b/source/Octopus.Manager.Tentacle/Util/TelemetryService.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Octopus.Manager.Tentacle.Infrastructure;
+
+namespace Octopus.Manager.Tentacle.Util
+{
+    public interface ITelemetryService
+    {
+        Task<bool> SendTelemetryEvent(Uri serverUri, TelemetryEvent eventObj);
+    }
+    
+    public class TelemetryService: ITelemetryService
+    {
+        public async Task<bool> SendTelemetryEvent(Uri serverUri, TelemetryEvent eventObj)
+        {
+            using (var httpClient = new HttpClient())
+            {
+                httpClient.BaseAddress = serverUri;
+
+                var eventBatch = new TelemetryEventBatch(eventObj);
+                var stringPayload = JsonConvert.SerializeObject(eventBatch);
+
+                var response = await httpClient.PostAsync("api/telemetry/process", new StringContent(stringPayload, Encoding.UTF8, "application/json"));
+                return response.IsSuccessStatusCode;
+            }
+        }
+    }
+}

--- a/source/Octopus.Manager.Tentacle/Util/TentacleManagerInstanceIdentifierService.cs
+++ b/source/Octopus.Manager.Tentacle/Util/TentacleManagerInstanceIdentifierService.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Octopus.Manager.Tentacle.Util
+{
+    public interface ITentacleManagerInstanceIdentifierService
+    {
+        Task<string> GetIdentifier();
+    }
+
+    public class TentacleManagerInstanceIdentifierService : ITentacleManagerInstanceIdentifierService
+    {
+        public const string IdentifierFileName = "TentacleManagerInstanceID";
+
+        readonly DirectoryInfo identifierLocation;
+
+        public TentacleManagerInstanceIdentifierService(DirectoryInfo identifierLocation)
+        {
+            this.identifierLocation = identifierLocation;
+        }
+
+        public async Task<string> GetIdentifier()
+        {
+            var identifierFilePath = Path.Combine(identifierLocation.FullName, IdentifierFileName);
+
+            if (File.Exists(identifierFilePath))
+            {
+                var fileContentsLines = File.ReadAllLines(identifierFilePath);
+                if (Guid.TryParseExact(fileContentsLines.First(), "N", out var id))
+                {
+                    return id.ToString("N");
+                }
+            }
+
+            using (var streamWriter = File.CreateText(identifierFilePath))
+            {
+                var identifier = Guid.NewGuid().ToString("N");
+                await streamWriter.WriteLineAsync(identifier);
+                return identifier;
+            }
+        }
+    }
+}

--- a/source/Octopus.Manager.Tentacle/Util/TentacleManagerInstanceIdentifierService.cs
+++ b/source/Octopus.Manager.Tentacle/Util/TentacleManagerInstanceIdentifierService.cs
@@ -12,19 +12,15 @@ namespace Octopus.Manager.Tentacle.Util
 
     public class TentacleManagerInstanceIdentifierService : ITentacleManagerInstanceIdentifierService
     {
-        public const string IdentifierFileName = "TentacleManagerInstanceID";
+        readonly string identifierFilePath;
 
-        readonly DirectoryInfo identifierLocation;
-
-        public TentacleManagerInstanceIdentifierService(DirectoryInfo identifierLocation)
+        public TentacleManagerInstanceIdentifierService(string identifierFilePath)
         {
-            this.identifierLocation = identifierLocation;
+            this.identifierFilePath = identifierFilePath;
         }
 
         public async Task<string> GetIdentifier()
         {
-            var identifierFilePath = Path.Combine(identifierLocation.FullName, IdentifierFileName);
-
             if (File.Exists(identifierFilePath))
             {
                 var fileContentsLines = File.ReadAllLines(identifierFilePath);


### PR DESCRIPTION
# Background
We currently have no visibility into our customer’s use of Tentacle Manager. This makes it difficult to decide how to prioritize potential future work, as there is no evidence on which to base these decisions.

This PR makes the first step to improve this situation by introducing telemetry to Tentacle Manager.

# Results
Tentacle Manager will now send telemetry to Amplitude (via Octopus Server) when:

_An instance of a polling Tentacle (deployment target, or worker) is installed/registered/configured._

The telemetry data is very basic and only contains:
* User ID
* Device ID (unique to the instance of Tentacle Manager)
* Communication Style (i.e. polling/listening)
* Machine Type (Worker, or Deployment Target)

Octopus Server will augment the event with some further Server-specific data before sending to Amplitude. This data is standard to every event sent to Amplitude by Octopus Server and includes:
* Installation ID
* License Hash
* Feature toggles
* Feature settings
* Host environment (i.e. on-prem, cloud)
* Version

![The new 'Tentacle Manager script executed' event in Amplitude](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/d460fb43-a60d-4833-8be5-0ce635de6bf9)

## Why only send telemetry for installing polling tentacles?
We are constrained by the requirement that Tentacle Manager _only_ communicate with Octopus Server, and no other remote endpoint.

Many (most?) Tentacles are installed within restricted corporate networks, therefore requiring additional outgoing requests from Tentacle Manager would often involve updating firewall policies etc, which is not feasible for this scenario.

There is an existing mechanism, used by the front-end portal, to send Amplitude messages via Octopus Server. While this is adequate for our needs, it does mean that we can only send telemetry when we have _a valid Octopus Server API endpoint_. Tentacle Manager is not inherently associated with an instance of Octopus Server, and only communicates with an instance of Server during the ‘Install Polling Tentacle’ wizard process.

Our metrics show that ~30% of Tentacles are polling, which is a large enough sample size to get some valuable data on Tentacle Manager usage.

## What is the Tentacle Manager Instance ID?
The ability to differentiate between instances of Tentacle Manager could be a useful data point when analyzing the telemetry events.

For example, we see from the telemetry that a user uses Tentacle Manager to configure 3 polling Tentacle instances over 1 week. It may be useful to know if that was 3 polling Tentacles installed on 3 different machines, or if they installed (and uninstalled) a Tentacle 3 times on a single machine.

To provide this data, a very simple instance identifier was implemented for Tentacle Manager. When Tentacle Manager is started, it looks for a specific file in the executable’s current directory called `TentacleManagerInstanceID`. This file only contains a unique identifier (i.e. GUID) which Tentacle Manager can use to populate the ‘DeviceID’ field in Amplitude messages. If this file does not exist, it is automatically generated.

This allows us to differentiate between instances of Tentacle Manager, without relying on any system-specific or identifiable data (e.g. Machine name, IP address, Windows Registry ID value).

# Potential future work
This PR represents the minimum amount of work required to produce useful telemetry data for Tentacle Manager, but there is plenty that has been intentionally not done in the interest of time and scope:

## Telemetry for more events
This PR is the simplest implementation available, but an implementation involving changes to both Tentacle and Server would allow more telemetry events (e.g. Deleting, Modifying, Starting/Stopping services) for both polling and listening Tentacles.

## More telemetry tests
We have a single ‘happy path’ test for sending telemetry. This can be expanded upon in the future as necessary.

## Further refactoring to separate UI and business logic
Working on this PR exposed some more rough edges on how we separate our UI and business logic in Tentacle Manager. This can be improved in the future to allow more comprehensive unit tests (rather than relying on manual testing).

# How to review this PR
:heavy_check_mark: General code quality, and manual testing of the ‘install new Tentacle’ wizard.

# Pre-requisites
- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.