### PR TITLE
Trap SIGTERM and send to tentacle

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -42,6 +42,8 @@ RUN rm -rf /tmp/*
 
 ENV OCTOPUS_RUNNING_IN_CONTAINER=Y
 ENV ACCEPT_EULA=N
+ENV AsKubernetesTentacle=""
+ENV BearerToken=""
 ENV CustomPublicHostName=""
 ENV DISABLE_DIND=N
 ENV ListeningPort=""

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -64,7 +64,7 @@ ENV TargetWorkerPool=""
 
 VOLUME /var/lib/docker
 
-CMD /scripts/configure-tentacle.sh && /scripts/run-tentacle.sh
+ENTRYPOINT [ "/scripts/configure-and-run.sh" ]
 
 LABEL \
     org.label-schema.schema-version="1.0" \

--- a/docker/linux/scripts/configure-and-run.sh
+++ b/docker/linux/scripts/configure-and-run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu
+
+/scripts/configure-tentacle.sh
+CONFIGURE_RESULT=$?
+if [ "$CONFIGURE_RESULT" != "0" ]; then
+  exit $CONFIGURE_RESULT
+fi
+
+exec /scripts/run-tentacle.sh

--- a/docker/linux/scripts/configure-and-run.sh
+++ b/docker/linux/scripts/configure-and-run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -u
 
 /scripts/configure-tentacle.sh
 CONFIGURE_RESULT=$?

--- a/docker/linux/scripts/configure-and-run.sh
+++ b/docker/linux/scripts/configure-and-run.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
-set -u
+set -eu
 
 /scripts/configure-tentacle.sh
-CONFIGURE_RESULT=$?
-if [ "$CONFIGURE_RESULT" != "0" ]; then
-  exit $CONFIGURE_RESULT
-fi
 
 exec /scripts/run-tentacle.sh

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eu
 
 if [[ "$ACCEPT_EULA" != "Y" ]]; then
     echo "ERROR: You must accept the EULA at https://octopus.com/company/legal by passing an environment variable 'ACCEPT_EULA=Y'"

--- a/docker/linux/scripts/run-tentacle.sh
+++ b/docker/linux/scripts/run-tentacle.sh
@@ -37,13 +37,13 @@ else
     if [ "$exited_process" == "$DIND_PID" ]; then
         echo "Docker-in-Docker Daemon exited with code $waited_exit_code"
         echo "Terminating Tentacle..."
-        kill -s INT $TENTACLE_PID
+        kill -s TERM $TENTACLE_PID
         wait $TENTACLE_PID
         tentacle_exit_code=$?
     else
         echo "Tentacle exited with code $waited_exit_code"
         echo "Terminating Docker-in-Docker..."
-        kill -s INT $DIND_PID
+        kill -s TERM $DIND_PID
         wait $DIND_PID
         tentacle_exit_code=$waited_exit_code
     fi

--- a/docker/linux/scripts/run-tentacle.sh
+++ b/docker/linux/scripts/run-tentacle.sh
@@ -1,35 +1,59 @@
 #!/bin/bash
-set -eux
+set -ux
 
 if [[ "$DISABLE_DIND" == "Y" ]]; then
     echo Docker-in-Docker is disabled.
-    DIND_PID=""
-else
-    echo "Starting Docker-in-Docker daemon. This requires that this container be run in privileged mode."
-    nohup /usr/local/bin/dockerd-entrypoint.sh dockerd &
-    DIND_PID=$!
+    echo "Starting Tentacle"
+    exec tentacle agent --instance Tentacle --noninteractive
 fi
 
-function handle_interrupt() {
-    echo "Received SIGINT. Forwarding..."
-    kill -INT $TENTACLE_PID $DIND_PID
-}
+echo "Starting Docker-in-Docker daemon. This requires that this container be run in privileged mode."
+nohup /usr/local/bin/dockerd-entrypoint.sh dockerd &
+DIND_PID=$!
 
-function handle_term() {
-    echo "Received SIGTERM. Forwarding..."
-    kill -TERM $TENTACLE_PID $DIND_PID
-}
-
-function handle_kill() {
-    echo "Received SIGKILL. Forwarding..."
-    kill -KILL $TENTACLE_PID $DIND_PID
-}
-
+echo "Starting Tentacle"
 tentacle agent --instance Tentacle --noninteractive &
 TENTACLE_PID=$!
 
+EXTERNAL_SIGNAL=""
+
+function handle_interrupt() {
+    EXTERNAL_SIGNAL="INT"
+    echo "Received SIGINT. Forwarding..."
+    kill -s INT $TENTACLE_PID $DIND_PID
+}
+
+function handle_term() {
+    EXTERNAL_SIGNAL="TERM"
+    echo "Received SIGTERM. Forwarding..."
+    kill -s TERM $TENTACLE_PID $DIND_PID
+}
+
 trap handle_interrupt SIGINT
 trap handle_term SIGTERM
-trap handle_kill SIGKILL
 
-wait
+exited_process=0
+
+wait -n -p exited_process $TENTACLE_PID $DIND_PID
+waited_exit_code=$?
+if [ -n "$EXTERNAL_SIGNAL" ]; then
+    echo "Exiting due to external signal: $EXTERNAL_SIGNAL"
+    wait
+    tentacle_exit_code=$waited_exit_code
+else
+    if [ "$exited_process" == "$DIND_PID" ]; then
+        echo "Docker-in-Docker Daemon exited with code $waited_exit_code"
+        echo "Terminating Tentacle..."
+        kill -s INT $TENTACLE_PID
+        wait $TENTACLE_PID
+        tentacle_exit_code=$?
+    else
+        echo "Tentacle exited with code $waited_exit_code"
+        echo "Terminating Docker-in-Docker..."
+        kill -s INT $DIND_PID
+        wait $DIND_PID
+        tentacle_exit_code=$waited_exit_code
+    fi
+fi
+
+exit $tentacle_exit_code

--- a/docker/linux/scripts/run-tentacle.sh
+++ b/docker/linux/scripts/run-tentacle.sh
@@ -17,19 +17,12 @@ TENTACLE_PID=$!
 
 EXTERNAL_SIGNAL=""
 
-function handle_interrupt() {
-    EXTERNAL_SIGNAL="INT"
-    echo "Received SIGINT. Forwarding..."
-    kill -s INT $TENTACLE_PID $DIND_PID
-}
-
 function handle_term() {
     EXTERNAL_SIGNAL="TERM"
     echo "Received SIGTERM. Forwarding..."
     kill -s TERM $TENTACLE_PID $DIND_PID
 }
 
-trap handle_interrupt SIGINT
 trap handle_term SIGTERM
 
 exited_process=0

--- a/docker/linux/scripts/run-tentacle.sh
+++ b/docker/linux/scripts/run-tentacle.sh
@@ -3,9 +3,33 @@ set -eux
 
 if [[ "$DISABLE_DIND" == "Y" ]]; then
     echo Docker-in-Docker is disabled.
+    DIND_PID=""
 else
     echo "Starting Docker-in-Docker daemon. This requires that this container be run in privileged mode."
     nohup /usr/local/bin/dockerd-entrypoint.sh dockerd &
+    DIND_PID=$!
 fi
 
-tentacle agent --instance Tentacle --noninteractive
+function handle_interrupt() {
+    echo "Received SIGINT. Forwarding..."
+    kill -INT $TENTACLE_PID $DIND_PID
+}
+
+function handle_term() {
+    echo "Received SIGTERM. Forwarding..."
+    kill -TERM $TENTACLE_PID $DIND_PID
+}
+
+function handle_kill() {
+    echo "Received SIGKILL. Forwarding..."
+    kill -KILL $TENTACLE_PID $DIND_PID
+}
+
+tentacle agent --instance Tentacle --noninteractive &
+TENTACLE_PID=$!
+
+trap handle_interrupt SIGINT
+trap handle_term SIGTERM
+trap handle_kill SIGKILL
+
+wait


### PR DESCRIPTION
# Background

When a container is shut down (e.g., via `docker stop`), the root process is sent the `SIGTERM` signal and given a grace period to shut down before being sent `SIGKILL`. Tentacle has support for handling this event, but due to script nesting, the signal is not propagated to the Tentacle process.

Including Docker-In-Docker introduces additional complexity, as both processes need to receive the signal. The container should also coordinate the independent failure of either process and signal the other to terminate.

# Results

- Graceful shutdown will occur when stopping a Tentacle container.
- If the Docker in Docker daemon terminates (e.g. crashes), the Tentacle will be terminated gracefully.
- Shortcut [SC-73505]
- Resolves #865 

# How this was tested

To test the PR, I created a small application that would run in the container, listen for and log signals and terminate on SIGTERM. I replaced `tentacle` and `dockerd-entrypoint.sh` with this application.

I then ran various scenarios against the container:

- Terminate the container using the `docker container stop` command to see both processes handle the signal and the container exits.
- Terminate the `tentacle` process within the container to see that `dockerd-entrypoint.sh` is terminated and the container exits.
- Terminate the `dockerd-entrypoint.sh` process within the container to see that `tentacle` is terminated and the container exits.

I also ran the tentacle from the CI build in multiple configurations to verify it was working correctly:

- Listening Worker
- Polling Worker
- Listening Tentacle
- Polling Tentacle

I successfully ran scripts against the tentacle, including using docker where it was enabled.

# How to review this PR

Quality :heavy_check_mark:

I've signposted the diff significantly.

Please consider any risks associated with terminating the tentacle if Docker-In-Docker is terminated.

<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.