### PR TITLE
Change the Autofac scope Halibut services are registered in

### DIFF
--- a/source/Octopus.Tentacle.Tests/Communications/AutofacServiceFactoryFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Communications/AutofacServiceFactoryFixture.cs
@@ -69,7 +69,7 @@ namespace Octopus.Tentacle.Tests.Communications
         }
 
         [Test]
-        public void Resolved_WithPerLifetimeScopeSingleSource_EachCreateServiceReturnsNewInstance()
+        public void Resolved_WithPerLifetimeScopeSingleSource_EachCreateServiceReturnsSameInstance()
         {
             var builder = new ContainerBuilder();
             builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
@@ -85,7 +85,7 @@ namespace Octopus.Tentacle.Tests.Communications
             var service1 = factory.CreateService(nameof(ISimpleService));
             var service2 = factory.CreateService(nameof(ISimpleService));
 
-            service1.Service.Should().NotBeSameAs(service2.Service);
+            service1.Service.Should().BeSameAs(service2.Service);
         }
 
         [Test]

--- a/source/Octopus.Tentacle/Communications/AutofacServiceFactory.cs
+++ b/source/Octopus.Tentacle/Communications/AutofacServiceFactory.cs
@@ -37,12 +37,8 @@ namespace Octopus.Tentacle.Communications
             {
                 if (knownServices.TryGetValue(serviceName, out var knownService))
                 {
-                    //create a nested scope for the service lease. Halibut will automatically dispose of this lease at the end of the RPC call,
-                    //so pass the nested scope to the lease for disposal
-                    var nestedScope = scope.BeginLifetimeScope();
-
-                    //because the service implementations are registered `AsSelf()`, we can resolve them directly from the nested scope
-                    return new Lease(nestedScope.Resolve(knownService.ServiceImplementationType), nestedScope);
+                    //because the service implementations are registered `AsSelf()`, we can resolve them directly from the scope
+                    return new Lease(scope.Resolve(knownService.ServiceImplementationType));
                 }
 
                 throw new UnknownServiceNameException(serviceName);
@@ -57,11 +53,8 @@ namespace Octopus.Tentacle.Communications
 
         class Lease : IServiceLease
         {
-            readonly ILifetimeScope scope;
-
-            public Lease(object service, ILifetimeScope scope)
+            public Lease(object service)
             {
-                this.scope = scope;
                 Service = service;
             }
 
@@ -69,7 +62,6 @@ namespace Octopus.Tentacle.Communications
 
             public void Dispose()
             {
-                scope.Dispose();
                 if (Service is IDisposable disposable)
                     disposable.Dispose();
             }

--- a/source/Octopus.Tentacle/Services/ServicesModule.cs
+++ b/source/Octopus.Tentacle/Services/ServicesModule.cs
@@ -39,8 +39,18 @@ namespace Octopus.Tentacle.Services
                 .Select(x => new KnownService(x.ServiceImplementationType, x.ServiceAttribute!.ContractType))
                 .ToArray();
 
-            var assemblyServices = new KnownServiceSource(knownServices);
-            builder.RegisterInstance(assemblyServices).AsImplementedInterfaces();
+            var knownServiceSources = new KnownServiceSource(knownServices);
+            builder.RegisterInstance(knownServiceSources).AsImplementedInterfaces();
+
+            //register all halibut services with the root container
+            foreach (var knownServiceSource in knownServices)
+            {
+                builder
+                    .RegisterType(knownServiceSource.ServiceImplementationType)
+                    .AsSelf()
+                    .AsImplementedInterfaces()
+                    .SingleInstance();
+            }
         }
     }
 }


### PR DESCRIPTION
# Background

Halibut services were being registered in a nested scope of the main lifetime scope. This caused an issue in #860 where they then couldn't be resolved in another part of the application due to the incorrect scoping.

# Results

This PR changes Halibut services to be registered in the root lifetime scope, however still maintains the nested scope for _each_ execution of an RPC call.

Because all halibut services are registered as `SingleInstance`, it means they are shared to all nested scopes. If there are services that will need to be per RPC call, we create a nested scope for each call to `CreateService`, which returns a `IServiceLease` that lives for the lifetime of the RPC call in halibut and is disposed at the end.

Ideally, each service wouldn't be registered as `SingleInstance` but Tentacle services are not stateless in that way (see `RunningScriptWrapper` etc), but this opens up the possibility

See https://github.com/OctopusDeploy/Halibut/blob/8c5546305ab73b81e1d92e9979dfcff121994efe/source/Halibut/ServiceModel/ServiceInvoker.cs#L26

This also solves the issue where we were performing an service-locator anti-pattern to resolve script services in the WorkspaceCleaner, as opposed to resolving a common interface etc.

# How to review this PR

I feel comfortable that the change regarding scopes isn't going to be breaking in any way and that automated testing will cover the scenarios.

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.