### PR TITLE
Add ability for Tentacle to write to the task log

### DIFF
--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
@@ -34,7 +34,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             podService = Substitute.For<IKubernetesPodService>();
             log = new InMemoryLog();
             clock = new FixedClock(startTime);
-            monitor = new KubernetesPodMonitor(podService, log);
+            monitor = new KubernetesPodMonitor(podService, log, new TentacleScriptLogProvider());
 
             scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
 

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesOrphanedPodCleanerTests.cs
@@ -26,6 +26,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         TimeSpan overCutoff;
         TimeSpan underCutoff;
         DateTimeOffset startTime;
+        ITentacleScriptLogProvider scriptLogProvider;
 
         [SetUp]
         public void Setup()
@@ -34,14 +35,22 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             podService = Substitute.For<IKubernetesPodService>();
             log = new InMemoryLog();
             clock = new FixedClock(startTime);
-            monitor = new KubernetesPodMonitor(podService, log, new TentacleScriptLogProvider());
+            scriptLogProvider = Substitute.For<ITentacleScriptLogProvider>();
+            monitor = new KubernetesPodMonitor(podService, log, scriptLogProvider);
 
             scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
 
-            cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock);
+            cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock, scriptLogProvider);
 
             overCutoff = cleaner.CompletedPodConsideredOrphanedAfterTimeSpan + 1.Minutes();
             underCutoff = cleaner.CompletedPodConsideredOrphanedAfterTimeSpan - 1.Minutes();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP", null);
+            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__PODSCONSIDEREDORPHANEDAFTERMINUTES", null);
         }
 
         [Test]
@@ -60,6 +69,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
 
             //Assert
             await podService.Received().Delete(scriptTicket, Arg.Any<CancellationToken>());
+            scriptLogProvider.Received().Delete(scriptTicket);
         }
 
         [TestCase("Succeeded", true)]
@@ -84,10 +94,12 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             if (shouldBeDeleted)
             {
                 await podService.Received().Delete(scriptTicket, Arg.Any<CancellationToken>());
+                scriptLogProvider.Received().Delete(scriptTicket);
             }
             else
             {
                 await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
+                scriptLogProvider.DidNotReceive().Delete(scriptTicket);
             }
         }
 
@@ -107,6 +119,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
 
             //Assert
             await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
+            scriptLogProvider.DidNotReceive().Delete(scriptTicket);
         }
 
         [Test]
@@ -126,9 +139,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
 
             //Assert
             await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
-
-            //Cleanup
-            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP", null);
+            scriptLogProvider.Received().Delete(scriptTicket);
         }
 
         [TestCase(1, false)]
@@ -139,7 +150,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__PODSCONSIDEREDORPHANEDAFTERMINUTES", "2");
 
             // We need to reinitialise the sut after changing the env var value
-            cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock);
+            cleaner = new KubernetesOrphanedPodCleaner(monitor, podService, log, clock, scriptLogProvider);
             const WatchEventType type = WatchEventType.Added;
             var pod = CreatePod(TrackedScriptPodState.Succeeded, startTime);
 
@@ -154,14 +165,13 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             if (shouldDelete)
             {
                 await podService.Received().Delete(scriptTicket, Arg.Any<CancellationToken>());
+                scriptLogProvider.Received().Delete(scriptTicket);
             }
             else
             {
                 await podService.DidNotReceive().Delete(scriptTicket, Arg.Any<CancellationToken>());
+                scriptLogProvider.DidNotReceive().Delete(scriptTicket);
             }
-
-            //Cleanup
-            Environment.SetEnvironmentVariable("OCTOPUS__K8STENTACLE__PODSCONSIDEREDORPHANEDAFTERMINUTES", null);
         }
 
         V1Pod CreatePod(TrackedScriptPodState? phase, DateTimeOffset? finishedAt = null, int exitCode = 0) => CreatePod(phase?.ToString(), finishedAt, exitCode);

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
@@ -22,15 +22,13 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         ISystemLog log;
         KubernetesPodMonitor monitor;
         ScriptTicket scriptTicket;
