### PR TITLE
Automatic Cleanup of Orphaned Pods

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
@@ -28,6 +28,7 @@ namespace Octopus.Tentacle.Tests.Commands
         IApplicationInstanceSelector selector = null!;
         IWorkspaceCleanerTask workspaceCleanerTask = null!;
         IKubernetesPodMonitorTask kubernetesPodMonitorTask = null!;
+        IKubernetesOrphanedPodCleanerTask kubernetesOrphanedPodCleanerTask = null!;
 
         [SetUp]
         public override void SetUp()
@@ -42,6 +43,7 @@ namespace Octopus.Tentacle.Tests.Commands
             sleep = Substitute.For<ISleep>();
             workspaceCleanerTask = Substitute.For<IWorkspaceCleanerTask>();
             kubernetesPodMonitorTask = Substitute.For<IKubernetesPodMonitorTask>();
+            kubernetesOrphanedPodCleanerTask = Substitute.For<IKubernetesOrphanedPodCleanerTask>();
 
             Command = new RunAgentCommand(
                 new Lazy<IHalibutInitializer>(() => halibut),
@@ -56,7 +58,8 @@ namespace Octopus.Tentacle.Tests.Commands
                 new AppVersion(GetType().Assembly),
                 Substitute.For<ILogFileOnlyLogger>(),
                 new Lazy<IWorkspaceCleanerTask>(() => workspaceCleanerTask),
-                new Lazy<IKubernetesPodMonitorTask>(() => kubernetesPodMonitorTask));
+                new Lazy<IKubernetesPodMonitorTask>(() => kubernetesPodMonitorTask),
+                new Lazy<IKubernetesOrphanedPodCleanerTask>(() => kubernetesOrphanedPodCleanerTask));
 
             selector.Current.Returns(new ApplicationInstanceConfiguration("MyTentacle", null, null, null));
         }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     Phase = "Succeeded"
                 }
             };
-            await monitor.OnNewEvent(type, pod);
+            await monitor.OnNewEvent(type, pod, CancellationToken.None);
 
             clock.WindForward(overCutoff);
 
@@ -94,7 +94,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     Phase = phase
                 }
             };
-            await monitor.OnNewEvent(type, pod);
+            await monitor.OnNewEvent(type, pod, CancellationToken.None);
 
             clock.WindForward(overCutoff);
 
@@ -131,7 +131,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     Phase = "Succeeded"
                 }
             };
-            await monitor.OnNewEvent(type, pod);
+            await monitor.OnNewEvent(type, pod, CancellationToken.None);
 
             clock.WindForward(underCutoff);
 
@@ -162,7 +162,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     Phase = "Succeeded"
                 }
             };
-            await monitor.OnNewEvent(type, pod);
+            await monitor.OnNewEvent(type, pod, CancellationToken.None);
 
             clock.WindForward(overCutoff);
 

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
@@ -181,7 +181,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         public async Task EnvironmentVariableDictatesWhenPodsAreConsideredOrphaned(int checkAfterMinutes, bool shouldDelete)
         {
             //Arrange
-            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__PODSCONSIDEREDORPHANEDAFTERTIMESPAN", "2");
+            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__PODSCONSIDEREDORPHANEDAFTERMINUTES", "2");
 
             // We need to reinitialise the sut after changing the env var value
             cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock);
@@ -218,7 +218,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             }
 
             //Cleanup
