### PR TITLE
Support opening multiple polling connections

### DIFF
--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -128,16 +128,16 @@ namespace Octopus.Tentacle.Communications
             switch (connectionCount)
             {
                 case > MaximumPollingConnectionCount:
-                    log.InfoFormat("Maximum polling connection count: {0}", MaximumPollingConnectionCount);
+                    log.InfoFormat("The requested polling connection count exceeds the maximum of {0}, limiting to {0}", MaximumPollingConnectionCount);
                     connectionCount = 8;
                     break;
                 case 0:
-                    log.InfoFormat("Minimum polling connection count: {0}", 1);
+                    log.InfoFormat("The requested polling connection count must be greater than 0, setting to 1");
                     connectionCount = 1;
                     break;
             }
 
-            log.InfoFormat("Opening {0} polling connections", connectionCount);
+            log.InfoFormat("Starting {0} polling connections", connectionCount);
             return connectionCount;
         }
 

--- a/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
+++ b/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
@@ -23,5 +23,6 @@ namespace Octopus.Tentacle.Variables
         public const string TentacleTcpKeepAliveEnabled = "TentacleTcpKeepAliveEnabled";
         public const string TentacleUseRecommendedTimeoutsAndLimits = "TentacleUseRecommendedTimeoutsAndLimits";
         public const string TentacleMachineConfigurationHomeDirectory = "TentacleMachineConfigurationHomeDirectory";
+        public const string TentaclePollingConnectionCount = "TentaclePollingConnectionCount";
     }
 }


### PR DESCRIPTION
# Background

Now we have [safeguards](https://github.com/OctopusDeploy/Halibut/pull/599) in Halibut to stop DoS-ing a server, we can add a new environment value to open multiple polling connections. This improves throughput and performance by having multiple connections polling for work.

# Results

The env var name is `TentaclePollingConnectionCount`.

I also considered adding a hard max per tentacle (say 16 or something), but felt like people setting this env var should understand what that means to the target server. As mentioned, we also have the new safety nets in Octopus Server to handle this.

Will be tested via the k8s agent against a branch instance with the Server limit set

Shortcut story: [sc-74991]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.