-        IClock clock;
 
         [SetUp]
         public void SetUp()
         {
             podService = Substitute.For<IKubernetesPodService>();
             log = new InMemoryLog();
-            clock = new FixedClock(DateTimeOffset.MinValue);
-            monitor = new KubernetesPodMonitor(podService, log);
+            monitor = new KubernetesPodMonitor(podService, log, new TentacleScriptLogProvider());
 
             scriptTicket = new ScriptTicket(Guid.NewGuid().ToString());
         }

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -18,9 +18,9 @@ namespace Octopus.Tentacle.Kubernetes
     class KubernetesPodLogService : KubernetesService, IKubernetesPodLogService
     {
         readonly IKubernetesPodMonitor podMonitor;
-        readonly TentacleScriptLogProvider scriptLogProvider;
+        readonly ITentacleScriptLogProvider scriptLogProvider;
 
-        public KubernetesPodLogService(IKubernetesClientConfigProvider configProvider, IKubernetesPodMonitor podMonitor, TentacleScriptLogProvider scriptLogProvider) : base(configProvider)
+        public KubernetesPodLogService(IKubernetesClientConfigProvider configProvider, IKubernetesPodMonitor podMonitor, ITentacleScriptLogProvider scriptLogProvider) : base(configProvider)
         {
             this.podMonitor = podMonitor;
             this.scriptLogProvider = scriptLogProvider;
@@ -58,7 +58,7 @@ namespace Octopus.Tentacle.Kubernetes
                 podMonitor.MarkAsCompleted(scriptTicket, podLogs.ExitCode.Value);
 
             //We are making the assumption that the clock on the Tentacle Pod is in sync with API Server
-            var tentacleLogs = ReadTentacleLogs();
+            var tentacleLogs = tentacleScriptLog.PopLogs();
             var combinedLogs = podLogs.Outputs.Concat(tentacleLogs).OrderBy(o => o.Occurred).ToList();
             return (combinedLogs, podLogs.NextSequenceNumber);
 
@@ -68,11 +68,6 @@ namespace Octopus.Tentacle.Kubernetes
                 {
                     return await PodLogReader.ReadPodLogs(lastLogSequence, reader);
                 }
-            }
-            
-            IReadOnlyCollection<ProcessOutput> ReadTentacleLogs()
-            {
-                return tentacleScriptLog.PopLogs();
             }
         }
     }

