### PR TITLE
Allow filtering tests that require systemd

### DIFF
--- a/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
+++ b/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
@@ -21,7 +21,7 @@ set +e
 if [ -n "$TENTACLE_IT_WITH_SUDO" ]; then
   TEST_CASE_FILTER="TestCategory!=TentacleBackwardsCompatibility"
   if [ "$TENTACLE_IT_WITH_SUDO" = "NO_SYSTEMD" ]; then
-    TEST_CASE_FILTER="$TEST_CASE_FILTER&TestCategory!=RequiresSystemd"
+    TEST_CASE_FILTER="$TEST_CASE_FILTER&TestCategory!=RequiresSystemdOnLinux"
   fi
   sudo -E env PATH=$PATH dotnet vstest $itdll "/testcasefilter:$TEST_CASE_FILTER" /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 else

--- a/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
+++ b/build/test-scripts/integration/common/run-integration-tests-on-vm-agents.sh
@@ -18,9 +18,13 @@ itdll=`pwd`/build/outputs/integrationtests/net6.0/linux-x64/Octopus.Tentacle.Tes
 
 # We don't care about the exit code of dotnet test and instead depend on tests passing.
 set +e
-if [ "$TENTACLE_IT_WITH_SUDO" = "1" ]; then
-sudo -E env PATH=$PATH dotnet vstest $itdll "/testcasefilter:TestCategory!=TentacleBackwardsCompatibility" /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
+if [ -n "$TENTACLE_IT_WITH_SUDO" ]; then
+  TEST_CASE_FILTER="TestCategory!=TentacleBackwardsCompatibility"
+  if [ "$TENTACLE_IT_WITH_SUDO" = "NO_SYSTEMD" ]; then
+    TEST_CASE_FILTER="$TEST_CASE_FILTER&TestCategory!=RequiresSystemd"
+  fi
+  sudo -E env PATH=$PATH dotnet vstest $itdll "/testcasefilter:$TEST_CASE_FILTER" /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 else
-dotnet vstest $itdll "/testcasefilter:TestCategory!=RequiresSudoOnLinux&TestCategory!=TentacleBackwardsCompatibility" /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
+  dotnet vstest $itdll "/testcasefilter:TestCategory!=RequiresSudoOnLinux&TestCategory!=TentacleBackwardsCompatibility" /logger:logger://teamcity /TestAdapterPath:/opt/TeamCity/BuildAgent/plugins/dotnet/tools/vstest15 /logger:console;verbosity=detailed
 fi
 

--- a/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
@@ -21,6 +21,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
     {
         [Test]
         [RequiresSudoOnLinux]
+        [RequiresSystemdOnLinux]
         public void CanInstallServiceAsRoot()
         {
             CanInstallService(null, null);
@@ -28,6 +29,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
 
         [Test]
         [RequiresSudoOnLinux]
+        [RequiresSystemdOnLinux]
         public void CanInstallServiceAsUser()
         {
             var user = new LinuxTestUserPrincipal("octo-shared-svc-test");
@@ -36,6 +38,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
 
         [Test]
         [RequiresSudoOnLinux]
+        [RequiresSystemdOnLinux]
         public void CannotWriteToServiceFileAsUser()
         {
             const string serviceName = "OctopusShared.ServiceHelperTest";

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TestAttributes/RequiresSystemdOnLinuxAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TestAttributes/RequiresSystemdOnLinuxAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+using NUnit.Framework;
+
+namespace Octopus.Tentacle.Tests.Integration.Support.TestAttributes
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class RequiresSystemdOnLinuxAttribute : CategoryAttribute
+    {
+    }
+}


### PR DESCRIPTION
# Background

When executing integration tests in a container, systemd is not an available option. This extends the mechanism used to filter out tests requiring sudo to better separate the underlying requirement on systemd.

# Results

Allows tests to run that require sudo while skipping tests that require systemd.

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.