### PR TITLE
Move free space check out of Workspace constructor

### DIFF
--- a/source/Octopus.Tentacle/Scripts/IScriptWorkspace.cs
+++ b/source/Octopus.Tentacle/Scripts/IScriptWorkspace.cs
@@ -22,5 +22,6 @@ namespace Octopus.Tentacle.Scripts
         string LogFilePath { get; }
         void WriteFile(string filename, string contents);
         void CopyFile(string sourceFilePath, string destFileName, bool overwrite);
+        void CheckReadiness();
     }
 }

--- a/source/Octopus.Tentacle/Scripts/ScriptWorkspace.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptWorkspace.cs
@@ -27,7 +27,6 @@ namespace Octopus.Tentacle.Scripts
             WorkingDirectory = workingDirectory;
             FileSystem = fileSystem;
             SensitiveValueMasker = sensitiveValueMasker;
-            fileSystem.EnsureDiskHasEnoughFreeSpace(workingDirectory);
         }
 
         const string BootstrapScriptFileName = "Bootstrap.ps1";
@@ -106,6 +105,11 @@ namespace Octopus.Tentacle.Scripts
         public IScriptLog CreateLog()
         {
             return new ScriptLog(ResolvePath(LogFileName), FileSystem, SensitiveValueMasker);
+        }
+
+        public void CheckReadiness()
+        {
+            FileSystem.EnsureDiskHasEnoughFreeSpace(WorkingDirectory);
         }
     }
 }

--- a/source/Octopus.Tentacle/Scripts/ScriptWorkspaceFactory.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptWorkspaceFactory.cs
@@ -37,7 +37,9 @@ namespace Octopus.Tentacle.Scripts
         {
             var workingDirectory = FindWorkingDirectory(ticket);
 
-            return CreateWorkspace(ticket, workingDirectory);
+            var workspace = CreateWorkspace(ticket, workingDirectory);
+            workspace.CheckReadiness();
+            return workspace;
         }
 
         public async Task<IScriptWorkspace> PrepareWorkspace(


### PR DESCRIPTION
# Background

When cleaning up workspaces, Tentacle checks for available free space. This check is not necessary during this process.

# Results

Move the check out of the constructor so that a `ScriptWorkspace` can be created without performing the check. The check can now be performed by calling the `CheckReadiness()` method on `IScriptWorkspace`. This helps separate the side effect from the object creation.

All creation of script workspaces is managed through the `ScriptWorkspaceFactory` which will perform this check when getting a Workspace.

For uncompleted workspaces, the check does not need to be performed.

Fixes #920 

# How to review this PR

- Quality :heavy_check_mark:
- Method naming feedback/alternative suggestions

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.