### PR TITLE
Move start script command builders to test utils

### DIFF
--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandBuilder.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Octopus.Tentacle.Contracts;
 
-namespace Octopus.Tentacle.Contracts.Builders
+namespace Octopus.Tentacle.CommonTestUtils.Builders
 {
     public class StartScriptCommandBuilder
     {

--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV2Builder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV2Builder.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.Builders;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
-namespace Octopus.Tentacle.Contracts.Builders
+namespace Octopus.Tentacle.CommonTestUtils.Builders
 {
     public class StartScriptCommandV2Builder
     {

--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV2BuilderExtensionMethods.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV2BuilderExtensionMethods.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Text;
-using Octopus.Tentacle.Contracts.Builders;
-using Octopus.Tentacle.Tests.Integration.Util.Builders;
 
 namespace Octopus.Tentacle.CommonTestUtils.Builders
 {
@@ -14,23 +12,6 @@ namespace Octopus.Tentacle.CommonTestUtils.Builders
             builder.WithScriptBody(scriptBody.ToString());
 
             return builder;
-        }
-
-        public static StartScriptCommandV2Builder WithScriptBody(this StartScriptCommandV2Builder builder, ScriptBuilder scriptBuilder)
-        {
-            var scriptBody = new StringBuilder(scriptBuilder.BuildForCurrentOs());
-
-            builder.WithScriptBody(scriptBody.ToString());
-
-            return builder;
-        }
-
-        public static StartScriptCommandV2Builder WithScriptBody(this StartScriptCommandV2Builder builder, Action<ScriptBuilder> builderFunc)
-        {
-            var scriptBuilder = new ScriptBuilder();
-            builderFunc(scriptBuilder);
-
-            return builder.WithScriptBody(scriptBuilder);
         }
     }
 }

--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV3AlphaBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/StartScriptCommandV3AlphaBuilder.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.Builders;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
 
-namespace Octopus.Tentacle.Contracts.Builders
+namespace Octopus.Tentacle.CommonTestUtils.Builders
 {
     public class StartScriptCommandV3AlphaBuilder
     {
@@ -11,12 +13,12 @@ namespace Octopus.Tentacle.Contracts.Builders
         readonly List<string> arguments = new();
         readonly Dictionary<ScriptType, string> additionalScripts = new();
         StringBuilder scriptBody = new(string.Empty);
-        ScriptIsolationLevel isolation = ScriptIsolationLevel.FullIsolation;
+        ScriptIsolationLevel isolation = ScriptIsolationLevel.NoIsolation;
         TimeSpan scriptIsolationMutexTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
         string scriptIsolationMutexName = "RunningScript";
         string taskId = Guid.NewGuid().ToString();
         ScriptTicket scriptTicket = new UniqueScriptTicketBuilder().Build();
-        TimeSpan? durationStartScriptCanWaitForScriptToFinish = TimeSpan.FromSeconds(5);
+        TimeSpan? durationStartScriptCanWaitForScriptToFinish;
         IScriptExecutionContext executionContext = new LocalShellScriptExecutionContext();
 
         public StartScriptCommandV3AlphaBuilder WithScriptBody(string scriptBody)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/ScriptExecutionOrchestrator.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/ScriptExecutionOrchestrator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Builders;
 using Octopus.Tentacle.Util;
@@ -24,7 +25,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
         public async Task<ScriptStatusResponse> ExecuteScript(string windowsScript, string nixScript, CancellationToken cancellationToken)
         {
             var scriptTicket = await StartScript(windowsScript, nixScript, cancellationToken);
-            
+
             var scriptStatusResponse = await ObserverUntilComplete(scriptTicket, cancellationToken);
 
             scriptStatusResponse = await CompleteScript(scriptStatusResponse, cancellationToken);
@@ -43,7 +44,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
             cancellationToken.ThrowIfCancellationRequested();
 
             var scriptTicket = await tentacleClient.ScriptService.StartScriptAsync(startScriptCommand, new(cancellationToken));
-            
+
             logger.Information("Started script execution");
 
             return scriptTicket;
@@ -63,7 +64,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
                 scriptStatusResponse = await tentacleClient.ScriptService.GetStatusAsync(
                     new ScriptStatusRequest(scriptTicket, scriptStatusResponse.NextLogSequence),
                     new(cancellationToken));
-                
+
                 logs.AddRange(scriptStatusResponse.Logs);
 
                 logger.Information("Current script status: {ScriptStatus}", scriptStatusResponse.State);
@@ -101,7 +102,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
                 scriptStatusResponse = await tentacleClient.ScriptService.GetStatusAsync(
                     new ScriptStatusRequest(scriptTicket, scriptStatusResponse.NextLogSequence),
                     new(cancellationToken));
-                
+
                 logger.Information("Current script status: {ScriptStatus}", scriptStatusResponse.State);
 
                 foreach (var log in scriptStatusResponse.Logs)
@@ -123,13 +124,13 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
         public async Task<ScriptStatusResponse> CompleteScript(ScriptStatusResponse scriptStatusResponse, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             logger.Information("Starting CompleteScript call");
 
             var finalStatus = await tentacleClient.ScriptService.CompleteScriptAsync(
                 new CompleteScriptCommand(scriptStatusResponse.Ticket, scriptStatusResponse.NextLogSequence),
                 new(cancellationToken));
-            
+
             var logs = new List<ProcessOutput>();
             logs.AddRange(scriptStatusResponse.Logs);
             logs.AddRange(finalStatus.Logs);


### PR DESCRIPTION
# Background

As part of the feedback for #845 from @LukeButters, he recommended certain changes be a separate PR, so here it is 😄 

This PR moves the start script command builders into the `CommonTestUtils` project. These builders are only used in the tests as well as in Server, however with the follow up PR #845 and https://github.com/OctopusDeploy/OctopusDeploy/pull/23506, these are no longer to be used in Server.

These were move into the contracts library in Jan by @nathanwoctopusdeploy  in #764 so they could be used in DynamicWorkers, in the upcoming PR they aren't used in TentacleClient, so they don't need to be in the contracts library

# Results

I also change 2 default values for the `StartScriptCommandV3Alpha` to be consistent with the `LatestStartScriptCommandBuilder`

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.