### PR TITLE
Remove usage of ApplicationInstanceSelector from Tentacle Manager

### DIFF
--- a/source/Octopus.Manager.Tentacle.Tests/ConfiguringTentacleServiceFixture.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/ConfiguringTentacleServiceFixture.cs
@@ -7,6 +7,7 @@ using Octopus.Manager.Tentacle.Controls;
 using Octopus.Manager.Tentacle.DeleteWizard;
 using Octopus.Manager.Tentacle.Proxy;
 using Octopus.Manager.Tentacle.Shell;
+using Octopus.Manager.Tentacle.TentacleConfiguration;
 using Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard;
 using Octopus.Manager.Tentacle.TentacleConfiguration.TentacleManager;
 using Octopus.Manager.Tentacle.Tests.Utils;
@@ -95,9 +96,8 @@ namespace Octopus.Manager.Tentacle.Tests.ModelFixtures
             instanceSelectionModel.New(tentacleInstanceName);
 
             var model = new TentacleManagerModel(
-                Substitute.For<IOctopusFileSystem>(),
-                Substitute.For<IApplicationInstanceSelector>(),
                 Substitute.For<ICommandLineRunner>(),
+                Substitute.For<IInstanceConfigurationLoader>(),
                 instanceSelectionModel,
                 Substitute.For<Func<DeleteWizardModel>>(),
                 Substitute.For<Func<ProxyWizardModel>>(),

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/InstanceConfigurationLoader.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/InstanceConfigurationLoader.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Linq;
+using Octopus.Diagnostics;
+using Octopus.Tentacle;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Manager.Tentacle.TentacleConfiguration
+{
+    public interface IInstanceConfigurationLoader
+    {
+        InstanceConfiguration LoadConfiguration(ApplicationInstanceRecord applicationInstanceRecord);
+    }
+
+    public class InstanceConfiguration
+    {
+        public InstanceConfiguration(
+            IWritableKeyValueStore keyStore,
+            IHomeConfiguration homeConfiguration,
+            ILoggingConfiguration loggingConfiguration,
+            ITentacleConfiguration tentacleConfiguration)
+        {
+            KeyStore = keyStore;
+            HomeConfiguration = homeConfiguration;
+            LoggingConfiguration = loggingConfiguration;
+            TentacleConfiguration = tentacleConfiguration;
+        }
+
+        public IWritableKeyValueStore KeyStore { get; }
+        public IHomeConfiguration HomeConfiguration { get; }
+        public ILoggingConfiguration LoggingConfiguration { get; }
+        public ITentacleConfiguration TentacleConfiguration { get; }
+    }
+
+    public class InstanceConfigurationLoader : IInstanceConfigurationLoader
+    {
+        readonly IApplicationConfigurationContributor[] instanceStrategies;
+        readonly IOctopusFileSystem fileSystem;
+        readonly ISystemLog systemLog;
+
+        public InstanceConfigurationLoader(
+            IApplicationConfigurationContributor[] instanceStrategies,
+            IOctopusFileSystem fileSystem,
+            ISystemLog systemLog)
+        {
+            this.instanceStrategies = instanceStrategies;
+            this.fileSystem = fileSystem;
+            this.systemLog = systemLog;
+        }
+
+        public InstanceConfiguration LoadConfiguration(ApplicationInstanceRecord applicationInstanceRecord)
+        {
+            var keyStore = new XmlFileKeyValueStore(fileSystem, applicationInstanceRecord.ConfigurationFilePath);
+
+            var selector = new SimpleApplicationInstanceSelectorForTentacleManager(
+                instanceStrategies,
+                fileSystem,
+                systemLog,
+                applicationInstanceRecord.ConfigurationFilePath);
+
+            var homeConfig = new HomeConfiguration(ApplicationName.Tentacle, selector);
+            var loggingConfig = new LoggingConfiguration(homeConfig);
+            var tentacleConfig = new Octopus.Tentacle.Configuration.TentacleConfiguration(
+                selector,
+                homeConfig,
+                new ProxyConfiguration(keyStore),
+                new PollingProxyConfiguration(keyStore),
+                new SystemLog()
+            );
+
+            return new InstanceConfiguration(keyStore, homeConfig, loggingConfig, tentacleConfig);
+        }
+
+        class SimpleApplicationInstanceSelectorForTentacleManager : IApplicationInstanceSelector
+        {
+            readonly IApplicationConfigurationContributor[] instanceStrategies;
+            readonly IOctopusFileSystem fileSystem;
+            readonly ISystemLog log;
+            
+            readonly string configFilePath;
+            readonly bool canLoadCurrentInstance;
+
+            public SimpleApplicationInstanceSelectorForTentacleManager(
+                IApplicationConfigurationContributor[] instanceStrategies,
+                IOctopusFileSystem fileSystem,
+                ISystemLog log,
+                string configFilePath)
+            {
+                this.instanceStrategies = instanceStrategies;
+                this.fileSystem = fileSystem;
+                this.log = log;
+                this.configFilePath = configFilePath;
+
+                try
+                {
+                    Current = LoadInstance();
+                    canLoadCurrentInstance = true;
+
+                }
+                catch
+                {
+                    canLoadCurrentInstance = false;
+                }
+            }
+
+            public ApplicationName ApplicationName => ApplicationName.Tentacle;
+            public ApplicationInstanceConfiguration Current { get; }
+            public bool CanLoadCurrentInstance() => canLoadCurrentInstance;
+
+            ApplicationInstanceConfiguration LoadInstance()
+            {
+                var (aggregatedKeyValueStore, writableConfig) = LoadConfigurationStore(configFilePath);
+                return new ApplicationInstanceConfiguration(null, configFilePath, aggregatedKeyValueStore, writableConfig);
+            }
+
+            (IKeyValueStore, IWritableKeyValueStore) LoadConfigurationStore(string configurationPath)
+            {
+                EnsureConfigurationExists(configurationPath);
+
+                log.Verbose($"Loading configuration from {configurationPath}");
+                var writable = new XmlFileKeyValueStore(fileSystem, configurationPath);
+                return (ContributeAdditionalConfiguration(writable), writable);
+            }
+
+            void EnsureConfigurationExists(string configurationPath)
+            {
+                if (!fileSystem.FileExists(configurationPath ?? string.Empty))
+                {
+                    var message = $"The configuration file at {configurationPath} could not be located at the specified location.";
+
+                    throw new ControlledFailureException(message);
+                }
+            }
+
+            AggregatedKeyValueStore ContributeAdditionalConfiguration(IAggregatableKeyValueStore writableConfig)
+            {
+                // build composite configuration pulling values out of the environment
+                var keyValueStores = instanceStrategies
+                    .OrderBy(x => x.Priority)
+                    .Select(s => s.LoadContributedConfiguration())
+                    .WhereNotNull()
+                    .ToList();
+
+                // Allow contributed values to override the core writable values.
+                keyValueStores.Add(writableConfig);
+
+                return new AggregatedKeyValueStore(keyValueStores.ToArray());
+            }
+        }
+    }
+}

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManagerModule.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/TentacleManagerModule.cs
@@ -22,6 +22,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration
             builder.RegisterType<InstanceSelectionModel>().AsSelf().SingleInstance().WithParameter("applicationName", ApplicationName.Tentacle);
             builder.RegisterType<CommandLineRunner>().As<ICommandLineRunner>();
             builder.RegisterType<TelemetryService>().As<ITelemetryService>();
+            builder.RegisterType<InstanceConfigurationLoader>().As<IInstanceConfigurationLoader>();
 
             RegisterTentacleManagerInstanceIdentifierService(builder);
 


### PR DESCRIPTION
# Background

We've had a bug turn up in Tentacle Manager [sc-74641], which occurs in the specific scenario where:
1. There are multiple instances of Tentacle installed, _and_
2. There is no default instance i.e. an instance named **(Default)**

This bug manifests as a nasty looking error in the UI which also prevents the user from being able to configure the Tentacle(s):

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/277700/fd6f2a17-35f9-4fe7-a8cb-bacac281393b)

The bug is caused by some [changes to the configuration code in Tentacle itself](https://github.com/OctopusDeploy/OctopusTentacle/pull/674). Tentacle Manager uses these same classes to load configuration and display to the user, but Tentacle and Tentacle Manager do not operate in the same way and these changes are not compatible with Tentacle Manager.

# Results

The fix in this PR does the following:

1. Moves the configuration loading logic from `TentacleManagerModel` into a separate class `InstanceConfigurationLoader`
2. Implements a simplified version of `IApplicationInstanceSelector` which only contains the logic necessary to load configuration in Tentacle Manager. The existing implementation is unchanged and continues to be used in Tentacle itself. 
3. Refactors the relocated code to use the new simplified implementation of `IApplicationInstanceSelector`

I would like to refactor the Tentacle configuration code further in the future to make it simpler to use, but that is beyond the scope of this PR.

Fixes [sc-74641]

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.