### PR TITLE
Helping Fix one cause of the flaky WhenRunningTentacleAsAServiceItShouldBeAbleToRestartItself Test

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -365,7 +365,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                 }
 
                 // Listening Tentacle
-                if (lastLogFileContents.Contains("Listener started"))
+                if (lastLogFileContents.Contains("Listener started") && lastLogFileContents.Contains("Agent listening on"))
                 {
                     var listeningPort = Convert.ToInt32(ListeningPortRegex.Match(lastLogFileContents).Groups[1].Value);
                     return (true, listeningPort, lastLogFileContents);


### PR DESCRIPTION
[sc-78418]

# Background

The test `WhenRunningTentacleAsAServiceItShouldBeAbleToRestartItself ` has been flaky for a while, and needs to be made stable.

It is currently permanently muted for Linux builds, but it still fails on Windows sometimes. This PR addresses one of the causes for the Windows failure.

# Results

## Before

For most of the failures found ([for example](https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacle_VLatest_IntegrationTestNet60onWindows10ltscNet48service/12062342?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandPull+Request+Details=true&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true)), the logs would show `The Tentacle failed to start correctly`:
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/58980dcd-f895-4866-a357-00b32417dce5)

It would then show the log of the Tentacle to help track down why. This would always end with the `Listener started` line:
![image](https://github.com/OctopusDeploy/OctopusTentacle/assets/91929764/87282736-ed45-4803-b300-0d708c60e37b)

The method that is waiting for the Tentacle to start (`TentacleBuilder.WaitForTentacleToStart`) will wait until it sees the `Listener started` line (which is clearly there). But as soon as it reads that, it will _only_ succeed if the log _also_ contains "Agent will not listen" or "Agent listening on".

What if the log had not finished writing yet? 🤔 If only part of the log has been written (i.e. only `Listener started`), then the code as it was would look for `Agent listening on`, and fail because it isn't there.

## After
We now instead wait for both `Listener started` and `Agent listening on` to be written before we harvest the port and return success.

This should be fine, as the only thing that happens between these two operations is starting a thread.

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.