### PR TITLE
Only pull Script Pod logs newer than the last set we got

### DIFF
--- a/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"sync"
-	"time"
 )
 
 type SafeCounter struct {
@@ -88,7 +87,7 @@ func Write(stream string, text string, counter *SafeCounter) {
 	//https://go.dev/tour/concurrency/9
 	counter.Mutex.Lock()
 
-	fmt.Printf("%d|%s|%s|%s\n", counter.Value, time.Now().UTC().Format(time.RFC3339Nano), stream, text)
+	fmt.Printf("|%d|%s|%s\n", counter.Value, stream, text)
 	counter.Value++
 
 	counter.Mutex.Unlock()

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Extensions;
@@ -14,6 +16,23 @@ using Octopus.Time;
 
 namespace Octopus.Tentacle.Tests.Kubernetes
 {
+    public class Foo
+    {
+        [Test]
+        public async Task fdfs()
+        {
+            var client = new k8s.Kubernetes(new LocalMachineKubernetesClientConfigProvider().Get());
+
+            var pods = await client.ListPodForAllNamespacesAsync();
+            var v1Pod = pods.Items.First();
+            var stream = await client.ReadNamespacedPodLogAsync(v1Pod.Name(), v1Pod.Namespace(), timestamps: true);
+
+            using var foo = new StreamReader(stream);
+
+            var logs = await foo.ReadToEndAsync();
+        }
+    }
+
     [TestFixture]
     public class KubernetesOrphanedPodCleanerTests
     {

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
@@ -27,6 +27,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         TimeSpan underCutoff;
         DateTimeOffset startTime;
         ITentacleScriptLogProvider scriptLogProvider;
+        IScriptPodSinceTimeStore scriptPodSinceTimeStore;
 
         [SetUp]
         public void Setup()
@@ -36,11 +37,12 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             log = new InMemoryLog();
             clock = new FixedClock(startTime);
             scriptLogProvider = Substitute.For<ITentacleScriptLogProvider>();
+            scriptPodSinceTimeStore = Substitute.For<IScriptPodSinceTimeStore>();
             monitor = new KubernetesPodMonitor(podService, log, scriptLogProvider);
 
             scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
 
-            cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock, scriptLogProvider);
+            cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock, scriptLogProvider, scriptPodSinceTimeStore);
 
             overCutoff = cleaner.CompletedPodConsideredOrphanedAfterTimeSpan + 1.Minutes();
             underCutoff = cleaner.CompletedPodConsideredOrphanedAfterTimeSpan - 1.Minutes();
@@ -70,6 +72,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             //Assert
             await podService.Received().Delete(scriptTicket, Arg.Any<CancellationToken>());
             scriptLogProvider.Received().Delete(scriptTicket);
+            scriptPodSinceTimeStore.Received().Delete(scriptTicket);
         }
 
         [TestCase("Succeeded", true)]
@@ -95,11 +98,13 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             {
                 await podService.Received().Delete(scriptTicket, Arg.Any<CancellationToken>());
                 scriptLogProvider.Received().Delete(scriptTicket);
+                scriptPodSinceTimeStore.Received().Delete(scriptTicket);
             }
             else
             {
-                await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
-                scriptLogProvider.DidNotReceive().Delete(scriptTicket);
+                await podService.DidNotReceiveWithAnyArgs().Delete(scriptTicket, Arg.Any<CancellationToken>());
+                scriptLogProvider.DidNotReceiveWithAnyArgs().Delete(scriptTicket);
+                scriptPodSinceTimeStore.DidNotReceiveWithAnyArgs().Delete(scriptTicket);
             }
         }
 
@@ -118,8 +123,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             await cleaner.CheckForOrphanedPods(CancellationToken.None);
 
             //Assert
-            await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
-            scriptLogProvider.DidNotReceive().Delete(scriptTicket);
+            await podService.DidNotReceiveWithAnyArgs().Delete(scriptTicket, Arg.Any<CancellationToken>());
+            scriptLogProvider.DidNotReceiveWithAnyArgs().Delete(scriptTicket);
         }
 
         [Test]
@@ -140,6 +145,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             //Assert
             await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
             scriptLogProvider.Received().Delete(scriptTicket);
+            scriptPodSinceTimeStore.Received().Delete(scriptTicket);
         }
 
         [TestCase(1, false)]
@@ -150,7 +156,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__PODSCONSIDEREDORPHANEDAFTERMINUTES", "2");
 
             // We need to reinitialise the sut after changing the env var value
-            cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock, scriptLogProvider);
+            cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock, scriptLogProvider, scriptPodSinceTimeStore);
             const WatchEventType type = WatchEventType.Added;
             var pod = CreatePod(TrackedScriptPodState.Succeeded, startTime);
 
@@ -166,11 +172,13 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             {
                 await podService.Received().Delete(scriptTicket, Arg.Any<CancellationToken>());
                 scriptLogProvider.Received().Delete(scriptTicket);
+                scriptPodSinceTimeStore.Received().Delete(scriptTicket);
             }
             else
             {
-                await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
-                scriptLogProvider.DidNotReceive().Delete(scriptTicket);
+                await podService.DidNotReceiveWithAnyArgs().Delete(scriptTicket, Arg.Any<CancellationToken>());
+                scriptLogProvider.DidNotReceiveWithAnyArgs().Delete(scriptTicket);
+                scriptPodSinceTimeStore.DidNotReceiveWithAnyArgs().Delete(scriptTicket);
             }
         }
 

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
@@ -16,23 +16,6 @@ using Octopus.Time;
 
 namespace Octopus.Tentacle.Tests.Kubernetes
 {
-    public class Foo
-    {
-        [Test]
-        public async Task fdfs()
-        {
-            var client = new k8s.Kubernetes(new LocalMachineKubernetesClientConfigProvider().Get());
-
-            var pods = await client.ListPodForAllNamespacesAsync();
-            var v1Pod = pods.Items.First();
-            var stream = await client.ReadNamespacedPodLogAsync(v1Pod.Name(), v1Pod.Namespace(), timestamps: true);
-
-            using var foo = new StreamReader(stream);
-
-            var logs = await foo.ReadToEndAsync();
-        }
-    }
-
     [TestFixture]
     public class KubernetesOrphanedPodCleanerTests
     {

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
@@ -38,16 +38,17 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             result.Error.Should().Contain("source");
         }
         
-        [Test]
-        public void SimpleMessage()
+        [TestCase("2024-04-08T15:02:40+10:00")]
+        [TestCase("2024-04-08T05:02:40+00:00")]
+        public void SimpleMessage(string timeString)
         {
-            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|This is the message")
+            var logLine = PodLogLineParser.ParseLine($"{timeString} |123|stdout|This is the message")
                 .Should().BeOfType<ValidPodLogLineParseResult>().Subject.LogLine;
 
             logLine.LineNumber.Should().Be(123);
             logLine.Source.Should().Be(ProcessOutputSource.StdOut);
             logLine.Message.Should().Be("This is the message");
-            logLine.Occurred.Should().BeCloseTo(new DateTimeOffset(2024, 4, 3, 6, 3, 10, 501, TimeSpan.Zero), TimeSpan.FromMilliseconds(1));
+            logLine.Occurred.Should().Be(new DateTimeOffset(2024, 4, 8, 5, 2, 40, TimeSpan.Zero));
         }
         
         [Test]

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
@@ -16,22 +16,22 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             var result = PodLogLineParser.ParseLine(line).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
             result.Error.Should().Contain("delimited");
         }
