### PR TITLE
Using node affinity to also specify that script pods must use arm64 or amd64 nodes

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -208,11 +208,15 @@ namespace Octopus.Tentacle.Kubernetes
                             }
                         }
                     },
-                    //currently we only support running on linux nodes
-                    NodeSelector = new Dictionary<string, string>
+                    //currently we only support running on linux/arm64 nodes
+                    Affinity = new V1Affinity(new V1NodeAffinity(requiredDuringSchedulingIgnoredDuringExecution: new V1NodeSelector(new List<V1NodeSelectorTerm>
                     {
-                        ["kubernetes.io/os"] = "linux"
-                    }
+                        new(matchExpressions: new List<V1NodeSelectorRequirement>
+                        {
+                            new("kubernetes.io/os", "In", new List<string>{"linux"}),
+                            new("kubernetes.io/arch", "In", new List<string>{"arm64","amd64"})
+                        })
+                    })))
                 }
             };
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -208,7 +208,7 @@ namespace Octopus.Tentacle.Kubernetes
                             }
                         }
                     },
-                    //currently we only support running on linux/arm64 nodes
+                    //currently we only support running on linux/arm64 and linux/amd64 nodes
                     Affinity = new V1Affinity(new V1NodeAffinity(requiredDuringSchedulingIgnoredDuringExecution: new V1NodeSelector(new List<V1NodeSelectorTerm>
                     {
                         new(matchExpressions: new List<V1NodeSelectorRequirement>


### PR DESCRIPTION
If a user has any nodes that are running linux with a 32 bit or other architecture, this change will make sure that kubernetes doesn't try to schedule script pods on those nodes as we only have container images for linux/amd64 and linux/arm64.

A related change is being made in the helm chart repo so that kubernetes won't schedule nfs or tentacle pods on nodes with invalid architectures: https://github.com/OctopusDeploy/helm-charts/pull/136