### PR TITLE
Support registering machines with environment slug or ids

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
@@ -90,7 +90,7 @@ namespace Octopus.Tentacle.Tests.Commands
                   "--tenant=Tenant1",
                   "--tenantTag=CustomerType/VIP");
 
-            Assert.That(operation.EnvironmentNames.Single(), Is.EqualTo("Development"));
+            Assert.That(operation.Environments.Single(), Is.EqualTo("Development"));
             Assert.That(operation.MachineName, Is.EqualTo("MyMachine"));
             Assert.That(operation.TentacleHostname, Is.EqualTo("mymachine.test"));
             Assert.That(operation.TentaclePort, Is.EqualTo(90210));
@@ -177,7 +177,7 @@ namespace Octopus.Tentacle.Tests.Commands
 
             Start(args);
 
-            Assert.That(operation.EnvironmentNames.Single(), Is.EqualTo("Development"));
+            Assert.That(operation.Environments.Single(), Is.EqualTo("Development"));
             Assert.That(operation.MachineName, Is.EqualTo("MyMachine"));
             Assert.That(operation.TentacleHostname, Is.Empty);
             Assert.That(operation.TentaclePort, Is.EqualTo(0));

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommand.cs
@@ -22,7 +22,7 @@ namespace Octopus.Tentacle.Commands
 
     public class RegisterMachineCommand<TRegisterMachineOperation> : RegisterMachineCommandBase<TRegisterMachineOperation> where TRegisterMachineOperation : IRegisterMachineOperation
     {
-        readonly List<string> environmentNames = new List<string>();
+        readonly List<string> environments = new List<string>();
         readonly List<string> roles = new List<string>();
         readonly List<string> tenants = new List<string>();
         readonly List<string> tenantTgs = new List<string>();
@@ -39,7 +39,7 @@ namespace Octopus.Tentacle.Commands
                                       ILogFileOnlyLogger logFileOnlyLogger)
             : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger)
         {
-            Options.Add("env|environment=", "The environment name to add the machine to - e.g., 'Production'; specify this argument multiple times to add multiple environments", s => environmentNames.Add(s));
+            Options.Add("env|environment=", "The environment name, slug or Id to add the machine to - e.g., 'Production'; specify this argument multiple times to add multiple environments", s => environments.Add(s));
             Options.Add("r|role=", "The machine role that the machine will assume - e.g., 'web-server'; specify this argument multiple times to add multiple roles", s => roles.Add(s));
             Options.Add("tenant=", "A tenant who the machine will be connected to; specify this argument multiple times to add multiple tenants", s => tenants.Add(s));
             Options.Add("tenanttag=", "A tenant tag which the machine will be tagged with - e.g., 'CustomerType/VIP'; specify this argument multiple times to add multiple tenant tags", s => tenantTgs.Add(s));
@@ -54,8 +54,8 @@ namespace Octopus.Tentacle.Commands
 
         protected override void CheckArgs()
         {
-            if (environmentNames.Count == 0 || string.IsNullOrWhiteSpace(environmentNames.First()))
-                throw new ControlledFailureException("Please specify an environment name, e.g., --environment=Development");
+            if (environments.Count == 0 || string.IsNullOrWhiteSpace(environments.First()))
+                throw new ControlledFailureException("Please specify an environment name, slug or Id, e.g., --environment=Development");
 
             if (roles.Count == 0 || string.IsNullOrWhiteSpace(roles.First()))
                 throw new ControlledFailureException("Please specify a role name, e.g., --role=web-server");
@@ -65,7 +65,7 @@ namespace Octopus.Tentacle.Commands
         {
             registerOperation.Tenants = tenants.ToArray();
             registerOperation.TenantTags = tenantTgs.ToArray();
-            registerOperation.EnvironmentNames = environmentNames.ToArray();
+            registerOperation.Environments = environments.ToArray();
             registerOperation.Roles = roles.ToArray();
             registerOperation.TenantedDeploymentParticipation = tenantedDeploymentMode;
         }

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -52,7 +52,7 @@
 		<PackageReference Include="KubernetesClient" Version="13.0.26" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Octopus.Client" Version="14.3.1348" />
+		<PackageReference Include="Octopus.Client" Version="14.3.1385-ap-register-environment-slugs" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="4.6.2" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -52,7 +52,7 @@
 		<PackageReference Include="KubernetesClient" Version="13.0.26" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Octopus.Client" Version="14.3.1385-ap-register-environment-slugs" />
+		<PackageReference Include="Octopus.Client" Version="14.3.1389" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="4.6.2" />


### PR DESCRIPTION
# Background

When registering a machine, we only accept environment names. This is a problem as the Kubernetes agent helm chart is generated with the environment slugs. This PR updates `Octopus.Client` to get the changes in https://github.com/OctopusDeploy/OctopusClients/pull/845, which allow for environment names, slugs or Ids.

The change in OctopusClients is backwards compatible, so if you provide only environment names, it continues to work.

# Results

Uses the new property `IRegisterMachineOperation.Environments` instead of `EnvironmentNames` and adjusted the command line message to say you can use slugs, ids and names.

Tested locally using Kubernetes agent registration where there is a mix of slug, id and name

`--set agent.targetEnvironments="{qa,Environments-42,development}" `

results in 
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/332730/9da09e31-566d-46ab-9a61-8582b2323dfb)

Where env `Boring` has an id of `Environments-42` and `UAT (not qa)` has a slug of `qa`)

This PR will be updated with the released clients version when the linked PR is merged.

Shortcut story: [sc-77588]
Related to: https://github.com/OctopusDeploy/Issues/issues/8760

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.