-        
-        [TestCase("a|b|c|d", Reason = "Not a line number")]
-        public void FirstPartIsNotALineNumber(string line)
-        {
-            var result = PodLogLineParser.ParseLine(line).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
-            result.Error.Should().Contain("line number");
-        }
-        
-        [TestCase("1|b|c|d", Reason = "Not a date")]
-        public void SecondPartIsNotALineDate(string line)
+
+        [TestCase("1 |b|c|d", Reason = "Not a date")]
+        public void FirstPartIsNotALineDate(string line)
         {
             var result = PodLogLineParser.ParseLine(line).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
             result.Error.Should().Contain("DateTimeOffset");
         }
-        
-        [TestCase("1|2024-04-03T06:03:10.501025551Z|c|d", Reason = "Not a valid source")]
+
+        [TestCase("2024-04-03T06:03:10.501025551Z |b|c|d", Reason = "Not a line number")]
+        public void SecondPartIsNotALineNumber(string line)
+        {
+            var result = PodLogLineParser.ParseLine(line).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
+            result.Error.Should().Contain("line number");
+        }
+
+        [TestCase("2024-04-03T06:03:10.501025551Z |1|c|d", Reason = "Not a valid source")]
         public void ThirdPartIsNotAValidSource(string line)
         {
             var result = PodLogLineParser.ParseLine(line).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
@@ -53,7 +53,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void ServiceMessage()
         {
-            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|##octopus[stdout-verbose]")
+            var logLine = PodLogLineParser.ParseLine("2024-04-03T06:03:10.501025551Z |123|stdout|##octopus[stdout-verbose]")
                 .Should().BeOfType<ValidPodLogLineParseResult>().Subject.LogLine;
 
             logLine.LineNumber.Should().Be(123);
@@ -65,7 +65,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void ErrorMessage()
         {
-            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stderr|Error!")
+            var logLine = PodLogLineParser.ParseLine("2024-04-03T06:03:10.501025551Z |123|stderr|Error!")
                 .Should().BeOfType<ValidPodLogLineParseResult>().Subject.LogLine;
 
             logLine.LineNumber.Should().Be(123);
@@ -77,7 +77,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void MessageHasPipeInIt()
         {
-            var logLine = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|This is the me|ss|age")
+            var logLine = PodLogLineParser.ParseLine("2024-04-03T06:03:10.501025551Z |123|stdout|This is the me|ss|age")
                 .Should().BeOfType<ValidPodLogLineParseResult>().Subject.LogLine;
 
             logLine.LineNumber.Should().Be(123);
@@ -89,7 +89,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void ValidEndOfStreamWithPositiveExitCode()
         {
-            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|debug|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>4")
+            var result = PodLogLineParser.ParseLine("2024-04-03T06:03:10.501025551Z |123|debug|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>4")
                 .Should().BeOfType<EndOfStreamPodLogLineParseResult>().Subject;
 
             result.ExitCode.Should().Be(4);
@@ -103,7 +103,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void ValidEndOfStreamWithNegativeExitCode()
         {
-            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|debug|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>-64")
+            var result = PodLogLineParser.ParseLine("2024-04-03T06:03:10.501025551Z |123|debug|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>-64")
                 .Should().BeOfType<EndOfStreamPodLogLineParseResult>().Subject;
 
             result.ExitCode.Should().Be(-64);
@@ -117,7 +117,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public void InvalidEndOfStream()
         {
-            var result = PodLogLineParser.ParseLine("123|2024-04-03T06:03:10.501025551Z|stdout|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>")
+            var result = PodLogLineParser.ParseLine("2024-04-03T06:03:10.501025551Z |123|stdout|EOS-075CD4F0-8C76-491D-BA76-0879D35E9CFE<<>>")
                 .Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
 
             result.Error.Should().Contain("end of stream");

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
@@ -38,17 +38,16 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             result.Error.Should().Contain("source");
         }
         
-        [TestCase("2024-04-08T15:02:40+10:00")]
-        [TestCase("2024-04-08T05:02:40+00:00")]
-        public void SimpleMessage(string timeString)
+        [Test]
+        public void SimpleMessage()
         {
-            var logLine = PodLogLineParser.ParseLine($"{timeString} |123|stdout|This is the message")
+            var logLine = PodLogLineParser.ParseLine($"2024-04-03T06:03:10.501025551Z |123|stdout|This is the message")
                 .Should().BeOfType<ValidPodLogLineParseResult>().Subject.LogLine;
 
             logLine.LineNumber.Should().Be(123);
             logLine.Source.Should().Be(ProcessOutputSource.StdOut);
             logLine.Message.Should().Be("This is the message");
-            logLine.Occurred.Should().Be(new DateTimeOffset(2024, 4, 8, 5, 2, 40, TimeSpan.Zero));
+            logLine.Occurred.Should().BeCloseTo(new DateTimeOffset(2024, 4, 3, 6, 3, 10, 501, TimeSpan.Zero), TimeSpan.FromMilliseconds(1));
         }
         
         [Test]

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
@@ -8,7 +8,6 @@ using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Kubernetes;
-using Octopus.Tentacle.Tests.Support;
 
 namespace Octopus.Tentacle.Tests.Kubernetes
 {
@@ -23,7 +22,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             string[] podLines = Array.Empty<string>();
             
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader,new InMemoryLog());
+            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader);
             result.NextSequenceNumber.Should().Be(lastLogSequence);
             result.Lines.Should().BeEmpty();
         }
@@ -36,7 +35,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
 
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(0, reader,new InMemoryLog());
+            var result = await PodLogReader.ReadPodLogs(0, reader);
             result.NextSequenceNumber.Should().Be(1);
             result.Lines.Should().BeEquivalentTo(new[]
             {
@@ -54,7 +53,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
 
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(4, reader, new InMemoryLog());
+            var result = await PodLogReader.ReadPodLogs(4, reader);
             result.NextSequenceNumber.Should().Be(7);
             result.Lines.Should().BeEquivalentTo(new[]
             {
@@ -75,12 +74,12 @@ namespace Octopus.Tentacle.Tests.Kubernetes
 
             var allTaskLogs = new List<ProcessOutput>();
             var reader = SetupReader(podLines.Take(1).ToArray());
-            var result = await PodLogReader.ReadPodLogs(4, reader,new InMemoryLog());
+            var result = await PodLogReader.ReadPodLogs(4, reader);
             result.NextSequenceNumber.Should().Be(5);
             allTaskLogs.AddRange(result.Lines);
             
             reader = SetupReader(podLines.ToArray());
-            result = await PodLogReader.ReadPodLogs(5, reader, new InMemoryLog());
+            result = await PodLogReader.ReadPodLogs(5, reader);
             result.NextSequenceNumber.Should().Be(7);
             allTaskLogs.AddRange(result.Lines);
             
@@ -118,7 +117,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
         
             var reader = SetupReader(podLines);
-            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader,new InMemoryLog());
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader);
             await action.Should().ThrowAsync<MissingPodLogException>();
         }
         

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Kubernetes;
+using Octopus.Tentacle.Tests.Support;
 
 namespace Octopus.Tentacle.Tests.Kubernetes
 {
@@ -22,7 +23,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             string[] podLines = Array.Empty<string>();
             
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader);
+            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader,new InMemoryLog());
             result.NextSequenceNumber.Should().Be(lastLogSequence);
             result.Lines.Should().BeEmpty();
         }
@@ -35,7 +36,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
 
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(0, reader);
+            var result = await PodLogReader.ReadPodLogs(0, reader,new InMemoryLog());
             result.NextSequenceNumber.Should().Be(1);
             result.Lines.Should().BeEquivalentTo(new[]
             {
@@ -53,7 +54,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
 
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(4, reader);
+            var result = await PodLogReader.ReadPodLogs(4, reader, new InMemoryLog());
             result.NextSequenceNumber.Should().Be(7);
             result.Lines.Should().BeEquivalentTo(new[]
             {
@@ -74,12 +75,12 @@ namespace Octopus.Tentacle.Tests.Kubernetes
 
             var allTaskLogs = new List<ProcessOutput>();
             var reader = SetupReader(podLines.Take(1).ToArray());
-            var result = await PodLogReader.ReadPodLogs(4, reader);
+            var result = await PodLogReader.ReadPodLogs(4, reader,new InMemoryLog());
             result.NextSequenceNumber.Should().Be(5);
             allTaskLogs.AddRange(result.Lines);
             
             reader = SetupReader(podLines.ToArray());
-            result = await PodLogReader.ReadPodLogs(5, reader);
+            result = await PodLogReader.ReadPodLogs(5, reader, new InMemoryLog());
             result.NextSequenceNumber.Should().Be(7);
             allTaskLogs.AddRange(result.Lines);
             
@@ -99,7 +100,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
         
             var reader = SetupReader(podLines);
-            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader);
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader,new InMemoryLog());
             await action.Should().ThrowAsync<MissingPodLogException>();
         }
         

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
@@ -11,119 +11,119 @@ using Octopus.Tentacle.Kubernetes;
 
 namespace Octopus.Tentacle.Tests.Kubernetes
 {
-    [TestFixture]
-    public class PodLogReaderFixture
-    {
-        [TestCase(0, Reason = "Initial position")]
-        [TestCase(4, Reason = "Subsequent position")]
-        [TestCase(12387126, Reason = "Large position")]
-        public async Task NoLines_SameSequenceNumber(long lastLogSequence)
-        {
-            string[] podLines = Array.Empty<string>();
-            
-            var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader);
-            result.NextSequenceNumber.Should().Be(lastLogSequence);
-            result.Lines.Should().BeEmpty();
-        }
-
-        [Test]
-        public async Task FirstLine_SequenceNumberIncreasesByOne()
-        {
-            string[] podLines = {
-                "1|2024-04-03T06:03:10.517865655Z|stdout|Kubernetes Script Pod completed",
-            };
-
-            var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(0, reader);
-            result.NextSequenceNumber.Should().Be(1);
-            result.Lines.Should().BeEquivalentTo(new[]
-            {
-                new ProcessOutput(ProcessOutputSource.StdOut, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z"))
-            });
-        }
-
-        [Test]
-        public async Task ThreeSubsequentLines_SequenceNumberIncreasesByThree()
-        {
-            string[] podLines = {
-                "5|2024-04-03T06:03:10.517857755Z|stdout|##octopus[stdout-verbose]",
-                "6|2024-04-03T06:03:10.517865655Z|stderr|Kubernetes Script Pod completed",
-                "7|2024-04-03T06:03:10.517867355Z|stdout|##octopus[stdout-default]"
-            };
-
-            var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(4, reader);
-            result.NextSequenceNumber.Should().Be(7);
-            result.Lines.Should().BeEquivalentTo(new[]
-            {
-                new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-verbose]", DateTimeOffset.Parse("2024-04-03T06:03:10.517857755Z")),
-                new ProcessOutput(ProcessOutputSource.StdErr, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z")),
-                new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
-            });
-        }
-        
-        [Test]
-        public async Task StreamContainsPreviousLines_Deduplicates()
-        {
-            string[] podLines = {
-                "5|2024-04-03T06:03:10.517857755Z|stdout|##octopus[stdout-verbose]",
-                "6|2024-04-03T06:03:10.517865655Z|stderr|Kubernetes Script Pod completed",
-                "7|2024-04-03T06:03:10.517867355Z|stdout|##octopus[stdout-default]"
-            };
-
-            var allTaskLogs = new List<ProcessOutput>();
-            var reader = SetupReader(podLines.Take(1).ToArray());
-            var result = await PodLogReader.ReadPodLogs(4, reader);
-            result.NextSequenceNumber.Should().Be(5);
-            allTaskLogs.AddRange(result.Lines);
-            
-            reader = SetupReader(podLines.ToArray());
-            result = await PodLogReader.ReadPodLogs(5, reader);
-            result.NextSequenceNumber.Should().Be(7);
-            allTaskLogs.AddRange(result.Lines);
-            
-            allTaskLogs.Should().BeEquivalentTo(new[]
-            {
-                new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-verbose]", DateTimeOffset.Parse("2024-04-03T06:03:10.517857755Z")),
-                new ProcessOutput(ProcessOutputSource.StdErr, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z")),
-                new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
-            });
-        }
-
-        [Test]
-        public async Task ParseError_AppearsAsError()
-        {
-            string[] podLines =
-            {
-                "abcdefg",
-            };
-
-            var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(0, reader);
-            
-            result.NextSequenceNumber.Should().Be(0, "The sequence number doesn't move on parse errors");
-            var outputLine = result.Lines.Should().ContainSingle().Subject;
-            outputLine.Source.Should().Be(ProcessOutputSource.StdErr);
-            outputLine.Text.Should().Be("Invalid log line detected. 'abcdefg' is not correctly pipe-delimited.");
-            outputLine.Occurred.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
-        }
-        
-        [Test]
-        public async Task MissingLine_Throws()
-        {
-            string[] podLines = {
-                "100|2024-04-03T06:03:10.517865655Z|stdout|Kubernetes Script Pod completed",
-            };
-        
-            var reader = SetupReader(podLines);
-            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader);
-            await action.Should().ThrowAsync<MissingPodLogException>();
-        }
-        
-        static StreamReader SetupReader(params string[] lines)
-        {
-            return new StreamReader(new MemoryStream(Encoding.Default.GetBytes(string.Join("\n", lines))));
-        }
-    }
+    // [TestFixture]
+    // public class PodLogReaderFixture
+    // {
+    //     [TestCase(0, Reason = "Initial position")]
+    //     [TestCase(4, Reason = "Subsequent position")]
+    //     [TestCase(12387126, Reason = "Large position")]
+    //     public async Task NoLines_SameSequenceNumber(long lastLogSequence)
+    //     {
+    //         string[] podLines = Array.Empty<string>();
+    //         
+    //         var reader = SetupReader(podLines);
+    //         var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader);
+    //         result.NextSequenceNumber.Should().Be(lastLogSequence);
+    //         result.Lines.Should().BeEmpty();
+    //     }
+    //
+    //     [Test]
+    //     public async Task FirstLine_SequenceNumberIncreasesByOne()
+    //     {
+    //         string[] podLines = {
+    //             "1|2024-04-03T06:03:10.517865655Z|stdout|Kubernetes Script Pod completed",
+    //         };
+    //
+    //         var reader = SetupReader(podLines);
+    //         var result = await PodLogReader.ReadPodLogs(0, reader);
+    //         result.NextSequenceNumber.Should().Be(1);
+    //         result.Lines.Should().BeEquivalentTo(new[]
+    //         {
+    //             new ProcessOutput(ProcessOutputSource.StdOut, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z"))
+    //         });
+    //     }
+    //
+    //     [Test]
+    //     public async Task ThreeSubsequentLines_SequenceNumberIncreasesByThree()
+    //     {
+    //         string[] podLines = {
+    //             "5|2024-04-03T06:03:10.517857755Z|stdout|##octopus[stdout-verbose]",
+    //             "6|2024-04-03T06:03:10.517865655Z|stderr|Kubernetes Script Pod completed",
+    //             "7|2024-04-03T06:03:10.517867355Z|stdout|##octopus[stdout-default]"
+    //         };
+    //
+    //         var reader = SetupReader(podLines);
+    //         var result = await PodLogReader.ReadPodLogs(4, reader);
+    //         result.NextSequenceNumber.Should().Be(7);
+    //         result.Lines.Should().BeEquivalentTo(new[]
+    //         {
+    //             new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-verbose]", DateTimeOffset.Parse("2024-04-03T06:03:10.517857755Z")),
+    //             new ProcessOutput(ProcessOutputSource.StdErr, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z")),
+    //             new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
+    //         });
+    //     }
+    //     
+    //     [Test]
+    //     public async Task StreamContainsPreviousLines_Deduplicates()
+    //     {
+    //         string[] podLines = {
+    //             "5|2024-04-03T06:03:10.517857755Z|stdout|##octopus[stdout-verbose]",
+    //             "6|2024-04-03T06:03:10.517865655Z|stderr|Kubernetes Script Pod completed",
+    //             "7|2024-04-03T06:03:10.517867355Z|stdout|##octopus[stdout-default]"
+    //         };
+    //
+    //         var allTaskLogs = new List<ProcessOutput>();
+    //         var reader = SetupReader(podLines.Take(1).ToArray());
+    //         var result = await PodLogReader.ReadPodLogs(4, reader);
+    //         result.NextSequenceNumber.Should().Be(5);
+    //         allTaskLogs.AddRange(result.Lines);
+    //         
+    //         reader = SetupReader(podLines.ToArray());
+    //         result = await PodLogReader.ReadPodLogs(5, reader);
+    //         result.NextSequenceNumber.Should().Be(7);
+    //         allTaskLogs.AddRange(result.Lines);
+    //         
+    //         allTaskLogs.Should().BeEquivalentTo(new[]
+    //         {
+    //             new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-verbose]", DateTimeOffset.Parse("2024-04-03T06:03:10.517857755Z")),
+    //             new ProcessOutput(ProcessOutputSource.StdErr, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z")),
+    //             new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
+    //         });
+    //     }
+    //
+    //     [Test]
+    //     public async Task ParseError_AppearsAsError()
+    //     {
+    //         string[] podLines =
+    //         {
+    //             "abcdefg",
+    //         };
+    //
+    //         var reader = SetupReader(podLines);
+    //         var result = await PodLogReader.ReadPodLogs(0, reader);
+    //         
+    //         result.NextSequenceNumber.Should().Be(0, "The sequence number doesn't move on parse errors");
+    //         var outputLine = result.Lines.Should().ContainSingle().Subject;
+    //         outputLine.Source.Should().Be(ProcessOutputSource.StdErr);
+    //         outputLine.Text.Should().Be("Invalid log line detected. 'abcdefg' is not correctly pipe-delimited.");
+    //         outputLine.Occurred.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
+    //     }
+    //     
+    //     [Test]
+    //     public async Task MissingLine_Throws()
+    //     {
+    //         string[] podLines = {
+    //             "100|2024-04-03T06:03:10.517865655Z|stdout|Kubernetes Script Pod completed",
+    //         };
+    //     
+    //         var reader = SetupReader(podLines);
+    //         Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader);
+    //         await action.Should().ThrowAsync<MissingPodLogException>();
+    //     }
+    //     
+    //     static StreamReader SetupReader(params string[] lines)
+    //     {
+    //         return new StreamReader(new MemoryStream(Encoding.Default.GetBytes(string.Join("\n", lines))));
+    //     }
+    // }
 }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
@@ -11,119 +11,146 @@ using Octopus.Tentacle.Kubernetes;
 
 namespace Octopus.Tentacle.Tests.Kubernetes
 {
-    // [TestFixture]
-    // public class PodLogReaderFixture
-    // {
-    //     [TestCase(0, Reason = "Initial position")]
-    //     [TestCase(4, Reason = "Subsequent position")]
-    //     [TestCase(12387126, Reason = "Large position")]
-    //     public async Task NoLines_SameSequenceNumber(long lastLogSequence)
-    //     {
-    //         string[] podLines = Array.Empty<string>();
-    //         
-    //         var reader = SetupReader(podLines);
-    //         var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader);
-    //         result.NextSequenceNumber.Should().Be(lastLogSequence);
-    //         result.Lines.Should().BeEmpty();
-    //     }
-    //
-    //     [Test]
-    //     public async Task FirstLine_SequenceNumberIncreasesByOne()
-    //     {
-    //         string[] podLines = {
-    //             "1|2024-04-03T06:03:10.517865655Z|stdout|Kubernetes Script Pod completed",
-    //         };
-    //
-    //         var reader = SetupReader(podLines);
-    //         var result = await PodLogReader.ReadPodLogs(0, reader);
-    //         result.NextSequenceNumber.Should().Be(1);
-    //         result.Lines.Should().BeEquivalentTo(new[]
-    //         {
-    //             new ProcessOutput(ProcessOutputSource.StdOut, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z"))
-    //         });
-    //     }
-    //
-    //     [Test]
-    //     public async Task ThreeSubsequentLines_SequenceNumberIncreasesByThree()
-    //     {
-    //         string[] podLines = {
-    //             "5|2024-04-03T06:03:10.517857755Z|stdout|##octopus[stdout-verbose]",
-    //             "6|2024-04-03T06:03:10.517865655Z|stderr|Kubernetes Script Pod completed",
-    //             "7|2024-04-03T06:03:10.517867355Z|stdout|##octopus[stdout-default]"
-    //         };
-    //
-    //         var reader = SetupReader(podLines);
-    //         var result = await PodLogReader.ReadPodLogs(4, reader);
-    //         result.NextSequenceNumber.Should().Be(7);
-    //         result.Lines.Should().BeEquivalentTo(new[]
-    //         {
-    //             new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-verbose]", DateTimeOffset.Parse("2024-04-03T06:03:10.517857755Z")),
-    //             new ProcessOutput(ProcessOutputSource.StdErr, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z")),
-    //             new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
-    //         });
-    //     }
-    //     
-    //     [Test]
-    //     public async Task StreamContainsPreviousLines_Deduplicates()
-    //     {
-    //         string[] podLines = {
-    //             "5|2024-04-03T06:03:10.517857755Z|stdout|##octopus[stdout-verbose]",
-    //             "6|2024-04-03T06:03:10.517865655Z|stderr|Kubernetes Script Pod completed",
-    //             "7|2024-04-03T06:03:10.517867355Z|stdout|##octopus[stdout-default]"
-    //         };
-    //
-    //         var allTaskLogs = new List<ProcessOutput>();
-    //         var reader = SetupReader(podLines.Take(1).ToArray());
-    //         var result = await PodLogReader.ReadPodLogs(4, reader);
-    //         result.NextSequenceNumber.Should().Be(5);
-    //         allTaskLogs.AddRange(result.Lines);
-    //         
-    //         reader = SetupReader(podLines.ToArray());
-    //         result = await PodLogReader.ReadPodLogs(5, reader);
-    //         result.NextSequenceNumber.Should().Be(7);
-    //         allTaskLogs.AddRange(result.Lines);
-    //         
-    //         allTaskLogs.Should().BeEquivalentTo(new[]
-    //         {
-    //             new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-verbose]", DateTimeOffset.Parse("2024-04-03T06:03:10.517857755Z")),
-    //             new ProcessOutput(ProcessOutputSource.StdErr, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z")),
-    //             new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
-    //         });
-    //     }
-    //
-    //     [Test]
-    //     public async Task ParseError_AppearsAsError()
-    //     {
-    //         string[] podLines =
-    //         {
-    //             "abcdefg",
-    //         };
-    //
-    //         var reader = SetupReader(podLines);
-    //         var result = await PodLogReader.ReadPodLogs(0, reader);
-    //         
-    //         result.NextSequenceNumber.Should().Be(0, "The sequence number doesn't move on parse errors");
-    //         var outputLine = result.Lines.Should().ContainSingle().Subject;
-    //         outputLine.Source.Should().Be(ProcessOutputSource.StdErr);
-    //         outputLine.Text.Should().Be("Invalid log line detected. 'abcdefg' is not correctly pipe-delimited.");
-    //         outputLine.Occurred.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
-    //     }
-    //     
-    //     [Test]
-    //     public async Task MissingLine_Throws()
-    //     {
-    //         string[] podLines = {
-    //             "100|2024-04-03T06:03:10.517865655Z|stdout|Kubernetes Script Pod completed",
-    //         };
-    //     
-    //         var reader = SetupReader(podLines);
-    //         Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader);
-    //         await action.Should().ThrowAsync<MissingPodLogException>();
-    //     }
-    //     
-    //     static StreamReader SetupReader(params string[] lines)
-    //     {
-    //         return new StreamReader(new MemoryStream(Encoding.Default.GetBytes(string.Join("\n", lines))));
-    //     }
-    // }
+    [TestFixture]
+    public class PodLogReaderFixture
+    {
+        [TestCase(0, Reason = "Initial position")]
+        [TestCase(4, Reason = "Subsequent position")]
+        [TestCase(12387126, Reason = "Large position")]
+        public async Task NoLines_SameSequenceNumber(long lastLogSequence)
+        {
+            string[] podLines = Array.Empty<string>();
+            
+            var reader = SetupReader(podLines);
+            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader, new InMemoryTentacleScriptLog());
+            result.NextSequenceNumber.Should().Be(lastLogSequence);
+            result.Lines.Should().BeEmpty();
+        }
+    
+        [Test]
+        public async Task FirstLine_SequenceNumberIncreasesByOne()
+        {
+            string[] podLines = {
+                "2024-04-03T06:03:10.517865655Z |1|stdout|Kubernetes Script Pod completed",
+            };
+    
+            var reader = SetupReader(podLines);
+            var result = await PodLogReader.ReadPodLogs(0, reader, new InMemoryTentacleScriptLog());
+            result.NextSequenceNumber.Should().Be(1);
+            result.Lines.Should().BeEquivalentTo(new[]
+            {
+                new ProcessOutput(ProcessOutputSource.StdOut, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z"))
+            });
+        }
+    
+        [Test]
+        public async Task ThreeSubsequentLines_SequenceNumberIncreasesByThree()
+        {
+            string[] podLines = {
+                "2024-04-03T06:03:10.517857755Z |5|stdout|##octopus[stdout-verbose]",
+                "2024-04-03T06:03:10.517865655Z |6|stderr|Kubernetes Script Pod completed",
+                "2024-04-03T06:03:10.517867355Z |7|stdout|##octopus[stdout-default]"
+            };
+    
+            var reader = SetupReader(podLines);
+            var result = await PodLogReader.ReadPodLogs(4, reader, new InMemoryTentacleScriptLog());
+            result.NextSequenceNumber.Should().Be(7);
+            result.Lines.Should().BeEquivalentTo(new[]
+            {
+                new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-verbose]", DateTimeOffset.Parse("2024-04-03T06:03:10.517857755Z")),
+                new ProcessOutput(ProcessOutputSource.StdErr, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z")),
+                new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
+            });
+        }
+        
+        [Test]
+        public async Task StreamContainsPreviousLines_Deduplicates()
+        {
+            string[] podLines = {
+                "2024-04-03T06:03:10.517857755Z |5|stdout|##octopus[stdout-verbose]",
+                "2024-04-03T06:03:10.517865655Z |6|stderr|Kubernetes Script Pod completed",
+                "2024-04-03T06:03:10.517867355Z |7|stdout|##octopus[stdout-default]"
+            };
+    
+            var allTaskLogs = new List<ProcessOutput>();
+            var reader = SetupReader(podLines.Take(1).ToArray());
+            var result = await PodLogReader.ReadPodLogs(4, reader, new InMemoryTentacleScriptLog());
+            result.NextSequenceNumber.Should().Be(5);
+            allTaskLogs.AddRange(result.Lines);
+            
+            reader = SetupReader(podLines.ToArray());
+            result = await PodLogReader.ReadPodLogs(5, reader, new InMemoryTentacleScriptLog());
+            result.NextSequenceNumber.Should().Be(7);
+            allTaskLogs.AddRange(result.Lines);
+            
+            allTaskLogs.Should().BeEquivalentTo(new[]
+            {
+                new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-verbose]", DateTimeOffset.Parse("2024-04-03T06:03:10.517857755Z")),
+                new ProcessOutput(ProcessOutputSource.StdErr, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z")),
+                new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
+            });
+        }
+    
+        [Test]
+        public async Task ParseError_AppearsAsError()
+        {
+            string[] podLines =
+            {
+                "abcdefg",
+            };
+    
+            var reader = SetupReader(podLines);
+            var result = await PodLogReader.ReadPodLogs(0, reader, new InMemoryTentacleScriptLog());
+            
+            result.NextSequenceNumber.Should().Be(0, "The sequence number doesn't move on parse errors");
+            var outputLine = result.Lines.Should().ContainSingle().Subject;
+            outputLine.Source.Should().Be(ProcessOutputSource.StdErr);
+            outputLine.Text.Should().Be("Invalid log line detected. 'abcdefg' is not correctly pipe-delimited.");
+            outputLine.Occurred.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
+        }
+
+        [Test]
+        public async Task MissingLine_Throws()
+        {
+            string[] podLines = {
+                "2024-04-03T06:03:10.517865655Z |100|stdout|Kubernetes Script Pod completed",
+            };
+        
+            var reader = SetupReader(podLines);
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader, new InMemoryTentacleScriptLog());
+            await action.Should().ThrowAsync<UnexpectedPodLogLineNumberException>();
+        }
+
+        [Test]
+        public async Task LineOutOfOrderAtStart_Throws()
+        {
+            string[] podLines = {
+                "2024-04-03T06:03:10.517865655Z |5|stdout|Kubernetes Script Pod completed",
+                "2024-04-03T06:03:10.517865655Z |4|stderr|Kubernetes Script Pod completed",
+            };
+        
+            var reader = SetupReader(podLines);
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(4, reader, new InMemoryTentacleScriptLog());
+            await action.Should().ThrowAsync<UnexpectedPodLogLineNumberException>();
+        }
+
+        [Test]
+        public async Task LineOutOfOrderMidway_Throws()
+        {
+            string[] podLines = {
+                "2024-04-03T06:03:10.517865655Z |3|stdout|Kubernetes Script Pod completed",
+                "2024-04-03T06:03:10.517865655Z |5|stdout|Kubernetes Script Pod completed",
+                "2024-04-03T06:03:10.517865655Z |4|stderr|Kubernetes Script Pod completed",
+            };
+        
+            var reader = SetupReader(podLines);
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(2, reader, new InMemoryTentacleScriptLog());
+            await action.Should().ThrowAsync<UnexpectedPodLogLineNumberException>();
+        }
+        
+        static StreamReader SetupReader(params string[] lines)
+        {
+            return new StreamReader(new MemoryStream(Encoding.Default.GetBytes(string.Join("\n", lines))));
+        }
+    }
 }

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -27,10 +27,6 @@ namespace Octopus.Tentacle.Kubernetes
         {
         }
 
-        void GetTentacleLogger()
-        {
-        }
-
 // disposable
         //public ISinceTimeStore GetTimeProvider(ScriptTicket scriptTicket);
         
@@ -54,11 +50,14 @@ namespace Octopus.Tentacle.Kubernetes
     {
         readonly IKubernetesPodMonitor podMonitor;
         readonly ITentacleScriptLogProvider scriptLogProvider;
+        readonly ScriptPodResources scriptPodResources;
 
-        public KubernetesPodLogService(IKubernetesClientConfigProvider configProvider, IKubernetesPodMonitor podMonitor, ITentacleScriptLogProvider scriptLogProvider) : base(configProvider)
+        public KubernetesPodLogService(IKubernetesClientConfigProvider configProvider, IKubernetesPodMonitor podMonitor, ITentacleScriptLogProvider scriptLogProvider, ScriptPodResources scriptPodResources) 
+            : base(configProvider)
         {
             this.podMonitor = podMonitor;
             this.scriptLogProvider = scriptLogProvider;
+            this.scriptPodResources = scriptPodResources;
         }
 
         public async Task<(IReadOnlyCollection<ProcessOutput> Outputs, long NextSequenceNumber)> GetLogs(ScriptTicket scriptTicket, long lastLogSequence, CancellationToken cancellationToken)
@@ -91,7 +90,7 @@ namespace Octopus.Tentacle.Kubernetes
             if (podLogs.Outputs.Any())
             {
                 var nextSinceTime = podLogs.Outputs.Max(o => o.Occurred);
-                log.Verbose("K8s Next SinceTime: " + nextSinceTime);
+                //log.Verbose("K8s Next SinceTime: " + nextSinceTime);
                 scriptPodResources.UpdateSinceTime(scriptTicket, nextSinceTime);
                 
                 //We can use our EOS marker to detect completion quicker than the Pod status
@@ -108,7 +107,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 using (var reader = new StreamReader(stream))
                 {
-                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader, log);
+                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader);
                 }
             }
         }

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -74,7 +74,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 using (var reader = new StreamReader(stream))
                 {
-                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader);
+                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader, tentacleScriptLog);
                 }
             }
         }

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -1,14 +1,47 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using k8s;
 using k8s.Autorest;
