### PR TITLE
Rename ExecuteScriptCommandBuilder methods

### DIFF
--- a/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteScriptCommandBuilder.cs
@@ -27,7 +27,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
                 ScriptIsolationConfiguration.NoTimeout);
         }
 
-        public ExecuteScriptCommandBuilder SetScriptBody(string scriptBody)
+        public ExecuteScriptCommandBuilder WithScriptBody(string scriptBody)
         {
             ScriptBody = new StringBuilder(scriptBody);
             return this;
@@ -39,22 +39,28 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
             return this;
         }
 
-        public ExecuteScriptCommandBuilder AddAdditionalScriptType(ScriptType scriptType, string scriptBody)
+        public ExecuteScriptCommandBuilder WithAdditionalScriptType(ScriptType scriptType, string scriptBody)
         {
             AdditionalScripts.Add(scriptType, scriptBody);
             return this;
         }
 
-        public ExecuteScriptCommandBuilder SetIsolationLevel(ScriptIsolationLevel isolation)
+        public ExecuteScriptCommandBuilder WithIsolationLevel(ScriptIsolationLevel isolation)
         {
             IsolationConfiguration = IsolationConfiguration with { IsolationLevel= isolation };
             return this;
         }
 
-        public ExecuteScriptCommandBuilder SetNoIsolationLevel() => SetIsolationLevel(ScriptIsolationLevel.NoIsolation);
-        public ExecuteScriptCommandBuilder SetFullIsolationLevel() => SetIsolationLevel(ScriptIsolationLevel.FullIsolation);
+        public ExecuteScriptCommandBuilder WithScriptFile(ScriptFile scriptFile)
+        {
+            Files.Add(scriptFile);
+            return this;
+        }
 
-        public ExecuteScriptCommandBuilder SetFiles(IEnumerable<ScriptFile>? files)
+        public ExecuteScriptCommandBuilder WithNoIsolationLevel() => WithIsolationLevel(ScriptIsolationLevel.NoIsolation);
+        public ExecuteScriptCommandBuilder WithFullIsolationLevel() => WithIsolationLevel(ScriptIsolationLevel.FullIsolation);
+
+        public ExecuteScriptCommandBuilder WithFiles(IEnumerable<ScriptFile>? files)
         {
             Files.Clear();
             if (files is not null)
@@ -65,7 +71,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
             return this;
         }
 
-        public ExecuteScriptCommandBuilder SetArguments(IEnumerable<string>? arguments)
+        public ExecuteScriptCommandBuilder WithArguments(IEnumerable<string>? arguments)
         {
             Arguments.Clear();
             if (arguments is not null)
@@ -76,27 +82,20 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
             return this;
         }
 
-        public ExecuteScriptCommandBuilder SetIsolationMutexTimeout(TimeSpan scriptIsolationMutexTimeout)
+        public ExecuteScriptCommandBuilder WithIsolationMutexTimeout(TimeSpan scriptIsolationMutexTimeout)
         {
             IsolationConfiguration = IsolationConfiguration with { MutexTimeout= scriptIsolationMutexTimeout };
             return this;
         }
 
-        public ExecuteScriptCommandBuilder SetNoIsolationMutexTimeout() => SetIsolationMutexTimeout(ScriptIsolationConfiguration.NoTimeout);
+        public ExecuteScriptCommandBuilder WithNoIsolationMutexTimeout() => WithIsolationMutexTimeout(ScriptIsolationConfiguration.NoTimeout);
 
-        public ExecuteScriptCommandBuilder SetIsolationMutexName(string name)
+        public ExecuteScriptCommandBuilder WithIsolationMutexName(string name)
         {
             IsolationConfiguration = IsolationConfiguration with { MutexName= name };
             return this;
         }
 
         public abstract ExecuteScriptCommand Build();
-
-
-        public ExecuteScriptCommandBuilder AddFile(ScriptFile scriptFile)
-        {
-            Files.Add(scriptFile);
-            return this;
-        }
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteShellScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteShellScriptCommandBuilder.cs
@@ -11,7 +11,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
         {
         }
 