--- a/source/Octopus.Tentacle/Kubernetes/InMemoryTentacleScriptLog.cs
+++ b/source/Octopus.Tentacle/Kubernetes/InMemoryTentacleScriptLog.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public class InMemoryTentacleScriptLog
+    {
+        readonly List<ProcessOutput> logs = new();
+        
+        public void Verbose(string message)
+        {
+            lock (logs)
+                logs.Add(new ProcessOutput(ProcessOutputSource.Debug, message));
+        }
+
+        public void Info(string message)
+        {
+            lock (logs)
+                logs.Add(new ProcessOutput(ProcessOutputSource.StdOut, message));
+        }
+
+        public void Error(string message)
+        {
+            lock (logs)
+                logs.Add(new ProcessOutput(ProcessOutputSource.StdErr, message));
+        }
+
+        public IReadOnlyCollection<ProcessOutput> PopLogs()
+        {
+            lock (logs)
+            {
+                var copy = logs.ToList();
+                logs.Clear();
+                return copy;
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -15,6 +15,7 @@ namespace Octopus.Tentacle.Kubernetes
 
             builder.RegisterType<KubernetesScriptPodCreator>().As<IKubernetesScriptPodCreator>().SingleInstance();
             builder.RegisterType<KubernetesPodLogService>().As<IKubernetesPodLogService>().SingleInstance();
+            builder.RegisterType<TentacleScriptLogProvider>().SingleInstance();
 
             builder.RegisterType<KubernetesPodMonitorTask>().As<IKubernetesPodMonitorTask>().As<IBackgroundTask>().SingleInstance();
             builder.RegisterType<KubernetesPodMonitor>().As<IKubernetesPodMonitor>().As<IKubernetesPodStatusProvider>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -15,7 +15,7 @@ namespace Octopus.Tentacle.Kubernetes
 
             builder.RegisterType<KubernetesScriptPodCreator>().As<IKubernetesScriptPodCreator>().SingleInstance();
             builder.RegisterType<KubernetesPodLogService>().As<IKubernetesPodLogService>().SingleInstance();
-            builder.RegisterType<TentacleScriptLogProvider>().SingleInstance();
+            builder.RegisterType<TentacleScriptLogProvider>().As<ITentacleScriptLogProvider>().SingleInstance();
 
             builder.RegisterType<KubernetesPodMonitorTask>().As<IKubernetesPodMonitorTask>().As<IBackgroundTask>().SingleInstance();
             builder.RegisterType<KubernetesPodMonitor>().As<IKubernetesPodMonitor>().As<IKubernetesPodStatusProvider>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -29,13 +29,15 @@ namespace Octopus.Tentacle.Kubernetes
     {
         readonly IKubernetesPodService podService;
         readonly ISystemLog log;
-
+        readonly TentacleScriptLogProvider scriptLogProvider;
+        
         ConcurrentDictionary<ScriptTicket, TrackedScriptPod> podStatusLookup = new();
 
-        public KubernetesPodMonitor(IKubernetesPodService podService, ISystemLog log)
+        public KubernetesPodMonitor(IKubernetesPodService podService, ISystemLog log, TentacleScriptLogProvider scriptLogProvider)
         {
             this.podService = podService;
             this.log = log;
+            this.scriptLogProvider = scriptLogProvider;
         }
 
         async Task IKubernetesPodMonitor.StartAsync(CancellationToken cancellationToken)
@@ -57,7 +59,9 @@ namespace Octopus.Tentacle.Kubernetes
         {
             if (podStatusLookup.TryGetValue(scriptTicket, out var status))
             {
-                log.Verbose($"Marking {scriptTicket.TaskId} as completed");
+                var text = $"Marking '{scriptTicket.TaskId}' as completed with exit code: '{exitCode}'";
+                scriptLogProvider.GetOrCreate(scriptTicket).Verbose(text);
+                log.Verbose(text);
                 status.MarkAsCompleted(exitCode, DateTimeOffset.UtcNow);
             }
         }
@@ -94,7 +98,7 @@ namespace Octopus.Tentacle.Kubernetes
                 }
                 status.Update(pod);
 
-                log.Verbose($"Preloaded pod {pod.Name()}. {status}");
+                log.Verbose($"Preloaded pod {pod.Name()} ({status})");
                 newStatuses[scriptTicket] = status;
             }
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -29,11 +29,11 @@ namespace Octopus.Tentacle.Kubernetes
     {
         readonly IKubernetesPodService podService;
         readonly ISystemLog log;
-        readonly TentacleScriptLogProvider scriptLogProvider;
+        readonly ITentacleScriptLogProvider scriptLogProvider;
         
         ConcurrentDictionary<ScriptTicket, TrackedScriptPod> podStatusLookup = new();
 
-        public KubernetesPodMonitor(IKubernetesPodService podService, ISystemLog log, TentacleScriptLogProvider scriptLogProvider)
+        public KubernetesPodMonitor(IKubernetesPodService podService, ISystemLog log, ITentacleScriptLogProvider scriptLogProvider)
         {
             this.podService = podService;
             this.log = log;

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -28,14 +28,14 @@ namespace Octopus.Tentacle.Kubernetes
         readonly IKubernetesPodContainerResolver containerResolver;
         readonly IApplicationInstanceSelector appInstanceSelector;
         readonly ISystemLog log;
-        readonly TentacleScriptLogProvider scriptLogProvider;
+        readonly ITentacleScriptLogProvider scriptLogProvider;
         
         public KubernetesScriptPodCreator(
             IKubernetesPodService podService,
             IKubernetesSecretService secretService,
             IKubernetesPodContainerResolver containerResolver,
             IApplicationInstanceSelector appInstanceSelector,
-            ISystemLog log, TentacleScriptLogProvider scriptLogProvider)
+            ISystemLog log, ITentacleScriptLogProvider scriptLogProvider)
         {
             this.podService = podService;
             this.secretService = secretService;

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -6,13 +6,11 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using k8s;
 using k8s.Models;
 using Newtonsoft.Json;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Configuration.Instances;
 using Octopus.Tentacle.Contracts.KubernetesScriptServiceV1Alpha;
-using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Variables;
 
@@ -30,19 +28,21 @@ namespace Octopus.Tentacle.Kubernetes
         readonly IKubernetesPodContainerResolver containerResolver;
         readonly IApplicationInstanceSelector appInstanceSelector;
         readonly ISystemLog log;
-
+        readonly TentacleScriptLogProvider scriptLogProvider;
+        
         public KubernetesScriptPodCreator(
             IKubernetesPodService podService,
             IKubernetesSecretService secretService,
             IKubernetesPodContainerResolver containerResolver,
             IApplicationInstanceSelector appInstanceSelector,
-            ISystemLog log)
+            ISystemLog log, TentacleScriptLogProvider scriptLogProvider)
         {
             this.podService = podService;
             this.secretService = secretService;
             this.containerResolver = containerResolver;
             this.appInstanceSelector = appInstanceSelector;
             this.log = log;
+            this.scriptLogProvider = scriptLogProvider;
         }
 
         public async Task CreatePod(StartKubernetesScriptCommandV1Alpha command, IScriptWorkspace workspace, CancellationToken cancellationToken)
@@ -143,9 +143,10 @@ namespace Octopus.Tentacle.Kubernetes
         async Task CreatePod(StartKubernetesScriptCommandV1Alpha command, IScriptWorkspace workspace, string? imagePullSecretName, CancellationToken cancellationToken)
         {
             var podName = command.ScriptTicket.ToKubernetesScriptPobName();
+            var tentacleScriptLog = scriptLogProvider.GetOrCreate(command.ScriptTicket);
 
-            log.Verbose($"Creating Kubernetes Pod '{podName}'.");
-
+            LogVerboseToBothLogs($"Creating Kubernetes Pod '{podName}'.");
+                
             //write the bootstrap runner script to the workspace
             workspace.CopyFile(KubernetesConfig.BootstrapRunnerExecutablePath, "bootstrapRunner");
 
@@ -236,7 +237,13 @@ namespace Octopus.Tentacle.Kubernetes
 
             await podService.Create(pod, cancellationToken);
 
-            log.Verbose($"Executing script in Kubernetes Pod '{podName}'.");
+            LogVerboseToBothLogs($"Executing script in Kubernetes Pod '{podName}'.");
+
+            void LogVerboseToBothLogs(string message)
+            {
+                log.Verbose(message);
+                tentacleScriptLog.Verbose(message);
+            }
         }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
@@ -27,33 +27,41 @@ namespace Octopus.Tentacle.Kubernetes
 
                 var parseResult = PodLogLineParser.ParseLine(line!);
 
-                if (parseResult is ValidPodLogLineParseResult validParseResult)
+                switch (parseResult)
                 {
-                    var podLogLine = validParseResult.LogLine;
-
-                    //Pod log line numbers are 1-based, log sequence is 0-based
-                    if (podLogLine.LineNumber > lastLogSequence)
+                    case ValidPodLogLineParseResult validParseResult:
                     {
-                        if (podLogLine.LineNumber == lastLogSequence + 1)
-                            haveSeenPodLogEntryMatchingLogSequence = true;
+                        var podLogLine = validParseResult.LogLine;
 
-                        if (!haveSeenPodLogEntryMatchingLogSequence)
-                            throw new MissingPodLogException();
+                        //Pod log line numbers are 1-based, log sequence is 0-based
+                        if (podLogLine.LineNumber > lastLogSequence)
+                        {
+                            if (podLogLine.LineNumber == lastLogSequence + 1)
+                                haveSeenPodLogEntryMatchingLogSequence = true;
 
-                        if (validParseResult is EndOfStreamPodLogLineParseResult endOfStreamParseResult)
-                            exitCode = endOfStreamParseResult.ExitCode;
+                            if (!haveSeenPodLogEntryMatchingLogSequence)
+                                throw new MissingPodLogException();
 
-                        results.Add(new ProcessOutput(podLogLine.Source, podLogLine.Message, podLogLine.Occurred));
-                        nextSequenceNumber = podLogLine.LineNumber;
+                            if (validParseResult is EndOfStreamPodLogLineParseResult endOfStreamParseResult)
+                                exitCode = endOfStreamParseResult.ExitCode;
+
+                            results.Add(new ProcessOutput(podLogLine.Source, podLogLine.Message, podLogLine.Occurred));
+                            nextSequenceNumber = podLogLine.LineNumber;
+                        }
+
+                        break;
                     }
-                    else
-                    {
-                        //TODO: print parse errors
-                    }
-
-
-                    //TODO: try not to read any more if we see a panic?
+                    case InvalidPodLogLineParseResult invalidParseResult:
+                        //Unfortunately we don't have a good way to get the timestamp right to get this line to appear in the right order 
+                        results.Add(new ProcessOutput(ProcessOutputSource.StdErr, invalidParseResult.Error, DateTimeOffset.UtcNow));
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(parseResult), parseResult.GetType(), "Unexpected parse result type");
                 }
+
+
+                //TODO: try not to read any more if we see a panic?
+
             }
         }
     }

