### PR TITLE
Assert all Script Pod logs are in sequential order

### DIFF
--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
@@ -20,40 +20,42 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         public async Task NoLines_SameSequenceNumber(long lastLogSequence)
         {
             string[] podLines = Array.Empty<string>();
-            
+
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader, new InMemoryTentacleScriptLog());
+            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader);
             result.NextSequenceNumber.Should().Be(lastLogSequence);
             result.Lines.Should().BeEmpty();
         }
-    
+
         [Test]
         public async Task FirstLine_SequenceNumberIncreasesByOne()
         {
-            string[] podLines = {
+            string[] podLines =
+            {
                 "2024-04-03T06:03:10.517865655Z |1|stdout|Kubernetes Script Pod completed",
             };
-    
+
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(0, reader, new InMemoryTentacleScriptLog());
+            var result = await PodLogReader.ReadPodLogs(0, reader);
             result.NextSequenceNumber.Should().Be(1);
             result.Lines.Should().BeEquivalentTo(new[]
             {
                 new ProcessOutput(ProcessOutputSource.StdOut, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z"))
             });
         }
-    
+
         [Test]
         public async Task ThreeSubsequentLines_SequenceNumberIncreasesByThree()
         {
-            string[] podLines = {
+            string[] podLines =
+            {
                 "2024-04-03T06:03:10.517857755Z |5|stdout|##octopus[stdout-verbose]",
                 "2024-04-03T06:03:10.517865655Z |6|stderr|Kubernetes Script Pod completed",
                 "2024-04-03T06:03:10.517867355Z |7|stdout|##octopus[stdout-default]"
             };
-    
+
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(4, reader, new InMemoryTentacleScriptLog());
+            var result = await PodLogReader.ReadPodLogs(4, reader);
             result.NextSequenceNumber.Should().Be(7);
             result.Lines.Should().BeEquivalentTo(new[]
             {
@@ -62,27 +64,28 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
             });
         }
-        
+
         [Test]
         public async Task StreamContainsPreviousLines_Deduplicates()
         {
-            string[] podLines = {
+            string[] podLines =
+            {
                 "2024-04-03T06:03:10.517857755Z |5|stdout|##octopus[stdout-verbose]",
                 "2024-04-03T06:03:10.517865655Z |6|stderr|Kubernetes Script Pod completed",
                 "2024-04-03T06:03:10.517867355Z |7|stdout|##octopus[stdout-default]"
             };
-    
+
             var allTaskLogs = new List<ProcessOutput>();
             var reader = SetupReader(podLines.Take(1).ToArray());
-            var result = await PodLogReader.ReadPodLogs(4, reader, new InMemoryTentacleScriptLog());
+            var result = await PodLogReader.ReadPodLogs(4, reader);
             result.NextSequenceNumber.Should().Be(5);
             allTaskLogs.AddRange(result.Lines);
-            
+
             reader = SetupReader(podLines.ToArray());
-            result = await PodLogReader.ReadPodLogs(5, reader, new InMemoryTentacleScriptLog());
+            result = await PodLogReader.ReadPodLogs(5, reader);
             result.NextSequenceNumber.Should().Be(7);
             allTaskLogs.AddRange(result.Lines);
-            
+
             allTaskLogs.Should().BeEquivalentTo(new[]
             {
                 new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-verbose]", DateTimeOffset.Parse("2024-04-03T06:03:10.517857755Z")),
@@ -90,7 +93,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
             });
         }
-    
+
         [Test]
         public async Task ParseError_AppearsAsError()
         {
@@ -98,10 +101,10 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             {
                 "abcdefg",
             };
-    
+
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(0, reader, new InMemoryTentacleScriptLog());
-            
+            var result = await PodLogReader.ReadPodLogs(0, reader);
+
             result.NextSequenceNumber.Should().Be(0, "The sequence number doesn't move on parse errors");
             var outputLine = result.Lines.Should().ContainSingle().Subject;
             outputLine.Source.Should().Be(ProcessOutputSource.StdErr);
@@ -112,42 +115,45 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [Test]
         public async Task MissingLine_Throws()
         {
-            string[] podLines = {
+            string[] podLines =
+            {
                 "2024-04-03T06:03:10.517865655Z |100|stdout|Kubernetes Script Pod completed",
             };
-        
+
             var reader = SetupReader(podLines);
-            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader, new InMemoryTentacleScriptLog());
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader);
             await action.Should().ThrowAsync<UnexpectedPodLogLineNumberException>();
         }
 
         [Test]
         public async Task LineOutOfOrderAtStart_Throws()
         {
-            string[] podLines = {
+            string[] podLines =
+            {
                 "2024-04-03T06:03:10.517865655Z |5|stdout|Kubernetes Script Pod completed",
                 "2024-04-03T06:03:10.517865655Z |4|stderr|Kubernetes Script Pod completed",
             };
-        
+
             var reader = SetupReader(podLines);
-            Func<Task> action = async () => await PodLogReader.ReadPodLogs(4, reader, new InMemoryTentacleScriptLog());
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(4, reader);
             await action.Should().ThrowAsync<UnexpectedPodLogLineNumberException>();
         }
 
         [Test]
         public async Task LineOutOfOrderMidway_Throws()
         {
-            string[] podLines = {
+            string[] podLines =
+            {
                 "2024-04-03T06:03:10.517865655Z |3|stdout|Kubernetes Script Pod completed",
                 "2024-04-03T06:03:10.517865655Z |5|stdout|Kubernetes Script Pod completed",
                 "2024-04-03T06:03:10.517865655Z |4|stderr|Kubernetes Script Pod completed",
             };
-        
+
             var reader = SetupReader(podLines);
-            Func<Task> action = async () => await PodLogReader.ReadPodLogs(2, reader, new InMemoryTentacleScriptLog());
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(2, reader);
             await action.Should().ThrowAsync<UnexpectedPodLogLineNumberException>();
         }
-        
+
         static StreamReader SetupReader(params string[] lines)
         {
             return new StreamReader(new MemoryStream(Encoding.Default.GetBytes(string.Join("\n", lines))));

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogReaderFixture.cs
@@ -22,27 +22,27 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             string[] podLines = Array.Empty<string>();
             
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader);
+            var result = await PodLogReader.ReadPodLogs(lastLogSequence, reader, new InMemoryTentacleScriptLog());
             result.NextSequenceNumber.Should().Be(lastLogSequence);
             result.Lines.Should().BeEmpty();
         }
-
+    
         [Test]
         public async Task FirstLine_SequenceNumberIncreasesByOne()
         {
             string[] podLines = {
                 "2024-04-03T06:03:10.517865655Z |1|stdout|Kubernetes Script Pod completed",
             };
-
+    
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(0, reader);
+            var result = await PodLogReader.ReadPodLogs(0, reader, new InMemoryTentacleScriptLog());
             result.NextSequenceNumber.Should().Be(1);
             result.Lines.Should().BeEquivalentTo(new[]
             {
                 new ProcessOutput(ProcessOutputSource.StdOut, "Kubernetes Script Pod completed", DateTimeOffset.Parse("2024-04-03T06:03:10.517865655Z"))
             });
         }
-
+    
         [Test]
         public async Task ThreeSubsequentLines_SequenceNumberIncreasesByThree()
         {
@@ -51,9 +51,9 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 "2024-04-03T06:03:10.517865655Z |6|stderr|Kubernetes Script Pod completed",
                 "2024-04-03T06:03:10.517867355Z |7|stdout|##octopus[stdout-default]"
             };
-
+    
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(4, reader);
+            var result = await PodLogReader.ReadPodLogs(4, reader, new InMemoryTentacleScriptLog());
             result.NextSequenceNumber.Should().Be(7);
             result.Lines.Should().BeEquivalentTo(new[]
             {
@@ -71,15 +71,15 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 "2024-04-03T06:03:10.517865655Z |6|stderr|Kubernetes Script Pod completed",
                 "2024-04-03T06:03:10.517867355Z |7|stdout|##octopus[stdout-default]"
             };
-
+    
             var allTaskLogs = new List<ProcessOutput>();
             var reader = SetupReader(podLines.Take(1).ToArray());
-            var result = await PodLogReader.ReadPodLogs(4, reader);
+            var result = await PodLogReader.ReadPodLogs(4, reader, new InMemoryTentacleScriptLog());
             result.NextSequenceNumber.Should().Be(5);
             allTaskLogs.AddRange(result.Lines);
             
             reader = SetupReader(podLines.ToArray());
-            result = await PodLogReader.ReadPodLogs(5, reader);
+            result = await PodLogReader.ReadPodLogs(5, reader, new InMemoryTentacleScriptLog());
             result.NextSequenceNumber.Should().Be(7);
             allTaskLogs.AddRange(result.Lines);
             
@@ -90,7 +90,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]", DateTimeOffset.Parse("2024-04-03T06:03:10.517867355Z")),
             });
         }
-
+    
         [Test]
         public async Task ParseError_AppearsAsError()
         {
@@ -98,9 +98,9 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             {
                 "abcdefg",
             };
-
+    
             var reader = SetupReader(podLines);
-            var result = await PodLogReader.ReadPodLogs(0, reader);
+            var result = await PodLogReader.ReadPodLogs(0, reader, new InMemoryTentacleScriptLog());
             
             result.NextSequenceNumber.Should().Be(0, "The sequence number doesn't move on parse errors");
             var outputLine = result.Lines.Should().ContainSingle().Subject;
@@ -108,7 +108,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             outputLine.Text.Should().Be("Invalid log line detected. 'abcdefg' is not correctly pipe-delimited.");
             outputLine.Occurred.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
         }
-        
+
         [Test]
         public async Task MissingLine_Throws()
         {
@@ -117,8 +117,35 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             };
         
             var reader = SetupReader(podLines);
-            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader);
-            await action.Should().ThrowAsync<MissingPodLogException>();
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(50, reader, new InMemoryTentacleScriptLog());
+            await action.Should().ThrowAsync<UnexpectedPodLogLineNumberException>();
+        }
+
+        [Test]
+        public async Task LineOutOfOrderAtStart_Throws()
+        {
+            string[] podLines = {
+                "2024-04-03T06:03:10.517865655Z |5|stdout|Kubernetes Script Pod completed",
+                "2024-04-03T06:03:10.517865655Z |4|stderr|Kubernetes Script Pod completed",
+            };
+        
+            var reader = SetupReader(podLines);
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(4, reader, new InMemoryTentacleScriptLog());
+            await action.Should().ThrowAsync<UnexpectedPodLogLineNumberException>();
+        }
+
+        [Test]
+        public async Task LineOutOfOrderMidway_Throws()
+        {
+            string[] podLines = {
+                "2024-04-03T06:03:10.517865655Z |3|stdout|Kubernetes Script Pod completed",
+                "2024-04-03T06:03:10.517865655Z |5|stdout|Kubernetes Script Pod completed",
+                "2024-04-03T06:03:10.517865655Z |4|stderr|Kubernetes Script Pod completed",
+            };
+        
+            var reader = SetupReader(podLines);
+            Func<Task> action = async () => await PodLogReader.ReadPodLogs(2, reader, new InMemoryTentacleScriptLog());
+            await action.Should().ThrowAsync<UnexpectedPodLogLineNumberException>();
         }
         
         static StreamReader SetupReader(params string[] lines)

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -74,7 +74,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 using (var reader = new StreamReader(stream))
                 {
-                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader);
+                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader, tentacleScriptLog);
                 }
             }
         }

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -74,7 +74,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 using (var reader = new StreamReader(stream))
                 {
-                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader, tentacleScriptLog);
+                    return await PodLogReader.ReadPodLogs(lastLogSequence, reader);
                 }
             }
         }

