### PR TITLE
Update integration test Helm command

### DIFF
--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/agent-values.yaml
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/agent-values.yaml
@@ -1,5 +1,5 @@
-tentacle:
-  ACCEPT_EULA: "Y"
+agent:
+  acceptEula: "Y"
   targetName: "#{TargetName}"
   serverCommsAddress: "#{ServerCommsAddress}"
   serverUrl: "https://this.is.not.required.com/"


### PR DESCRIPTION
# Background

Now we have published `1.0.0` of the Kubernetes Agent helm command, we need to update the helm chart values in the integration tests.

I also added the ability to specify a custom helm chart version via `KubernetesIntegrationTests_HelmChartVersion` environment variable which will try and pull that version from Artifactory. This is useful when the Tentacle changes being tested need a custom build of the helm chart (such as new env vars)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.