### PR TITLE
Fix logging when DU fails

### DIFF
--- a/source/Octopus.Tentacle.CommonTestUtils/Diagnostics/InMemoryLog.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Diagnostics/InMemoryLog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -34,6 +35,11 @@ namespace Octopus.Tentacle.CommonTestUtils.Diagnostics
         public string GetLog()
         {
             return events.Aggregate(new StringBuilder(), (sb, e) => sb.AppendLine($"{e.Category} {e.MessageText} {e.Error}"), sb => sb.ToString());
+        }
+
+        public IReadOnlyList<string?> GetLogsForCategory(LogCategory category)
+        {
+            return events.Where(e => e.Category == category).Select(e => e.MessageText.ToString()).ToArray();
         }
 
         public void AssertContains(string partialString)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Octopus.Client.Extensions;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Util;
 
@@ -42,8 +43,8 @@ namespace Octopus.Tentacle.Kubernetes
             if (exitCode != 0)
             {
                 log.Warn("Could not reliably get disk space using du. Getting best approximation...");
-                log.Info($"Du stdout returned {stdOut}");
-                log.Info($"Du stderr returned {stdErr}");
+                log.Info($"Du stdout returned {stdOut.CommaSeparate()}");
+                log.Info($"Du stderr returned {stdErr.CommaSeparate()}");
             }
 
             var lineWithDirectory = stdOut.LastOrDefault(outputLine => outputLine.Contains(directoryPath));


### PR DESCRIPTION
[sc-77040]

# Background
When DU fails to get the disk usage, it'd be good to get the reasons for failure, which usually come in `stdout`. Improperly printing a list led to this not being done in production. This change ensures that the logs are available in the Tentacle container, and adds a test to make sure it continues to work.

# Results
The logs from DU now show correctly as comma-delimited output in the console logs.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.