### PR TITLE
Include net6.0-windows package when running PackCrossPlatforrmBundle

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -451,6 +451,8 @@ partial class Build
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-x64.msi", workingDirectory / "Octopus.Tentacle-x64.msi");
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net6.0-win-x86.msi", workingDirectory / "Octopus.Tentacle-net6.0-win-x86.msi");
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net6.0-win-x64.msi", workingDirectory / "Octopus.Tentacle-net6.0-win-x64.msi");
+            FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net6.0-windows-win-x64.msi", workingDirectory / "Octopus.Tentacle-net6.0-windows-win-x64.msi");
+            FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net6.0-windows-win-x64.msi", workingDirectory / "Octopus.Tentacle-net6.0-windows-win-x64.msi");
 
             FileSystemTasks.CopyFile(BuildDirectory / "Octopus.Tentacle.Upgrader" / NetCore / "win-x86" / "Octopus.Tentacle.Upgrader.exe", workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x86.exe");
             FileSystemTasks.CopyFile(BuildDirectory / "Octopus.Tentacle.Upgrader" / NetCore / "win-x64" / "Octopus.Tentacle.Upgrader.exe", workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x64.exe");
@@ -468,19 +470,26 @@ partial class Build
             {
                 foreach (var runtimeId in RuntimeIds)
                 {
-                    if (runtimeId == "win" && framework != "net48"
-                        || runtimeId != "win" && framework == "net48") continue;
+                    if (runtimeId == "win" && framework != NetFramework
+                        || runtimeId != "win" && framework == NetFramework) continue;
 
                     var fileExtension = runtimeId.StartsWith("win") ? "zip" : "tar.gz";
                     FileSystemTasks.CopyFile(ArtifactsDirectory / "zip" / $"tentacle-{FullSemVer}-{framework}-{runtimeId}.{fileExtension}",
                         workingDirectory / $"tentacle-{framework}-{runtimeId}.{fileExtension}");
                 }
             }
+            
+            FileSystemTasks.CopyFile(ArtifactsDirectory / "zip" / $"tentacle-{FullSemVer}-{NetCoreWindows}-win-x86.zip",
+                workingDirectory / $"tentacle-{NetCoreWindows}-win-x86.zip");
+            FileSystemTasks.CopyFile(ArtifactsDirectory / "zip" / $"tentacle-{FullSemVer}-{NetCoreWindows}-win-x64.zip",
+                workingDirectory / $"tentacle-{NetCoreWindows}-win-x64.zip");
 
             Assert.True((workingDirectory / "Octopus.Tentacle.msi").FileExists(), "Missing Octopus.Tentacle.msi");
             Assert.True((workingDirectory / "Octopus.Tentacle-x64.msi").FileExists(), "Missing Octopus.Tentacle-x64.msi");
             Assert.True((workingDirectory / "Octopus.Tentacle-net6.0-win-x86.msi").FileExists(), "Missing Octopus.Tentacle-net6.0-win-x86.msi");
             Assert.True((workingDirectory / "Octopus.Tentacle-net6.0-win-x64.msi").FileExists(), "Missing Octopus.Tentacle-net6.0-win-x64.msi");
+            Assert.True((workingDirectory / "Octopus.Tentacle-net6.0-windows-win-x86.msi").FileExists(), "Missing Octopus.Tentacle-net6.0-windows-win-x86.msi");
+            Assert.True((workingDirectory / "Octopus.Tentacle-net6.0-windows-win-x64.msi").FileExists(), "Missing Octopus.Tentacle-net6.0-windows-win-x64.msi");
             Assert.True((workingDirectory / "Octopus.Tentacle.Upgrader.exe").FileExists(), "Missing Octopus.Tentacle.Upgrader.exe");
             Assert.True((workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x86.exe").FileExists(), "Missing Octopus.Tentacle.Upgrader-net6.0-win-x86.exe");
             Assert.True((workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x64.exe").FileExists(), "Missing Octopus.Tentacle.Upgrader-net6.0-win-x64.exe");

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -451,7 +451,7 @@ partial class Build
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-x64.msi", workingDirectory / "Octopus.Tentacle-x64.msi");
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net6.0-win-x86.msi", workingDirectory / "Octopus.Tentacle-net6.0-win-x86.msi");
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net6.0-win-x64.msi", workingDirectory / "Octopus.Tentacle-net6.0-win-x64.msi");
-            FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net6.0-windows-win-x64.msi", workingDirectory / "Octopus.Tentacle-net6.0-windows-win-x64.msi");
+            FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net6.0-windows-win-x86.msi", workingDirectory / "Octopus.Tentacle-net6.0-windows-win-x86.msi");
             FileSystemTasks.CopyFile(ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net6.0-windows-win-x64.msi", workingDirectory / "Octopus.Tentacle-net6.0-windows-win-x64.msi");
 
             FileSystemTasks.CopyFile(BuildDirectory / "Octopus.Tentacle.Upgrader" / NetCore / "win-x86" / "Octopus.Tentacle.Upgrader.exe", workingDirectory / "Octopus.Tentacle.Upgrader-net6.0-win-x86.exe");


### PR DESCRIPTION
# Background

Currently in our Tentacle build on deploy.octopus.app, we only upload .net6.0 and net48 versions of Tentacle to AWS S3 for direct downloads.

https://deploy.octopus.app/app#/Spaces-1/projects/octopus-tentacle/deployments/releases/8.1.998/deployments/Deployments-797858

We'd like to have the .net6,0-windows version of Tentacle (which has ,NET6 Tentacle Manager bundled within) to be uploaded as well.

This PR ensures we also pack `net6.0-windows` packages when running PackCrossPlatforrmBundle, which will then later be used to upload the `msi` executable files to AWS S3.

[sc-72678]

# Results

Changes in this PR ensure we also pack `net6.0-windows` packages when running PackCrossPlatforrmBundle, which will then later be used to upload the `msi` executable files to AWS S3.

## Before
`net6.0-windows` packages were not included in the cross-platform bundle output.
Screenshot taken from: https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacleNet48_SensibleDefaultsBuildCreateCrossPlatformBundle/11417589?buildTab=artifacts&focusLine=NaN#%2Fnuget%2FOctopus.Tentacle.CrossPlatformBundle.8.1.1017-main-nightly.nupkg

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/79076870/7df34572-1114-4e0a-a0b0-8c7fcd56da9f)

## After
`net6.0-windows` packages are now included in the cross-platform bundle output.
Screenshot taken from: 
https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacleNet48_SensibleDefaultsBuildCreateCrossPlatformBundle/11424325?buildTab=artifacts#%2Fnuget%2FOctopus.Tentacle.CrossPlatformBundle.8.1.1022-pull-831.nupkg

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/79076870/9721f08f-90f3-400b-9ca6-51d15606493e)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.