--- a/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Kubernetes
 {
     static class PodLogReader
     {
-        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader, InMemoryTentacleScriptLog tentacleScriptLog)
+        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader)
         {
             int? exitCode = null;
             var results = new List<ProcessOutput>();
@@ -29,7 +29,6 @@ namespace Octopus.Tentacle.Kubernetes
                     return (results, nextSequenceNumber, exitCode);
                 }
 
-                tentacleScriptLog.Verbose("Parsing line: " + line);
                 var parseResult = PodLogLineParser.ParseLine(line!);
 
                 switch (parseResult)

--- a/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
@@ -37,6 +37,7 @@ namespace Octopus.Tentacle.Kubernetes
                     {
                         var podLogLine = validParseResult.LogLine;
 
+                        //The stream might contain lines from the last batch (so we need to ignore the older lines)
                         //Once we see a line number that's large enough,
                         //then we've read past the previous batch.
                         if (!haveReadPastPreviousBatchOfRows && podLogLine.LineNumber > lastLogSequence)
@@ -47,7 +48,7 @@ namespace Octopus.Tentacle.Kubernetes
                         {
                             //Lines must appear in order
                             if (podLogLine.LineNumber != expectedLineNumber)
-                                throw new UnexpectedPodLogLineNumberException();
+                                throw new UnexpectedPodLogLineNumberException(expectedLineNumber, podLogLine.LineNumber);
 
                             expectedLineNumber++;
                             
@@ -77,5 +78,9 @@ namespace Octopus.Tentacle.Kubernetes
 
     class UnexpectedPodLogLineNumberException : Exception
     {
+        public UnexpectedPodLogLineNumberException(long expectedLineNumber, long actualLineNumber)
+        : base($"Unexpected Script Pod log line number, expected: {expectedLineNumber}, actual: {actualLineNumber}")
+        {
+        }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogReader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Util;
 
@@ -9,12 +10,15 @@ namespace Octopus.Tentacle.Kubernetes
 {
     static class PodLogReader
     {
-        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader)
+        public static async Task<(IReadOnlyCollection<ProcessOutput> Lines, long NextSequenceNumber, int? exitCode)> ReadPodLogs(long lastLogSequence, StreamReader reader, InMemoryTentacleScriptLog tentacleScriptLog)
         {
             int? exitCode = null;
             var results = new List<ProcessOutput>();
             var nextSequenceNumber = lastLogSequence;
-            bool haveSeenPodLogEntryMatchingLogSequence = false;
+            long expectedLineNumber = lastLogSequence+1;
+            
+            bool haveReadPastPreviousBatchOfRows = false;
+            
             while (true)
             {
                 var line = await reader.ReadLineAsync();
@@ -25,6 +29,7 @@ namespace Octopus.Tentacle.Kubernetes
                     return (results, nextSequenceNumber, exitCode);
                 }
 
+                tentacleScriptLog.Verbose("Parsing line: " + line);
                 var parseResult = PodLogLineParser.ParseLine(line!);
 
                 switch (parseResult)
@@ -33,16 +38,20 @@ namespace Octopus.Tentacle.Kubernetes
                     {
                         var podLogLine = validParseResult.LogLine;
 
+                        //Once we see a line number that's large enough,
+                        //then we've read past the previous batch.
+                        if (!haveReadPastPreviousBatchOfRows && podLogLine.LineNumber > lastLogSequence)
+                            haveReadPastPreviousBatchOfRows = true;
+
                         //Pod log line numbers are 1-based, log sequence is 0-based
-                        if (podLogLine.LineNumber > lastLogSequence)
+                        if (haveReadPastPreviousBatchOfRows)
                         {
-                            //TODO: assert all lines are sequential
-                            if (podLogLine.LineNumber == lastLogSequence + 1)
-                                haveSeenPodLogEntryMatchingLogSequence = true;
+                            //Lines must appear in order
+                            if (podLogLine.LineNumber != expectedLineNumber)
+                                throw new UnexpectedPodLogLineNumberException();
 
-                            if (!haveSeenPodLogEntryMatchingLogSequence)
-                                throw new MissingPodLogException();
-
+                            expectedLineNumber++;
+                            
                             if (validParseResult is EndOfStreamPodLogLineParseResult endOfStreamParseResult)
                                 exitCode = endOfStreamParseResult.ExitCode;
 
@@ -67,7 +76,7 @@ namespace Octopus.Tentacle.Kubernetes
         }
     }
 
-    class MissingPodLogException : Exception
+    class UnexpectedPodLogLineNumberException : Exception
     {
     }
 }


### PR DESCRIPTION
[sc-71685]

# Background

This PR builds on top of https://github.com/OctopusDeploy/OctopusTentacle/pull/879/files#r1556936695 to ensure we error if the Script Pod logs look out of shape.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.