### PR TITLE
Update ScriptPod to pull image from Dockerhub

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerRegistry.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerRegistry.cs
@@ -36,7 +36,7 @@ namespace Octopus.Tentacle.Kubernetes
 
             var tag = tagVersion?.ToString(2) ?? "latest";
 
-            return $"docker.packages.octopushq.com/octopusdeploy/kubernetes-agent-tools-base:{tag}";
+            return $"octopusdeploy/kubernetes-agent-tools-base:{tag}";
         }
     }
 }


### PR DESCRIPTION
# Background
#project-k8s-agent
[SC-76030]

The image used in the ScriptPod is currently been pulled from Artifactory a PR in the image repo  https://github.com/OctopusDeploy/kubernetes-agent-tools-base/pull/5 is going to make it push the image to dockerhub.

# Results
Updated to get the image from dockerhub

# Pre-requisites
- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.