### PR TITLE
Change the WorkspaceCleaner to load script services by new interface

### DIFF
--- a/source/Octopus.Tentacle/Communications/AutofacServiceFactory.cs
+++ b/source/Octopus.Tentacle/Communications/AutofacServiceFactory.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Communications
     /// However, before resolving, one or more IAutofacServiceSources must also be registered.
     /// This is so that only explicitly specified services will be resolved, and the types of all messages are known when the service is instantiated.
     /// </summary>
-    public class AutofacServiceFactory : IServiceFactory, IServiceRegistration, IDisposable
+    public class AutofacServiceFactory : IServiceFactory, IDisposable
     {
         // Must never be modified as it is required for backwards compatability in BackwardsCompatibleCapabilitiesV2Decorator
         const string TentacleServiceShuttingDownMessage = "The Tentacle service is shutting down and cannot process this request.";
@@ -70,11 +70,6 @@ namespace Octopus.Tentacle.Communications
         public void Dispose()
         {
             scope.Dispose();
-        }
-
-        public T GetService<T>()
-        {
-            return scope.Resolve<T>();
         }
     }
 }

--- a/source/Octopus.Tentacle/Communications/IServiceRegistration.cs
+++ b/source/Octopus.Tentacle/Communications/IServiceRegistration.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace Octopus.Tentacle.Communications
-{
-    public interface IServiceRegistration
-    {
-        T GetService<T>();
-    }
-}

--- a/source/Octopus.Tentacle/Maintenance/IRunningScriptReporter.cs
+++ b/source/Octopus.Tentacle/Maintenance/IRunningScriptReporter.cs
@@ -1,0 +1,9 @@
+﻿using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Maintenance
+{
+    public interface IRunningScriptReporter
+    {
+        bool IsRunningScript(ScriptTicket ticket);
+    }
+}

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
@@ -4,12 +4,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Maintenance;
 using Octopus.Tentacle.Scripts;
 
 namespace Octopus.Tentacle.Services.Scripts
 {
     [Service(typeof(IScriptService))]
-    public class ScriptService : IAsyncScriptService
+    public class ScriptService : IAsyncScriptService, IRunningScriptReporter
     {
         readonly IShell shell;
         readonly IScriptWorkspaceFactory workspaceFactory;

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
@@ -6,13 +6,14 @@ using System.Threading.Tasks;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
+using Octopus.Tentacle.Maintenance;
 using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Services.Scripts
 {
     [Service(typeof(IScriptServiceV2))]
-    public class ScriptServiceV2 : IAsyncScriptServiceV2
+    public class ScriptServiceV2 : IAsyncScriptServiceV2, IRunningScriptReporter
     {
         readonly IShell shell;
         readonly IScriptWorkspaceFactory workspaceFactory;

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha.cs
@@ -3,16 +3,16 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.ScriptServiceV3Alpha;
+using Octopus.Tentacle.Maintenance;
 using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Services.Scripts
 {
     [Service(typeof(IScriptServiceV3Alpha))]
-    public class ScriptServiceV3Alpha : IAsyncScriptServiceV3Alpha
+    public class ScriptServiceV3Alpha : IAsyncScriptServiceV3Alpha, IRunningScriptReporter
     {
         readonly IScriptExecutor scriptExecutor;
         readonly IScriptWorkspaceFactory workspaceFactory;
@@ -71,7 +71,7 @@ namespace Octopus.Tentacle.Services.Scripts
                     runningScript.ScriptStateStore.Create();
                 }
 
-                if(!scriptExecutor.CanExecute(command))
+                if (!scriptExecutor.CanExecute(command))
                     throw new InvalidOperationException($"The execution context type {command.ExecutionContext.GetType().Name} cannot be used with script executor {scriptExecutor.GetType().Name}.");
 
                 var process = scriptExecutor.ExecuteOnBackgroundThread(command, workspace, runningScript.ScriptStateStore, runningScript.CancellationToken);
@@ -167,7 +167,7 @@ namespace Octopus.Tentacle.Services.Scripts
 
         class RunningScriptWrapper : IDisposable
         {
-            readonly CancellationTokenSource cancellationTokenSource = new ();
+            readonly CancellationTokenSource cancellationTokenSource = new();
 
             public RunningScriptWrapper(ScriptStateStore scriptStateStore)
             {


### PR DESCRIPTION
# Background

Workspace cleaner is resolving the script services by name via a service locator-style pattern, which is generally considered an [anti-pattern](https://blog.ploeh.dk/2010/02/03/ServiceLocatorisanAnti-Pattern/).

This will also cause an issue in a forthcoming PR as the `KubernetesScriptServiceV1Alpha` will not be registered for normal tentacles, so we need a way to not resolve the services directly.

# Results

This PR introduces a new interface, `IRunningScriptReporter` which is added to the appropriate script services and exposes a single `IsRunningScript(ScriptTicket)` method.

Then the workspace cleaner receives a list of registered `IRunningScriptReporter`'s, which it then can do an `Any()` on to see if any of the services are running that script ticket.

To support this change, halibut services are now registered with the `AsImplementedInterfaces()`

Shortcut story: [[sc-73757](https://app.shortcut.com/octopusdeploy/story/73757)]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.