### PR TITLE
Force flush to log files before bootstrapRunner exits

### DIFF
--- a/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -80,9 +80,13 @@ func main() {
 	}
 
 	// Perform a final flush of the file buffers, just in case they didn't get flushed before
-	stdoutLogFile.Flush()
-	stderrLogFile.Flush()
-
+	if err := stdoutLogFile.Flush(); err != nil {	
+		fmt.Fprintln(os.Stderr, "bootstrapRunner.go: Failed to perform final flush of stdoutLogFile", err)
+	}
+	if err := stderrLogFile.Flush(); err != nil {	
+		fmt.Fprintln(os.Stderr, "bootstrapRunner.go: Failed to perform final flush of stderrLogFile", err)
+	}
+	
 	os.Exit(cmd.ProcessState.ExitCode())
 }
 

--- a/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -79,6 +79,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "bootstrapRunner.go: Failed to execute bootstrap script", err)
 	}
 
+	// Perform a final flush of the file buffers, just in case they didn't get flushed before
 	stdoutLogFile.Flush()
 	stderrLogFile.Flush()
 

--- a/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -79,6 +79,9 @@ func main() {
 		fmt.Fprintln(os.Stderr, "bootstrapRunner.go: Failed to execute bootstrap script", err)
 	}
 
+	stdoutLogFile.Flush()
+	stderrLogFile.Flush()
+
 	os.Exit(cmd.ProcessState.ExitCode())
 }
 


### PR DESCRIPTION
# Background

We should be doubly sure that we've written all logs from the buffer before exiting

# Results

Added flush calls to both bufio writers

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.