### PR TITLE
Add Modern Deployments as owners of Kubernetes code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @OctopusDeploy/team-server-at-scale
+
+# The Kubernetes parts of Tentacle are owned by Modern Deployments
+/docker/kubernetes-tentacle/ @OctopusDeploy/team-modern-deployments
+/source/Octopus.Tentacle/Kubernetes/ @OctopusDeploy/team-modern-deployments


### PR DESCRIPTION
# Background

Adding Modern Deployments as owners of the Kubernetes code in Tentacle

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.