### PR TITLE
Sanitize Kubernetes cluster version

### DIFF
--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesVersionParserTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesVersionParserTests.cs
@@ -1,0 +1,43 @@
+using System;
+using FluentAssertions;
+using k8s.Models;
+using NUnit.Framework;
+using Octopus.Tentacle.Kubernetes;
+
+namespace Octopus.Tentacle.Tests.Kubernetes
+{
+    [TestFixture]
+    public class KubernetesVersionParserTests
+    {
+        [TestCase("0", "1", 0, 1, false)]
+        [TestCase("1abc", "1", 1, 1, false)]
+        [TestCase("0", "1abc", 0, 1, false)]
+        [TestCase("1+", "0", 1, 0, false)]
+        [TestCase("0", "1+", 0, 1, false)]
+        [TestCase("abc", "1", 999, 999, true)]
+        public void ParseClusterVersion_SanitizesAndReturnsClusterVersion(string major, string minor, int expectedMajor, int expectedMinor, bool shouldFail)
+        {
+            try
+            {
+                var versionInfo = new VersionInfo
+                {
+                    Major = major,
+                    Minor = minor
+                };
+                var result = KubernetesVersionParser.ParseClusterVersion(versionInfo);
+                result.Should().BeEquivalentTo(new ClusterVersion(expectedMajor, expectedMinor));
+            }
+            catch (Exception e)
+            {
+                if (shouldFail)
+                {
+                    e.Should().BeOfType<FormatException>();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesClusterService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesClusterService.cs
@@ -20,14 +20,11 @@ namespace Octopus.Tentacle.Kubernetes
             lazyVersion = new AsyncLazy<ClusterVersion>(async () =>
             {
                 var versionInfo = await Client.Version.GetCodeAsync();
-
-                return new ClusterVersion(int.Parse(versionInfo.Major), int.Parse(versionInfo.Minor));
+                return KubernetesVersionParser.ParseClusterVersion(versionInfo);
             });
         }
 
         public async Task<ClusterVersion> GetClusterVersion()
             => await lazyVersion;
     }
-
-    public record ClusterVersion(int Major, int Minor);
 }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesVersionParser.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesVersionParser.cs
@@ -6,6 +6,8 @@ namespace Octopus.Tentacle.Kubernetes
 {
     public static class KubernetesVersionParser
     {
+        static Regex clusterVersionRegex = new Regex("[^0-9]");
+        
         public static ClusterVersion ParseClusterVersion(VersionInfo versionInfo)
         {
             return new ClusterVersion(SanitizeAndParseVersionNumber(versionInfo.Major), SanitizeAndParseVersionNumber(versionInfo.Minor));
@@ -13,11 +15,7 @@ namespace Octopus.Tentacle.Kubernetes
         
         static int SanitizeAndParseVersionNumber(string version)
         {
-            if (int.TryParse(version, out var result))
-                return result;
-            
             var sanitized = Regex.Replace(version, "[^0-9]", "");
-
             return int.Parse(sanitized);
         }
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesVersionParser.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesVersionParser.cs
@@ -6,8 +6,6 @@ namespace Octopus.Tentacle.Kubernetes
 {
     public static class KubernetesVersionParser
     {
-        static Regex clusterVersionRegex = new Regex("[^0-9]");
-        
         public static ClusterVersion ParseClusterVersion(VersionInfo versionInfo)
         {
             return new ClusterVersion(SanitizeAndParseVersionNumber(versionInfo.Major), SanitizeAndParseVersionNumber(versionInfo.Minor));

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesVersionParser.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesVersionParser.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text.RegularExpressions;
+using k8s.Models;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public static class KubernetesVersionParser
+    {
+        public static ClusterVersion ParseClusterVersion(VersionInfo versionInfo)
+        {
+            return new ClusterVersion(SanitizeAndParseVersionNumber(versionInfo.Major), SanitizeAndParseVersionNumber(versionInfo.Minor));
+        }
+        
+        static int SanitizeAndParseVersionNumber(string version)
+        {
+            if (int.TryParse(version, out var result))
+                return result;
+            
+            var sanitized = Regex.Replace(version, "[^0-9]", "");
+
+            return int.Parse(sanitized);
+        }
+
+    }
+    public record ClusterVersion(int Major, int Minor);
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesVersionParser.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesVersionParser.cs
@@ -15,8 +15,7 @@ namespace Octopus.Tentacle.Kubernetes
         
         static int SanitizeAndParseVersionNumber(string version)
         {
-            var sanitized = Regex.Replace(version, "[^0-9]", "");
-            return int.Parse(sanitized);
+            return int.Parse(Regex.Replace(version, "[^0-9]", ""));
         }
 
     }


### PR DESCRIPTION
# Background
#project-k8s-agent

EKS returns the cluster version as, where the minor version number has a non-numeric character which causes the cluster version parsing to fail with a `System.FormatException`
```
{
"major": "1",
"minor": "29+",
"gitVersion": "v1.29.1-eks-b9c9ed7",
"gitCommit": "07600c74de018baffb16c82771a48adcb843a932",
"gitTreeState": "clean",
"buildDate": "2024-03-02T03:46:35Z",
"goVersion": "go1.21.6",
"compiler": "gc",
"platform": "linux/amd64"
}
```

[SC-75848]

# Results
- Added `KubernetesVersionParser` class to handle the parsing of version numbers related to K8s and refactored `KubernetesClusterService` to use it.
- Moved `ClusterVersion` into `KubernetesVersionParser`
- Added tests for `KubernetesVersionParser` 

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites
- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.