### PR TITLE
Show Script Pod phase to help users troubleshoot

### DIFF
--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodMonitorTests.cs
@@ -65,7 +65,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
 
             status.Should().Match<TrackedScriptPod>(status =>
                 status.ScriptTicket == scriptTicket &&
-                status.State.Phase == TrackedScriptPodPhase.Running &&
+                status.State.Phase == TrackedScriptPodPhase.Pending &&
                 status.State.ExitCode == null
             );
         }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/TrackedScriptPodFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/TrackedScriptPodFixture.cs
@@ -21,6 +21,14 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             trackedPod = new TrackedScriptPod(scriptTicket);
         }
 
+        [Test]
+        public void CanTransitionFromPendingToRunning()
+        {
+            trackedPod.State.Phase.Should().Be(TrackedScriptPodPhase.Pending);
+            
+            GetPodInRunningState();
+        }
+
         [TestCase(PodPhases.Succeeded, 0, TrackedScriptPodPhase.Succeeded)]
         [TestCase(PodPhases.Failed, 123, TrackedScriptPodPhase.Failed)]
         public void UpdateWithCompletedPod(string podPhase, int exitCode, TrackedScriptPodPhase expectedPhase)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -233,13 +233,16 @@ namespace Octopus.Tentacle.Kubernetes
         public TrackedScriptPod(ScriptTicket ticket)
         {
             ScriptTicket = ticket;
-            State = TrackedScriptPodState.Running();
+            State = TrackedScriptPodState.Pending();
         }
 
         public void Update(V1Pod pod)
         {
             switch (pod.Status?.Phase)
                 {
+                    case PodPhases.Running:
+                        State = TrackedScriptPodState.Running();
+                        break;
                     case PodPhases.Succeeded:
                         var succeededState = GetTerminatedState();
                         State = TrackedScriptPodState.Succeeded(succeededState.ExitCode, GetFinishedAt(succeededState));
@@ -293,6 +296,11 @@ namespace Octopus.Tentacle.Kubernetes
         {
         }
 
+        public static TrackedScriptPodState Pending()
+        {
+            return new TrackedScriptPodState() { Phase = TrackedScriptPodPhase.Pending };
+        }
+        
         public static TrackedScriptPodState Running()
         {
             return new TrackedScriptPodState() { Phase = TrackedScriptPodPhase.Running };
@@ -325,6 +333,7 @@ namespace Octopus.Tentacle.Kubernetes
 
     public enum TrackedScriptPodPhase
     {
+        Pending,
         Running,
         Succeeded,
         Failed

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -238,7 +238,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         public void Update(V1Pod pod)
         {
-            var conditions = pod.Status.Conditions.Select(c => c.Message).ToArray();
+            var conditions = pod.Status.Conditions?.Select(c => c.Message).ToArray() ?? new string[]{};
 
             switch (pod.Status?.Phase)
                 {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -243,29 +243,18 @@ namespace Octopus.Tentacle.Kubernetes
             switch (pod.Status?.Phase)
                 {
                     case PodPhases.Pending:
-                        //var pod.Status.Conditions.SingleOrDefault(c => c.Type == "PodScheduled");
-                        State = TrackedScriptPodState.Pending(conditions);
-                        // conditions:
-                        // - type: PodScheduled
-                        // status: 'False'
-                        // lastProbeTime: null
-                        // lastTransitionTime: '2024-04-17T03:43:42Z'
-                        // reason: Unschedulable
-                        // message: >-
-                        //     0/1 nodes are available: 1 node(s) were unschedulable. preemption: 0/1
-                        // nodes are available: 1 Preemption is not helpful for scheduling.
-                        //     qosClass: Burstable
+                        State = TrackedScriptPodState.Pending();
                         break;
                     case PodPhases.Running:
-                        State = TrackedScriptPodState.Running(conditions);
+                        State = TrackedScriptPodState.Running();
                         break;
                     case PodPhases.Succeeded:
                         var succeededState = GetTerminatedState();
-                        State = TrackedScriptPodState.Succeeded(succeededState.ExitCode, GetFinishedAt(succeededState), conditions);
+                        State = TrackedScriptPodState.Succeeded(succeededState.ExitCode, GetFinishedAt(succeededState));
                         break;
                     case PodPhases.Failed:
                         var failedState = GetTerminatedState();
-                        State = TrackedScriptPodState.Failed(failedState.ExitCode, GetFinishedAt(failedState), conditions);
+                        State = TrackedScriptPodState.Failed(failedState.ExitCode, GetFinishedAt(failedState));
                         break;
                 }
 
@@ -312,50 +301,45 @@ namespace Octopus.Tentacle.Kubernetes
         {
         }
 
-        public static TrackedScriptPodState Pending(params string[] conditionMessages)
+        public static TrackedScriptPodState Pending()
         {
             return new TrackedScriptPodState()
             {
                 Phase = TrackedScriptPodPhase.Pending,
-                ConditionMessages = conditionMessages
             };
         }
         
-        public static TrackedScriptPodState Running(params string[] conditionMessages)
+        public static TrackedScriptPodState Running()
         {
             return new TrackedScriptPodState()
             {
                 Phase = TrackedScriptPodPhase.Running,
-                ConditionMessages = conditionMessages
             };
         }
 
-        public static TrackedScriptPodState Succeeded(int exitCode, DateTimeOffset finishedAt, params string[] conditionMessages)
+        public static TrackedScriptPodState Succeeded(int exitCode, DateTimeOffset finishedAt)
         {
             return new TrackedScriptPodState()
             {
                 Phase = TrackedScriptPodPhase.Succeeded,
                 ExitCode = exitCode, 
                 FinishedAt = finishedAt,
-                ConditionMessages = conditionMessages
             };
         }
 
-        public static TrackedScriptPodState Failed(int exitCode, DateTimeOffset finishedAt, params string[] conditionMessages)
+        public static TrackedScriptPodState Failed(int exitCode, DateTimeOffset finishedAt)
         {
             return new TrackedScriptPodState()
             {
                 Phase = TrackedScriptPodPhase.Failed,
                 ExitCode = exitCode, 
                 FinishedAt = finishedAt,
-                ConditionMessages = conditionMessages
             };
         }
 
         public TrackedScriptPodPhase Phase { get; private init; }
         public int? ExitCode { get; private init; }
         public DateTimeOffset? FinishedAt { get; private init; }
-        public IReadOnlyCollection<string> ConditionMessages { get; private init; } = new string[] { };
     }
 
     public enum TrackedScriptPodPhase

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -238,8 +238,6 @@ namespace Octopus.Tentacle.Kubernetes
 
         public void Update(V1Pod pod)
         {
-            var conditions = pod.Status.Conditions?.Select(c => c.Message).ToArray() ?? new string[]{};
-
             switch (pod.Status?.Phase)
                 {
                     case PodPhases.Pending:
@@ -305,7 +303,7 @@ namespace Octopus.Tentacle.Kubernetes
         {
             return new TrackedScriptPodState()
             {
-                Phase = TrackedScriptPodPhase.Pending,
+                Phase = TrackedScriptPodPhase.Pending
             };
         }
         
@@ -313,7 +311,7 @@ namespace Octopus.Tentacle.Kubernetes
         {
             return new TrackedScriptPodState()
             {
-                Phase = TrackedScriptPodPhase.Running,
+                Phase = TrackedScriptPodPhase.Running
             };
         }
 
@@ -323,7 +321,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 Phase = TrackedScriptPodPhase.Succeeded,
                 ExitCode = exitCode, 
-                FinishedAt = finishedAt,
+                FinishedAt = finishedAt
             };
         }
 
@@ -333,7 +331,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 Phase = TrackedScriptPodPhase.Failed,
                 ExitCode = exitCode, 
-                FinishedAt = finishedAt,
+                FinishedAt = finishedAt
             };
         }
 

--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
@@ -134,7 +134,7 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
             var podStatusOutputs = new []
             {
                 //Help users notice if Pods are in the Pending state for too long
-                new ProcessOutput(ProcessOutputSource.Debug, $"The Kubernetes Pod '{trackedPod.ScriptTicket.ToKubernetesScriptPodName()}' is in the '{state.Phase}' phase")
+                new ProcessOutput(ProcessOutputSource.Debug, $"The Kubernetes Pod '{trackedPod.ScriptTicket.ToKubernetesScriptPodName()}' is in the '{state.Phase}' phase with these messages: {string.Join("\n", state.ConditionMessages)}")
             };
 
             var (podLogs, nextLogSequence) = await podLogService.GetLogs(trackedPod.ScriptTicket, lastLogSequence, cancellationToken);

--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1Alpha.cs
@@ -131,13 +131,14 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
                 _ => throw new ArgumentOutOfRangeException()
             };
 
+            var (podLogs, nextLogSequence) = await podLogService.GetLogs(trackedPod.ScriptTicket, lastLogSequence, cancellationToken);
+
             var podStatusOutputs = new []
             {
                 //Help users notice if Pods are in the Pending state for too long
-                new ProcessOutput(ProcessOutputSource.Debug, $"The Kubernetes Pod '{trackedPod.ScriptTicket.ToKubernetesScriptPodName()}' is in the '{state.Phase}' phase with these messages: {string.Join("\n", state.ConditionMessages)}")
+                new ProcessOutput(ProcessOutputSource.Debug, $"The Kubernetes Pod '{trackedPod.ScriptTicket.ToKubernetesScriptPodName()}' is in the '{state.Phase}' phase")
             };
-
-            var (podLogs, nextLogSequence) = await podLogService.GetLogs(trackedPod.ScriptTicket, lastLogSequence, cancellationToken);
+            //Print the status first, since that's what we are basing our decisions on (printing it at the end might be confusing)
             var outputLogs = podStatusOutputs.Concat(podLogs).ToList();
 
             return new KubernetesScriptStatusResponseV1Alpha(


### PR DESCRIPTION
[sc-74374]
# Background

We want to know if a Pod can't be scheduled due to cluster problems - this PR logs a verbose message for the Pod state for every `GetStatus` request.

We still get 3 `Pending` log messages when the Pod gets scheduled immediately, hence the verbose level.
![CleanShot 2024-04-17 at 13 36 45@2x](https://github.com/OctopusDeploy/OctopusTentacle/assets/2888279/91c9f31c-df4e-463b-b871-3e141df8e4a8)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.