### PR TITLE
Fixing DuringStartScript_ForListeningTentacle_ThatIsRetryingTheRpc_AndConnecting_ScriptExecutionCanBeCancelled 

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.603" />
+    <PackageReference Include="Halibut" Version="7.0.641-sast-including-prepare-exchange-as-connection-failure-20240515094223" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.641-sast-including-prepare-exchange-as-connection-failure-20240515094223" />
+    <PackageReference Include="Halibut" Version="7.0.655" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">


### PR DESCRIPTION
[sc-70984]

# Background
The `ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.DuringStartScript_ForListeningTentacle_ThatIsRetryingTheRpc_AndConnecting_ScriptExecutionCanBeCancelled` test was flaky. 

On closer inspection, it was found that when it failed, it was forever trying to send a `Cancel` message to the Tentacle when it should not be.

It looks as though what was happening was that an exception was being thrown during "prepare exchange" in Halibut, and this exception was being considered as `ConnectionState.Unknown`. 

The reason we care about the connection state is because if we cancel, and encounter an exception while connecting, then we can walk away. The Tentacle never received any instructions.

But if we encounter an exception after we have connected, then the Tentacle may have received instructions, and we should send a "Cancel" message to the Tentacle.

# Results

## Before

If we managed to get a successful connection, or reused an existing connection, but failed during the `MessageExchangeProtocol.PrepareExchangeAsClientAsync` (i.e. before we ever sent any request information), it would **not** be considered "connecting" in the exception.

This logic is found within Halibut itself.

## After

We now consider an exception here as "connecting". This was fixed in Halibut with [this PR](https://github.com/OctopusDeploy/Halibut/pull/609)

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.