### PR TITLE
Add End-of-Stream (EOS) Marker to speed up Script Pod completion

### DIFF
--- a/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -71,8 +71,7 @@ func main() {
 	Write("stdout", "Kubernetes Script Pod completed", &lineCounter)
 	Write("stdout", "##octopus[stdout-default]", &lineCounter)
 
-	//TODO: Add this back to speed things up
-	//Write("stdout", fmt.Sprintf("EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>%d", exitCode))
+	Write("stdout", fmt.Sprintf("EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>%d", exitCode), &lineCounter)
 
 	os.Exit(exitCode)
 }

--- a/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -71,7 +71,7 @@ func main() {
 	Write("stdout", "Kubernetes Script Pod completed", &lineCounter)
 	Write("stdout", "##octopus[stdout-default]", &lineCounter)
 
-	Write("stdout", fmt.Sprintf("EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>%d", exitCode), &lineCounter)
+	Write("debug", fmt.Sprintf("EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>%d", exitCode), &lineCounter)
 
 	os.Exit(exitCode)
 }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
@@ -104,7 +104,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     new()
                     {
                         Name = scriptTicket.ToKubernetesScriptPobName(),
-                        State = new V1ContainerState(terminated: new V1ContainerStateTerminated(0))
+                        State = new V1ContainerState(terminated: new V1ContainerStateTerminated(0, finishedAt: DateTime.UtcNow))
                     }
                 }
             };
@@ -164,7 +164,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                         {
                             Terminated = new V1ContainerStateTerminated
                             {
-                                ExitCode = -99
+                                ExitCode = -99,
+                                FinishedAt = DateTime.UtcNow
                             }
                         }
                     }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
