### PR TITLE
Add ability to set Kubernetes script pod service account

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -106,9 +106,9 @@
             "type": "string",
             "enum": [
               "BuildAll",
-              "BuildAndPushForMicrok8sKubernetesTentacleContainerImage",
               "BuildAndLoadLocalDebugKubernetesTentacleContainerImage",
               "BuildAndLoadLocallyKubernetesTentacleContainerImage",
+              "BuildAndPushForMicrok8sKubernetesTentacleContainerImage",
               "BuildAndPushKubernetesTentacleContainerImage",
               "BuildLinux",
               "BuildOsx",
@@ -155,9 +155,9 @@
             "type": "string",
             "enum": [
               "BuildAll",
-              "BuildAndPushForMicrok8sKubernetesTentacleContainerImage",
               "BuildAndLoadLocalDebugKubernetesTentacleContainerImage",
               "BuildAndLoadLocallyKubernetesTentacleContainerImage",
+              "BuildAndPushForMicrok8sKubernetesTentacleContainerImage",
               "BuildAndPushKubernetesTentacleContainerImage",
               "BuildLinux",
               "BuildOsx",

--- a/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteKubernetesScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteKubernetesScriptCommandBuilder.cs
@@ -6,15 +6,22 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
     public class ExecuteKubernetesScriptCommandBuilder : ExecuteScriptCommandBuilder
     {
         KubernetesImageConfiguration? configuration;
+        string? scriptPodServiceAccountName;
 
         public ExecuteKubernetesScriptCommandBuilder(string taskId)
             : base(taskId, ScriptIsolationLevel.NoIsolation) //Kubernetes Agents don't need isolation since the scripts won't clash with each other (it won't clash more than Workers anyway)
         {
         }
 
-        public ExecuteKubernetesScriptCommandBuilder SetKubernetesImageConfiguration(KubernetesImageConfiguration configuration)
+        public ExecuteKubernetesScriptCommandBuilder WithKubernetesImageConfiguration(KubernetesImageConfiguration configuration)
         {
             this.configuration = configuration;
+            return this;
+        }
+
+        public ExecuteKubernetesScriptCommandBuilder WithScriptPodServiceAccountName(string serviceAccountName)
+        {
+            scriptPodServiceAccountName = serviceAccountName;
             return this;
         }
 
@@ -27,7 +34,8 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
                 IsolationConfiguration,
                 AdditionalScripts,
                 Files.ToArray(),
-                configuration
+                configuration,
+                scriptPodServiceAccountName
             );
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/Models/ExecuteKubernetesScriptCommand.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/ExecuteKubernetesScriptCommand.cs
@@ -8,6 +8,8 @@ namespace Octopus.Tentacle.Client.Scripts.Models
     {
         public KubernetesImageConfiguration? ImageConfiguration { get; }
 
+        public string? ScriptPodServiceAccountName { get;}
+
         public ExecuteKubernetesScriptCommand(
             ScriptTicket scriptTicket,
             string taskId,
@@ -16,10 +18,12 @@ namespace Octopus.Tentacle.Client.Scripts.Models
             ScriptIsolationConfiguration isolationConfiguration,
             Dictionary<ScriptType, string>? additionalScripts,
             ScriptFile[] additionalFiles,
-            KubernetesImageConfiguration? imageConfiguration)
+            KubernetesImageConfiguration? imageConfiguration, 
+            string? scriptPodServiceAccountName)
             : base(scriptTicket, taskId, scriptBody, arguments, isolationConfiguration, additionalScripts, additionalFiles)
         {
             ImageConfiguration = imageConfiguration;
+            ScriptPodServiceAccountName = scriptPodServiceAccountName;
         }
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV3AlphaOrchestrator.cs
@@ -67,6 +67,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 kubernetesScriptCommand.IsolationConfiguration.MutexTimeout,
                 kubernetesScriptCommand.IsolationConfiguration.MutexName,
                 podImageConfiguration,
+                kubernetesScriptCommand.ScriptPodServiceAccountName,
                 kubernetesScriptCommand.Scripts,
                 kubernetesScriptCommand.Files.ToArray());
         }

--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/StartKubernetesScriptCommandV1AlphaBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/StartKubernetesScriptCommandV1AlphaBuilder.cs
@@ -19,6 +19,7 @@ namespace Octopus.Tentacle.CommonTestUtils.Builders
         string taskId = Guid.NewGuid().ToString();
         ScriptTicket scriptTicket = new UniqueScriptTicketBuilder().Build();
         PodImageConfiguration? podImageConfiguration = null;
+        string? scriptPodServiceAccountName;
 
         public StartKubernetesScriptCommandV1AlphaBuilder WithScriptBody(string scriptBody)
         {
@@ -84,6 +85,12 @@ namespace Octopus.Tentacle.CommonTestUtils.Builders
             return this;
         }
 
+        public StartKubernetesScriptCommandV1AlphaBuilder WithScriptPodServiceAccountName(string serviceAccountName)
+        {
+            scriptPodServiceAccountName = serviceAccountName;
+            return this;
+        }
+
         public StartKubernetesScriptCommandV1Alpha Build()
             => new(
                 scriptTicket,
@@ -94,6 +101,7 @@ namespace Octopus.Tentacle.CommonTestUtils.Builders
                 scriptIsolationMutexTimeout,
                 scriptIsolationMutexName,
                 podImageConfiguration,
+                scriptPodServiceAccountName,
                 additionalScripts,
                 files.ToArray());
     }

--- a/source/Octopus.Tentacle.Contracts/KubernetesScriptServiceV1Alpha/StartKubernetesScriptCommandV1Alpha.cs
+++ b/source/Octopus.Tentacle.Contracts/KubernetesScriptServiceV1Alpha/StartKubernetesScriptCommandV1Alpha.cs
@@ -14,7 +14,8 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1Alpha
             ScriptIsolationLevel isolation,
             TimeSpan scriptIsolationMutexTimeout,
             string isolationMutexName,
-            PodImageConfiguration? podImageConfiguration,
+            PodImageConfiguration? podImageConfiguration, 
+            string? scriptPodServiceAccountName,
             Dictionary<ScriptType, string>? additionalScripts,
             ScriptFile[]? additionalFiles)
         {
@@ -26,6 +27,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1Alpha
             ScriptIsolationMutexTimeout = scriptIsolationMutexTimeout;
             IsolationMutexName = isolationMutexName;
             PodImageConfiguration = podImageConfiguration;
+            ScriptPodServiceAccountName = scriptPodServiceAccountName;
 
             if (additionalFiles != null)
                 Files.AddRange(additionalFiles);
@@ -51,5 +53,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1Alpha
         public Dictionary<ScriptType, string> Scripts { get; } = new();
         public List<ScriptFile> Files { get; } = new();
         public string[] Arguments { get; }
+
+        public string? ScriptPodServiceAccountName { get; }
     }
 }


### PR DESCRIPTION
# Background

The Kubernetes Agent will soon have functionality to allow Octopus Server to specify a pre-configured Kubernetes service account that the pod that the individual script is run inside of.

# Results

Adds a new `ScriptPodServiceAccountName` property to the `ExecuteKubernetesScriptCommand` which is then included in the `StartKubernetesScriptCommandV1Alpha` as a nullable/optional property. Providing no value (`null`) results in the existing behaviour of using the service account created as part of the helm chart. Any non-whitespace string provided here is used in lieu of this when create the pod.

No validation is performed on the supplied service account name.

Shortcut story: [sc-75593]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.