### PR TITLE
Update to Kubernetes SDK 14 and add new test

### DIFF
--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgentIntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgentIntegrationTest.cs
@@ -8,6 +8,7 @@ using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.CommonTestUtils;
 using Octopus.Tentacle.Contracts.Observability;
 using Octopus.Tentacle.Kubernetes.Tests.Integration.Setup;
+using Octopus.Tentacle.Kubernetes.Tests.Integration.Setup.Tooling;
 using Octopus.Tentacle.Tests.Integration.Common.Builders.Decorators;
 using Octopus.Tentacle.Tests.Integration.Common.Logging;
 
@@ -27,6 +28,7 @@ public abstract class KubernetesAgentIntegrationTest
     protected CancellationToken CancellationToken { get; private set; }
 
     protected TentacleServiceDecoratorBuilder? TentacleServiceDecoratorBuilder { get; set; }
+    protected KubeCtlTool KubeCtl { get; private set; }
 
     [OneTimeSetUp]
     public async Task OneTimeSetUp()
@@ -36,6 +38,13 @@ public abstract class KubernetesAgentIntegrationTest
             KubernetesTestsGlobalContext.Instance.HelmExePath,
             KubernetesTestsGlobalContext.Instance.KubeCtlExePath,
             KubernetesTestsGlobalContext.Instance.KubeConfigPath,
+            KubernetesTestsGlobalContext.Instance.Logger);
+
+        KubeCtl = new KubeCtlTool(
+            KubernetesTestsGlobalContext.Instance.TemporaryDirectory,
+            KubernetesTestsGlobalContext.Instance.KubeCtlExePath,
+            KubernetesTestsGlobalContext.Instance.KubeConfigPath,
+            kubernetesAgentInstaller.Namespace,
             KubernetesTestsGlobalContext.Instance.Logger);
 
         //create a new server halibut runtime
@@ -48,6 +57,7 @@ public abstract class KubernetesAgentIntegrationTest
 
         BuildTentacleClient(thumbprint);
     }
+
 
     [SetUp]
     public void SetUp()

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesClusterOneTimeSetUp.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesClusterOneTimeSetUp.cs
@@ -18,12 +18,12 @@ public class KubernetesClusterOneTimeSetUp
         await installer.Install();
 
         //if we are not running in TeamCity, then we need to find the latest local tag and use that if it exists 
-        if (!TeamCityDetection.IsRunningInTeamCity())
+        if (!TeamCityDetection.IsRunningInTeamCity() && bool.TryParse(Environment.GetEnvironmentVariable("KubernetesAgentTests_UseLocalImage"), out var useLocal) && useLocal)
         {
             var imageLoader = new DockerImageLoader(KubernetesTestsGlobalContext.Instance.TemporaryDirectory, KubernetesTestsGlobalContext.Instance.Logger, kindExePath);
             KubernetesTestsGlobalContext.Instance.TentacleImageAndTag = imageLoader.LoadMostRecentImageIntoKind(installer.ClusterName);
         }
-        else
+        else if(TeamCityDetection.IsRunningInTeamCity())
         {
             var tag = Environment.GetEnvironmentVariable("KubernetesAgentTests_ImageTag");
             KubernetesTestsGlobalContext.Instance.TentacleImageAndTag = $"docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:{tag}";

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1IntegrationTest.cs
@@ -59,4 +59,66 @@ done
             return Task.CompletedTask;
         }
     }
