### PR TITLE
Add simple cache to directory information provider

### DIFF
--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
@@ -112,7 +112,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
                 });
             
-            Thread.Sleep(TimeSpan.FromSeconds(15));
+            Thread.Sleep(TimeSpan.FromSeconds(30));
             
             sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
         }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
@@ -81,7 +81,9 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         {
             var spr = Substitute.For<ISilentProcessRunner>();
             spr.ReturnsForAll(1);
-            var memoryCache = new MemoryCache(new MemoryCacheOptions());
+            var baseTime = DateTimeOffset.UtcNow;
+            var clock = new TestClock(baseTime);
+            var memoryCache = new MemoryCache(new MemoryCacheOptions(){ Clock = clock});
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(null);
             
@@ -92,7 +94,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     x.ArgAt<Action<string>>(3).Invoke($"123\t/octopus");
                     x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
                 });
-            
+            clock.UtcNow = baseTime + TimeSpan.FromSeconds(29);
+
             sut.GetPathUsedBytes("/octopus").Should().Be(null);
         }
         

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
 using NSubstitute;
 using NSubstitute.Extensions;
 using NUnit.Framework;
@@ -24,7 +25,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 {
                     x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
                 });
-            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);
+            var memoryCache = new MemoryCache(new MemoryCacheOptions());
+            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
         }
         
@@ -40,7 +42,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
                     x.ArgAt<Action<string>>(3).Invoke($"{usedSize+1000}\tTotal");
                 });
-            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);
+            var memoryCache = new MemoryCache(new MemoryCacheOptions());
+            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
         }
 
@@ -56,7 +59,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                     x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
                 });
             spr.ReturnsForAll(1);
-            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);
+            var memoryCache = new MemoryCache(new MemoryCacheOptions());
+            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
         }
         
@@ -65,7 +69,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         {
             var spr = Substitute.For<ISilentProcessRunner>();
             spr.ReturnsForAll(1);
-            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr);
+            var memoryCache = new MemoryCache(new MemoryCacheOptions());
+            var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(null);
         }
     }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
@@ -28,7 +28,7 @@ namespace Octopus.Tentacle.Kubernetes
         {
             return directoryInformationCache.GetOrCreate(directoryPath, e =>
             {
-                e.SetAbsoluteExpiration(TimeSpan.FromSeconds(15));
+                e.SetAbsoluteExpiration(TimeSpan.FromSeconds(30));
                 return GetDriveBytesUsingDu(directoryPath);
             });
         }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Microsoft.Extensions.Caching.Memory;
 using Octopus.Tentacle.Background;
 
 namespace Octopus.Tentacle.Kubernetes
@@ -24,6 +25,7 @@ namespace Octopus.Tentacle.Kubernetes
             builder.RegisterType<KubernetesOrphanedPodCleanerTask>().As<IKubernetesOrphanedPodCleanerTask>().As<IBackgroundTask>().SingleInstance();
             builder.RegisterType<KubernetesOrphanedPodCleaner>().As<IKubernetesOrphanedPodCleaner>().SingleInstance();
             builder.RegisterType<KubernetesDirectoryInformationProvider>().As<IKubernetesDirectoryInformationProvider>().SingleInstance();
+            builder.RegisterType<MemoryCache>().As<IMemoryCache>().SingleInstance();
 #if DEBUG
             builder.RegisterType<LocalMachineKubernetesClientConfigProvider>().As<IKubernetesClientConfigProvider>().SingleInstance();
 #else

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using Octopus.Tentacle.Background;
 
 namespace Octopus.Tentacle.Kubernetes
@@ -26,6 +27,7 @@ namespace Octopus.Tentacle.Kubernetes
             builder.RegisterType<KubernetesOrphanedPodCleaner>().As<IKubernetesOrphanedPodCleaner>().SingleInstance();
             builder.RegisterType<KubernetesDirectoryInformationProvider>().As<IKubernetesDirectoryInformationProvider>().SingleInstance();
             builder.RegisterType<MemoryCache>().As<IMemoryCache>().SingleInstance();
+            builder.RegisterType<MemoryCacheOptions>().As<IOptions<MemoryCacheOptions>>().SingleInstance();
 #if DEBUG
             builder.RegisterType<LocalMachineKubernetesClientConfigProvider>().As<IKubernetesClientConfigProvider>().SingleInstance();
 #else

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -72,6 +72,7 @@
 		<PackageReference Include="TaskScheduler" Version="2.7.2" />
 		<PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
 		<PackageReference Include="NLog" Version="5.0.4" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="..\Solution Items\SolutionInfo.cs">


### PR DESCRIPTION
# Background
When we run `du`, it takes a lot longer to get information back instead of using the normal disk APIs. This can slow down scripts quite a lot when running in parallel. The disk space is unlikely to change much in a short period of time so we plan to cache the results to speed things up a bit. 

[There is an ADR for this change.
](https://github.com/OctopusDeploy/adr/pull/10)
# Results

This PR adds an IMemoryCache that caches for 30s, as well as tests to ensure the cache behaviour is correct. In practice, we've seen the following results:
_For 50 Concurrent Cloud deployments_
| Cache Length | Time per Deployment |
| ------------ | ------------------- |
| No DU        | 8min                |
| No Cache     | 30min               |
| 60s          | 9min                |
| 30s          | 11min               |
| 15s          | 15min               |

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.