### PR TITLE
Rename IsRunningInKubernetes to IsRunningAsKubernetesAgent

### DIFF
--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -136,7 +136,7 @@ namespace Octopus.Tentacle.Commands
             workspaceCleanerTask.Value.Start();
             workspaceCleanerHasStarted = true;
 
-            if (!PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
+            if (PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
             {
                 kubernetesPodMonitorTask.Value.Start();
                 kubernetesOrphanedPodCleanerTask.Value.Start();

--- a/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RunAgentCommand.cs
@@ -136,7 +136,7 @@ namespace Octopus.Tentacle.Commands
             workspaceCleanerTask.Value.Start();
             workspaceCleanerHasStarted = true;
 
-            if (!KubernetesConfig.ExecuteScriptsInLocalShell)
+            if (!PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
             {
                 kubernetesPodMonitorTask.Value.Start();
                 kubernetesOrphanedPodCleanerTask.Value.Start();

--- a/source/Octopus.Tentacle/Configuration/Crypto/LinuxGeneratedMachineKey.cs
+++ b/source/Octopus.Tentacle/Configuration/Crypto/LinuxGeneratedMachineKey.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Configuration.Crypto
         readonly IOctopusFileSystem fileSystem;
 
         static string FileName =>
-            PlatformDetection.Kubernetes.IsRunningInKubernetes
+            PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent
                 //if we are running in K8S, we want to save the machine key to the home directory, which is likely on a network drives
                 ? Path.Combine(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleHome)!, "machinekey")
                 : "/etc/octopus/machinekey";

--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceManager.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceManager.cs
@@ -54,7 +54,7 @@ namespace Octopus.Tentacle.Configuration.Instances
             // If completely dynamic (no instance or configFile provided) then dont bother setting anything
             if (startUpInstanceRequest is StartUpDynamicInstanceRequest)
                 return;
-            
+
             var instance = new ApplicationInstanceRecord(instanceName, configurationFile);
             instanceStore.RegisterInstance(instance);
         }
@@ -68,7 +68,7 @@ namespace Octopus.Tentacle.Configuration.Instances
         void EnsureConfigurationFileExists(string configurationFile, string homeDirectory)
         {
             //Skip this step if we're running on Kubernetes
-            if (PlatformDetection.Kubernetes.IsRunningInKubernetes) return;
+            if (PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent) return;
 
             // Ensure we can write configuration file
             string configurationDirectory = Path.GetDirectoryName(configurationFile) ?? homeDirectory;
@@ -97,15 +97,15 @@ namespace Octopus.Tentacle.Configuration.Instances
                 ? $"{applicationName}.config"
                 : configurationFile!;
 
-            // If configuration File isn't rooted, root it to the home directory 
+            // If configuration File isn't rooted, root it to the home directory
             if (!Path.IsPathRooted(configurationFilePath))
             {
                 configurationFilePath = Path.Combine(homeDirectory, configurationFilePath);
             }
-            
+
             // get the configurationPath for writing, even if it is a relative path
             configurationFilePath = fileSystem.GetFullPath(configurationFilePath);
-            
+
             return (configurationFilePath, homeDirectory);
         }
     }

--- a/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceSelector.cs
+++ b/source/Octopus.Tentacle/Configuration/Instances/ApplicationInstanceSelector.cs
@@ -78,7 +78,7 @@ namespace Octopus.Tentacle.Configuration.Instances
         (IKeyValueStore, IWritableKeyValueStore) LoadConfigurationStore((string? instanceName, string? configurationpath) appInstance)
         {
             if (appInstance is { instanceName: not null, configurationpath: null } &&
-                PlatformDetection.Kubernetes.IsRunningInKubernetes)
+                PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
             {
                 log.Verbose($"Loading configuration from ConfigMap for namespace {KubernetesConfig.Namespace}");
                 var configMapWritableStore = configMapStoreFactory.Value;
@@ -117,7 +117,7 @@ namespace Octopus.Tentacle.Configuration.Instances
 
             // Allow contributed values to override the core writable values.
             keyValueStores.Add(writableConfig);
-            
+
             return new AggregatedKeyValueStore(keyValueStores.ToArray());
         }
 
@@ -134,8 +134,8 @@ namespace Octopus.Tentacle.Configuration.Instances
                     var indexInstance = applicationInstanceStore.LoadInstanceDetails(registryInstanceRequest.InstanceName);
                     return (indexInstance.InstanceName, indexInstance.ConfigurationFilePath);
                 }
-                case StartUpConfigFileInstanceRequest configFileInstanceRequest: 
-                {   // `--config` parameter provided. Use that 
+                case StartUpConfigFileInstanceRequest configFileInstanceRequest:
+                {   // `--config` parameter provided. Use that
                     return (null, configFileInstanceRequest.ConfigFile);
                 }
                 default:
@@ -146,7 +146,7 @@ namespace Octopus.Tentacle.Configuration.Instances
 
                     // This will throw a ControlledFailureException if it can't find the instance so it won't be null
                     var indexDefaultInstance = applicationInstanceStore.LoadInstanceDetails(null);
-                    
+
                     return (indexDefaultInstance.InstanceName, indexDefaultInstance.ConfigurationFilePath);
                 }
             }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -11,8 +11,6 @@ namespace Octopus.Tentacle.Kubernetes
         public static string PodServiceAccountName => GetRequiredEnvVar($"{EnvVarPrefix}__PODSERVICEACCOUNTNAME", "Unable to determine Kubernetes Pod service account name.");
         public static string PodVolumeJson => GetRequiredEnvVar($"{EnvVarPrefix}__PODVOLUMEJSON", "Unable to determine Kubernetes Pod volume json.");
 
-        // We default this to true if we can't parse the environment variable
-        public static bool ExecuteScriptsInLocalShell => !bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__EXECUTEINLOCALSHELL"), out var executeInLocalShell) || executeInLocalShell;
         public static int PodMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODMONITORTIMEOUT"), out var podMonitorTimeout) ? podMonitorTimeout : 10*60; //10min
 
         public static TimeSpan PodsConsideredOrphanedAfterTimeSpan => TimeSpan.FromMinutes(int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODSCONSIDEREDORPHANEDAFTERMINUTES"), out var podsConsideredOrphanedAfterTimeSpan) ? podsConsideredOrphanedAfterTimeSpan : 10);

--- a/source/Octopus.Tentacle/Services/ServicesModule.cs
+++ b/source/Octopus.Tentacle/Services/ServicesModule.cs
@@ -3,10 +3,10 @@ using System.Linq;
 using System.Reflection;
 using Autofac;
 using Octopus.Tentacle.Communications;
-using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Kubernetes.Scripts;
 using Octopus.Tentacle.Packages;
 using Octopus.Tentacle.Scripts;
+using Octopus.Tentacle.Util;
 using Module = Autofac.Module;
 
 namespace Octopus.Tentacle.Services
@@ -23,13 +23,13 @@ namespace Octopus.Tentacle.Services
             builder.RegisterType<NuGetPackageInstaller>().As<IPackageInstaller>();
 
             // Register the script executor based on if we should
-            if (KubernetesConfig.ExecuteScriptsInLocalShell)
+            if (PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
             {
-                builder.RegisterType<LocalShellScriptExecutor>().AsSelf().As<IScriptExecutor>();
+                builder.RegisterType<KubernetesPodScriptExecutor>().AsSelf().As<IScriptExecutor>();
             }
             else
             {
-                builder.RegisterType<KubernetesPodScriptExecutor>().AsSelf().As<IScriptExecutor>();
+                builder.RegisterType<LocalShellScriptExecutor>().AsSelf().As<IScriptExecutor>();
             }
 
             // Register our Halibut services

--- a/source/Octopus.Tentacle/Startup/OctopusProgram.cs
+++ b/source/Octopus.Tentacle/Startup/OctopusProgram.cs
@@ -308,7 +308,7 @@ namespace Octopus.Tentacle.Startup
                 Target.Register<NullLogTarget>("EventLog");
 #endif
 #if REQUIRES_EXPLICIT_LOG_CONFIG
-            var nLogFileExtension = !PlatformDetection.Kubernetes.IsRunningInKubernetes
+            var nLogFileExtension = !PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent
                 ? "exe.nlog"
                 : "exe.k8s.nlog";
 
@@ -384,7 +384,7 @@ namespace Octopus.Tentacle.Startup
 
             if (!string.IsNullOrWhiteSpace(instanceName))
             {
-                return PlatformDetection.Kubernetes.IsRunningInKubernetes
+                return PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent
                     ? new StartUpKubernetesConfigMapInstanceRequest(instanceName)
                     : new StartUpRegistryInstanceRequest(instanceName);
             }

--- a/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
@@ -266,7 +266,7 @@ namespace Octopus.Tentacle.Util
                 return;
 
             //We can't perform this check in Kubernetes due to how drives are mounted and reported (always returns 0 byte sized drives)
-            if(PlatformDetection.Kubernetes.IsRunningInKubernetes)
+            if(PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
                 return;
 
             var driveInfo = SafelyGetDriveInfo(directoryPath);

--- a/source/Octopus.Tentacle/Util/PlatformDetection.cs
+++ b/source/Octopus.Tentacle/Util/PlatformDetection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using Octopus.Tentacle.Kubernetes;
 
 namespace Octopus.Tentacle.Util
 {
@@ -12,9 +13,9 @@ namespace Octopus.Tentacle.Util
         public static class Kubernetes
         {
             /// <summary>
-            /// Indicates if the Tentacle is running inside a Kubernetes cluster.
+            /// Indicates if the Tentacle is running inside a Kubernetes cluster as the Kubernetes Agent. This is done by checking if the namespace environment variable is set
             /// </summary>
-            public static bool IsRunningInKubernetes => bool.TryParse(Environment.GetEnvironmentVariable("OCTOPUS__K8STENTACLE__FORCE"), out var b) && b;
+            public static bool IsRunningAsKubernetesAgent => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(KubernetesConfig.NamespaceVariableName));
         }
     }
 }


### PR DESCRIPTION
# Background

This PR splits out a few changes from #852 to make it easier to review that PR and understand the changes.

To make it clearer about when the Tentacle code is running as the Kubernetes agent, I have changed the `PlatformDetection.Kubernetes.IsRunningInKubernetes` check to be `IsRunningAsKubernetesAgent` and changed the environment variable to be one that is always set when running as the Kubernetes agent.

I also removed the `KubernetesConfig.ExecuteScriptsInLocalShell` because we are never going to execute scripts in a local shell when running in the Kubernetes agent.

<!-- Why does this PR exist? -->

# Results

Shortcut story: [sc-73757]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.