+
+    [Test]
+    public async Task TentaclePodIsTerminatedDuringScriptExecution_ShouldRestartAndPickUpPodStatus()
+    {
+        // Arrange
+        var logs = new List<ProcessOutput>();
+        var scriptCompleted = false;
+        var count = 50;
+        var scriptBody = $@"echo ""Hello World""
+for i in $(seq 1 {50});
+do
+    echo Count: $i
+    sleep 0.1
+done
+";
+        var command = new ExecuteKubernetesScriptCommandBuilder(LoggingUtils.CurrentTestHash())
+            .WithScriptBody(scriptBody)
+            .Build();
+
+        var commandResult = await KubeCtl.ExecuteNamespacedCommand("get pods -l app.kubernetes.io/name=octopus-agent -o \"Name\"");
+        var initialPodName = commandResult.StdOut.Single();
+
+        //act
+        var scriptTask = TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken.None);
+        var killTask = KubeCtl.ExecuteNamespacedCommand("delete pods -l app.kubernetes.io/name=octopus-agent");
+
+        await Task.WhenAll(scriptTask, killTask);
+
+        var result = scriptTask.Result;
+
+        commandResult = await KubeCtl.ExecuteNamespacedCommand("get pods -l app.kubernetes.io/name=octopus-agent -o \"Name\"");
+        var finalPodName = commandResult.StdOut.Single();
+
+        //Assert
+        logs.Should().Contain(po => po.Source == ProcessOutputSource.StdOut && po.Text == "Hello World");
+
+        //verify that we are getting all the logs and that the tentacle has been killed
+        for (var i = 1; i <= count; i++)
+        {
+            var i1 = i;
+            logs.Should().Contain(po => po.Source == ProcessOutputSource.StdOut && po.Text == $"Count: {i1}");
+        }
+
+        scriptCompleted.Should().BeTrue();
+        result.ExitCode.Should().Be(0);
+        result.State.Should().Be(ProcessState.Complete);
+
+        finalPodName.Should().NotBe(initialPodName, because: "the tentacle pod should have been killed and restarted");
+
+        return;
+
+        void StatusReceived(ScriptExecutionStatus status)
+        {
+            logs.AddRange(status.Logs);
+        }
+
+        Task ScriptCompleted(CancellationToken ct)
+        {
+            scriptCompleted = true;
+            return Task.CompletedTask;
+        }
+    }
 }

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesTestsGlobalContext.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesTestsGlobalContext.cs
@@ -6,15 +6,15 @@ namespace Octopus.Tentacle.Kubernetes.Tests.Integration;
 public class KubernetesTestsGlobalContext : IDisposable
 {
     public static KubernetesTestsGlobalContext Instance { get; } = new();
-    
+
     public TemporaryDirectory TemporaryDirectory { get; }
-    
+
     public ILogger Logger { get; }
 
     public string KubeConfigPath { get; set; } = "<unset>";
 
     public string HelmExePath { get; private set; } = null!;
-    public string KubeCtlExePath { get; private set; }= null!;
+    public string KubeCtlExePath { get; private set; } = null!;
     public string? TentacleImageAndTag { get; set; }
 
     KubernetesTestsGlobalContext()

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
@@ -35,7 +35,7 @@ public class KubernetesAgentInstaller
 
     public string AgentName { get; }
 
-    string Namespace => $"octopus-agent-{AgentName}";
+    public string Namespace => $"octopus-agent-{AgentName}";
 
     public Uri SubscriptionId { get; } = PollingSubscriptionId.Generate();
 

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/KubeCtlTool.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/KubeCtlTool.cs
@@ -1,0 +1,63 @@
+﻿using System.Text;
+using Octopus.Tentacle.CommonTestUtils;
+using Octopus.Tentacle.CommonTestUtils.Logging;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Kubernetes.Tests.Integration.Setup.Tooling;
+
+public class KubeCtlTool
+{
+    readonly TemporaryDirectory temporaryDirectory;
+    readonly string kubeCtlExePath;
+    readonly string kubeConfigPath;
+    readonly string ns;
+    readonly ILogger logger;
+
+    public KubeCtlTool(TemporaryDirectory temporaryDirectory, string kubeCtlExePath, string kubeConfigPath, string ns, ILogger logger)
+    {
+        this.temporaryDirectory = temporaryDirectory;
+        this.kubeCtlExePath = kubeCtlExePath;
+        this.kubeConfigPath = kubeConfigPath;
+        this.ns = ns;
+        this.logger = logger;
+    }
+
+    public Task<KubeCtlCommandResult> ExecuteNamespacedCommand(string command, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() => ExecuteCommand($"{command} --namespace {ns}", cancellationToken), cancellationToken);
+    }
+
+    KubeCtlCommandResult ExecuteCommand(string command, CancellationToken cancellationToken = default)
+    {
+        var sb = new StringBuilder();
+        var sprLogger = new LoggerConfiguration()
+            .WriteTo.Logger(logger)
+            .WriteTo.StringBuilder(sb)
+            .MinimumLevel.Debug()
+            .CreateLogger();
+
+        var stdOut = new List<string>();
+        var stdErr = new List<string>();
+
+        var exitCode = SilentProcessRunner.ExecuteCommand(
+            kubeCtlExePath,
+            $"{command} --kubeconfig=\"{kubeConfigPath}\"",
+            temporaryDirectory.DirectoryPath,
+            sprLogger.Debug,
+            x =>
+            {
+                sprLogger.Information(x);
+                stdOut.Add(x);
+            },
+            y =>
+            {
+                sprLogger.Error(y);
+                stdErr.Add(y);
+            },
+            cancellationToken);
+
+        return new (exitCode, stdOut, stdErr);
+    }
+
+    public record KubeCtlCommandResult(int ExitCode, IEnumerable<string> StdOut, IEnumerable<string> StdError);
+}

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -46,10 +46,7 @@
 		<DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS;REQUIRES_EXPLICIT_LOG_CONFIG;REQUIRES_CODE_PAGE_PROVIDER;USER_INTERACTIVE_DOES_NOT_WORK;DEFAULT_PROXY_IS_NOT_AVAILABLE;HAS_NULLABLE_REF_TYPES</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
-		<PackageReference Include="KubernetesClient.Classic" Version="13.0.26" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net6.0-windows'">
-		<PackageReference Include="KubernetesClient" Version="13.0.26" />
+		<PackageReference Include="KubernetesClient.Classic" Version="14.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Octopus.Client" Version="14.3.1389" />
@@ -126,5 +123,11 @@
 	  <EmbeddedResource Include="Startup\PathsToDeleteOnStartup.core.txt" />
 	  <EmbeddedResource Include="Startup\PathsToDeleteOnStartup.netfx.txt" />
 	  <None Remove="Kubernetes\bootstrapRunner.sh" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+	  <PackageReference Include="KubernetesClient" Version="14.0.2" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
+	  <PackageReference Include="KubernetesClient" Version="14.0.2" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
# Background

The Kubernetes C# SDK that supports Kubernetes 1.30 has been [released](https://github.com/kubernetes-client/csharp/releases/tag/v14.0.2)

This PR updates the package references and also adds a new integration test which tests what happens when the tentacle pod is killed midway through a script.

# Results

Adds a new `KubeCtlTool` class that is used for interacting with KubeCtl. I think eventually this will have named methods like `DeletePod` etc

We will also need to update the documentation to indicate that v1.30 is a supported Kubernetes version

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.