### PR TITLE
Add NFS watchdog to script pods

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -12,6 +12,8 @@ namespace Octopus.Tentacle.Kubernetes
         public static string PodVolumeClaimName => GetRequiredEnvVar($"{EnvVarPrefix}__PODVOLUMECLAIMNAME", "Unable to determine Kubernetes Pod persistent volume claim name.");
 
         public static int PodMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODMONITORTIMEOUT"), out var podMonitorTimeout) ? podMonitorTimeout : 10*60; //10min
+        public static string NfsWatchdogImageVariableName => $"{EnvVarPrefix}__NFSWATCHDOGIMAGE";
+        public static string? NfsWatchdogImage => Environment.GetEnvironmentVariable(NfsWatchdogImageVariableName);
 
         public static TimeSpan PodsConsideredOrphanedAfterTimeSpan => TimeSpan.FromMinutes(int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODSCONSIDEREDORPHANEDAFTERMINUTES"), out var podsConsideredOrphanedAfterTimeSpan) ? podsConsideredOrphanedAfterTimeSpan : 10);
         public static bool DisableAutomaticPodCleanup => bool.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__DISABLEAUTOPODCLEANUP"), out var disableAutoCleanup) && disableAutoCleanup;

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -245,7 +245,7 @@ namespace Octopus.Tentacle.Kubernetes
                     new(KubernetesConfig.NamespaceVariableName, KubernetesConfig.Namespace),
                     new(KubernetesConfig.HelmReleaseNameVariableName, KubernetesConfig.HelmReleaseName),
                     new(KubernetesConfig.HelmChartVersionVariableName, KubernetesConfig.HelmChartVersion),
-                    new(EnvironmentVariables.TentacleHome, $"/octopus"),
+                    new(EnvironmentVariables.TentacleHome, "/octopus"),
                     new(EnvironmentVariables.TentacleInstanceName, appInstanceSelector.Current.InstanceName),
                     new(EnvironmentVariables.TentacleVersion, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleVersion)),
                     new(EnvironmentVariables.TentacleCertificateSignatureAlgorithm, Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleCertificateSignatureAlgorithm)),
@@ -264,12 +264,14 @@ namespace Octopus.Tentacle.Kubernetes
                 }
             };
         }
-          V1Container? CreateWatchdogContainer()
+
+        V1Container? CreateWatchdogContainer()
         {
             if (KubernetesConfig.NfsWatchdogImage is null)
             {
                 return null;
             }
+
             return new V1Container
             {
                 Name = "nfs-watchdog",
@@ -280,7 +282,7 @@ namespace Octopus.Tentacle.Kubernetes
                 },
                 Env = new List<V1EnvVar>
                 {
-                    new(EnvironmentVariables.NfsWatchdogDirectory, $"/octopus")
+                    new(EnvironmentVariables.NfsWatchdogDirectory, "/octopus")
                 },
                 Resources = new V1ResourceRequirements
                 {

--- a/source/Octopus.Tentacle/Util/ListExtensions.cs
+++ b/source/Octopus.Tentacle/Util/ListExtensions.cs
@@ -34,5 +34,12 @@ namespace Octopus.Tentacle.Util
             foreach (var item in itemsToAdd)
                 source.Add(item);
         }
+        public static List<T> AddIfNotNull<T>(this List<T> list, T? item)
+        {
+            if (item != null)
+                list.Add(item);
+
+            return list;
+        }
     }
 }

--- a/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
+++ b/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
@@ -24,5 +24,6 @@ namespace Octopus.Tentacle.Variables
         public const string TentacleUseRecommendedTimeoutsAndLimits = "TentacleUseRecommendedTimeoutsAndLimits";
         public const string TentacleMachineConfigurationHomeDirectory = "TentacleMachineConfigurationHomeDirectory";
         public const string TentaclePollingConnectionCount = "TentaclePollingConnectionCount";
+        public const string NfsWatchdogDirectory = "watchdog_directory";
     }
 }


### PR DESCRIPTION
# Background
When NFS goes down, we can get corrupted file shares, which are impossible to read from, but can be written to (but not persisted over the network). This causes all sorts of issues, so we've decided that deleting the pod (which also deletes the mount) is the safest way to recover from this error, so that we don't expect that we've completed work which hasn't persisted. 

This led to the creation of the Kubernetes Agent NFS Watchdog, which checks that there are no read errors coming from the agent. It's designed to run as a lightweight sidecar, and will delete the pod it's running in if there are read errors.

# Results

This PR adds the NFS watchdog to all script containers spawned by the tentacle agent. 

If NFS _or_ the watchdog itself is not in use, the environment variables that we use to determine the image don't get set, and `CreateWatchdogContainer()` returns null. The `null` container can't be added to the containerList because there's no `null` handling in the library itself, so I made a quick extension method to only add an item to a list if it's not null.

I've manually tested this extensively. The only time this breaks is if the environment variable is overwritten, but the actual watchdog is not.

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.