-            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__PODSCONSIDEREDORPHANEDAFTERTIMESPAN", null);
+            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__PODSCONSIDEREDORPHANEDAFTERMINUTES", null);
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions.Extensions;
+using k8s;
+using k8s.Models;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Kubernetes;
+using Octopus.Tentacle.Tests.Support;
+using Octopus.Time;
+
+namespace Octopus.Tentacle.Tests.Kubernetes
+{
+    [TestFixture]
+    public class KubernetesOrphanedPodCleanerTests
+    {
+        IKubernetesPodService podService;
+        InMemoryLog log;
+        FixedClock clock;
+        KubernetesPodMonitor monitor;
+        ScriptTicket scriptTicket;
+        KubernetesOrphanedPodCleaner cleaner;
+
+        [SetUp]
+        public void Setup()
+        {
+            podService = Substitute.For<IKubernetesPodService>();
+            log = new InMemoryLog();
+            clock = new FixedClock(DateTimeOffset.MinValue + 1.Days());
+            monitor = new KubernetesPodMonitor(podService, log, clock);
+
+            scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
+
+            cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock);
+        }
+
+        [Test]
+        public async Task OrphanedPodCleanedUpIfOver10MinutesHavePassed()
+        {
+            //Arrange
+            const WatchEventType type = WatchEventType.Added;
+            var pod = new V1Pod
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        [OctopusLabels.ScriptTicketId] = scriptTicket.TaskId
+                    }
+                },
+                Status = new V1PodStatus
+                {
+                    Phase = "Succeeded"
+                }
+            };
+            await monitor.OnNewEvent(type, pod);
+
+            clock.WindForward(11.Minutes());
+
+            //Act
+            await cleaner.CheckForOrphanedPods(CancellationToken.None);
+
+            //Assert
+            await podService.Received().Delete(scriptTicket, Arg.Any<CancellationToken>());
+        }
+
+        [TestCase("Succeeded", true)]
+        [TestCase("Failed", true)]
+        [TestCase("Running", false)]
+        [TestCase(null, false)]
+        public async Task OrphanedPodOnlyCleanedUpWhenNotRunning(string? phase, bool shouldBeDeleted)
+        {
+            //Arrange
+            const WatchEventType type = WatchEventType.Added;
+            var pod = new V1Pod
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        [OctopusLabels.ScriptTicketId] = scriptTicket.TaskId
+                    }
+                },
+                Status = new V1PodStatus
+                {
+                    Phase = phase
+                }
+            };
+            await monitor.OnNewEvent(type, pod);
+
+            clock.WindForward(11.Minutes());
+
+            //Act
+            await cleaner.CheckForOrphanedPods(CancellationToken.None);
+
+            //Assert
+            if (shouldBeDeleted)
+            {
+                await podService.Received().Delete(scriptTicket, Arg.Any<CancellationToken>());
+            }
+            else
+            {
+                await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
+            }
+        }
+
+        [Test]
+        public async Task OrphanedPodNotCleanedUpIfOnly9MinutesHavePassed()
+        {
+            //Arrange
+            const WatchEventType type = WatchEventType.Added;
+            var pod = new V1Pod
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        [OctopusLabels.ScriptTicketId] = scriptTicket.TaskId
+                    }
+                },
+                Status = new V1PodStatus
+                {
+                    Phase = "Succeeded"
+                }
+            };
+            await monitor.OnNewEvent(type, pod);
+
+            clock.WindForward(9.Minutes());
+
+            //Act
+            await cleaner.CheckForOrphanedPods(CancellationToken.None);
+
+            //Assert
+            await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
+        }
+
+        [Test]
+        public async Task OrphanedPodNotCleanedUpIfPodCleanupIsDisabled()
+        {
+            //Arrange
+            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP", "true");
+            const WatchEventType type = WatchEventType.Added;
+            var pod = new V1Pod
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Labels = new Dictionary<string, string>
+                    {
+                        [OctopusLabels.ScriptTicketId] = scriptTicket.TaskId
+                    }
+                },
+                Status = new V1PodStatus
+                {
+                    Phase = "Succeeded"
+                }
+            };
+            await monitor.OnNewEvent(type, pod);
+
+            clock.WindForward(11.Minutes());
+
+            //Act
+            await cleaner.CheckForOrphanedPods(CancellationToken.None);
+
+            //Assert
+            await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
+
+            //Cleanup
+            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP", "false");
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
@@ -23,6 +23,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         KubernetesPodMonitor monitor;
         ScriptTicket scriptTicket;
         KubernetesOrphanedPodCleaner cleaner;
+        TimeSpan overCutoff;
+        TimeSpan underCutoff;
 
         [SetUp]
         public void Setup()
@@ -35,6 +37,9 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
 
             cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock);
+
+            overCutoff = cleaner.CompletedPodConsideredOrphanedAfterTimeSpan + 1.Minutes();
+            underCutoff = cleaner.CompletedPodConsideredOrphanedAfterTimeSpan - 1.Minutes();
         }
 
         [Test]
@@ -58,7 +63,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
             await monitor.OnNewEvent(type, pod);
 
-            clock.WindForward(11.Minutes());
+            clock.WindForward(overCutoff);
 
             //Act
             await cleaner.CheckForOrphanedPods(CancellationToken.None);
@@ -91,7 +96,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
             await monitor.OnNewEvent(type, pod);
 
-            clock.WindForward(11.Minutes());
+            clock.WindForward(overCutoff);
 
             //Act
             await cleaner.CheckForOrphanedPods(CancellationToken.None);
@@ -128,7 +133,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
             await monitor.OnNewEvent(type, pod);
 
-            clock.WindForward(9.Minutes());
+            clock.WindForward(underCutoff);
 
             //Act
             await cleaner.CheckForOrphanedPods(CancellationToken.None);
@@ -159,7 +164,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
             await monitor.OnNewEvent(type, pod);
 
-            clock.WindForward(11.Minutes());
+            clock.WindForward(overCutoff);
 
             //Act
             await cleaner.CheckForOrphanedPods(CancellationToken.None);

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
@@ -52,7 +52,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
 
             //Act
-            await monitor.OnNewEvent(type, pod);
+            await monitor.OnNewEvent(type, pod, CancellationToken.None);
 
             //Assert
             var status = ((IKubernetesPodStatusProvider)monitor).TryGetPodStatus(scriptTicket);
@@ -100,7 +100,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             {
                 Phase = "Succeeded"
             };
-            await monitor.OnNewEvent(type, pod);
+            await monitor.OnNewEvent(type, pod, CancellationToken.None);
 
             //Assert
             var status = ((IKubernetesPodStatusProvider)monitor).TryGetPodStatus(scriptTicket);
@@ -161,7 +161,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     }
                 }
             };
-            await monitor.OnNewEvent(type, pod);
+            await monitor.OnNewEvent(type, pod, CancellationToken.None);
 
             //Assert
             var status = ((IKubernetesPodStatusProvider)monitor).TryGetPodStatus(scriptTicket);
@@ -205,7 +205,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             await monitor.InitialLoadAsync(CancellationToken.None);
 
             //Update the pod
