### PR TITLE
Fix bug where pod monitoring stops working after a while for Kubernetes agent

### DIFF
--- a/source/Octopus.Tentacle.Tests/Scripts/ExponentialBackoffFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Scripts/ExponentialBackoffFixture.cs
@@ -9,8 +9,6 @@ namespace Octopus.Tentacle.Tests.Scripts
     [TestFixture]
     public class ExponentialBackoffFixture
     {
-        readonly Foo foo = new Foo();
-
         [TestCase(1, 1)]
         [TestCase(2, 2)]
         [TestCase(3, 4)]

--- a/source/Octopus.Tentacle.Tests/Scripts/ExponentialBackoffFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Scripts/ExponentialBackoffFixture.cs
@@ -1,0 +1,31 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Time;
+
+namespace Octopus.Tentacle.Tests.Scripts
+{
+    [TestFixture]
+    public class ExponentialBackoffFixture
+    {
+        readonly Foo foo = new Foo();
+
+        [TestCase(1, 1)]
+        [TestCase(2, 2)]
+        [TestCase(3, 4)]
+        [TestCase(4, 8)]
+        public void BelowMaxDuration_ExponentiallyGrows(int retryAttempt, int expectedDuration)
+        {
+            ExponentialBackoff.GetDuration(retryAttempt, 20).Should().Be(expectedDuration);
+        }
+        
+        [TestCase(6)]
+        [TestCase(50)]
+        [TestCase(1000000000)]
+        public void AboveMaxDuration_CapsAtMax(int retryAttempt)
+        {
+            ExponentialBackoff.GetDuration(retryAttempt, 20).Should().Be(20);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         // We default this to true if we can't parse the environment variable
         public static bool ExecuteScriptsInLocalShell => !bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__EXECUTEINLOCALSHELL"), out var executeInLocalShell) || executeInLocalShell;
-        public static int PodMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODMONITORTIMEOUT"), out var podMonitorTimeout) ? podMonitorTimeout : 1800; //30min
+        public static int PodMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODMONITORTIMEOUT"), out var podMonitorTimeout) ? podMonitorTimeout : 10*60; //10min
         public static bool DisableAutomaticPodCleanup => bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__DISABLEAUTOPODCLEANUP"), out var disableAutoCleanup) && disableAutoCleanup;
 
         public static string HelmReleaseNameVariableName => $"{EnvVarPrefix}__HELMRELEASENAME";

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -36,7 +36,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         async Task IKubernetesPodMonitor.StartAsync(CancellationToken cancellationToken)
         {
-            var maxDurationSeconds = 70;
+            const int maxDurationSeconds = 70;
             
             //We don't want the monitoring to ever stop
             var policy = Policy.Handle<Exception>().WaitAndRetryForeverAsync(

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -7,6 +7,8 @@ using k8s;
 using k8s.Models;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Time;
+using Polly;
 
 namespace Octopus.Tentacle.Kubernetes
 {
@@ -34,6 +36,21 @@ namespace Octopus.Tentacle.Kubernetes
 
         async Task IKubernetesPodMonitor.StartAsync(CancellationToken cancellationToken)
         {
+            var maxDurationSeconds = 70;
+            
+            //We don't want the monitoring to ever stop
+            var policy = Policy.Handle<Exception>().WaitAndRetryForeverAsync(
+                retry => TimeSpan.FromSeconds(ExponentialBackoff.GetDuration(retry, maxDurationSeconds)),
+                (ex, duration) =>
+                {
+                    log.Error(ex, "An unexpected error occured while monitoring Pods, waiting for: " + duration);
+                });
+
+            await policy.ExecuteAsync(async ct => await UpdateLoop(ct), cancellationToken);
+        }
+
+        async Task UpdateLoop(CancellationToken cancellationToken)
+        {
             while (!cancellationToken.IsCancellationRequested)
             {
                 //initially load all the pods and their status's
@@ -43,7 +60,7 @@ namespace Octopus.Tentacle.Kubernetes
                 // This means we only receive events that occur after the resource version
                 await podService.WatchAllPods(initialResourceVersion, OnNewEvent, ex =>
                     {
-                        log.Error(ex, "An unhandled error occured in monitoring the pods");
+                        log.Error(ex, "An unhandled error occured while watching Pods");
                     }, cancellationToken
                 );
             }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
@@ -59,7 +59,6 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 await foreach (var (type, pod) in response.WatchAsync<V1Pod, V1PodList>(internalOnError, cancellationToken: watchErrorCancellationTokenSource.Token))
                 {
-                    
                     await onChange(type, pod);
                 }
             }

--- a/source/Octopus.Tentacle/Time/ExponentialBackoff.cs
+++ b/source/Octopus.Tentacle/Time/ExponentialBackoff.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Octopus.Tentacle.Time
+{
+    public static class ExponentialBackoff
+    {
+        //retryAttempt is 1 for the first retry
+        public static int GetDuration(int retryAttempt, int maxDuration)
+        {
+            return (int)Math.Min(maxDuration, Math.Pow(2, retryAttempt-1));
+        }
+    }
+}


### PR DESCRIPTION
[sc-73237]

# Background

https://github.com/OctopusDeploy/OctopusTentacle/pull/824 starting using a Watcher to get updates for Pods. Unfortunately the Kubernetes API Server will [close the connection after some time](https://stackoverflow.com/questions/51399407/watch-in-k8s-golang-api-watches-and-get-events-but-after-sometime-doesnt-get-an) (we can't have the watch open forever).

# Results

This PR adds a short timeout of 10min and reloads the status after that.

We also add a try/catch around the entire status loading so we don't silently lose track of Pod statuses.

Screenshot of Pod status loading at startup:
![CleanShot 2024-03-14 at 13 26 44@2x](https://github.com/OctopusDeploy/OctopusTentacle/assets/2888279/b844a58c-1fd6-4843-b545-ba1dd069d647)

Status is reloaded after 10min:
![CleanShot 2024-03-14 at 13 27 35@2x](https://github.com/OctopusDeploy/OctopusTentacle/assets/2888279/e56d8695-5f93-4433-840e-37ef9e5e69c4)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.