### PR TITLE
Change to accept PVC name, not full volume JSON

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -9,7 +9,7 @@ namespace Octopus.Tentacle.Kubernetes
         public static string NamespaceVariableName => $"{EnvVarPrefix}__NAMESPACE";
         public static string Namespace => GetRequiredEnvVar(NamespaceVariableName, "Unable to determine Kubernetes namespace.");
         public static string PodServiceAccountName => GetRequiredEnvVar($"{EnvVarPrefix}__PODSERVICEACCOUNTNAME", "Unable to determine Kubernetes Pod service account name.");
-        public static string PodVolumeJson => GetRequiredEnvVar($"{EnvVarPrefix}__PODVOLUMEJSON", "Unable to determine Kubernetes Pod volume json.");
+        public static string PodVolumeClaimName => GetRequiredEnvVar($"{EnvVarPrefix}__PODVOLUMECLAIMNAME", "Unable to determine Kubernetes Pod persistent volume claim name.");
 
         public static int PodMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODMONITORTIMEOUT"), out var podMonitorTimeout) ? podMonitorTimeout : 10*60; //10min
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -151,8 +151,6 @@ namespace Octopus.Tentacle.Kubernetes
 
             var scriptName = Path.GetFileName(workspace.BootstrapScriptFilePath);
 
-            //Deserialize the volume configuration from the environment configuration
-            var volumes = KubernetesJson.Deserialize<List<V1Volume>>(KubernetesConfig.PodVolumeJson);
             var pod = new V1Pod
             {
                 Metadata = new V1ObjectMeta
@@ -217,7 +215,17 @@ namespace Octopus.Tentacle.Kubernetes
                         : new List<V1LocalObjectReference>(),
                     ServiceAccountName = KubernetesConfig.PodServiceAccountName,
                     RestartPolicy = "Never",
-                    Volumes = volumes,
+                    Volumes = new List<V1Volume>
+                    {
+                        new()
+                        {
+                            Name = "tentacle-home",
+                            PersistentVolumeClaim = new V1PersistentVolumeClaimVolumeSource
+                            {
+                                ClaimName = KubernetesConfig.PodVolumeClaimName
+                            }
+                        }
+                    },
                     //currently we only support running on linux nodes
                     NodeSelector = new Dictionary<string, string>
                     {


### PR DESCRIPTION
# Background

We are now always using a PVC for the Tentacle pod shared storage, so we no longer need to pass the volume JSON to the Tentacle container

# Results

Changes environment variable name to make it clear it's just the name and update the usage when creating the script pod

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.