### PR TITLE
Move symlink generation into dockerfile

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -32,8 +32,9 @@ COPY _artifacts/deb/tentacle_${BUILD_NUMBER}_amd64.deb /tmp/
 RUN apt-get update && \
     apt install ./tentacle_${BUILD_NUMBER}_amd64.deb && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /opt/octopus/tentacle/Tentacle /usr/bin/tentacle
+    
 WORKDIR /
 
 # We know this won't reduce the image size at all. It's just to make the filesystem a little tidier.

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -16,10 +16,6 @@ internalListeningPort=10933
 mkdir -p $configurationDirectory
 mkdir -p $applicationsDirectory
 
-if [ ! -f /usr/bin/tentacle ]; then
-    ln -s /opt/octopus/tentacle/Tentacle /usr/bin/tentacle
-fi
-
 if [ -f "$alreadyConfiguredSemaphore" ]; then
     echo "Octopus Tentacle is already configured. Skipping reconfiguration."
     echo "If you want to force reconfiguration, please delete the file $alreadyConfiguredSemaphore and re-launch the container."


### PR DESCRIPTION
# Background

We symlink Tentacle into /usr/local/bin in the configure tentacle script, which runs at container start. For users running the container in a `readonlyrootfilesystem` security context, this means that they need to use a volume mount or other convoluted setup for this one file. Baking it into the docker build step, removes this need.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [X] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [X] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [X] I have considered appropriate testing for my change.