-        public ExecuteScriptCommandBuilder SetDurationStartScriptCanWaitForScriptToFinish(TimeSpan? duration)
+        public ExecuteScriptCommandBuilder WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan? duration)
         {
             durationStartScriptCanWaitForScriptToFinish = duration;
             return this;

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1AlphaIntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1AlphaIntegrationTest.cs
@@ -34,7 +34,7 @@ do
 done
 ";
         var command = new ExecuteKubernetesScriptCommandBuilder(LoggingUtils.CurrentTestHash())
-            .SetScriptBody(scriptBody)
+            .WithScriptBody(scriptBody)
             .Build();
 
         //act

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1IntegrationTest.cs
@@ -34,7 +34,7 @@ do
 done
 ";
         var command = new ExecuteKubernetesScriptCommandBuilder(LoggingUtils.CurrentTestHash())
-            .SetScriptBody(scriptBody)
+            .WithScriptBody(scriptBody)
             .Build();
 
         //act

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
@@ -29,12 +29,12 @@ namespace Octopus.Tentacle.Tests.Integration
                 .Print("Hello");
 
             var startScriptCommand = new TestExecuteShellScriptCommandBuilder()
-                .AddAdditionalScriptType(ScriptType.Bash, scriptBuilder.BuildBashScript())
+                .WithAdditionalScriptType(ScriptType.Bash, scriptBuilder.BuildBashScript())
                 // Additional Scripts don't actually work on tentacle for anything other than bash.
                 // Below is what we would have expected to tentacle to work with.
                 //.WithAdditionalScriptTypes(ScriptType.PowerShell, scriptBuilder.BuildPowershellScript())
                 // But instead we need to send the powershell in the scriptbody.
-                .SetScriptBody(scriptBuilder.BuildPowershellScript())
+                .WithScriptBody(scriptBuilder.BuildPowershellScript())
                 .Build();
 
             var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -44,7 +44,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .WaitForFileToExist(waitForFile)
                     .Print("hello"))
                 // Configure the start script command to wait a long time, so we have plenty of time to kill the connection.
-                .SetDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromHours(1))
+                .WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromHours(1))
                 .Build();
 
             var inMemoryLog = new InMemoryLog();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionIsolationMutex.cs
@@ -36,14 +36,14 @@ namespace Octopus.Tentacle.Tests.Integration
                 .SetScriptBody(new ScriptBuilder()
                     .CreateFile(firstScriptStartFile)
                     .WaitForFileToExist(firstScriptWaitFile))
-                .SetIsolationLevel(ScriptIsolationLevel.FullIsolation)
-                .SetIsolationMutexName("mymutex")
+                .WithIsolationLevel(ScriptIsolationLevel.FullIsolation)
+                .WithIsolationMutexName("mymutex")
                 .Build();
 
             var secondStartScriptCommand = new TestExecuteShellScriptCommandBuilder()
                 .SetScriptBody(new ScriptBuilder().CreateFile(secondScriptStart))
-                .SetIsolationLevel(levelOfSecondScript)
-                .SetIsolationMutexName("mymutex")
+                .WithIsolationLevel(levelOfSecondScript)
+                .WithIsolationMutexName("mymutex")
                 .Build();
 
             var tentacleClient = clientTentacle.TentacleClient;
@@ -96,14 +96,14 @@ namespace Octopus.Tentacle.Tests.Integration
                 .SetScriptBody(new ScriptBuilder()
                     .CreateFile(firstScriptStartFile)
                     .WaitForFileToExist(firstScriptWaitFile))
-                .SetIsolationLevel(scriptsInParallelTestCase.LevelOfFirstScript)
-                .SetIsolationMutexName(scriptsInParallelTestCase.MutexForFirstScript)
+                .WithIsolationLevel(scriptsInParallelTestCase.LevelOfFirstScript)
+                .WithIsolationMutexName(scriptsInParallelTestCase.MutexForFirstScript)
                 .Build();
 
             var secondStartScriptCommand = new TestExecuteShellScriptCommandBuilder()
                 .SetScriptBody(new ScriptBuilder().CreateFile(secondScriptStart))
-                .SetIsolationLevel(scriptsInParallelTestCase.LevelOfSecondScript)
-                .SetIsolationMutexName(scriptsInParallelTestCase.MutexForSecondScript)
+                .WithIsolationLevel(scriptsInParallelTestCase.LevelOfSecondScript)
+                .WithIsolationMutexName(scriptsInParallelTestCase.MutexForSecondScript)
                 .Build();
 
             var tentacleClient = clientTentacle.TentacleClient;

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -314,7 +314,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Sleep(TimeSpan.FromHours(1))
                     .Print("End Script"))
                 // Don't wait in start script as we want to tst get status
-                .SetDurationStartScriptCanWaitForScriptToFinish(null)
+                .WithDurationStartScriptCanWaitForScriptToFinish(null)
                 .Build();
 
             var duration = Stopwatch.StartNew();
