### PR TITLE
Use `du` for space checks in Kubernetes

### DIFF
--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
@@ -1,0 +1,90 @@
+using System;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.Extensions;
+using NUnit.Framework;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Kubernetes;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Tests.Kubernetes
+{
+    public class KubernetesDirectoryInformationProviderFixture
+    {
+        // Sizes
+        const ulong Megabyte = 1000 * 1000;
+        const ulong Mebibyte = 1024 * 1024;
+        const ulong Gibibyte = 1024 * 1024 * 1024;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            Environment.SetEnvironmentVariable(KubernetesConfig.NamespaceVariableName, "test-namespace");
+        }
+
+        [Test]
+        public void DuOutputParses()
+        {
+            const ulong usedSize = 500 * Megabyte;
+            var spr = Substitute.For<ISilentProcessRunner>();
+            spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
+                .Do(x =>
+                {
+                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                });
+            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);
+            sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
+        }
+        
+        [Test]
+        public void DuOutputParsesWithMultipleLines()
+        {
+            const ulong usedSize = 500 * Megabyte;
+            var spr = Substitute.For<ISilentProcessRunner>();
+            spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
+                .Do(x =>
+                {
+                    x.ArgAt<Action<string>>(3).Invoke($"500\t/octopus/extradir");
+                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize+1000}\tTotal");
+                });
+            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);
+            sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
+        }
+
+        [Test]
+        public void IfDuFailsWeStillGetData()
+        {
+            const ulong usedSize = 500 * Megabyte;
+            var spr = Substitute.For<ISilentProcessRunner>();
+            spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
+                .Do(x =>
+                {
+                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    x.ArgAt<Action<string>>(3).Invoke($"500\t/octopus");
+                });
+            spr.ReturnsForAll(1);
+            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);
+            sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
+        }
+        
+        [Test]
+        public void IfDuFailsCompletelyReturnNull()
+        {
+            var spr = Substitute.For<ISilentProcessRunner>();
+            spr.ReturnsForAll(1);
+            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);
+            sut.GetPathUsedBytes("/octopus").Should().Be(null);
+        }
+
+        [TestCase("1Gi", 1 * Gibibyte)]
+        [TestCase("10Gi", 10 * Gibibyte)]
+        [TestCase("10Mi", 10 * Mebibyte)]
+        [TestCase("1M", 1 * Megabyte)]
+        public void CorrectlyParsesTotalSize(string sizeString, ulong expected)
+        {
+            KubernetesUtilities.GetResourceBytes(sizeString).Should().Be(expected);
+        }
+        
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
@@ -13,15 +13,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
     {
         // Sizes
         const ulong Megabyte = 1000 * 1000;
-        const ulong Mebibyte = 1024 * 1024;
-        const ulong Gibibyte = 1024 * 1024 * 1024;
         
-        [SetUp]
-        public void SetUp()
-        {
-            Environment.SetEnvironmentVariable(KubernetesConfig.NamespaceVariableName, "test-namespace");
-        }
-
         [Test]
         public void DuOutputParses()
         {
@@ -76,15 +68,5 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);
             sut.GetPathUsedBytes("/octopus").Should().Be(null);
         }
-
-        [TestCase("1Gi", 1 * Gibibyte)]
-        [TestCase("10Gi", 10 * Gibibyte)]
-        [TestCase("10Mi", 10 * Mebibyte)]
-        [TestCase("1M", 1 * Megabyte)]
-        public void CorrectlyParsesTotalSize(string sizeString, ulong expected)
-        {
-            KubernetesUtilities.GetResourceBytes(sizeString).Should().Be(expected);
-        }
-        
     }
 }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
