### PR TITLE
Force configuration to reload after changing the logging directory

### DIFF
--- a/installer/Octopus.Tentacle.Installer/Product.wxs
+++ b/installer/Octopus.Tentacle.Installer/Product.wxs
@@ -14,7 +14,7 @@
     - Product/Version      : Change this every major build
     - Product/UpgradeCode  : Never change this
   -->
-  <Product Id="*" Name="Octopus Deploy Tentacle" Language="1033" Version="8.1.902" Manufacturer="Octopus Deploy Pty. Ltd." UpgradeCode="1B32E04F-49C2-4907-8879-A556986F7F16">
+  <Product Id="*" Name="Octopus Deploy Tentacle" Language="1033" Version="8.1.1436" Manufacturer="Octopus Deploy Pty. Ltd." UpgradeCode="1B32E04F-49C2-4907-8879-A556986F7F16">
     <Package InstallerVersion="200" Compressed="yes" Description="Octopus Deploy Tentacle" Platform="$(var.Platform)" InstallScope="perMachine" />
     <Media Id="1" Cabinet="Files.cab" EmbedCab="yes" />
     <Property Id="MSIFASTINSTALL" Value="3" />

--- a/source/Octopus.Tentacle/Configuration/LogInitializer.cs
+++ b/source/Octopus.Tentacle/Configuration/LogInitializer.cs
@@ -40,6 +40,9 @@ namespace Octopus.Tentacle.Configuration
 
                 OctopusLogsDirectoryRenderer.History.Add(logDirectory);
                 OctopusLogsDirectoryRenderer.LogsDirectory = logDirectory;
+                
+                // Reload the configuration so NLog picks up the change immediately 
+                NLog.LogManager.Configuration = NLog.LogManager.Configuration.Reload();
 
                 //log to the new log file that we were logging somewhere else
                 logFileOnlyLogger.Info(new string('=', 80));


### PR DESCRIPTION
# Background
#project-k8s-agent

[SC-73181]

When the logging directory configuration is changed the change isn't picked up by NLog immediately and there is a quite a significant delay until it actually does, this is potentially okay for long running commands since it will eventually start logging in the correct location but for anything else it means that the logs will always end up in the default directory `Octopus/Logs` rather than the `{TentacleHome}/Logs`. This only seems to be an issue for the K8s agent, the standard polling/listening tentacles aren't affected.

# Results
- Updated `LogInitializer` to update the NLog configuration with a reloaded version of it which has the updated logging directory 

## Before
*Note*: The log line that is just `Changed log folder from Octopus/Logs to /octopus/Logs` is meant to appear in the new log file
```
2024-04-18 06:35:22.3868      1      1 DEBUG  2024-04-18 06:35:22.3868 | DEBUG | Machine configuration home directory is /etc/octopus
2024-04-18 06:35:22.4018      1      1 DEBUG  2024-04-18 06:35:22.4018 | DEBUG | Loading configuration from ConfigMap for namespace octopus-agent-travisl-aks
2024-04-18 06:35:22.6762      1      1  INFO  2024-04-18 06:35:22.6762 |  INFO | Changing log folder from Octopus/Logs to /octopus/Logs
2024-04-18 06:35:22.6762      1      1  INFO  2024-04-18 06:35:22.6762 |  INFO | ================================================================================
2024-04-18 06:35:22.6762      1      1  INFO  2024-04-18 06:35:22.6762 |  INFO | Changed log folder from Octopus/Logs to /octopus/Logs
2024-04-18 06:35:22.6762      1      1  INFO  2024-04-18 06:35:22.6762 |  INFO | Tentacle version 8.1.1426 (8.1.1426) instance Tentacle
2024-04-18 06:35:22.6762      1      1  INFO  2024-04-18 06:35:22.6762 |  INFO | Environment Information:
  OperatingSystem: Linux 5.15.0-1059-azure #67-Ubuntu SMP Sat Mar 9 03:28:53 UTC 2024
  OsBitVersion: x64
  Is64BitProcess: True
  CurrentUser: root
  MachineName: octopus-agent-tentacle-664fd5448b-g96h8
  ProcessorCount: 2
  CurrentDirectory: /
  TempDirectory: /tmp/
  HostProcessName: tentacle
  PID: 1
2024-04-18 06:35:22.7176      1      1  INFO  2024-04-18 06:35:22.7176 |  INFO | ==== RunAgentCommand ====
2024-04-18 06:35:22.7176      1      1  INFO  2024-04-18 06:35:22.7176 |  INFO | CommandLine: /opt/octopus/tentacle/Tentacle.dll agent --instance Tentacle --noninteractive
```

## After
*Note*: The `Changed log folder from Octopus/Logs to /octopus/Logs` no longer appears in the default log file and is instead in the new directory.
```
2024-04-19 00:59:59.9981      1      1  INFO  2024-04-19 00:59:59.9981 |  INFO | Tentacle version 8.1.1430-20240419105636 (8.1.1430+Branch.main.Sha.15d5f29b7bf6d1adc789347adeb26f0c3772bf3c) instance Tentacle
2024-04-19 01:00:00.0677      1      1  INFO  2024-04-19 01:00:00.0677 |  INFO | Environment Information:
  OperatingSystem: Linux 6.6.16-linuxkit #1 SMP Fri Feb 16 11:54:02 UTC 2024
  OsBitVersion: x64
  Is64BitProcess: True
  CurrentUser: root
  MachineName: octopus-agent-tentacle-6d55b6cf56-wmhhf
  ProcessorCount: 10
  CurrentDirectory: /
  TempDirectory: /tmp/
  HostProcessName: tentacle
  PID: 1
2024-04-19 01:00:00.3219      1      1 DEBUG  2024-04-19 01:00:00.3219 | DEBUG | Machine configuration home directory is /etc/octopus
2024-04-19 01:00:00.3709      1      1 DEBUG  2024-04-19 01:00:00.3709 | DEBUG | Loading configuration from ConfigMap for namespace octopus-agent-sanitycheck
2024-04-19 01:00:01.1531      1      1  INFO  2024-04-19 01:00:01.1531 |  INFO | Changing log folder from Octopus/Logs to /octopus/Logs
```

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites
- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.