@@ -370,7 +370,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .SetScriptBody(b => b
                     .Sleep(TimeSpan.FromHours(1)))
                 // Don't wait in start script as we want to test get status
-                .SetDurationStartScriptCanWaitForScriptToFinish(null)
+                .WithDurationStartScriptCanWaitForScriptToFinish(null)
                 .Build();
 
             var executeScriptTask = clientAndTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog);
@@ -439,7 +439,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Sleep(TimeSpan.FromHours(1))
                     .Print("End Script"))
                 // Don't wait in start script as we want to tst get status
-                .SetDurationStartScriptCanWaitForScriptToFinish(null)
+                .WithDurationStartScriptCanWaitForScriptToFinish(null)
                 .Build();
 
             // Start the script which will wait for a file to exist
@@ -509,7 +509,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 .SetScriptBody(b => b
                     .Sleep(TimeSpan.FromHours(1)))
                 // Don't wait in start script as we want to test get status
-                .SetDurationStartScriptCanWaitForScriptToFinish(null)
+                .WithDurationStartScriptCanWaitForScriptToFinish(null)
                 .Build();
 
             // Start the script which will wait for a file to exist

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptArgumentsWork.cs
@@ -23,7 +23,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var startScriptCommand = new TestExecuteShellScriptCommandBuilder()
                 .SetScriptBody(new ScriptBuilder().PrintArguments())
-                .SetArguments(new[] { "First", "Second", "AndSpacesAreNotHandledWellInTentacle" })
+                .WithArguments(new[] { "First", "Second", "AndSpacesAreNotHandledWellInTentacle" })
                 .Build();
 
             var tentacleServicesDecorator = new TentacleServiceDecoratorBuilder().Build();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptFilesAreSent.cs
@@ -22,7 +22,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var startScriptCommand = new TestExecuteShellScriptCommandBuilder()
                 .SetScriptBody(new ScriptBuilder().PrintFileContents("foo.txt"))
-                .AddFile(new ScriptFile("foo.txt", DataStream.FromString("The File Contents")))
+                .WithScriptFile(new ScriptFile("foo.txt", DataStream.FromString("The File Contents")))
                 .Build();
 
             var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceV1IsNotRetried.cs
@@ -50,8 +50,8 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Print("hello")
                     .WaitForFileToExist(waitForFile)
                     .Print("AllDone"))
-                .SetIsolationLevel(ScriptIsolationLevel.FullIsolation)
-                .SetIsolationMutexName("bob")
+                .WithIsolationLevel(ScriptIsolationLevel.FullIsolation)
+                .WithIsolationMutexName("bob")
                 .Build();
 
             var logs = new List<ProcessOutput>();

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptServiceV2IntegrationTest.cs
@@ -65,7 +65,7 @@ namespace Octopus.Tentacle.Tests.Integration
                     .Print("Lets do it")
                     .PrintNTimesWithDelay("another one", 10, TimeSpan.FromSeconds(1))
                     .Print("All done"))
-                .SetDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromMinutes(1))
+                .WithDurationStartScriptCanWaitForScriptToFinish(TimeSpan.FromMinutes(1))
                 .Build();
 
             var (finalResponse, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TestExecuteScriptCommandBuilderExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TestExecuteScriptCommandBuilderExtensionMethods.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders
         {
             var scriptBody = new StringBuilder(PlatformDetection.IsRunningOnWindows ? windowsScript : bashScript);
 
-            builder.SetScriptBody(scriptBody.ToString());
+            builder.WithScriptBody(scriptBody.ToString());
 
             return builder;
         }
@@ -19,7 +19,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders
         {
             var scriptBody = new StringBuilder(scriptBuilder.BuildForCurrentOs());
 
-            builder.SetScriptBody(scriptBody.ToString());
+            builder.WithScriptBody(scriptBody.ToString());
 
             return builder;
         }

--- a/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TestExecuteShellScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/Builders/TestExecuteShellScriptCommandBuilder.cs
@@ -9,7 +9,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders
         public TestExecuteShellScriptCommandBuilder()
             : base(Guid.NewGuid().ToString(), ScriptIsolationLevel.NoIsolation)
         {
-            SetDurationStartScriptCanWaitForScriptToFinish(null);
+            WithDurationStartScriptCanWaitForScriptToFinish(null);
         }
     }
 }


### PR DESCRIPTION
# Background

I had some feedback from @sburmanoctopus that the ExecuteScriptCommandBuilder method names don't match our standards. I renamed the methods and will update Server with these changes in a following PR

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.