--- a/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
@@ -36,6 +36,7 @@ namespace Octopus.Tentacle.Kubernetes
                         //Pod log line numbers are 1-based, log sequence is 0-based
                         if (podLogLine.LineNumber > lastLogSequence)
                         {
+                            //TODO: assert all lines are sequential
                             if (podLogLine.LineNumber == lastLogSequence + 1)
                                 haveSeenPodLogEntryMatchingLogSequence = true;
 

--- a/source/Octopus.Tentacle/Kubernetes/TentacleScriptLogProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/TentacleScriptLogProvider.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Concurrent;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public class TentacleScriptLogProvider
+    {
+        readonly ConcurrentDictionary<ScriptTicket, InMemoryTentacleScriptLog> logs = new();
+
+        //Tentacle might restart after a script has started, so we always have to create this logger on demand
+        public InMemoryTentacleScriptLog GetOrCreate(ScriptTicket scriptTicket)
+        {
+            return logs.GetOrAdd(scriptTicket, _ => new InMemoryTentacleScriptLog());
+        }
+
+        //Having this clean up should reduce significant memory leaks
+        //Assuming there's always a chance that GetOrCreate() might be called after Delete()
+        public void Delete(ScriptTicket scriptTicket)
+        {
+            logs.TryRemove(scriptTicket, out _);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/TentacleScriptLogProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/TentacleScriptLogProvider.cs
@@ -4,7 +4,13 @@ using Octopus.Tentacle.Contracts;
 
 namespace Octopus.Tentacle.Kubernetes
 {
-    public class TentacleScriptLogProvider
+    public interface ITentacleScriptLogProvider
+    {
+        InMemoryTentacleScriptLog GetOrCreate(ScriptTicket scriptTicket);
+        void Delete(ScriptTicket scriptTicket);
+    }
+
+    public class TentacleScriptLogProvider : ITentacleScriptLogProvider
     {
         readonly ConcurrentDictionary<ScriptTicket, InMemoryTentacleScriptLog> logs = new();
 

--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
@@ -21,8 +21,9 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
         readonly IScriptWorkspaceFactory workspaceFactory;
         readonly IKubernetesPodStatusProvider podStatusProvider;
         readonly IKubernetesScriptPodCreator podCreator;
-        readonly IKubernetesPodLogService logService;
+        readonly IKubernetesPodLogService podLogService;
         readonly ISystemLog log;
+        readonly TentacleScriptLogProvider scriptLogProvider;
 
         //TODO: check what will happen when Tentacle restarts
         readonly ConcurrentDictionary<ScriptTicket, Lazy<SemaphoreSlim>> startScriptMutexes = new();
@@ -32,15 +33,16 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
             IScriptWorkspaceFactory workspaceFactory,
             IKubernetesPodStatusProvider podStatusProvider,
             IKubernetesScriptPodCreator podCreator,
-            IKubernetesPodLogService logService,
-            ISystemLog log)
+            IKubernetesPodLogService podLogService,
+            ISystemLog log, TentacleScriptLogProvider scriptLogProvider)
         {
             this.podService = podService;
             this.workspaceFactory = workspaceFactory;
             this.podStatusProvider = podStatusProvider;
             this.podCreator = podCreator;
-            this.logService = logService;
+            this.podLogService = podLogService;
             this.log = log;
+            this.scriptLogProvider = scriptLogProvider;
         }
 
         public async Task<KubernetesScriptStatusResponseV1Alpha> StartScriptAsync(StartKubernetesScriptCommandV1Alpha command, CancellationToken cancellationToken)
@@ -68,7 +70,7 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
                 //create the pod
                 await podCreator.CreatePod(command, workspace, cancellationToken);
 
-                var (logs, _) = await logService.GetLogs(command.ScriptTicket, 0, cancellationToken);
+                var (logs, _) = await podLogService.GetLogs(command.ScriptTicket, 0, cancellationToken);
 
                 //return a status that say's we are pending
                 return new KubernetesScriptStatusResponseV1Alpha(command.ScriptTicket, ProcessState.Pending, 0, logs.ToList(), 0);
@@ -108,6 +110,8 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
             var workspace = workspaceFactory.GetWorkspace(command.ScriptTicket);
             await workspace.Delete(cancellationToken);
 
+            scriptLogProvider.Delete(command.ScriptTicket);
+
             //we do a try delete as the cancel might have already deleted it
             if (!KubernetesConfig.DisableAutomaticPodCleanup)
                 await podService.TryDelete(command.ScriptTicket, cancellationToken);
@@ -123,7 +127,7 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
                 _ => throw new ArgumentOutOfRangeException()
             };
 
-            var (outputLogs, nextLogSequence) = await logService.GetLogs(trackedPod.ScriptTicket, lastLogSequence, cancellationToken);
+            var (outputLogs, nextLogSequence) = await podLogService.GetLogs(trackedPod.ScriptTicket, lastLogSequence, cancellationToken);
 
             return new KubernetesScriptStatusResponseV1Alpha(
                 trackedPod.ScriptTicket,

--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
@@ -23,7 +23,7 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
         readonly IKubernetesScriptPodCreator podCreator;
         readonly IKubernetesPodLogService podLogService;
         readonly ISystemLog log;
-        readonly TentacleScriptLogProvider scriptLogProvider;
+        readonly ITentacleScriptLogProvider scriptLogProvider;
 
         //TODO: check what will happen when Tentacle restarts
         readonly ConcurrentDictionary<ScriptTicket, Lazy<SemaphoreSlim>> startScriptMutexes = new();
@@ -34,7 +34,7 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
             IKubernetesPodStatusProvider podStatusProvider,
             IKubernetesScriptPodCreator podCreator,
             IKubernetesPodLogService podLogService,
-            ISystemLog log, TentacleScriptLogProvider scriptLogProvider)
+            ISystemLog log, ITentacleScriptLogProvider scriptLogProvider)
         {
             this.podService = podService;
             this.workspaceFactory = workspaceFactory;


### PR DESCRIPTION
[sc-71685]
# Background

Now that we pull Script Pod logs directly from the K8s API, we need another way for Tentacle to add messages to the task log (previously this was all on the file system).

This PR adds an in-memory log that gets merged with the Script Pod logs. There's a catch that you'll lose the in-memory log messages if Tentacle is restarted (but these are verbose debugging messages, so they shouldn't affect deployment)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.