### PR TITLE
Fix Kubernetes Agent integration test flake

### DIFF
--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
@@ -150,7 +150,7 @@ public class KubernetesAgentInstaller
 
     async Task<string> GetAgentThumbprint()
     {
-        var maxAttempts = 10;
+        var maxAttempts = 30;
 
         string? thumbprint = null;
         var attempt = 0;
@@ -194,7 +194,7 @@ public class KubernetesAgentInstaller
             }
 
             attempt++;
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(2));
         } while (thumbprint is null);
 
         throw new InvalidOperationException($"Failed to load the generated thumbprint after {maxAttempts} attempts");

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
@@ -150,8 +150,9 @@ public class KubernetesAgentInstaller
 
     async Task<string> GetAgentThumbprint()
     {
-        string? thumbprint = null;
+        var maxAttempts = 10;
 
+        string? thumbprint = null;
         var attempt = 0;
         do
         {
@@ -187,16 +188,16 @@ public class KubernetesAgentInstaller
                 return thumbprint;
             }
 
-            if (attempt == 5)
+            if (attempt == maxAttempts)
             {
                 break;
             }
 
             attempt++;
-            await Task.Delay(500);
+            await Task.Delay(TimeSpan.FromSeconds(1));
         } while (thumbprint is null);
 
-        throw new InvalidOperationException("Failed to load the generated thumbprint after 5 attempts");
+        throw new InvalidOperationException($"Failed to load the generated thumbprint after {maxAttempts} attempts");
     }
 
     string NamespaceFlag => $"--namespace \"{Namespace}\"";


### PR DESCRIPTION
[sc-78146]

# Background

Currently we're only trying up to 2.5s for the Agent to generate a thumbprint and put it into the config map. This time may not be enough depending on how fast the Teamcity agent is running.

Sample failing test:
https://build.octopushq.com/test/3616094188807382982?currentProjectId=TeamFireAndMotion_OctopusTentacle_VLatest&expandTestHistoryChartSection=true

This PR simply extends the time we wait from 2.5s to 10s. @tleed5 is in the [process of changing the Helm chart such that we provide the thumbprint to the Agent](https://octopusdeploy.slack.com/archives/C05KK1G85J5/p1715129850265649?thread_ts=1715124896.774339&cid=C05KK1G85J5) (rather than try to retrieve it later) - so this code will go away soon.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.