### PR TITLE
Add v2 ExecuteScript overload to ITentacleClient

### DIFF
--- a/source/Octopus.Tentacle.Client.Tests/Builders/AsyncClientCapabilitiesServiceV2Builder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/AsyncClientCapabilitiesServiceV2Builder.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Halibut.ServiceModel;
+using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    public class AsyncClientCapabilitiesServiceV2Builder
+    {
+        private readonly List<string> capabilities = new();
+
+        public AsyncClientCapabilitiesServiceV2Builder WithCapability(string capability)
+        {
+            capabilities.Add(capability);
+            return this;
+        }
+
+        public AsyncClientCapabilitiesServiceV2Builder WithCapabilities(params string[] capabilities)
+        {
+            this.capabilities.AddRange(capabilities);
+            return this;
+        }
+
+        public AsyncClientCapabilitiesServiceV2Builder RemoveCapability(string capability)
+        {
+            capabilities.Remove(capability);
+            return this;
+        }
+
+        public AsyncClientCapabilitiesServiceV2Builder ClearCapabilities()
+        {
+            capabilities.Clear();
+            return this;
+        }
+
+        public IAsyncClientCapabilitiesServiceV2 Build() =>
+            new FixedCapabilitiesService(capabilities);
+
+        public static IAsyncClientCapabilitiesServiceV2 Default() => new AsyncClientCapabilitiesServiceV2Builder()
+            .WithCapability(nameof(IScriptServiceV2))
+            .WithCapability(nameof(IScriptServiceV3Alpha))
+            .Build();
+
+        class FixedCapabilitiesService : IAsyncClientCapabilitiesServiceV2
+        {
+            readonly List<string> capabilities;
+
+            public FixedCapabilitiesService(List<string> capabilities)
+            {
+                this.capabilities = capabilities;
+            }
+
+            public async Task<CapabilitiesResponseV2> GetCapabilitiesAsync(HalibutProxyRequestOptions halibutProxyRequestOptions)
+            {
+                await Task.CompletedTask;
+                return new CapabilitiesResponseV2(capabilities.ToList());
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/AsyncClientScriptServiceBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/AsyncClientScriptServiceBuilder.cs
@@ -1,0 +1,15 @@
+using NSubstitute;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    public class AsyncClientScriptServiceBuilder
+    {
+        public IAsyncClientScriptService Build()
+        {
+            return Substitute.For<IAsyncClientScriptService>();
+        }
+
+        public static IAsyncClientScriptService Default() => new AsyncClientScriptServiceBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/AsyncClientScriptServiceV2Builder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/AsyncClientScriptServiceV2Builder.cs
@@ -1,0 +1,15 @@
+using NSubstitute;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    public class AsyncClientScriptServiceV2Builder
+    {
+        public IAsyncClientScriptServiceV2 Build()
+        {
+            return Substitute.For<IAsyncClientScriptServiceV2>();
+        }
+
+        public static IAsyncClientScriptServiceV2 Default() => new AsyncClientScriptServiceV2Builder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/AsyncClientScriptServiceV3AlphaBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/AsyncClientScriptServiceV3AlphaBuilder.cs
@@ -1,0 +1,15 @@
+using NSubstitute;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    public class AsyncClientScriptServiceV3AlphaBuilder
+    {
+        public IAsyncClientScriptServiceV3Alpha Build()
+        {
+            return Substitute.For<IAsyncClientScriptServiceV3Alpha>();
+        }
+
+        public static IAsyncClientScriptServiceV3Alpha Default() => new AsyncClientScriptServiceV3AlphaBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/ClientOperationMetricsBuilderBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/ClientOperationMetricsBuilderBuilder.cs
@@ -1,0 +1,20 @@
+using System;
+using Octopus.Tentacle.Client.Observability;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    class ClientOperationMetricsBuilderBuilder
+    {
+        DateTimeOffset? start;
+
+        public ClientOperationMetricsBuilderBuilder WithStart(DateTimeOffset start)
+        {
+            this.start = start;
+            return this;
+        }
+
+        public ClientOperationMetricsBuilder Build() => new(start.GetValueOrDefault(DateTimeOffset.Now));
+
+        public static ClientOperationMetricsBuilder Default() => new ClientOperationMetricsBuilderBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/RpcCallExecutorBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/RpcCallExecutorBuilder.cs
@@ -1,0 +1,31 @@
+using Octopus.Tentacle.Client.Execution;
+using Octopus.Tentacle.Client.Retries;
+using Octopus.Tentacle.Contracts.Observability;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    class RpcCallExecutorBuilder
+    {
+        RpcCallRetryHandler? rpcCallRetryHandler;
+        ITentacleClientObserver? tentacleClientObserver;
+
+        public RpcCallExecutorBuilder WithRpcCallRetryHandler(RpcCallRetryHandler rpcCallRetryHandler)
+        {
+            this.rpcCallRetryHandler = rpcCallRetryHandler;
+            return this;
+        }
+
+        public RpcCallExecutorBuilder WithTentacleClientObserver(ITentacleClientObserver tentacleClientObserver)
+        {
+            this.tentacleClientObserver = tentacleClientObserver;
+            return this;
+        }
+
+        public RpcCallExecutor Build() =>
+            new RpcCallExecutor(
+                rpcCallRetryHandler ?? RpcCallRetryHandlerBuilder.Default(),
+                tentacleClientObserver ?? TentacleClientObserverBuilder.Default());
+
+        public static RpcCallExecutor Default() => new RpcCallExecutorBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/RpcCallRetryHandlerBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/RpcCallRetryHandlerBuilder.cs
@@ -1,0 +1,15 @@
+using System;
+using Octopus.Tentacle.Client.Retries;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    class RpcCallRetryHandlerBuilder
+    {
+        public RpcCallRetryHandler Build()
+        {
+            return new RpcCallRetryHandler(TimeSpan.FromSeconds(5));
+        }
+
+        public static RpcCallRetryHandler Default() => new RpcCallRetryHandlerBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/RpcRetrySettingsBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/RpcRetrySettingsBuilder.cs
@@ -1,0 +1,32 @@
+using System;
+using Octopus.Tentacle.Client.Retries;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    public class RpcRetrySettingsBuilder
+    {
+        bool retriesEnabled;
+        TimeSpan retryDuration = TimeSpan.Zero;
+
+        public RpcRetrySettingsBuilder WithRetriesEnabled(bool retriesEnabled)
+        {
+            this.retriesEnabled = retriesEnabled;
+            return this;
+        }
+
+        public RpcRetrySettingsBuilder WithRetriesEnabled() => WithRetriesEnabled(true);
+
+        public RpcRetrySettingsBuilder WithRetriesDisabled() => WithRetriesEnabled(false);
+
+        public RpcRetrySettingsBuilder WithRetryDuration(TimeSpan retryDuration)
+        {
+            this.retryDuration = retryDuration;
+            return this;
+        }
+
+        public RpcRetrySettings Build() =>
+            new(retriesEnabled, retryDuration);
+
+        public static RpcRetrySettings Default() => new RpcRetrySettingsBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/ScriptObserverBackoffStrategyBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/ScriptObserverBackoffStrategyBuilder.cs
@@ -1,0 +1,15 @@
+using NSubstitute;
+using Octopus.Tentacle.Client.Scripts;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    public class ScriptObserverBackoffStrategyBuilder
+    {
+        public IScriptObserverBackoffStrategy Build()
+        {
+            return Substitute.For<IScriptObserverBackoffStrategy>();
+        }
+
+        public static IScriptObserverBackoffStrategy Default() => new ScriptObserverBackoffStrategyBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/ScriptOrchestratorFactoryBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/ScriptOrchestratorFactoryBuilder.cs
@@ -23,6 +23,7 @@ namespace Octopus.Tentacle.Client.Tests.Builders
         TimeSpan? onCancellationAbandonCompleteScriptAfter;
         TentacleClientOptions? clientOptions;
         ILog? logger;
+        ScriptServiceVersion? maxScriptServiceVersion;
 
         public ScriptOrchestratorFactoryBuilder WithClientScriptServiceV1(IAsyncClientScriptService clientScriptServiceV1)
         {
@@ -144,6 +145,12 @@ namespace Octopus.Tentacle.Client.Tests.Builders
             return this;
         }
 
+        public ScriptOrchestratorFactoryBuilder WithMaxScriptServiceVersion(ScriptServiceVersion maxScriptServiceVersion)
+        {
+            this.maxScriptServiceVersion = maxScriptServiceVersion;
+            return this;
+        }
+
         public ScriptOrchestratorFactory Build() =>
             new(
                 clientScriptServiceV1 ?? AsyncClientScriptServiceBuilder.Default(),
@@ -159,7 +166,8 @@ namespace Octopus.Tentacle.Client.Tests.Builders
                 onScriptCompleted ?? (_ => Task.CompletedTask),
                 onCancellationAbandonCompleteScriptAfter ?? TimeSpan.FromSeconds(5),
                 clientOptions ?? TentacleClientOptionsBuilder.Default(),
-                logger ?? Substitute.For<ILog>()
+                logger ?? Substitute.For<ILog>(),
+                maxScriptServiceVersion.GetValueOrDefault(ScriptServiceVersion.Version3Alpha)
             );
 
         public static ScriptOrchestratorFactory Default() => new ScriptOrchestratorFactoryBuilder().Build();

--- a/source/Octopus.Tentacle.Client.Tests/Builders/ScriptOrchestratorFactoryBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/ScriptOrchestratorFactoryBuilder.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Threading.Tasks;
+using NSubstitute;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Client.Execution;
+using Octopus.Tentacle.Client.Observability;
+using Octopus.Tentacle.Client.Scripts;
+using Octopus.Tentacle.Contracts.ClientServices;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    class ScriptOrchestratorFactoryBuilder
+    {
+        IAsyncClientScriptService? clientScriptServiceV1;
+        IAsyncClientScriptServiceV2? clientScriptServiceV2;
+        IAsyncClientScriptServiceV3Alpha? clientScriptServiceV3Alpha;
+        IAsyncClientCapabilitiesServiceV2? clientCapabilitiesServiceV2;
+        IScriptObserverBackoffStrategy? scriptObserverBackoffStrategy;
+        RpcCallExecutor? rpcCallExecutor;
+        ClientOperationMetricsBuilder? clientOperationMetricsBuilder;
+        OnScriptStatusResponseReceived? onScriptStatusResponseReceived;
+        OnScriptCompleted? onScriptCompleted;
+        TimeSpan? onCancellationAbandonCompleteScriptAfter;
+        TentacleClientOptions? clientOptions;
+        ILog? logger;
+
+        public ScriptOrchestratorFactoryBuilder WithClientScriptServiceV1(IAsyncClientScriptService clientScriptServiceV1)
+        {
+            this.clientScriptServiceV1 = clientScriptServiceV1;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientScriptServiceV2(Func<AsyncClientScriptServiceBuilder, AsyncClientScriptServiceBuilder> builder)
+        {
+            clientScriptServiceV1 = builder(new AsyncClientScriptServiceBuilder()).Build();
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientScriptServiceV2(IAsyncClientScriptServiceV2 clientScriptServiceV2)
+        {
+            this.clientScriptServiceV2 = clientScriptServiceV2;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientScriptServiceV2(Func<AsyncClientScriptServiceV2Builder, AsyncClientScriptServiceV2Builder> builder)
+        {
+            clientScriptServiceV2 = builder(new AsyncClientScriptServiceV2Builder()).Build();
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientScriptServiceV3Alpha(IAsyncClientScriptServiceV3Alpha clientScriptServiceV3Alpha)
+        {
+            this.clientScriptServiceV3Alpha = clientScriptServiceV3Alpha;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientScriptServiceV3Alpha(Func<AsyncClientScriptServiceV3AlphaBuilder, AsyncClientScriptServiceV3AlphaBuilder> builder)
+        {
+            clientScriptServiceV3Alpha = builder(new AsyncClientScriptServiceV3AlphaBuilder()).Build();
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientCapabilitiesServiceV2(IAsyncClientCapabilitiesServiceV2 clientCapabilitiesServiceV2)
+        {
+            this.clientCapabilitiesServiceV2 = clientCapabilitiesServiceV2;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientCapabilitiesServiceV2(Func<AsyncClientCapabilitiesServiceV2Builder, AsyncClientCapabilitiesServiceV2Builder> builder)
+        {
+            clientCapabilitiesServiceV2 = builder(new AsyncClientCapabilitiesServiceV2Builder()).Build();
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithScriptObserverBackoffStrategy(IScriptObserverBackoffStrategy scriptObserverBackoffStrategy)
+        {
+            this.scriptObserverBackoffStrategy = scriptObserverBackoffStrategy;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithScriptObserverBackoffStrategy(Func<ScriptObserverBackoffStrategyBuilder, ScriptObserverBackoffStrategyBuilder> builder)
+        {
+            scriptObserverBackoffStrategy = builder(new ScriptObserverBackoffStrategyBuilder()).Build();
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithRpcCallExecutor(RpcCallExecutor rpcCallExecutor)
+        {
+            this.rpcCallExecutor = rpcCallExecutor;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithRpcCallExecutor(Func<RpcCallExecutorBuilder, RpcCallExecutorBuilder> builder)
+        {
+            rpcCallExecutor = builder(new RpcCallExecutorBuilder()).Build();
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientOperationMetricsBuilder(ClientOperationMetricsBuilder clientOperationMetricsBuilder)
+        {
+            this.clientOperationMetricsBuilder = clientOperationMetricsBuilder;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientOperationMetricsBuilder(Func<ClientOperationMetricsBuilderBuilder, ClientOperationMetricsBuilderBuilder> builder)
+        {
+            clientOperationMetricsBuilder = builder(new ClientOperationMetricsBuilderBuilder()).Build();
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithOnScriptStatusResponseReceived(OnScriptStatusResponseReceived onScriptStatusResponseReceived)
+        {
+            this.onScriptStatusResponseReceived = onScriptStatusResponseReceived;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithOnScriptCompleted(OnScriptCompleted onScriptCompleted)
+        {
+            this.onScriptCompleted = onScriptCompleted;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithOnCancellationAbandonCompleteScriptAfter(TimeSpan onCancellationAbandonCompleteScriptAfter)
+        {
+            this.onCancellationAbandonCompleteScriptAfter = onCancellationAbandonCompleteScriptAfter;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientOptions(TentacleClientOptions clientOptions)
+        {
+            this.clientOptions = clientOptions;
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithClientOptions(Func<TentacleClientOptionsBuilder, TentacleClientOptionsBuilder> builder)
+        {
+            clientOptions = builder(new TentacleClientOptionsBuilder()).Build();
+            return this;
+        }
+
+        public ScriptOrchestratorFactoryBuilder WithLogger(ILog logger)
+        {
+            this.logger = logger;
+            return this;
+        }
+
+        public ScriptOrchestratorFactory Build() =>
+            new(
+                clientScriptServiceV1 ?? AsyncClientScriptServiceBuilder.Default(),
+                clientScriptServiceV2 ?? AsyncClientScriptServiceV2Builder.Default(),
+                clientScriptServiceV3Alpha ?? AsyncClientScriptServiceV3AlphaBuilder.Default(),
+                clientCapabilitiesServiceV2 ?? AsyncClientCapabilitiesServiceV2Builder.Default(),
+                scriptObserverBackoffStrategy ?? ScriptObserverBackoffStrategyBuilder.Default(),
+                rpcCallExecutor ?? RpcCallExecutorBuilder.Default(),
+                clientOperationMetricsBuilder ?? ClientOperationMetricsBuilderBuilder.Default(),
+                onScriptStatusResponseReceived ?? (_ =>
+                {
+                }),
+                onScriptCompleted ?? (_ => Task.CompletedTask),
+                onCancellationAbandonCompleteScriptAfter ?? TimeSpan.FromSeconds(5),
+                clientOptions ?? TentacleClientOptionsBuilder.Default(),
+                logger ?? Substitute.For<ILog>()
+            );
+
+        public static ScriptOrchestratorFactory Default() => new ScriptOrchestratorFactoryBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/TentacleClientObserverBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/TentacleClientObserverBuilder.cs
@@ -1,0 +1,15 @@
+using NSubstitute;
+using Octopus.Tentacle.Contracts.Observability;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    class TentacleClientObserverBuilder
+    {
+        public ITentacleClientObserver Build()
+        {
+            return Substitute.For<ITentacleClientObserver>();
+        }
+
+        public static ITentacleClientObserver Default() => new TentacleClientObserverBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/Builders/TentacleClientOptionsBuilder.cs
+++ b/source/Octopus.Tentacle.Client.Tests/Builders/TentacleClientOptionsBuilder.cs
@@ -1,0 +1,37 @@
+using System;
+using Octopus.Tentacle.Client.Retries;
+
+namespace Octopus.Tentacle.Client.Tests.Builders
+{
+    public class TentacleClientOptionsBuilder
+    {
+        RpcRetrySettings? rpcRetrySettings;
+        bool disableScriptServiceV3Alpha;
+
+        public TentacleClientOptionsBuilder WithRpcRetrySettings(RpcRetrySettings rpcRetrySettings)
+        {
+            this.rpcRetrySettings = rpcRetrySettings;
+            return this;
+        }
+
+        public TentacleClientOptionsBuilder WithRpcRetrySettings(Func<RpcRetrySettingsBuilder, RpcRetrySettingsBuilder> builder)
+        {
+            rpcRetrySettings = builder(new RpcRetrySettingsBuilder()).Build();
+            return this;
+        }
+
+        public TentacleClientOptionsBuilder WithDisableScriptServiceV3Alpha(bool disableScriptServiceV3Alpha)
+        {
+            this.disableScriptServiceV3Alpha = disableScriptServiceV3Alpha;
+            return this;
+        }
+
+        public TentacleClientOptions Build() =>
+            new(rpcRetrySettings ?? RpcRetrySettingsBuilder.Default())
+            {
+                DisableScriptServiceV3Alpha = disableScriptServiceV3Alpha
+            };
+
+        public static TentacleClientOptions Default() => new TentacleClientOptionsBuilder().Build();
+    }
+}

--- a/source/Octopus.Tentacle.Client.Tests/ScriptOrchestratorFactoryFixture.cs
+++ b/source/Octopus.Tentacle.Client.Tests/ScriptOrchestratorFactoryFixture.cs
@@ -78,5 +78,37 @@ namespace Octopus.Tentacle.Client.Tests
             orchestrator.Should().NotBeNull();
             orchestrator.Should().BeOfType<ScriptServiceV1Orchestrator>();
         }
+
+        [Test]
+        public async Task CreateOrchestratorReturnsV2WhenV2IsMaxVersion()
+        {
+            // Arrange
+            var factory = new ScriptOrchestratorFactoryBuilder()
+                .WithMaxScriptServiceVersion(ScriptServiceVersion.Version2)
+                .Build();
+
+            // Act
+            var orchestrator = await factory.CreateOrchestrator(CancellationToken);
+
+            // Assert
+            orchestrator.Should().NotBeNull();
+            orchestrator.Should().BeOfType<ScriptServiceV2Orchestrator>();
+        }
+
+        [Test]
+        public async Task CreateOrchestratorReturnsV1WhenV1IsMaxVersion()
+        {
+            // Arrange
+            var factory = new ScriptOrchestratorFactoryBuilder()
+                .WithMaxScriptServiceVersion(ScriptServiceVersion.Version1)
+                .Build();
+
+            // Act
+            var orchestrator = await factory.CreateOrchestrator(CancellationToken);
+
+            // Assert
+            orchestrator.Should().NotBeNull();
+            orchestrator.Should().BeOfType<ScriptServiceV1Orchestrator>();
+        }
     }
 }

--- a/source/Octopus.Tentacle.Client.Tests/ScriptOrchestratorFactoryFixture.cs
+++ b/source/Octopus.Tentacle.Client.Tests/ScriptOrchestratorFactoryFixture.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.Client.Scripts;
+using Octopus.Tentacle.Client.Tests.Builders;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
+
+namespace Octopus.Tentacle.Client.Tests
+{
+    [TestFixture]
+    public class ScriptOrchestratorFactoryFixture
+    {
+        readonly CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(42));
+
+        CancellationToken CancellationToken => cancellationTokenSource.Token;
+
+        [Test]
+        public async Task CreateOrchestratorReturnsV3AlphaByDefault()
+        {
+            // Arrange
+            var factory = new ScriptOrchestratorFactoryBuilder()
+                .Build();
+
+            // Act
+            var orchestrator = await factory.CreateOrchestrator(CancellationToken);
+
+            // Assert
+            orchestrator.Should().NotBeNull();
+            orchestrator.Should().BeOfType<ScriptServiceV3AlphaOrchestrator>();
+        }
+
+        [Test]
+        public async Task CreateOrchestratorReturnsV2WhenV3IsNotAvailable()
+        {
+            // Arrange
+            var factory = new ScriptOrchestratorFactoryBuilder()
+                .WithClientCapabilitiesServiceV2(builder => builder.WithCapability(nameof(IScriptServiceV2)))
+                .Build();
+
+            // Act
+            var orchestrator = await factory.CreateOrchestrator(CancellationToken);
+
+            // Assert
+            orchestrator.Should().NotBeNull();
+            orchestrator.Should().BeOfType<ScriptServiceV2Orchestrator>();
+        }
+
+        [Test]
+        public async Task CreateOrchestratorReturnsV2WhenV3IsDisabledInTentacleOptions()
+        {
+            // Arrange
+            var factory = new ScriptOrchestratorFactoryBuilder()
+                .WithClientOptions(builder => builder.WithDisableScriptServiceV3Alpha(true))
+                .Build();
+
+            // Act
+            var orchestrator = await factory.CreateOrchestrator(CancellationToken);
+
+            // Assert
+            orchestrator.Should().NotBeNull();
+            orchestrator.Should().BeOfType<ScriptServiceV2Orchestrator>();
+        }
+
+        [Test]
+        public async Task CreateOrchestratorReturnsV1WhenNeitherV2NorV3IsAvailable()
+        {
+            // Arrange
+            var factory = new ScriptOrchestratorFactoryBuilder()
+                .WithClientCapabilitiesServiceV2(builder => builder.ClearCapabilities())
+                .Build();
+
+            // Act
+            var orchestrator = await factory.CreateOrchestrator(CancellationToken);
+
+            // Assert
+            orchestrator.Should().NotBeNull();
+            orchestrator.Should().BeOfType<ScriptServiceV1Orchestrator>();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/ITentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleClient.cs
@@ -25,6 +25,23 @@ namespace Octopus.Tentacle.Client
         /// <param name="logger">Used to output user orientated log messages</param>
         /// <param name="scriptExecutionCancellationToken">When cancelled, will attempt to stop the execution of the script on Tentacle before returning.</param>
         /// <returns></returns>
+        Task<ScriptExecutionResult> ExecuteScript(
+            StartScriptCommandV2 startScriptCommand,
+            OnScriptStatusResponseReceived onScriptStatusResponseReceived,
+            OnScriptCompleted onScriptCompleted,
+            ILog logger,
+            CancellationToken scriptExecutionCancellationToken);
+
+        /// <summary>
+        /// Execute a script on Tentacle
+        /// </summary>
+        /// <param name="startScriptCommand">The start script command</param>
+        /// <param name="onScriptStatusResponseReceived"></param>
+        /// <param name="onScriptCompleted">Called when the script has finished executing on Tentacle but before the working directory is cleaned up.
+        /// This is called regardless of the outcome of the script. It will also be called if the script execution is cancelled.</param>
+        /// <param name="logger">Used to output user orientated log messages</param>
+        /// <param name="scriptExecutionCancellationToken">When cancelled, will attempt to stop the execution of the script on Tentacle before returning.</param>
+        /// <returns></returns>
         Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV3Alpha startScriptCommand,
             OnScriptStatusResponseReceived onScriptStatusResponseReceived,
             OnScriptCompleted onScriptCompleted,

--- a/source/Octopus.Tentacle.Client/Scripts/IScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/IScriptOrchestrator.cs
@@ -8,6 +8,7 @@ namespace Octopus.Tentacle.Client.Scripts
 {
     interface IScriptOrchestrator
     {
+        Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV2 startScriptCommand, CancellationToken scriptExecutionCancellationToken);
         Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV3Alpha startScriptCommand, CancellationToken scriptExecutionCancellationToken);
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -27,11 +27,21 @@ namespace Octopus.Tentacle.Client.Scripts
             this.onScriptCompleted = onScriptCompleted;
         }
 
+        public async Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV2 startScriptCommand, CancellationToken scriptExecutionCancellationToken)
+        {
+            var mappedStartCommand = Map(startScriptCommand);
+            return await ExecuteCommand(mappedStartCommand, scriptExecutionCancellationToken);
+        }
+
         public async Task<ScriptExecutionResult> ExecuteScript(StartScriptCommandV3Alpha startScriptCommand, CancellationToken scriptExecutionCancellationToken)
         {
             var mappedStartCommand = Map(startScriptCommand);
+            return await ExecuteCommand(mappedStartCommand, scriptExecutionCancellationToken);
+        }
 
-            var scriptStatusResponse = await StartScript(mappedStartCommand, scriptExecutionCancellationToken).ConfigureAwait(false);
+        async Task<ScriptExecutionResult> ExecuteCommand(TStartCommand startCommand, CancellationToken scriptExecutionCancellationToken)
+        {
+            var scriptStatusResponse = await StartScript(startCommand, scriptExecutionCancellationToken).ConfigureAwait(false);
 
             scriptStatusResponse = await ObserveUntilCompleteThenFinish(scriptStatusResponse, scriptExecutionCancellationToken).ConfigureAwait(false);
 
@@ -117,6 +127,8 @@ namespace Octopus.Tentacle.Client.Scripts
         }
 
         protected abstract TStartCommand Map(StartScriptCommandV3Alpha command);
+
+        protected abstract TStartCommand Map(StartScriptCommandV2 command);
 
         protected abstract ScriptExecutionStatus MapToStatus(TScriptStatusResponse response);
 

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Orchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Orchestrator.cs
@@ -7,6 +7,7 @@ using Octopus.Tentacle.Client.Observability;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.Observability;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using ILog = Octopus.Diagnostics.ILog;
 
@@ -40,6 +41,17 @@ namespace Octopus.Tentacle.Client.Scripts
             this.clientOperationMetricsBuilder = clientOperationMetricsBuilder;
             this.logger = logger;
         }
+
+        protected override StartScriptCommand Map(StartScriptCommandV2 command)
+            => new(
+                command.ScriptBody,
+                command.Isolation,
+                command.ScriptIsolationMutexTimeout,
+                command.IsolationMutexName!,
+                command.Arguments,
+                command.TaskId,
+                command.Scripts,
+                command.Files.ToArray());
 
         protected override StartScriptCommand Map(StartScriptCommandV3Alpha command)
             => new(

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Orchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Orchestrator.cs
@@ -47,6 +47,8 @@ namespace Octopus.Tentacle.Client.Scripts
             this.logger = logger;
         }
 
+        protected override StartScriptCommandV2 Map(StartScriptCommandV2 command) => command;
+
         protected override StartScriptCommandV2 Map(StartScriptCommandV3Alpha command)
             => new(
                 command.ScriptBody,

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
@@ -11,6 +11,7 @@ using Octopus.Tentacle.Client.Observability;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.Observability;
+using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 using ILog = Octopus.Diagnostics.ILog;
 
@@ -44,6 +45,11 @@ namespace Octopus.Tentacle.Client.Scripts
             this.clientOperationMetricsBuilder = clientOperationMetricsBuilder;
             this.onCancellationAbandonCompleteScriptAfter = onCancellationAbandonCompleteScriptAfter;
             this.logger = logger;
+        }
+
+        protected override StartScriptCommandV3Alpha Map(StartScriptCommandV2 command)
+        {
+            throw new NotSupportedException("ScriptServiceV3AlphaOrchestrator does not support V2 commands");
         }
 
         protected override StartScriptCommandV3Alpha Map(StartScriptCommandV3Alpha command) => command;


### PR DESCRIPTION
Add an overload for ITentacleClient.ExecuteScript that accepts a `StartScriptCommandV2`

Using this overload will ensure a V2 endpoint is used to execute the script, falling back to V1 if V2 is unsupported.

This is intended to reduce confusion from the existing method which takes a v3alpha version of the command.

[SC-69441]

# Background

The `ExecuteScript` method in `ITentacleClient` was changed to accept a `StartScriptCommandV3Alpha`. Depending on the available support, the underlying orchestrator would map that back to a V2 (or V1) command. This led to confusion, as the method required users to configure the client to explicitly disable support for the alpha command.

With a new overload accepting `StartScriptCommandV2`, a user can call the method without the risk of using the v3 alpha code paths.

# Results

- New overload: `ITentacleClient.ExecuteScript` accepting a `StartScriptCommandV2`
- New overload: `IScriptOrchestrator.ExecuteScript` accepting a `StartScriptCommandV2`
- Internal `ScriptOrchestratorFactory` now considers a maximum script service version

## Before

- Confusion as to how to avoid the v3 alpha script service.
- No unit test coverage of orchestrator factory logic

## After

- Pit of success path to avoid the v3 alpha script service
- New unit tests covering the `ScriptOrchestratorFactory` logic for creating the appropriate `IScriptOrchestrator`

# How to review this PR

- Quality :heavy_check_mark:
- Unit tests were created in a separate commit and verify existing logic. They were updated in the subsequent commit to handle the new cases.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.