@@ -89,7 +89,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void ValidEndOfStreamWithPositiveExitCode()
         {
-            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>4")
+            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|debug|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>4")
                 .Should().BeOfType<EndOfStreamPodLogLineParseResult>().Subject;
 
             result.ExitCode.Should().Be(4);
@@ -103,7 +103,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void ValidEndOfStreamWithNegativeExitCode()
         {
-            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>-64")
+            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|debug|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>-64")
                 .Should().BeOfType<EndOfStreamPodLogLineParseResult>().Subject;
 
             result.ExitCode.Should().Be(-64);

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
@@ -13,36 +13,36 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [TestCase("a|b|c", Reason = "Doesn't have 4 parts")]
         public void NotCorrectlyPipeDelimited(string line)
         {
-            var result = PodLogLineParser.ParseLine(line);
+            var result = PodLogLineParser.ParseLine(line).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
             result.Error.Should().Contain("delimited");
         }
         
         [TestCase("a|b|c|d", Reason = "Not a line number")]
         public void FirstPartIsNotALineNumber(string line)
         {
-            var result = PodLogLineParser.ParseLine(line);
+            var result = PodLogLineParser.ParseLine(line).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
             result.Error.Should().Contain("line number");
         }
         
         [TestCase("1|b|c|d", Reason = "Not a date")]
         public void SecondPartIsNotALineDate(string line)
         {
-            var result = PodLogLineParser.ParseLine(line);
+            var result = PodLogLineParser.ParseLine(line).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
             result.Error.Should().Contain("DateTimeOffset");
         }
         
         [TestCase("1|2024-04-03T06:03:10.501025551Z|c|d", Reason = "Not a valid source")]
         public void ThirdPartIsNotAValidSource(string line)
         {
-            var result = PodLogLineParser.ParseLine(line);
+            var result = PodLogLineParser.ParseLine(line).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
             result.Error.Should().Contain("source");
         }
         
         [Test]
         public void SimpleMessage()
         {
-            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|This is the message").LogLine;
-            logLine.Should().NotBeNull();
+            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|This is the message")
+                .Should().BeOfType<ValidPodLogLineParseResult>().Subject.LogLine;
 
             logLine.LineNumber.Should().Be(123);
             logLine.Source.Should().Be(ProcessOutputSource.StdOut);
@@ -53,8 +53,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void ServiceMessage()
         {
-            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|##octopus[stdout-verbose]").LogLine;
-            logLine.Should().NotBeNull();
+            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|##octopus[stdout-verbose]")
+                .Should().BeOfType<ValidPodLogLineParseResult>().Subject.LogLine;
 
             logLine.LineNumber.Should().Be(123);
             logLine.Source.Should().Be(ProcessOutputSource.StdOut);
@@ -65,8 +65,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void ErrorMessage()
         {
-            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stderr|Error!").LogLine;
-            logLine.Should().NotBeNull();
+            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stderr|Error!")
+                .Should().BeOfType<ValidPodLogLineParseResult>().Subject.LogLine;
 
             logLine.LineNumber.Should().Be(123);
             logLine.Source.Should().Be(ProcessOutputSource.StdErr);
@@ -77,13 +77,50 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void MessageHasPipeInIt()
         {
-            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|This is the me|ss|age").LogLine;
-            logLine.Should().NotBeNull();
+            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|This is the me|ss|age")
+                .Should().BeOfType<ValidPodLogLineParseResult>().Subject.LogLine;
 
             logLine.LineNumber.Should().Be(123);
             logLine.Source.Should().Be(ProcessOutputSource.StdOut);
             logLine.Message.Should().Be("This is the me|ss|age");
             logLine.Occurred.Should().BeCloseTo(new DateTimeOffset(2024, 4, 3, 6, 3, 10, 501, TimeSpan.Zero), TimeSpan.FromMilliseconds(1));
+        }
+        
+        [Test]
+        public void ValidEndOfStreamWithPositiveExitCode()
+        {
+            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>4")
+                .Should().BeOfType<EndOfStreamPodLogLineParseResult>().Subject;
+
+            result.ExitCode.Should().Be(4);
+            
+            var logLine = result.LogLine;
+            logLine.LineNumber.Should().Be(123);
+            logLine.Source.Should().Be(ProcessOutputSource.Debug);
+            logLine.Message.Should().Be("EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>4");
+        }
+        
+        [Test]
+        public void ValidEndOfStreamWithNegativeExitCode()
+        {
+            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>-64")
+                .Should().BeOfType<EndOfStreamPodLogLineParseResult>().Subject;
+
+            result.ExitCode.Should().Be(-64);
+            
+            var logLine = result.LogLine;
+            logLine.LineNumber.Should().Be(123);
+            logLine.Source.Should().Be(ProcessOutputSource.Debug);
+            logLine.Message.Should().Be("EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>-64");
+        }
+        
+        [Test]
+        public void InvalidEndOfStream()
+        {
+            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>")
+                .Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
+
+            result.Error.Should().Contain("end of stream");
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/TrackedScriptPodFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/TrackedScriptPodFixture.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using k8s.Models;
+using NUnit.Framework;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Kubernetes;
+
+namespace Octopus.Tentacle.Tests.Kubernetes
+{
+    [TestFixture]
+    public class TrackedScriptPodFixture
+    {
+        [Test]
+        public void Foo()
+        {
+            var scriptTicket = new ScriptTicket("ticketid");
+            var trackedPod = new TrackedScriptPod(scriptTicket);
+            var finishedAt = new DateTime(2024,1,1, 1,1,1, DateTimeKind.Utc);
+            var exitCode = 123;
+            
+            var podStatus = CreatePodStatus(scriptTicket, finishedAt, exitCode, "Succeeded");
+            trackedPod.Update(CreateV1Pod(podStatus));
+
+            trackedPod.ExitCode.Should().Be(exitCode);
+            trackedPod.FinishedAt.Should().Be(finishedAt);
+            
+        }
+
+        static V1PodStatus CreatePodStatus(ScriptTicket scriptTicket, DateTime finishedAt, int exitCode, string phase)
+        {
+            return new V1PodStatus()
+            {
+                Phase = phase,
+                ContainerStatuses = new List<V1ContainerStatus>()
+                {
+                    new()
+                    {
+                        Name = scriptTicket.ToKubernetesScriptPobName(),
+                        State = new V1ContainerState()
+                        {
+                            
+                            Terminated = new V1ContainerStateTerminated()
+                            {
+                                FinishedAt = finishedAt, 
+                                ExitCode = exitCode
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        static V1Pod CreateV1Pod(V1PodStatus podStatus)
+        {
+            return new V1Pod(status: podStatus, metadata: new V1ObjectMeta());
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -48,6 +48,7 @@ namespace Octopus.Tentacle.Kubernetes
 
             var podLogs = await ReadPodLogs();
 
+            //We can use our EOS marker to detect completion quicker than the Pod status
             if (podLogs.ExitCode != null)
                 podMonitor.MarkAsCompleted(scriptTicket, podLogs.ExitCode.Value);
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using k8s;
 using k8s.Models;
+using Newtonsoft.Json;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Time;
@@ -126,7 +127,8 @@ namespace Octopus.Tentacle.Kubernetes
                     {
                         var status = podStatusLookup.GetOrAdd(scriptTicket, st => new TrackedScriptPod(st));
                         status.Update(pod);
-                        log.Verbose($"Updated pod {pod.Name()} status. {status}");
+                        
+                        log.Verbose($"Updated pod {pod.Name()} status. {status}, JSON: \n{JsonConvert.SerializeObject(pod, Formatting.None)}");
 
                         break;
                     }
@@ -185,6 +187,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         public void Update(V1Pod pod)
         {
+            
             switch (pod.Status?.Phase)
             {
                 case PodPhases.Succeeded:

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using k8s;
 using k8s.Models;
-using Newtonsoft.Json;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Time;
@@ -127,8 +126,7 @@ namespace Octopus.Tentacle.Kubernetes
                     {
                         var status = podStatusLookup.GetOrAdd(scriptTicket, st => new TrackedScriptPod(st));
                         status.Update(pod);
-                        
-                        log.Verbose($"Updated pod {pod.Name()} status. {status}, JSON: \n{JsonConvert.SerializeObject(pod, Formatting.None)}");
+                        log.Verbose($"Updated pod {pod.Name()} status. {status}");
 
                         break;
                     }
@@ -187,7 +185,6 @@ namespace Octopus.Tentacle.Kubernetes
 
         public void Update(V1Pod pod)
         {
-            
             switch (pod.Status?.Phase)
             {
                 case PodPhases.Succeeded:

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -187,13 +187,13 @@ namespace Octopus.Tentacle.Kubernetes
         {
             switch (pod.Status?.Phase)
             {
-                case "Succeeded":
+                case PodPhases.Succeeded:
                     var terminatedState = pod.Status.ContainerStatuses.Single(c => c.Name == ScriptTicket.ToKubernetesScriptPobName()).State.Terminated;
                     FinishedAt = GetFinishedAt(terminatedState);
                     State = TrackedScriptPodState.Succeeded;
                     ExitCode = terminatedState.ExitCode;
                     break;
-                case "Failed":
+                case PodPhases.Failed:
                     var terminatedState2 = pod.Status.ContainerStatuses.Single(c => c.Name == ScriptTicket.ToKubernetesScriptPobName()).State.Terminated;
                     FinishedAt = GetFinishedAt(terminatedState2);
                     State = TrackedScriptPodState.Failed;
@@ -222,16 +222,19 @@ namespace Octopus.Tentacle.Kubernetes
             => $"ScriptTicket: {ScriptTicket}, State: {State}, ExitCode: {ExitCode}";
     }
 
+    //Pod lifecycle has these phases:
+    //https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+    static class PodPhases
+    {
+        public const string Pending = "Pending";
+        public const string Running = "Running";
+        public const string Succeeded = "Succeeded";
+        public const string Failed = "Failed";
+        public const string Unknown = "Unknown";
+    }
+
     public enum TrackedScriptPodState
     {
-        //Pod lifecycle has these phases:
-        //https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
-        //Pending
-        //Running
-        //Succeeded
-        //Failed
-        //Unknown
-        
         Running,
         Succeeded,
         Failed

--- a/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
@@ -57,6 +57,10 @@ namespace Octopus.Tentacle.Kubernetes
 
     static class PodLogLineParser
     {
+        //The EOS message looks something like EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>0
+        const string EndOfStreamMarkerPrefix = "EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE";
+        const string EndOfStreamMarkerExitCodeDelimiter = "<<>>";
+
         public static PodLogLineParseResult ParseLine(string line)
         {
             var logParts = line.Split(new[] { '|' }, 4);
@@ -84,12 +88,12 @@ namespace Octopus.Tentacle.Kubernetes
             //add the new line
             var message = logParts[3];
 
-            if (message.StartsWith("EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE"))
+            if (message.StartsWith(EndOfStreamMarkerPrefix))
             {
                 try
                 {
-                    var exitCode = int.Parse(message.Split(new[] { "<<>>" }, StringSplitOptions.None)[1]);
-                    return new EndOfStreamPodLogLineParseResult(new PodLogLine(lineNumber, ProcessOutputSource.Debug, message, occurred), exitCode);
+                    var exitCode = int.Parse(message.Split(new[] { EndOfStreamMarkerExitCodeDelimiter }, StringSplitOptions.None)[1]);
+                    return new EndOfStreamPodLogLineParseResult(new PodLogLine(lineNumber, source, message, occurred), exitCode);
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
[sc-71685]
# Background

Once a Pod has completed running its script, the Kubernetes API Server can take a few seconds to reflect the status update.

This PR adds an End-of-Stream (EOS) message to the bootstrapper script so we can detect this quicker than the Kubernetes API.

# Performance
For a deployment process with 7 steps:

- No EOS: **1m50s**
- With EOS: **1m43s**

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.