-            await monitor.OnNewEvent(type, pod);
+            await monitor.OnNewEvent(type, pod, CancellationToken.None);
 
             //Assert
             var status = ((IKubernetesPodStatusProvider)monitor).TryGetPodStatus(scriptTicket);

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
@@ -11,6 +11,7 @@ using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Tests.Support;
+using Octopus.Time;
 
 namespace Octopus.Tentacle.Tests.Kubernetes
 {
@@ -21,13 +22,15 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         ISystemLog log;
         KubernetesPodMonitor monitor;
         ScriptTicket scriptTicket;
+        IClock clock;
 
         [SetUp]
         public void SetUp()
         {
             podService = Substitute.For<IKubernetesPodService>();
             log = new InMemoryLog();
-            monitor = new KubernetesPodMonitor(podService, log);
+            clock = new FixedClock(DateTimeOffset.MinValue);
+            monitor = new KubernetesPodMonitor(podService, log, clock);
 
             scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
         }

--- a/source/Octopus.Tentacle/Background/BackgroundTask.cs
+++ b/source/Octopus.Tentacle/Background/BackgroundTask.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Diagnostics;
+
+namespace Octopus.Tentacle.Background
+{
+    public interface IBackgroundTask
+    {
+        void Start();
+        void Stop();
+    }
+
+    public abstract class BackgroundTask : IBackgroundTask, IDisposable
+    {
+        readonly string name;
+        readonly CancellationTokenSource cancellationTokenSource = new ();
+        readonly object @lock = new();
+
+        protected readonly ISystemLog log;
+        readonly TimeSpan terminationGracePeriod;
+
+        Task? backgroundTask;
+
+        protected BackgroundTask(ISystemLog log, TimeSpan terminationGracePeriod)
+        {
+            name = GetType().Name;
+            this.log = log;
+            this.terminationGracePeriod = terminationGracePeriod;
+        }
+
+        protected abstract Task RunTask(CancellationToken cancellationToken);
+
+        public void Start()
+        {
+            lock (@lock)
+            {
+                if (backgroundTask is not null)
+                {
+                    log.Error($"{name}.Start(): Already running.");
+                    return;
+                }
+
+                log.Info($"{name}.Start(): Starting");
+                backgroundTask = Task.Run(() => RunTask(cancellationTokenSource.Token));
+            }
+        }
+
+        public void Stop()
+        {
+            lock (@lock)
+            {
+                if (backgroundTask is null) return;
+
+                try
+                {
+                    log.Info($"{name}.Stop(): Stopping");
+                    cancellationTokenSource.Cancel();
+
+                    backgroundTask.Wait(terminationGracePeriod);
+                }
+                catch (Exception e)
+                {
+                    log.Error(e, $"{name}.Stop(): Could not stop");
+                }
+                finally
+                {
+                    log.Info($"{name}.Stop(): Stopped");
+                    backgroundTask = null;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            log.Info($"{name}.Dispose(): Disposing");
+            Stop();
+            cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Background/BackgroundTask.cs
+++ b/source/Octopus.Tentacle/Background/BackgroundTask.cs
@@ -17,7 +17,7 @@ namespace Octopus.Tentacle.Background
         readonly CancellationTokenSource cancellationTokenSource = new ();
         readonly object @lock = new();
 
-        protected readonly ISystemLog log;
+        protected readonly ISystemLog Log;
         readonly TimeSpan terminationGracePeriod;
 
         Task? backgroundTask;
@@ -25,7 +25,7 @@ namespace Octopus.Tentacle.Background
         protected BackgroundTask(ISystemLog log, TimeSpan terminationGracePeriod)
         {
             name = GetType().Name;
-            this.log = log;
+            this.Log = log;
             this.terminationGracePeriod = terminationGracePeriod;
         }
 
@@ -37,11 +37,11 @@ namespace Octopus.Tentacle.Background
             {
                 if (backgroundTask is not null)
                 {
-                    log.Error($"{name}.Start(): Already running.");
+                    Log.Error($"{name}.Start(): Already running.");
                     return;
                 }
 
-                log.Info($"{name}.Start(): Starting");
+                Log.Info($"{name}.Start(): Starting");
                 backgroundTask = Task.Run(() => RunTask(cancellationTokenSource.Token));
             }
         }
@@ -54,18 +54,18 @@ namespace Octopus.Tentacle.Background
 
                 try
                 {
-                    log.Info($"{name}.Stop(): Stopping");
+                    Log.Info($"{name}.Stop(): Stopping");
                     cancellationTokenSource.Cancel();
 
                     backgroundTask.Wait(terminationGracePeriod);
                 }
                 catch (Exception e)
                 {
-                    log.Error(e, $"{name}.Stop(): Could not stop");
+                    Log.Error(e, $"{name}.Stop(): Could not stop");
                 }
                 finally
                 {
-                    log.Info($"{name}.Stop(): Stopped");
+                    Log.Info($"{name}.Stop(): Stopped");
                     backgroundTask = null;
                 }
             }
@@ -73,7 +73,7 @@ namespace Octopus.Tentacle.Background
 
         public void Dispose()
         {
-            log.Info($"{name}.Dispose(): Disposing");
+            Log.Info($"{name}.Dispose(): Disposing");
             Stop();
             cancellationTokenSource.Dispose();
         }

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -178,7 +178,6 @@ namespace Octopus.Tentacle.Commands
             {
                 kubernetesOrphanedPodCleanerTask.Value.Stop();
             }
-
         }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -14,6 +14,8 @@ namespace Octopus.Tentacle.Kubernetes
         // We default this to true if we can't parse the environment variable
         public static bool ExecuteScriptsInLocalShell => !bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__EXECUTEINLOCALSHELL"), out var executeInLocalShell) || executeInLocalShell;
         public static int PodMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODMONITORTIMEOUT"), out var podMonitorTimeout) ? podMonitorTimeout : 10*60; //10min
+
+        public static TimeSpan PodsConsideredOrphanedAfterTimeSpan => TimeSpan.FromMinutes(int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODSCONSIDEREDORPHANEDAFTERTIMESPAN"), out var podsConsideredOrphanedAfterTimeSpan) ? podsConsideredOrphanedAfterTimeSpan : 10);
         public static bool DisableAutomaticPodCleanup => bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__DISABLEAUTOPODCLEANUP"), out var disableAutoCleanup) && disableAutoCleanup;
 
         public static string HelmReleaseNameVariableName => $"{EnvVarPrefix}__HELMRELEASENAME";

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -15,7 +15,7 @@ namespace Octopus.Tentacle.Kubernetes
         public static bool ExecuteScriptsInLocalShell => !bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__EXECUTEINLOCALSHELL"), out var executeInLocalShell) || executeInLocalShell;
         public static int PodMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODMONITORTIMEOUT"), out var podMonitorTimeout) ? podMonitorTimeout : 10*60; //10min
 
-        public static TimeSpan PodsConsideredOrphanedAfterTimeSpan => TimeSpan.FromMinutes(int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODSCONSIDEREDORPHANEDAFTERTIMESPAN"), out var podsConsideredOrphanedAfterTimeSpan) ? podsConsideredOrphanedAfterTimeSpan : 10);
+        public static TimeSpan PodsConsideredOrphanedAfterTimeSpan => TimeSpan.FromMinutes(int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODSCONSIDEREDORPHANEDAFTERMINUTES"), out var podsConsideredOrphanedAfterTimeSpan) ? podsConsideredOrphanedAfterTimeSpan : 10);
         public static bool DisableAutomaticPodCleanup => bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__DISABLEAUTOPODCLEANUP"), out var disableAutoCleanup) && disableAutoCleanup;
 
         public static string HelmReleaseNameVariableName => $"{EnvVarPrefix}__HELMRELEASENAME";

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -19,6 +19,8 @@ namespace Octopus.Tentacle.Kubernetes
             builder.RegisterType<KubernetesPodMonitorTask>().As<IKubernetesPodMonitorTask>().SingleInstance();
             builder.RegisterType<KubernetesPodMonitor>().As<IKubernetesPodMonitor>().As<IKubernetesPodStatusProvider>().SingleInstance();
 
+            builder.RegisterType<KubernetesOrphanedPodCleanerTask>().As<IKubernetesOrphanedPodCleanerTask>().SingleInstance();
+            builder.RegisterType<KubernetesOrphanedPodCleaner>().As<IKubernetesOrphanedPodCleaner>().SingleInstance();
 #if DEBUG
             builder.RegisterType<LocalMachineKubernetesClientConfigProvider>().As<IKubernetesClientConfigProvider>().SingleInstance();
 #else

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
@@ -69,7 +69,7 @@ namespace Octopus.Tentacle.Kubernetes
                 return;
             }
 
-            log.Info($"OrphanedPodCleaner: Found {orphanedPods.Count} Orphaned Pods, they will now be deleted");
+            log.Info($"OrphanedPodCleaner: Found {orphanedPods.Count} orphaned pods, they will now be deleted");
             foreach (var pod in orphanedPods)
             {
                 if (KubernetesConfig.DisableAutomaticPodCleanup)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
@@ -52,7 +52,8 @@ namespace Octopus.Tentacle.Kubernetes
                 log.Verbose("OrphanedPodCleaner: Checking for orphaned pods");
                 await CheckForOrphanedPods(cancellationToken);
 
-                log.Verbose($"OrphanedPodCleaner: Next check will happen at {clock.GetUtcTime() + CompletedPodConsideredOrphanedAfterTimeSpan}");
+                var nextCheckTime = clock.GetUtcTime() + CompletedPodConsideredOrphanedAfterTimeSpan;
+                log.Verbose($"OrphanedPodCleaner: Next check will happen at {nextCheckTime:O}");
                 await Task.Delay(CompletedPodConsideredOrphanedAfterTimeSpan, cancellationToken);
             }
         }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Kubernetes
         readonly IKubernetesPodService podService;
         readonly ISystemLog log;
         readonly IClock clock;
-        readonly TimeSpan completedPodConsideredOrphanedAfter = TimeSpan.FromMinutes(1);
+        readonly TimeSpan completedPodConsideredOrphanedAfterTimeSpan = TimeSpan.FromMinutes(10);
 
         public KubernetesOrphanedPodCleaner(IKubernetesPodStatusProvider podStatusProvider, IKubernetesPodService podService, ISystemLog log, IClock clock)
         {
@@ -51,7 +51,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 log.Verbose("OrphanedPodCleaner: Checking for orphaned pods");
                 var orphanedPods = podStatusProvider.GetAllPodStatuses()
-                    .Where(p => p.State != PodState.Running && p.LastUpdated <= clock.GetUtcTime() - completedPodConsideredOrphanedAfter).ToList();
+                    .Where(p => p.State != PodState.Running && p.LastUpdated <= clock.GetUtcTime() - completedPodConsideredOrphanedAfterTimeSpan).ToList();
 
                 log.Info($"OrphanedPodCleaner: Found {orphanedPods.Count} Orphaned Pods, they will now be deleted");
 
@@ -74,8 +74,8 @@ namespace Octopus.Tentacle.Kubernetes
                     }
                 }
 
-                log.Verbose($"OrphanedPodCleaner: Next check will happen at {clock.GetUtcTime() + completedPodConsideredOrphanedAfter}");
-                await Task.Delay(completedPodConsideredOrphanedAfter, cancellationToken);
+                log.Verbose($"OrphanedPodCleaner: Next check will happen at {clock.GetUtcTime() + completedPodConsideredOrphanedAfterTimeSpan}");
+                await Task.Delay(completedPodConsideredOrphanedAfterTimeSpan, cancellationToken);
             }
         }
     }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Kubernetes
         readonly IKubernetesPodService podService;
         readonly ISystemLog log;
         readonly IClock clock;
