### PR TITLE
Retry when Pod log line numbers don't match

### DIFF
--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1AlphaIntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1AlphaIntegrationTest.cs
@@ -16,8 +16,15 @@ public class KubernetesScriptServiceV1AlphaIntegrationTest : KubernetesAgentInte
         // Arrange
         var logs = new List<ProcessOutput>();
         var scriptCompleted = false;
+        string scriptBody = @"echo ""Hello World""
+for i in $(seq 1 50);
+do
+    echo $i
+    sleep 0.1
+done
+";
         var command = new ExecuteKubernetesScriptCommandBuilder(LoggingUtils.CurrentTestHash())
-            .SetScriptBody("echo \"Hello World\"")
+            .SetScriptBody(scriptBody)
             .Build();
 
         //act

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -60,7 +60,10 @@ namespace Octopus.Tentacle.Kubernetes
                 }
                 catch (UnexpectedPodLogLineNumberException ex)
                 {
-                    Log.Warn(ex, "Unexpected Pod log line numbers found, retrying with loading ");
+                    var message = $"Unexpected Pod log line numbers found with sinceTime='{sinceTime}', loading all logs";
+                    tentacleScriptLog.Verbose(message);
+                    Log.Warn(ex, message);
+                    
                     //If we somehow come across weird/missing line numbers, try load the whole Pod logs to see if that helps
                     return await GetPodLogsWithSinceTime(null);
                 }

--- a/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/IKubernetesPodLogService.cs
@@ -34,14 +34,8 @@ namespace Octopus.Tentacle.Kubernetes
         {
             var tentacleScriptLog = scriptLogProvider.GetOrCreate(scriptTicket);
             var podName = scriptTicket.ToKubernetesScriptPodName();
-            var sinceTime = scriptPodSinceTimeStore.GetSinceTime(scriptTicket);
 
-            var logStream = await GetLogStream(podName, sinceTime, cancellationToken: cancellationToken);
-            if (logStream == null)
-                return (new List<ProcessOutput>(), lastLogSequence);
-            
-            var podLogs = await ReadPodLogs(logStream);
-
+            var podLogs = await GetPodLogs();
             if (podLogs.Outputs.Any())
             {
                 var nextSinceTime = podLogs.Outputs.Max(o => o.Occurred);
@@ -57,7 +51,28 @@ namespace Octopus.Tentacle.Kubernetes
             var combinedLogs = podLogs.Outputs.Concat(tentacleLogs).OrderBy(o => o.Occurred).ToList();
             return (combinedLogs, podLogs.NextSequenceNumber);
 
-            async Task<(IReadOnlyCollection<ProcessOutput> Outputs, long NextSequenceNumber, int? ExitCode)> ReadPodLogs(Stream stream)
+            async Task<(IReadOnlyCollection<ProcessOutput> Outputs, long NextSequenceNumber, int? ExitCode)> GetPodLogs()
+            {
+                var sinceTime = scriptPodSinceTimeStore.GetSinceTime(scriptTicket);
+                try
+                {
+                    return await GetPodLogsWithSinceTime(sinceTime);
+                }
+                catch (UnexpectedPodLogLineNumberException ex)
+                {
+                    Log.Warn(ex, "Unexpected Pod log line numbers found, retrying with loading ");
+                    //If we somehow come across weird/missing line numbers, try load the whole Pod logs to see if that helps
+                    return await GetPodLogsWithSinceTime(null);
+                }
+            }
+
+            async Task<(IReadOnlyCollection<ProcessOutput> Outputs, long NextSequenceNumber, int? ExitCode)> GetPodLogsWithSinceTime(DateTimeOffset? sinceTime)
+            {
+                var logStream = await GetLogStream(podName, sinceTime, cancellationToken: cancellationToken);
+                return logStream != null ? await ReadPodLogsFromStream(logStream) : (new List<ProcessOutput>(), lastLogSequence, null);
+            }
+
+            async Task<(IReadOnlyCollection<ProcessOutput> Outputs, long NextSequenceNumber, int? ExitCode)> ReadPodLogsFromStream(Stream stream)
             {
                 using (var reader = new StreamReader(stream))
                 {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesService.cs
@@ -17,13 +17,14 @@ namespace Octopus.Tentacle.Kubernetes
     {
         const int MaxDurationSeconds = 30;
         
+        protected ISystemLog Log { get; }
         protected AsyncRetryPolicy RetryPolicy { get; }
         protected k8sClient Client { get; }
 
         protected KubernetesService(IKubernetesClientConfigProvider configProvider, ISystemLog log)
         {
+            Log = log;
             Client = new k8sClient(configProvider.Get());
-
             RetryPolicy = Policy.Handle<Exception>().WaitAndRetryAsync(5,
                 retry => TimeSpan.FromSeconds(ExponentialBackoff.GetDuration(retry, MaxDurationSeconds)),
                 (ex, duration) => log.Verbose(ex, $"An unexpected error occured while interacting the Kubernetes API, waiting for: " + duration));


### PR DESCRIPTION
[sc-76250]
# Background

During test, we found that sometimes the Pod logs returned by the K8s API was missing the first 3 lines, but the lines were there on a retry.

This problem is difficult to reproduce, so we've decided to add a simple retry to cater for the case where the K8s API isn't returning the Pod log lines we're expecting.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.