### PR TITLE
Use locally built docker image in Kubernetes integration tests

### DIFF
--- a/source/.run/Build and Push Kubernetes Tentacle docker image (powershell, amd64).run.xml
+++ b/source/.run/Build and Push Kubernetes Tentacle docker image (powershell, amd64).run.xml
@@ -1,0 +1,17 @@
+﻿<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build and Push Kubernetes Tentacle docker image (powershell, amd64)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value=".\build." />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="false" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/../build.ps1" />
+    <option name="SCRIPT_OPTIONS" value="-Target BuildAndLoadLocallyKubernetesTentacleContainerImage -DockerPlatform &quot;linux/amd64&quot;" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/../" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/source/.run/Build and Push Kubernetes Tentacle docker image (shell, arm64).run.xml
+++ b/source/.run/Build and Push Kubernetes Tentacle docker image (shell, arm64).run.xml
@@ -1,0 +1,17 @@
+﻿<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build and Push Kubernetes Tentacle docker image (shell, arm64)" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value=".\build." />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="false" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/../build.sh" />
+    <option name="SCRIPT_OPTIONS" value="-Target BuildAndLoadLocallyKubernetesTentacleContainerImage -DockerPlatform &quot;linux/arm64&quot;" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/../" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgentIntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgentIntegrationTest.cs
@@ -38,7 +38,7 @@ public abstract class KubernetesAgentIntegrationTest
         //create a new server halibut runtime
         var listeningPort = BuildServerHalibutRuntimeAndListen();
         
-        var thumbprint = await kubernetesAgentInstaller.InstallAgent(listeningPort);
+        var thumbprint = await kubernetesAgentInstaller.InstallAgent(listeningPort, KubernetesTestsGlobalContext.Instance.TentacleImageAndTag);
         
         //trust the generated cert thumbprint
         ServerHalibutRuntime.Trust(thumbprint);

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesTestsGlobalContext.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesTestsGlobalContext.cs
@@ -15,6 +15,7 @@ public class KubernetesTestsGlobalContext : IDisposable
 
     public string HelmExePath { get; private set; } = null!;
     public string KubeCtlExePath { get; private set; }= null!;
+    public string? TentacleImageAndTag { get; set; }
 
     KubernetesTestsGlobalContext()
     {

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/DockerImageLoader.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/DockerImageLoader.cs
@@ -1,0 +1,90 @@
+﻿using System.Text;
+using Octopus.Tentacle.CommonTestUtils;
+using Octopus.Tentacle.CommonTestUtils.Logging;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Kubernetes.Tests.Integration.Setup;
+
+public class DockerImageLoader
+{
+    readonly TemporaryDirectory temporaryDirectory;
+    readonly ILogger logger;
+    readonly string kindExePath;
+
+    public DockerImageLoader(TemporaryDirectory temporaryDirectory, ILogger logger, string kindExePath)
+    {
+        this.temporaryDirectory = temporaryDirectory;
+        this.logger = logger;
+        this.kindExePath = kindExePath;
+    }
+
+    public string? LoadMostRecentImageIntoKind(string clusterName)
+    {
+        var mostRecentTag = FindMostRecentTag();
+
+        return !string.IsNullOrWhiteSpace(mostRecentTag)
+            ? LoadImageIntoKind(mostRecentTag, clusterName)
+            : null;
+    }
+
+    string? FindMostRecentTag()
+    {
+        var sb = new StringBuilder();
+        var tags = new List<string>();
+        var sprLogger = new LoggerConfiguration()
+            .WriteTo.Logger(logger)
+            .WriteTo.StringBuilder(sb)
+            .CreateLogger();
+
+        var exitCode = SilentProcessRunner.ExecuteCommand(
+            "docker",
+            "images octopusdeploy/kubernetes-tentacle --format \"{{.Tag}}\"",
+            temporaryDirectory.DirectoryPath,
+            sprLogger.Debug,
+            line =>
+            {
+                sprLogger.Information(line);
+                tags.Add(line);
+            },
+            sprLogger.Error,
+            CancellationToken.None
+        );
+
+        if (exitCode != 0)
+        {
+            logger.Error("Failed to get latest image tag from docker");
+            throw new InvalidOperationException($"Failed to get latest image tag from docker. Logs: {sb}");
+        }
+        
+        return tags.FirstOrDefault();
+    }
+
+    string LoadImageIntoKind(string mostRecentTag, string clusterName)
+    {
+        var image = $"octopusdeploy/kubernetes-tentacle:{mostRecentTag}";
+
+        var sb = new StringBuilder();
+        var sprLogger = new LoggerConfiguration()
+            .WriteTo.Logger(logger)
+            .WriteTo.StringBuilder(sb)
+            .CreateLogger();
+
+        var exitCode = SilentProcessRunner.ExecuteCommand(
+            kindExePath,
+            $"load docker-image {image} --name={clusterName}",
+            temporaryDirectory.DirectoryPath,
+            sprLogger.Debug,
+            sprLogger.Information,
+            sprLogger.Error,
+            CancellationToken.None
+        );
+
+        if (exitCode != 0)
+        {
+            logger.Error("Failed to load the Kubernetes Tentacle image into Kind");
+            throw new InvalidOperationException($"Failed to load the Kubernetes Tentacle image into Kind. Logs: {sb}");
+        }
+
+        return image;
+    }
+}

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesClusterInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesClusterInstaller.cs
@@ -21,6 +21,7 @@ public class KubernetesClusterInstaller
     readonly ILogger logger;
 
     public string KubeConfigPath => Path.Combine(tempDir.DirectoryPath, kubeConfigName);
+    public string ClusterName => clusterName;
 
     public KubernetesClusterInstaller(TemporaryDirectory tempDirectory, string kindExePath, string helmExePath, string kubeCtlPath, ILogger logger)
     {


### PR DESCRIPTION
# Background

When developing the Kubernetes Tentacle/Agent locally, it will help developers if they can run the integration tests against locally built images.

This change adds this ability by inspecting the local docker image cache and then using `kind load docker-image` to load it into the integration test cluster.

On TeamCity, we still use the built image as pushed to Artifactory

# Results

Developers will need to run the `BuildAndLoadLocallyKubernetesTentacleContainerImage` Nuke build target first, before executing the tests. I played with running this during the test itself, but it didn't work due to dll locking and other things.

I've added 2 new rider build configurations to execute this nuke configuration.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.