### PR TITLE
Make ScriptLog.GetOutput async in preparation for the Kubernetes Agent implementation

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Util/TestScriptLog.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TestScriptLog.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Scripts;
 
@@ -15,7 +16,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         public IScriptLogWriter CreateWriter()
             => this;
 
-        public List<ProcessOutput> GetOutput(long afterSequenceNumber, out long nextSequenceNumber)
+        public Task<(List<ProcessOutput> Outputs, long NextSequenceNumber)> GetOutput(long afterSequenceNumber)
             => throw new NotImplementedException();
 
         public void Dispose()

--- a/source/Octopus.Tentacle/Scripts/IScriptLog.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptLog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Contracts;
 
 namespace Octopus.Tentacle.Scripts
@@ -7,6 +8,6 @@ namespace Octopus.Tentacle.Scripts
     public interface IScriptLog
     {
         IScriptLogWriter CreateWriter();
-        List<ProcessOutput> GetOutput(long afterSequenceNumber, out long nextSequenceNumber);
+        Task<(List<ProcessOutput> Outputs, long NextSequenceNumber)> GetOutput(long afterSequenceNumber);
     }
 }

--- a/source/Octopus.Tentacle/Scripts/ScriptLog.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptLog.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Diagnostics;
@@ -29,10 +30,12 @@ namespace Octopus.Tentacle.Services.Scripts
             return new Writer(logFile, fileSystem, sync, sensitiveValueMasker);
         }
 
-        public List<ProcessOutput> GetOutput(long afterSequenceNumber, out long nextSequenceNumber)
+        public async Task<(List<ProcessOutput> Outputs, long NextSequenceNumber)> GetOutput(long afterSequenceNumber)
         {
+            await Task.CompletedTask;
+            
             var results = new List<ProcessOutput>();
-            nextSequenceNumber = afterSequenceNumber;
+            var nextSequenceNumber = afterSequenceNumber;
             lock (sync)
             {
                 using (var writer = new StreamReader(fileSystem.OpenFile(logFile, FileAccess.Read, FileShare.ReadWrite), Encoding.UTF8))
@@ -79,7 +82,7 @@ namespace Octopus.Tentacle.Services.Scripts
                 }
             }
 
-            return results;
+            return (results, nextSequenceNumber);
         }
 
         static string SourceToString(ProcessOutputSource source)

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV3Alpha.cs
@@ -123,11 +123,9 @@ namespace Octopus.Tentacle.Services.Scripts
 
         async Task<ScriptStatusResponseV3Alpha> GetResponse(ScriptTicket ticket, long lastLogSequence, IRunningScript? runningScript)
         {
-            await Task.CompletedTask;
-
             var workspace = workspaceFactory.GetWorkspace(ticket);
             var scriptLog = runningScript?.ScriptLog ?? workspace.CreateLog();
-            var logs = scriptLog.GetOutput(lastLogSequence, out var next);
+            var (logs, next) = await scriptLog.GetOutput(lastLogSequence);
 
             if (runningScript != null)
             {


### PR DESCRIPTION
[sc-71685]

# Background

The Kubernetes Agent will read logs from the Kubernetes API, which are `async` calls. 

This PR makes the signature `async` to allow the change. Its callers are already async, so there shouldn't be any problems here.
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.