+using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Kubernetes
 {
+    public class ScriptPodResources
+    {
+        ConcurrentDictionary<ScriptTicket, DateTimeOffset?> sinceTimes = new ConcurrentDictionary<ScriptTicket, DateTimeOffset?>();
+        public void Create(ScriptTicket scriptTicket)
+        {
+            sinceTimes.GetOrAdd(scriptTicket, _ => null);
+        }
+
+        void Delete()
+        {
+        }
+
+        void GetTentacleLogger()
+        {
+        }
+
+        public DateTimeOffset? GetSinceTime(ScriptTicket scriptTicket)
+        {
+            return sinceTimes[scriptTicket];
+        }
+
+        public void UpdateSinceTime(ScriptTicket scriptTicket, DateTimeOffset nextSinceTime)
+        {
+            sinceTimes[scriptTicket] = nextSinceTime;
+        }
+    }
+
     public interface IKubernetesPodLogService
     {
         Task<(IReadOnlyCollection<ProcessOutput> Outputs, long NextSequenceNumber)> GetLogs(ScriptTicket scriptTicket, long lastLogSequence, CancellationToken cancellationToken);
@@ -17,23 +50,25 @@ namespace Octopus.Tentacle.Kubernetes
     class KubernetesPodLogService : KubernetesService, IKubernetesPodLogService
     {
         readonly IKubernetesPodMonitor podMonitor;
-
-        public KubernetesPodLogService(IKubernetesClientConfigProvider configProvider, IKubernetesPodMonitor podMonitor) : base(configProvider)
+        readonly ScriptPodResources scriptPodResources;
+        readonly ISystemLog log;
+        public KubernetesPodLogService(IKubernetesClientConfigProvider configProvider, IKubernetesPodMonitor podMonitor, ScriptPodResources scriptPodResources, ISystemLog log) : base(configProvider)
         {
             this.podMonitor = podMonitor;
+            this.scriptPodResources = scriptPodResources;
+            this.log = log;
         }
 
         public async Task<(IReadOnlyCollection<ProcessOutput> Outputs, long NextSequenceNumber)> GetLogs(ScriptTicket scriptTicket, long lastLogSequence, CancellationToken cancellationToken)
         {
             var podName = scriptTicket.ToKubernetesScriptPobName();
-            DateTimeOffset? sinceTime = null;
+            var sinceTime = scriptPodResources.GetSinceTime(scriptTicket);
 
             Stream logStream;
 
             try
             {
-                //TODO: Only grab recent
-                logStream = await Client.GetNamespacedPodLogsAsync(podName, KubernetesConfig.Namespace, podName, sinceTime, cancellationToken: cancellationToken);
+                logStream = await Client.GetNamespacedPodLogsAsync(log, podName, KubernetesConfig.Namespace, podName, sinceTime, cancellationToken: cancellationToken);
             }
             catch (HttpOperationException ex)
             {
@@ -46,19 +81,26 @@ namespace Octopus.Tentacle.Kubernetes
                 throw;
             }
 
-            var podLogs = await ReadPodLogs();
+            var podLogs = await ReadPodLogs(logStream);
 
-            //We can use our EOS marker to detect completion quicker than the Pod status
-            if (podLogs.ExitCode != null)
-                podMonitor.MarkAsCompleted(scriptTicket, podLogs.ExitCode.Value);
+            if (podLogs.Outputs.Any())
+            {
+                var nextSinceTime = podLogs.Outputs.Max(o => o.Occurred);
+                log.Verbose("K8s Next SinceTime: " + nextSinceTime);
+                scriptPodResources.UpdateSinceTime(scriptTicket, nextSinceTime);
+                
+                //We can use our EOS marker to detect completion quicker than the Pod status
+                if (podLogs.ExitCode != null)
+                    podMonitor.MarkAsCompleted(scriptTicket, podLogs.ExitCode.Value);
+            }
 
             return (podLogs.Outputs, podLogs.NextSequenceNumber);
 
-            async Task<(IReadOnlyCollection<ProcessOutput> Outputs, long NextSequenceNumber, int? ExitCode)> ReadPodLogs()
+            async Task<(IReadOnlyCollection<ProcessOutput> Outputs, long NextSequenceNumber, int? ExitCode)> ReadPodLogs(Stream stream)
             {
-                using (var reader = new StreamReader(logStream))
+                using (var reader = new StreamReader(stream))
                 {
-                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader);
+                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader, log);
                 }
             }
         }

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -31,6 +31,9 @@ namespace Octopus.Tentacle.Kubernetes
         {
         }
 
+// disposable
+        //public ISinceTimeStore GetTimeProvider(ScriptTicket scriptTicket);
+        
         public DateTimeOffset? GetSinceTime(ScriptTicket scriptTicket)
         {
             return sinceTimes[scriptTicket];

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -74,7 +74,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 using (var reader = new StreamReader(stream))
                 {
-                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader, tentacleScriptLog);
+                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader);
                 }
             }
         }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesClientExtensionMethods.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesClientExtensionMethods.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Kubernetes
 {
     public static class KubernetesClientExtensionMethods
     {
-        public static async Task<Stream> GetNamespacedPodLogsAsync(this k8s.Kubernetes client, ISystemLog log, string podName, string namespaceParameter, string container, DateTimeOffset? sinceTime, CancellationToken cancellationToken = default)
+        public static async Task<Stream> GetNamespacedPodLogsAsync(this k8s.Kubernetes client, string podName, string namespaceParameter, string container, DateTimeOffset? sinceTime, CancellationToken cancellationToken = default)
         {
             //Include Server timestamps so we can use it to specify "sinceTime" on the next call
             var url = $"api/v1/namespaces/{namespaceParameter}/pods/{podName}/log?container={container}&timestamps=true";
@@ -19,12 +19,10 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 var sinceTimeStr = sinceTime.Value.ToString("O");
                 url += $"&sinceTime={Uri.EscapeDataString(sinceTimeStr)}";
-                log.Verbose("K8s Query SinceTime: " + sinceTimeStr);
             }
             
             url = string.Concat(client.BaseUri, url);
 
-            log.Verbose("K8s URL: " + url);
             var httpRequest = new HttpRequestMessage(HttpMethod.Get, url);
 
             if (client.Credentials is not null)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesClientExtensionMethods.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesClientExtensionMethods.cs
@@ -4,23 +4,27 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using k8s.Autorest;
+using Octopus.Diagnostics;
 
 namespace Octopus.Tentacle.Kubernetes
 {
     public static class KubernetesClientExtensionMethods
     {
-        public static async Task<Stream> GetNamespacedPodLogsAsync(this k8s.Kubernetes client, string podName, string namespaceParameter, string container, DateTimeOffset? sinceTime = null, CancellationToken cancellationToken = default)
+        public static async Task<Stream> GetNamespacedPodLogsAsync(this k8s.Kubernetes client, ISystemLog log, string podName, string namespaceParameter, string container, DateTimeOffset? sinceTime, CancellationToken cancellationToken = default)
         {
-            var url = $"api/v1/namespaces/{namespaceParameter}/pods/{podName}/log?container={container}";
+            //Include Server timestamps so we can use it to specify "sinceTime" on the next call
+            var url = $"api/v1/namespaces/{namespaceParameter}/pods/{podName}/log?container={container}&timestamps=true";
 
             if (sinceTime is not null)
             {
                 var sinceTimeStr = sinceTime.Value.ToString("O");
                 url += $"&sinceTime={Uri.EscapeDataString(sinceTimeStr)}";
+                log.Verbose("K8s Query SinceTime: " + sinceTimeStr);
             }
-
+            
             url = string.Concat(client.BaseUri, url);
 
+            log.Verbose("K8s URL: " + url);
             var httpRequest = new HttpRequestMessage(HttpMethod.Get, url);
 
             if (client.Credentials is not null)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesClientExtensionMethods.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesClientExtensionMethods.cs
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Kubernetes
                 var sinceTimeStr = sinceTime.Value.ToString("O");
                 url += $"&sinceTime={Uri.EscapeDataString(sinceTimeStr)}";
             }
-            
+
             url = string.Concat(client.BaseUri, url);
 
             var httpRequest = new HttpRequestMessage(HttpMethod.Get, url);

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -15,7 +15,7 @@ namespace Octopus.Tentacle.Kubernetes
 
             builder.RegisterType<KubernetesScriptPodCreator>().As<IKubernetesScriptPodCreator>().SingleInstance();
             builder.RegisterType<KubernetesPodLogService>().As<IKubernetesPodLogService>().SingleInstance();
-            builder.RegisterType<ScriptPodResources>().SingleInstance();
+            builder.RegisterType<ScriptPodSinceTimeStore>().As<IScriptPodSinceTimeStore>().SingleInstance();
             builder.RegisterType<TentacleScriptLogProvider>().As<ITentacleScriptLogProvider>().SingleInstance();
 
             builder.RegisterType<KubernetesPodMonitorTask>().As<IKubernetesPodMonitorTask>().As<IBackgroundTask>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -15,6 +15,7 @@ namespace Octopus.Tentacle.Kubernetes
 
             builder.RegisterType<KubernetesScriptPodCreator>().As<IKubernetesScriptPodCreator>().SingleInstance();
             builder.RegisterType<KubernetesPodLogService>().As<IKubernetesPodLogService>().SingleInstance();
+            builder.RegisterType<ScriptPodResources>().SingleInstance();
 
             builder.RegisterType<KubernetesPodMonitorTask>().As<IKubernetesPodMonitorTask>().As<IBackgroundTask>().SingleInstance();
             builder.RegisterType<KubernetesPodMonitor>().As<IKubernetesPodMonitor>().As<IKubernetesPodStatusProvider>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
@@ -5,7 +5,7 @@ using YamlDotNet.Core.Tokens;
 
 namespace Octopus.Tentacle.Kubernetes
 {
-    public record PodLogLine(int LineNumber, ProcessOutputSource Source, string Message, DateTimeOffset Occurred);
+    public record PodLogLine(long LineNumber, ProcessOutputSource Source, string Message, DateTimeOffset Occurred);
 
     public abstract class PodLogLineParseResult
     {

--- a/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
@@ -70,14 +70,14 @@ namespace Octopus.Tentacle.Kubernetes
                 return new InvalidPodLogLineParseResult($"Invalid log line detected. '{line}' is not correctly pipe-delimited.");
             }
 
-            if (!int.TryParse(logParts[0], out int lineNumber))
-            {
-                return new InvalidPodLogLineParseResult($"Invalid log line detected. '{logParts[0]}' is not a valid line number.");
-            }
-
-            if (!DateTimeOffset.TryParse(logParts[1], out var occurred))
+            if (!DateTimeOffset.TryParse(logParts[0], out var occurred))
             {
                 return new InvalidPodLogLineParseResult($"Invalid log line detected. Failed to parse '{logParts[1]}' as a DateTimeOffset.");
+            }
+
+            if (!int.TryParse(logParts[1], out int lineNumber))
+            {
+                return new InvalidPodLogLineParseResult($"Invalid log line detected. '{logParts[0]}' is not a valid line number.");
             }
 
             if (!Enum.TryParse(logParts[2], true, out ProcessOutputSource source))

--- a/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Kubernetes
 {
     static class PodLogReader
     {
-        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader, ISystemLog log)
+        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader)
         {
             int? exitCode = null;
             var results = new List<ProcessOutput>();
@@ -20,7 +20,6 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 var line = await reader.ReadLineAsync();
 
-                log.Verbose($"Parsing line: '{line}'");
                 //No more to read
                 if (line.IsNullOrEmpty())
                 {

--- a/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Kubernetes
 {
     static class PodLogReader
     {
-        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader)
+        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader, InMemoryTentacleScriptLog tentacleScriptLog)
         {
             int? exitCode = null;
             var results = new List<ProcessOutput>();
@@ -26,6 +26,7 @@ namespace Octopus.Tentacle.Kubernetes
                     return (results, nextSequenceNumber, exitCode);
                 }
 
+                tentacleScriptLog.Verbose("Parsing line: " + line);
                 var parseResult = PodLogLineParser.ParseLine(line!);
 
                 switch (parseResult)

--- a/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Util;
 
@@ -9,7 +10,7 @@ namespace Octopus.Tentacle.Kubernetes
 {
     static class PodLogReader
     {
-        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader)
+        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader, ISystemLog log)
         {
             int? exitCode = null;
             var results = new List<ProcessOutput>();
@@ -19,6 +20,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 var line = await reader.ReadLineAsync();
 
+                log.Verbose($"Parsing line: '{line}'");
                 //No more to read
                 if (line.IsNullOrEmpty())
                 {

--- a/source/Octopus.Tentacle/Kubernetes/ScriptPodSinceTimeStore.cs
+++ b/source/Octopus.Tentacle/Kubernetes/ScriptPodSinceTimeStore.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Concurrent;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IScriptPodSinceTimeStore
+    {
+        DateTimeOffset? GetSinceTime(ScriptTicket scriptTicket);
+        void UpdateSinceTime(ScriptTicket scriptTicket, DateTimeOffset nextSinceTime);
+        void Delete(ScriptTicket scriptTicket);
+    }
+
+    public class ScriptPodSinceTimeStore : IScriptPodSinceTimeStore
+    {
+        readonly ConcurrentDictionary<ScriptTicket, DateTimeOffset?> sinceTimes = new();
+        
+        public DateTimeOffset? GetSinceTime(ScriptTicket scriptTicket)
+        {
+            return sinceTimes.GetOrAdd(scriptTicket, _ => null);
+        }
+
+        public void UpdateSinceTime(ScriptTicket scriptTicket, DateTimeOffset nextSinceTime)
+        {
+            sinceTimes[scriptTicket] = nextSinceTime;
+        }
+
+        public void Delete(ScriptTicket scriptTicket)
+        {
+            sinceTimes.TryRemove(scriptTicket, out _);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
@@ -56,8 +56,6 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
                     return await GetResponse(trackedPod, 0, cancellationToken);
                 }
 
-                scriptPodResources.Create(command.ScriptTicket);
-                
                 //TODO: consider adding an idempotent version of PrepareWorkspace
                 var workspace = await workspaceFactory.PrepareWorkspace(command.ScriptTicket,
                     command.ScriptBody,


### PR DESCRIPTION
[sc-71685]
# Background

We currently stream all logs from the Script Pod every time. There's a `sinceTime` filter we can use to only get the latest logs.

This PR adds `sinceTime` to the request we send. We also depend on the API Server's timestamp now instead of writing our own in the bootstrapper - in case the clocks are out of sync.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.