### PR TITLE
Properly propagate SIGTERM signal in Kubernetes Tentacle

### DIFF
--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -18,7 +18,7 @@ COPY _artifacts/docker/tentacle_${BUILD_NUMBER}_${TARGETOS}-${TARGETARCH}${TARGE
 RUN apt-get update
 RUN apt install ./tentacle.deb -y
 RUN apt-get clean
-RUN apt install curl tini -y
+RUN apt install curl -y
 RUN rm -rf /var/lib/apt/lists/*
 
 WORKDIR /
@@ -53,8 +53,7 @@ ENV OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP="False"
 ENV TentacleHome=""
 ENV TentacleApplications=""
 
-# We use tini here as the entrypoint so it correctly propagates SIGTERM signals to the tentacle child process (allowing for graceful shutdown to occur)
-ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/scripts/configure-and-run.sh"]
+ENTRYPOINT ["/scripts/configure-and-run.sh"]
 
 LABEL \
     org.label-schema.schema-version="1.0" \

--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -53,7 +53,7 @@ ENV OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP="False"
 ENV TentacleHome=""
 ENV TentacleApplications=""
 
-# Change the entrypoint to be tini
+# We use tini here as the entrypoint so it correctly propagates SIGTERM signals to the tentacle child process (allowing for graceful shutdown to occur)
 ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/scripts/configure-and-run.sh"]
 
 LABEL \

--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -18,7 +18,7 @@ COPY _artifacts/docker/tentacle_${BUILD_NUMBER}_${TARGETOS}-${TARGETARCH}${TARGE
 RUN apt-get update
 RUN apt install ./tentacle.deb -y
 RUN apt-get clean
-RUN apt install curl -y
+RUN apt install curl tini -y
 RUN rm -rf /var/lib/apt/lists/*
 
 WORKDIR /
@@ -53,7 +53,8 @@ ENV OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP="False"
 ENV TentacleHome=""
 ENV TentacleApplications=""
 
-CMD /scripts/configure-tentacle.sh && /scripts/run-tentacle.sh
+# Change the entrypoint to be tini
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/scripts/configure-and-run.sh"]
 
 LABEL \
     org.label-schema.schema-version="1.0" \

--- a/docker/kubernetes-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-tentacle/dev/Dockerfile
@@ -65,7 +65,7 @@ ENV OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP="False"
 ENV TentacleHome=""
 ENV TentacleApplications=""
 
-CMD /dev-scripts/bootstrap.sh
+ENTRYPOINT [ "/dev-scripts/bootstrap.sh" ] 
 
 LABEL \
     org.label-schema.schema-version="1.0" \

--- a/docker/kubernetes-tentacle/dev/scripts/bootstrap.sh
+++ b/docker/kubernetes-tentacle/dev/scripts/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-./dev-scripts/start-debugger.sh &
-
-(./scripts/configure-tentacle.sh && /scripts/run-tentacle.sh)
+./dev-scripts/start-debugger.sh & ./scripts/configure-and-run.sh
 
 wait -n
 

--- a/docker/kubernetes-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-and-run.sh
@@ -235,6 +235,7 @@ function run() {
     echo "Starting Octopus Deploy Kubernetes Tentacle"
     echo "==============================================="
 
+    # the exec here means that the host bash process is replaced by the tentacle process
     exec tentacle agent --instance Tentacle --noninteractive
 }
 

--- a/docker/kubernetes-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-and-run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eu
 
 if [[ "$ACCEPT_EULA" != "Y" ]]; then
     echo "ERROR: You must accept the EULA at https://octopus.com/company/legal by passing an environment variable 'ACCEPT_EULA=Y'"
@@ -230,13 +230,22 @@ function registerTentacle() {
     tentacle "${ARGS[@]}"
 }
 
+function run() {
+    echo "==============================================="
+    echo "Starting Octopus Deploy Kubernetes Tentacle"
+    echo "==============================================="
+
+    exec tentacle agent --instance Tentacle --noninteractive
+}
+
+
 function verifyTentacleIsNotRegistered() {
   setupVariablesForRegistrationCheck
   getStatusOfRegistration
 
   if [ "$IS_REGISTERED" == "true" ]; then
       echo "Tentacle is already configured and registered with server."
-      exit 0
+      run
   fi
 }
 
@@ -254,3 +263,5 @@ registerTentacle
 
 echo "Configuration successful."
 echo ""
+
+run

--- a/docker/kubernetes-tentacle/scripts/run-tentacle.sh
+++ b/docker/kubernetes-tentacle/scripts/run-tentacle.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -eux
-
-tentacle agent --instance Tentacle --noninteractive


### PR DESCRIPTION
# Background

Observation when updating the Kubernetes Agent tentacle container is that it always took 30s to terminate before the new container would start up. During this process, the terminating container would continue to handle halibut messages.

This indicated that Tentacle was not correctly handling the SIGTERM event that Kubernetes should be passing. Investigation indicated that because we were launching the tentacle as a sub-process of bash (which was a sub-process of the shell entrypoint), that this wasn't being passed down.

This PR updates the docker file and script

# Results

Changes the entrypoint of the kubernetes tentacle docker image to be a single bash script, which launches tentacle via `exec`, which replaces bash with the tentacle process. As a result, this becomes process with pid `1`, which is what receives the `SIGTERM` event.

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/332730/65151f1b-0e2e-40f2-9686-b8b13a859b73)

This means that Tentacle now shutdowns much faster (<1s)

This was verified by a testing with fixed 10s thread sleep in the app process shutdown handler and observice that termination took 10s.

Shortcut story: [sc-73493]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.