### PR TITLE
Use the defined max connections constant

### DIFF
--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -83,7 +83,7 @@ namespace Octopus.Tentacle.Communications
             }
         }
 
-        const int MaximumPollingConnectionCount = 8;
+
 
         void AddPollingEndpoints()
         {
@@ -113,7 +113,9 @@ namespace Octopus.Tentacle.Communications
                 }
             }
         }
-        
+                
+        const int MaximumPollingConnectionCount = 8;
+                
         uint GetPollingConnectionCount()
         {
             //Open multiple polling connections if the env var is set to a non-zero/negative number
@@ -129,7 +131,7 @@ namespace Octopus.Tentacle.Communications
             {
                 case > MaximumPollingConnectionCount:
                     log.InfoFormat("The requested polling connection count exceeds the maximum of {0}, limiting to {0}", MaximumPollingConnectionCount);
-                    connectionCount = 8;
+                    connectionCount = MaximumPollingConnectionCount;
                     break;
                 case 0:
                     log.InfoFormat("The requested polling connection count must be greater than 0, setting to 1");


### PR DESCRIPTION
# Background

Small mistake from #881 . NO functionality change, but now we only change the constant to change the max

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.