-        readonly TimeSpan completedPodConsideredOrphanedAfterTimeSpan = TimeSpan.FromMinutes(10);
+        internal readonly TimeSpan CompletedPodConsideredOrphanedAfterTimeSpan = TimeSpan.FromMinutes(11);
 
         public KubernetesOrphanedPodCleaner(IKubernetesPodStatusProvider podStatusProvider, IKubernetesPodService podService, ISystemLog log, IClock clock)
         {
@@ -52,14 +52,14 @@ namespace Octopus.Tentacle.Kubernetes
                 log.Verbose("OrphanedPodCleaner: Checking for orphaned pods");
                 await CheckForOrphanedPods(cancellationToken);
 
-                log.Verbose($"OrphanedPodCleaner: Next check will happen at {clock.GetUtcTime() + completedPodConsideredOrphanedAfterTimeSpan}");
-                await Task.Delay(completedPodConsideredOrphanedAfterTimeSpan, cancellationToken);
+                log.Verbose($"OrphanedPodCleaner: Next check will happen at {clock.GetUtcTime() + CompletedPodConsideredOrphanedAfterTimeSpan}");
+                await Task.Delay(CompletedPodConsideredOrphanedAfterTimeSpan, cancellationToken);
             }
         }
 
         internal async Task CheckForOrphanedPods(CancellationToken cancellationToken)
         {
-            var cutOffDateTime = clock.GetUtcTime() - completedPodConsideredOrphanedAfterTimeSpan;
+            var cutOffDateTime = clock.GetUtcTime() - CompletedPodConsideredOrphanedAfterTimeSpan;
             var orphanedPods = podStatusProvider.GetAllPodStatuses()
                 .Where(p => p.State != PodState.Running && p.LastUpdated <= cutOffDateTime).ToList();
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
@@ -63,8 +63,13 @@ namespace Octopus.Tentacle.Kubernetes
             var orphanedPods = podStatusProvider.GetAllPodStatuses()
                 .Where(p => p.State != PodState.Running && p.LastUpdated <= cutOffDateTime).ToList();
 
-            log.Info($"OrphanedPodCleaner: Found {orphanedPods.Count} Orphaned Pods, they will now be deleted");
+            if (orphanedPods.Count == 0)
+            {
+                log.Verbose("OrphanedPodCleaner: No orphaned pods found");
+                return;
+            }
 
+            log.Info($"OrphanedPodCleaner: Found {orphanedPods.Count} Orphaned Pods, they will now be deleted");
             foreach (var pod in orphanedPods)
             {
                 if (KubernetesConfig.DisableAutomaticPodCleanup)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
@@ -21,7 +21,7 @@ namespace Octopus.Tentacle.Kubernetes
         readonly ISystemLog log;
         readonly IClock clock;
         readonly TimeSpan initialDelay = TimeSpan.FromMinutes(1);
-        internal readonly TimeSpan CompletedPodConsideredOrphanedAfterTimeSpan = TimeSpan.FromMinutes(10);
+        internal readonly TimeSpan CompletedPodConsideredOrphanedAfterTimeSpan = KubernetesConfig.PodsConsideredOrphanedAfterTimeSpan;
 
         public KubernetesOrphanedPodCleaner(IKubernetesPodStatusProvider podStatusProvider, IKubernetesPodService podService, ISystemLog log, IClock clock)
         {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Kubernetes
         readonly IKubernetesPodService podService;
         readonly ISystemLog log;
         readonly IClock clock;
-        internal readonly TimeSpan CompletedPodConsideredOrphanedAfterTimeSpan = TimeSpan.FromMinutes(11);
+        internal readonly TimeSpan CompletedPodConsideredOrphanedAfterTimeSpan = TimeSpan.FromMinutes(10);
 
         public KubernetesOrphanedPodCleaner(IKubernetesPodStatusProvider podStatusProvider, IKubernetesPodService podService, ISystemLog log, IClock clock)
         {
@@ -60,8 +60,8 @@ namespace Octopus.Tentacle.Kubernetes
         internal async Task CheckForOrphanedPods(CancellationToken cancellationToken)
         {
             var cutOffDateTime = clock.GetUtcTime() - CompletedPodConsideredOrphanedAfterTimeSpan;
-            var orphanedPods = podStatusProvider.GetAllPodStatuses()
-                .Where(p => p.State != PodState.Running && p.LastUpdated <= cutOffDateTime).ToList();
+            var allPods = podStatusProvider.GetAllPodStatuses();
+            var orphanedPods = allPods.Where(p => p.State != PodState.Running && p.LastUpdated <= cutOffDateTime).ToList();
 
             if (orphanedPods.Count == 0)
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Time;
+using Octopus.Time;
+using Polly;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesOrphanedPodCleaner
+    {
+        Task StartAsync(CancellationToken cancellationToken);
+    }
+
+    public class KubernetesOrphanedPodCleaner : IKubernetesOrphanedPodCleaner
+    {
+        readonly IKubernetesPodStatusProvider podStatusProvider;
+        readonly IKubernetesPodService podService;
+        readonly ISystemLog log;
+        readonly IClock clock;
+        readonly TimeSpan completedPodConsideredOrphanedAfter = TimeSpan.FromMinutes(1);
+
+        public KubernetesOrphanedPodCleaner(IKubernetesPodStatusProvider podStatusProvider, IKubernetesPodService podService, ISystemLog log, IClock clock)
+        {
+            this.podStatusProvider = podStatusProvider;
+            this.podService = podService;
+            this.log = log;
+            this.clock = clock;
+        }
+
+        async Task IKubernetesOrphanedPodCleaner.StartAsync(CancellationToken cancellationToken)
+        {
+            const int maxDurationSeconds = 70;
+
+            //We don't want the monitoring to ever stop
+            var policy = Policy.Handle<Exception>().WaitAndRetryForeverAsync(
+                retry => TimeSpan.FromSeconds(ExponentialBackoff.GetDuration(retry, maxDurationSeconds)),
+                (ex, duration) =>
+                {
+                    log.Error(ex, "An unexpected error occured while monitoring Pods, waiting for: " + duration);
+                });
+
+            await policy.ExecuteAsync(async ct => await CleanupOrphanedPodsLoop(ct), cancellationToken);
+        }
+
+        async Task CleanupOrphanedPodsLoop(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                log.Verbose("Checking for orphaned pods");
+                var orphanedPods = podStatusProvider.GetAllPodStatuses()
+                    .Where(p => p.State != PodState.Running && p.LastUpdated <= clock.GetUtcTime() - completedPodConsideredOrphanedAfter).ToList();
+
+                log.Verbose($"Found {orphanedPods.Count} Orphaned Pods");
+
+                foreach (var pod in orphanedPods)
+                {
+                    try
+                    {
+                        log.Verbose($"Attempting to delete orphaned pod: {pod.ScriptTicket}");
+                        await podService.Delete(pod.ScriptTicket, cancellationToken);
+                    }
+                    catch
+                    {
+                        log.Warn($"Unable to delete orphaned pod: {pod.ScriptTicket}, will try again next check.");
+                    }
+                }
+
+                await Task.Delay(completedPodConsideredOrphanedAfter, cancellationToken);
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleaner.cs
@@ -20,6 +20,7 @@ namespace Octopus.Tentacle.Kubernetes
         readonly IKubernetesPodService podService;
         readonly ISystemLog log;
         readonly IClock clock;
+        readonly TimeSpan initialDelay = TimeSpan.FromMinutes(1);
         internal readonly TimeSpan CompletedPodConsideredOrphanedAfterTimeSpan = TimeSpan.FromMinutes(10);
 
         public KubernetesOrphanedPodCleaner(IKubernetesPodStatusProvider podStatusProvider, IKubernetesPodService podService, ISystemLog log, IClock clock)
@@ -47,6 +48,9 @@ namespace Octopus.Tentacle.Kubernetes
 
         async Task CleanupOrphanedPodsLoop(CancellationToken cancellationToken)
         {
+            // We wait a small initial period, so that Tentacle has a chance to fully load.
+            await Task.Delay(initialDelay, cancellationToken);
+
             while (!cancellationToken.IsCancellationRequested)
             {
                 log.Verbose("OrphanedPodCleaner: Checking for orphaned pods");

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleanerTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleanerTask.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Diagnostics;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesOrphanedPodCleanerTask
+    {
+        void Start();
+        void Stop();
+    }
+
+    public class KubernetesOrphanedPodCleanerTask : IKubernetesOrphanedPodCleanerTask, IDisposable
+    {
+        readonly IKubernetesOrphanedPodCleaner podCleaner;
+        readonly ISystemLog log;
+        readonly CancellationTokenSource cancellationTokenSource = new ();
+
+        readonly object @lock = new();
+
+        Task? cleanerTask;
+
+        public KubernetesOrphanedPodCleanerTask(IKubernetesOrphanedPodCleaner podCleaner, ISystemLog log)
+        {
+            this.podCleaner = podCleaner;
+            this.log = log;
+        }
+
+        public void Start()
+        {
+            lock (@lock)
+            {
+                if (cleanerTask is not null)
+                {
+                    log.Error("Kubernetes Orphaned Pod Cleaner task already running.");
+                    return;
+                }
+
+                log.Info("Starting Kubernetes Orphaned Pod Cleaner");
+                cleanerTask = Task.Run(() => podCleaner.StartAsync(cancellationTokenSource.Token));
+            }
+        }
+
+        public void Stop()
+        {
+            lock (@lock)
+            {
+                if (cleanerTask is null) return;
+
+                try
+                {
+                    log.Info("Stopping Kubernetes Orphaned Pod Cleaner");
+                    cancellationTokenSource.Cancel();
+
+                    // give the monitor 30 to gracefully shutdown
+                    cleanerTask.Wait(TimeSpan.FromSeconds(30));
+                }
+                catch (Exception e)
+                {
+                    log.Error(e, "Could not stop Kubernetes Orphaned Pod Cleaner");
+                }
+                finally
+                {
+                    log.Info("Stopped Kubernetes Orphaned Pod Cleaner");
+                    cleanerTask = null;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            log.Info("Disposing of Kubernetes Orphaned Pod Cleaner");
+            Stop();
+            cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleanerTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleanerTask.cs
@@ -2,77 +2,26 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Diagnostics;
+using Octopus.Tentacle.Background;
 
 namespace Octopus.Tentacle.Kubernetes
 {
-    public interface IKubernetesOrphanedPodCleanerTask
-    {
-        void Start();
-        void Stop();
-    }
+    public interface IKubernetesOrphanedPodCleanerTask : IBackgroundTask
+    {}
 
-    public class KubernetesOrphanedPodCleanerTask : IKubernetesOrphanedPodCleanerTask, IDisposable
+    public class KubernetesOrphanedPodCleanerTask : BackgroundTask, IKubernetesOrphanedPodCleanerTask
     {
         readonly IKubernetesOrphanedPodCleaner podCleaner;
-        readonly ISystemLog log;
-        readonly CancellationTokenSource cancellationTokenSource = new ();
-
-        readonly object @lock = new();
-
-        Task? cleanerTask;
 
         public KubernetesOrphanedPodCleanerTask(IKubernetesOrphanedPodCleaner podCleaner, ISystemLog log)
+            : base(log, TimeSpan.FromSeconds(30))
         {
             this.podCleaner = podCleaner;
-            this.log = log;
         }
 
-        public void Start()
+        protected override async Task RunTask(CancellationToken cancellationToken)
         {
-            lock (@lock)
-            {
-                if (cleanerTask is not null)
-                {
-                    log.Error("Kubernetes Orphaned Pod Cleaner task already running.");
-                    return;
-                }
-
-                log.Info("Starting Kubernetes Orphaned Pod Cleaner");
-                cleanerTask = Task.Run(() => podCleaner.StartAsync(cancellationTokenSource.Token));
-            }
-        }
-
-        public void Stop()
-        {
-            lock (@lock)
-            {
-                if (cleanerTask is null) return;
-
-                try
-                {
-                    log.Info("Stopping Kubernetes Orphaned Pod Cleaner");
-                    cancellationTokenSource.Cancel();
-
-                    // give the cleaner 30 to gracefully shutdown
-                    cleanerTask.Wait(TimeSpan.FromSeconds(30));
-                }
-                catch (Exception e)
-                {
-                    log.Error(e, "Could not stop Kubernetes Orphaned Pod Cleaner");
-                }
-                finally
-                {
-                    log.Info("Stopped Kubernetes Orphaned Pod Cleaner");
-                    cleanerTask = null;
-                }
-            }
-        }
-
-        public void Dispose()
-        {
-            log.Info("Disposing of Kubernetes Orphaned Pod Cleaner");
-            Stop();
-            cancellationTokenSource.Dispose();
+            await podCleaner.StartAsync(cancellationToken);
         }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleanerTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesOrphanedPodCleanerTask.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Diagnostics;
-using Octopus.Tentacle.Diagnostics;
 
 namespace Octopus.Tentacle.Kubernetes
 {
@@ -54,7 +53,7 @@ namespace Octopus.Tentacle.Kubernetes
                     log.Info("Stopping Kubernetes Orphaned Pod Cleaner");
                     cancellationTokenSource.Cancel();
 
-                    // give the monitor 30 to gracefully shutdown
+                    // give the cleaner 30 to gracefully shutdown
                     cleanerTask.Wait(TimeSpan.FromSeconds(30));
                 }
                 catch (Exception e)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -117,11 +117,7 @@ namespace Octopus.Tentacle.Kubernetes
                 {
                     case WatchEventType.Added or WatchEventType.Modified:
                     {
-                        if (!podStatusLookup.TryGetValue(scriptTicket, out var status))
-                        {
-                            podStatusLookup[scriptTicket] = status = new PodStatus(scriptTicket, clock);
-                        }
-
+                        var status = podStatusLookup.GetOrAdd(scriptTicket, st => new PodStatus(st, clock));
                         status.Update(pod);
                         log.Verbose($"Updated pod {pod.Name()} status. {status}");
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitorTask.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitorTask.cs
@@ -2,77 +2,25 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Diagnostics;
+using Octopus.Tentacle.Background;
 
 namespace Octopus.Tentacle.Kubernetes
 {
-    public interface IKubernetesPodMonitorTask
-    {
-        void Start();
-        void Stop();
-    }
+    public interface IKubernetesPodMonitorTask : IBackgroundTask
+    {}
 
-    public class KubernetesPodMonitorTask: IKubernetesPodMonitorTask, IDisposable
+    public class KubernetesPodMonitorTask: BackgroundTask, IKubernetesPodMonitorTask
     {
         readonly IKubernetesPodMonitor podMonitor;
-        readonly ISystemLog log;
-        readonly CancellationTokenSource cancellationTokenSource = new ();
 
-        readonly object LockObj = new();
-
-        Task? monitorTask;
-
-        public KubernetesPodMonitorTask(IKubernetesPodMonitor podMonitor, ISystemLog log)
+        public KubernetesPodMonitorTask(IKubernetesPodMonitor podMonitor, ISystemLog log) : base(log, TimeSpan.FromSeconds(30))
         {
             this.podMonitor = podMonitor;
-            this.log = log;
         }
 
-        public void Start()
+        protected override async Task RunTask(CancellationToken cancellationToken)
         {
-            lock (LockObj)
-            {
-                if (monitorTask is not null)
-                {
-                    log.Error("Kubernetes Pod Monitor task already running.");
-                    return;
-                }
-
-                log.Info("Starting Kubernetes Pod Monitor");
-                monitorTask = Task.Run(() => podMonitor.StartAsync(cancellationTokenSource.Token));
-            }
-        }
-
-        public void Stop()
-        {
-            lock (LockObj)
-            {
-                if (monitorTask is null) return;
-
-                try
-                {
-                    log.Info("Stopping Kubernetes Pod Monitor");
-                    cancellationTokenSource.Cancel();
-
-                    // give the monitor 30 to gracefully shutdown
-                    monitorTask.Wait(TimeSpan.FromSeconds(30));
-                }
-                catch (Exception e)
-                {
-                    log.Error(e, "Could not stop Kubernetes Pod Monitor");
-                }
-                finally
-                {
-                    log.Info("Stopped Kubernetes Pod Monitor");
-                    monitorTask = null;
-                }
-            }
-        }
-
-        public void Dispose()
-        {
-            log.Info("Disposing of Kubernetes Pod Monitor");
-            Stop();
-            cancellationTokenSource.Dispose();
+            await podMonitor.StartAsync(cancellationToken);
         }
     }
 }

--- a/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerTask.cs
+++ b/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerTask.cs
@@ -37,7 +37,7 @@ namespace Octopus.Tentacle.Maintenance
                 }
                 catch (Exception e)
                 {
-                    log.Error(e, "WorkspaceCleanerTask.RunTask:");
+                    Log.Error(e, "WorkspaceCleanerTask.RunTask:");
                 }
 
                 try

--- a/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerTask.cs
+++ b/source/Octopus.Tentacle/Maintenance/WorkspaceCleanerTask.cs
@@ -2,84 +2,29 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Diagnostics;
+using Octopus.Tentacle.Background;
 
 namespace Octopus.Tentacle.Maintenance
 {
-    public interface IWorkspaceCleanerTask
-    {
-        void Start();
-        void Stop();
-    }
+    public interface IWorkspaceCleanerTask : IBackgroundTask
+    {}
 
-    class WorkspaceCleanerTask : IWorkspaceCleanerTask, IDisposable
+    class WorkspaceCleanerTask : BackgroundTask, IWorkspaceCleanerTask
     {
         readonly WorkspaceCleanerConfiguration configuration;
         readonly WorkspaceCleaner workspaceCleaner;
-        readonly ISystemLog log;
-
-        readonly CancellationTokenSource cancellationTokenSource = new ();
-        readonly object taskLock = new();
-
-        Task? cleanerTask;
 
         public WorkspaceCleanerTask(
             WorkspaceCleanerConfiguration configuration,
             WorkspaceCleaner workspaceCleaner, 
-            ISystemLog log)
+            ISystemLog log) : base(log, TimeSpan.FromSeconds(30))
         {
             this.configuration = configuration;
             this.workspaceCleaner = workspaceCleaner;
-            this.log = log;
         }
 
-        public void Dispose()
+        protected override async Task RunTask(CancellationToken cancellationToken)
         {
-            Stop();
-
-            cancellationTokenSource.Dispose();
-        }
-
-        public void Start()
-        {
-            lock (taskLock)
-            {
-                if (cleanerTask is not null)
-                {
-                    log.Error("Workspace cleaner task already running.");
-                    return;
-                }
-
-                cleanerTask = Task.Run(RunTask);
-            }
-        }
-
-        public void Stop()
-        {
-            lock (taskLock)
-            {
-                if (cleanerTask is null) return;
-
-                try
-                {
-                    cancellationTokenSource.Cancel();
-
-                    cleanerTask.Wait();
-                }
-                catch (Exception e)
-                {
-                    log.Error(e, "Could not stop workspace cleaner");
-                }
-                finally
-                {
-                    cleanerTask = null;
-                }
-            }
-        }
-
-        async Task RunTask()
-        {
-            var cancellationToken = cancellationTokenSource.Token;
-
             while (!cancellationToken.IsCancellationRequested)
             {
                 try
@@ -92,7 +37,7 @@ namespace Octopus.Tentacle.Maintenance
                 }
                 catch (Exception e)
                 {
-                    log.Error(e, "Error running workspace cleaner");
+                    log.Error(e, "WorkspaceCleanerTask.RunTask:");
                 }
 
                 try


### PR DESCRIPTION
# Background

#project-k8s-agent

[sc-73516]

Sometimes a script pod gets orphaned, where for what ever reason server doesn't care about it anymore so it gets left in a completed or failed state, but it never gets cleaned up.

# Results

I've created a new task which creates a new task which checks for orphaned pods every 10 minutes. A pod is considered orphaned if it's in a non-running state, and has not received an update within 10 minutes.

When `OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP` is `true`, orphaned pods are not deleted, but we log a verbose message saying we are not deleting the pod.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.