### PR TITLE
Add openshift random user support

### DIFF
--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -38,6 +38,10 @@ WORKDIR /
 # We know this won't reduce the image size at all. It's just to make the filesystem a little tidier.
 RUN rm -rf /tmp/*
 
+# This is to run on Openshift with a random user
+RUN chgrp -R 0 /opt /usr /etc && \
+    chmod -R g=u /opt /usr /etc
+
 ENV BOOTSTRAPRUNNEREXECUTABLEPATH=/bootstrapRunner
 ENV OCTOPUS_RUNNING_IN_CONTAINER=Y
 ENV ACCEPT_EULA=N

--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -27,20 +27,22 @@ WORKDIR /tmp
 
 # Install Tentacle
 COPY _artifacts/docker/tentacle_${BUILD_NUMBER}_${TARGETOS}-${TARGETARCH}${TARGETVARIANT}.deb /tmp/tentacle.deb
-RUN apt-get update
-RUN apt install ./tentacle.deb -y
-RUN apt-get clean
-RUN apt install curl -y
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update  \
+    && apt install ./tentacle.deb curl -y  \
+    && apt-get clean  \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /
 
 # We know this won't reduce the image size at all. It's just to make the filesystem a little tidier.
 RUN rm -rf /tmp/*
 
+# Make the /.dotnet directory for certificate store purposes
+RUN mkdir /.dotnet
+
 # This is to run on Openshift with a random user
-RUN chgrp -R 0 /opt /usr && \
-    chmod -R g=u /opt /usr
+RUN chgrp -R 0 /opt /usr /.dotnet && \
+    chmod -R g=u /opt /usr /.dotnet
 
 RUN chgrp 0 /etc && \
     chmod g=u /etc

--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -39,8 +39,8 @@ WORKDIR /
 RUN rm -rf /tmp/*
 
 # This is to run on Openshift with a random user
-RUN chgrp -R 0 /opt /usr /.dotnet && \
-    chmod -R g=u /opt /usr /.dotnet
+RUN chgrp -R 0 /opt /usr && \
+    chmod -R g=u /opt /usr
 
 RUN chgrp 0 /etc && \
     chmod g=u /etc

--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -37,13 +37,18 @@ WORKDIR /
 # We know this won't reduce the image size at all. It's just to make the filesystem a little tidier.
 RUN rm -rf /tmp/*
 
-# Make the /.dotnet directory for certificate store purposes
+# Make the /.dotnet directory so that we can ensure ownership for the
+# certificate store 
 RUN mkdir /.dotnet
 
-# This is to run on Openshift with a random user
+# By default, OpenShift uses random UIDs 
+# This introduces support for it as per
+# https://docs.openshift.com/container-platform/4.15/openshift_images/create-images.html#use-uid_create-images
 RUN chgrp -R 0 /opt /usr /.dotnet && \
     chmod -R g=u /opt /usr /.dotnet
 
+# The same as above, but we shouldn't recursively own /etc, as it would add
+# ownership to system files like /etc/passwd
 RUN chgrp 0 /etc && \
     chmod g=u /etc
 

--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -39,8 +39,8 @@ WORKDIR /
 RUN rm -rf /tmp/*
 
 # This is to run on Openshift with a random user
-RUN chgrp -R 0 /opt /usr /etc && \
-    chmod -R g=u /opt /usr /etc
+RUN chgrp -R 0 /opt /usr && \
+    chmod -R g=u /opt /usr
 
 ENV BOOTSTRAPRUNNEREXECUTABLEPATH=/bootstrapRunner
 ENV OCTOPUS_RUNNING_IN_CONTAINER=Y

--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -39,8 +39,11 @@ WORKDIR /
 RUN rm -rf /tmp/*
 
 # This is to run on Openshift with a random user
-RUN chgrp -R 0 /opt /usr && \
-    chmod -R g=u /opt /usr
+RUN chgrp -R 0 /opt /usr /.dotnet && \
+    chmod -R g=u /opt /usr /.dotnet
+
+RUN chgrp 0 /etc && \
+    chmod g=u /etc
 
 ENV BOOTSTRAPRUNNEREXECUTABLEPATH=/bootstrapRunner
 ENV OCTOPUS_RUNNING_IN_CONTAINER=Y


### PR DESCRIPTION
[sc-77472]

# Background
When running the Kubernetes agent on OpenShift, Tentacle would fail to start due to permission errors.

This PR uses [this documentation](https://docs.openshift.com/container-platform/4.15/openshift_images/create-images.html#use-uid_create-images) to add support.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.