@@ -52,8 +52,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
                 .Do(x =>
                 {
-                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
                     x.ArgAt<Action<string>>(3).Invoke($"500\t/octopus");
+                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
                 });
             spr.ReturnsForAll(1);
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Kubernetes;
+
+namespace Octopus.Tentacle.Tests.Kubernetes
+{
+    [TestFixture]
+    public class KubernetesPhysicalFileSystemFixture
+    {
+        const ulong Megabyte = 1000 * 1000;
+        const ulong Mebibyte = 1024 * 1024;
+        const ulong Gibibyte = 1024 * 1024 * 1024;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Environment.SetEnvironmentVariable(KubernetesConfig.NamespaceVariableName, "test-namespace");
+        }
+
+        [TestCase(100 * Mebibyte, 300 * Mebibyte, true)]
+        [TestCase(100 * Mebibyte, 800 * Mebibyte, false)]
+        [TestCase(800 * Megabyte, 1 * Gibibyte, true)]
+        public void DiskSpaceUsed(ulong diskSpaceUsed, ulong totalDiskSpace, bool throwException)
+        {
+            const string directoryPath = "/octopus";
+            
+            var directoryInformationProvider = Substitute.For<IKubernetesDirectoryInformationProvider>();
+            directoryInformationProvider.GetPathTotalBytes().Returns(totalDiskSpace);
+            directoryInformationProvider.GetPathUsedBytes("/octopus").Returns(diskSpaceUsed);
+            
+            var fileSystem = new KubernetesPhysicalFileSystem(directoryInformationProvider, Substitute.For<ISystemLog>());
+            
+            if (throwException)
+            {
+                Action a = () => fileSystem.EnsureDiskHasEnoughFreeSpace(directoryPath);
+                a.Should().Throw<IOException>();
+            }
+            else
+            {
+                Action a = () => fileSystem.EnsureDiskHasEnoughFreeSpace(directoryPath);
+                a.Should().NotThrow();
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
@@ -30,7 +30,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             var homeConfiguration = Substitute.For<IHomeConfiguration>();
             homeConfiguration.HomeDirectory.Returns("/octopus");
             
-            var fileSystem = new KubernetesPhysicalFileSystem(directoryInformationProvider, Substitute.For<ISystemLog>(), homeConfiguration);
+            var fileSystem = new KubernetesPhysicalFileSystem(directoryInformationProvider, Substitute.For<ISystemLog>());
             
             if (throwException)
             {

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Diagnostics;
+using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Kubernetes;
 
 namespace Octopus.Tentacle.Tests.Kubernetes
@@ -32,7 +33,10 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             directoryInformationProvider.GetPathTotalBytes().Returns(totalDiskSpace);
             directoryInformationProvider.GetPathUsedBytes("/octopus").Returns(diskSpaceUsed);
             
-            var fileSystem = new KubernetesPhysicalFileSystem(directoryInformationProvider, Substitute.For<ISystemLog>());
+            var homeConfiguration = Substitute.For<IHomeConfiguration>();
+            homeConfiguration.HomeDirectory.Returns("/octopus");
+            
+            var fileSystem = new KubernetesPhysicalFileSystem(directoryInformationProvider, Substitute.For<ISystemLog>(), homeConfiguration);
             
             if (throwException)
             {

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
@@ -16,12 +16,6 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         const ulong Mebibyte = 1024 * 1024;
         const ulong Gibibyte = 1024 * 1024 * 1024;
 
-        [SetUp]
-        public void SetUp()
-        {
-            Environment.SetEnvironmentVariable(KubernetesConfig.NamespaceVariableName, "test-namespace");
-        }
-
         [TestCase(100 * Mebibyte, 300 * Mebibyte, true)]
         [TestCase(100 * Mebibyte, 800 * Mebibyte, false)]
         [TestCase(800 * Megabyte, 1 * Gibibyte, true)]

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesUtilitiesFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesUtilitiesFixture.cs
@@ -1,0 +1,22 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.Kubernetes;
+
+namespace Octopus.Tentacle.Tests.Kubernetes
+{
+    public class KubernetesUtilitiesFixture
+    {
+        const ulong Megabyte = 1000 * 1000;
+        const ulong Mebibyte = 1024 * 1024;
+        const ulong Gibibyte = 1024 * 1024 * 1024;
+
+        [TestCase("1Gi", 1 * Gibibyte)]
+        [TestCase("10Gi", 10 * Gibibyte)]
+        [TestCase("10Mi", 10 * Mebibyte)]
+        [TestCase("1M", 1 * Megabyte)]
+        public void CorrectlyParsesTotalSize(string sizeString, ulong expected)
+        {
+            KubernetesUtilities.GetResourceBytes(sizeString).Should().Be(expected);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -26,6 +26,9 @@ namespace Octopus.Tentacle.Kubernetes
 
         public static string BootstrapRunnerExecutablePath => GetRequiredEnvVar("BOOTSTRAPRUNNEREXECUTABLEPATH", "Unable to determine Bootstrap Runner Executable Path");
 
+        public static string PersistentVolumeSizeVariableName => $"{EnvVarPrefix}__PERSISTENTVOLUMESIZE";
+        public static string PersistentVolumeSize => GetRequiredEnvVar(PersistentVolumeSizeVariableName, "Unable to determine Persistent Volume Size");
+
         static string GetRequiredEnvVar(string variable, string errorMessage)
             => Environment.GetEnvironmentVariable(variable)
                 ?? throw new InvalidOperationException($"{errorMessage} The environment variable '{variable}' must be defined with a non-null value.");

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesDirectoryInformationProvider
+    {
+        public ulong? GetPathUsedBytes(string directoryPath);
+        public ulong? GetPathTotalBytes();
+    }
+
+    public class KubernetesDirectoryInformationProvider : IKubernetesDirectoryInformationProvider
+    {
+        readonly ISystemLog log;
+        readonly ISilentProcessRunner silentProcessRunner;
+
+        public KubernetesDirectoryInformationProvider(ISystemLog log, ISilentProcessRunner silentProcessRunner)
+        {
+            this.log = log;
+            this.silentProcessRunner = silentProcessRunner;
+        }
+
+        public ulong? GetPathUsedBytes(string directoryPath)
+        {
+            return GetDriveBytesUsingDu(directoryPath);
+        }
+
+        public ulong? GetPathTotalBytes()
+        {
+            return KubernetesUtilities.GetResourceBytes(KubernetesConfig.PersistentVolumeSize);
+        }
+        
+        
+        ulong? GetDriveBytesUsingDu(string directoryPath)
+        {
+            var stdOut = new List<string>();
+            var stdErr = new List<string>();
+            var exitCode = silentProcessRunner.ExecuteCommand("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add);
+
+            if (exitCode != 0)
+            {
+                log.Warn("Could not reliably get disk space using du. Getting best approximation...");
+                log.Info($"Du stdout returned {stdOut}");
+                log.Info($"Du stderr returned {stdErr}");
+            }
+
+            var lineWithDirectory = stdOut.LastOrDefault(outputLine => outputLine.Contains(directoryPath));
+
+            if (ulong.TryParse(lineWithDirectory?.Split('\t')[0], out var bytes))
+                return bytes;
+            return null;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -23,6 +23,7 @@ namespace Octopus.Tentacle.Kubernetes
 
             builder.RegisterType<KubernetesOrphanedPodCleanerTask>().As<IKubernetesOrphanedPodCleanerTask>().As<IBackgroundTask>().SingleInstance();
             builder.RegisterType<KubernetesOrphanedPodCleaner>().As<IKubernetesOrphanedPodCleaner>().SingleInstance();
+            builder.RegisterType<KubernetesDirectoryInformationProvider>().As<IKubernetesDirectoryInformationProvider>().SingleInstance();
 #if DEBUG
             builder.RegisterType<LocalMachineKubernetesClientConfigProvider>().As<IKubernetesClientConfigProvider>().SingleInstance();
 #else

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public class KubernetesPhysicalFileSystem : OctopusPhysicalFileSystem
+    {
+        ISystemLog Log { get; }
+
+        public KubernetesPhysicalFileSystem(ISystemLog log) : base(log)
+        {
+            Log = log;
+        }
+
+        public override void EnsureDiskHasEnoughFreeSpace(string directoryPath, long requiredSpaceInBytes)
+        {
+            if (!PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
+            {
+                Log.Error("Not running as Kubernetes agent, using default implementation");
+                base.EnsureDiskHasEnoughFreeSpace(directoryPath, requiredSpaceInBytes);
+            }
+            
+            var freeBytes = GetPathFreeBytes(directoryPath);
+
+            // If we can't get the free bytes, we just skip the check
+            if (freeBytes is null) return;
+
+            var required = requiredSpaceInBytes < 0 ? 0 : (ulong)requiredSpaceInBytes;
+            // Make sure there is 10% (and a bit extra) more than we need
+            required += required / 10 + 1024 * 1024;
+            if (freeBytes < required)
+            {
+                throw new IOException($"Not enough free space on disk. Required: {required} bytes, available: {freeBytes} bytes");
+            }
+        }
+
+        ulong? GetDriveBytesUsingDu(string directoryPath)
+        {
+            var stdOut = new List<string>();
+            var stdErr = new List<string>();
+            var exitCode = SilentProcessRunner.ExecuteCommand("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add);
+
+
+            if (exitCode != 0)
+            {
+                Log.Warn("Could not reliably get disk space using du. Getting best approximation...");
+                Log.Info($"Du stdout returned {stdOut}");
+                Log.Info($"Du stderr returned {stdErr}");
+            }
+
+            var lineWithDirectory = stdOut.SingleOrDefault(outputLine => outputLine.Contains(directoryPath));
+                
+            if (ulong.TryParse(lineWithDirectory?.Split('\t')[0], out var bytes))
+                return bytes;
+            return null;
+        }
+        
+        ulong? GetTotalBytesOfClaim(string volumeSize)
+        {
+            var persistentVolumeSize = new k8s.Models.ResourceQuantity(volumeSize);
+            return persistentVolumeSize.ToUInt64();
+        }
+
+        ulong? GetPathFreeBytes(string directoryPath)
+        {
+            var bytesUsed = GetDriveBytesUsingDu(directoryPath);
+            var bytesTotal = GetTotalBytesOfClaim(KubernetesConfig.PersistentVolumeSize);
+            if (bytesUsed.HasValue && bytesTotal.HasValue)
+                return bytesTotal - bytesUsed;
+            return null;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,21 +9,17 @@ namespace Octopus.Tentacle.Kubernetes
 {
     public class KubernetesPhysicalFileSystem : OctopusPhysicalFileSystem
     {
+        readonly IKubernetesDirectoryInformationProvider directoryInformationProvider;
         ISystemLog Log { get; }
 
-        public KubernetesPhysicalFileSystem(ISystemLog log) : base(log)
+        public KubernetesPhysicalFileSystem(IKubernetesDirectoryInformationProvider directoryInformationProvider, ISystemLog log) : base(log)
         {
+            this.directoryInformationProvider = directoryInformationProvider;
             Log = log;
         }
 
         public override void EnsureDiskHasEnoughFreeSpace(string directoryPath, long requiredSpaceInBytes)
         {
-            if (!PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
-            {
-                Log.Error("Not running as Kubernetes agent, using default implementation");
-                base.EnsureDiskHasEnoughFreeSpace(directoryPath, requiredSpaceInBytes);
-            }
-            
             var freeBytes = GetPathFreeBytes(directoryPath);
 
             // If we can't get the free bytes, we just skip the check
@@ -36,38 +33,11 @@ namespace Octopus.Tentacle.Kubernetes
                 throw new IOException($"Not enough free space on disk. Required: {required} bytes, available: {freeBytes} bytes");
             }
         }
-
-        ulong? GetDriveBytesUsingDu(string directoryPath)
-        {
-            var stdOut = new List<string>();
-            var stdErr = new List<string>();
-            var exitCode = SilentProcessRunner.ExecuteCommand("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add);
-
-
-            if (exitCode != 0)
-            {
-                Log.Warn("Could not reliably get disk space using du. Getting best approximation...");
-                Log.Info($"Du stdout returned {stdOut}");
-                Log.Info($"Du stderr returned {stdErr}");
-            }
-
-            var lineWithDirectory = stdOut.SingleOrDefault(outputLine => outputLine.Contains(directoryPath));
-                
-            if (ulong.TryParse(lineWithDirectory?.Split('\t')[0], out var bytes))
-                return bytes;
-            return null;
-        }
         
-        ulong? GetTotalBytesOfClaim(string volumeSize)
-        {
-            var persistentVolumeSize = new k8s.Models.ResourceQuantity(volumeSize);
-            return persistentVolumeSize.ToUInt64();
-        }
-
         ulong? GetPathFreeBytes(string directoryPath)
         {
-            var bytesUsed = GetDriveBytesUsingDu(directoryPath);
-            var bytesTotal = GetTotalBytesOfClaim(KubernetesConfig.PersistentVolumeSize);
+            var bytesUsed = directoryInformationProvider.GetPathUsedBytes(directoryPath);
+            var bytesTotal = directoryInformationProvider.GetPathTotalBytes();
             if (bytesUsed.HasValue && bytesTotal.HasValue)
                 return bytesTotal - bytesUsed;
             return null;

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesUtilities.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesUtilities.cs
@@ -1,0 +1,11 @@
+namespace Octopus.Tentacle.Kubernetes
+{
+    public static class KubernetesUtilities
+    {
+        public static ulong GetResourceBytes(string sizeString)
+        {
+            var persistentVolumeSize = new k8s.Models.ResourceQuantity(sizeString);
+            return persistentVolumeSize.ToUInt64();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Util/OctopusFileSystemModule.cs
+++ b/source/Octopus.Tentacle/Util/OctopusFileSystemModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Autofac;
+using Octopus.Tentacle.Kubernetes;
 
 namespace Octopus.Tentacle.Util
 {
@@ -8,7 +9,14 @@ namespace Octopus.Tentacle.Util
         protected override void Load(ContainerBuilder builder)
         {
             base.Load(builder);
-            builder.RegisterType<OctopusPhysicalFileSystem>().As<IOctopusFileSystem>();
+            if (PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
+            {
+                builder.RegisterType<KubernetesPhysicalFileSystem>().As<IOctopusFileSystem>();
+            }
+            else
+            {
+                builder.RegisterType<OctopusPhysicalFileSystem>().As<IOctopusFileSystem>();                
+            }
         }
     }
 }

--- a/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Util/OctopusPhysicalFileSystem.cs
@@ -257,7 +257,7 @@ namespace Octopus.Tentacle.Util
             EnsureDiskHasEnoughFreeSpace(directoryPath, FiveHundredMegabytes);
         }
 
-        public void EnsureDiskHasEnoughFreeSpace(string directoryPath, long requiredSpaceInBytes)
+        public virtual void EnsureDiskHasEnoughFreeSpace(string directoryPath, long requiredSpaceInBytes)
         {
             if (IsUncPath(directoryPath))
                 return;

--- a/source/Octopus.Tentacle/Util/ShellModule.cs
+++ b/source/Octopus.Tentacle/Util/ShellModule.cs
@@ -9,6 +9,8 @@ namespace Octopus.Tentacle.Util
         protected override void Load(ContainerBuilder builder)
         {
             base.Load(builder);
+            
+            builder.RegisterType<SilentProcessRunnerWrapper>().As<ISilentProcessRunner>().SingleInstance();
 
             if (PlatformDetection.IsRunningOnWindows)
                 builder.RegisterType<PowerShell>().As<IShell>();

--- a/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
@@ -12,6 +12,39 @@ using Octopus.Tentacle.Startup;
 
 namespace Octopus.Tentacle.Util
 {
+    public interface ISilentProcessRunner
+    {
+        public int ExecuteCommand(
+            string executable,
+            string arguments,
+            string workingDirectory,
+            Action<string> info,
+            Action<string> error,
+            CancellationToken cancel = default);
+
+        public int ExecuteCommand(
+            string executable,
+            string arguments,
+            string workingDirectory,
+            Action<string> debug,
+            Action<string> info,
+            Action<string> error,
+            CancellationToken cancel = default);
+    }
+
+    public class SilentProcessRunnerWrapper : ISilentProcessRunner
+    {
+        public int ExecuteCommand(string executable, string arguments, string workingDirectory, Action<string> info, Action<string> error, CancellationToken cancel = default)
+        {
+            return SilentProcessRunner.ExecuteCommand(executable, arguments, workingDirectory, info, error, cancel);
+        }
+
+        public int ExecuteCommand(string executable, string arguments, string workingDirectory, Action<string> debug, Action<string> info, Action<string> error, CancellationToken cancel = default)
+        {
+            return SilentProcessRunner.ExecuteCommand(executable, arguments, workingDirectory, debug, info, error, cancel);
+        }
+    }
+
     public static class SilentProcessRunner
     {
         public static CmdResult ExecuteCommand(this CommandLineInvocation invocation)


### PR DESCRIPTION
**Note that this change will require a [new helm chart version](https://github.com/OctopusDeploy/helm-charts/pull/125) to get a required environment variable!** 

# Background
When running Octopus Tentacle in the Kubernetes Agent, we can't reliably get disk space on the mounted volume using native disk space tools. This is because in some cases (especially using the default NFS implementation), the volume is actually an NFS export of a folder on the node. This means that disk space tools (like `df`) show the disk space free on the _node_ rather than the disk space that we've configured in Kubernetes to be available. When we exceed the disk space we've configured in Kubernetes, `kubelet` will evict the NFS pod.

As such, we've fallen back to using a simple `du` command to quickly get the disk space used on the filesystem. This is compared to the limit that's set on the PVC for tentacle. This is set as an environment variable by the helm chart.

# Results
_Most of the time, this works every time!™_

![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/68839108/c7bfcd93-2222-44db-9d71-6fde04d5d0bc)


`du` can have some issues getting space, for example:
* If the metadata is slow (using CIFS with many small files), it can take some time
* If we have no access to a file or folder, it can't count the space it takes up

We attempt to do our best, logging out warnings with the issues if we do experience a problem, but taking the space that it still managed to account for, and returning this. If it can't get _anything_ from DU, we just force the check to succeed, in an attempt to not block deployments where possible.

As a part of this, I've also written a non-static, injectable wrapper around the `SilentProcessRunner` so that I could mock it in the unit tests for the `KubernetesDirectoryInformationProvider`.


# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.