### PR TITLE
Adds a HalibutTimeoutsAndLimitsForTestBuilder

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ClientAndTentacleBuilder.cs
@@ -183,7 +183,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             // Server
             var serverHalibutRuntimeBuilder = new HalibutRuntimeBuilder()
                 .WithServerCertificate(TestCertificates.Server)
-                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits ?? HalibutTimeoutsAndLimits.RecommendedValues())
+                .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits ?? new HalibutTimeoutsAndLimitsForTestBuilder().Build())
                 .WithLegacyContractSupport();
             
             if (queueFactory != null)

--- a/source/Octopus.Tentacle.Tests.Integration/Support/HalibutTimeoutsAndLimitsForTestBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/HalibutTimeoutsAndLimitsForTestBuilder.cs
@@ -1,0 +1,15 @@
+using Halibut.Diagnostics;
+
+namespace Octopus.Tentacle.Tests.Integration.Support
+{
+    public class HalibutTimeoutsAndLimitsForTestBuilder
+    {
+
+        public HalibutTimeoutsAndLimits Build()
+        {
+            var halibutTimeoutAndLimits = HalibutTimeoutsAndLimits.RecommendedValues();
+            halibutTimeoutAndLimits.TcpKeepAliveEnabled = true;
+            return halibutTimeoutAndLimits;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Support/HalibutTimeoutsAndLimitsForTestBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/HalibutTimeoutsAndLimitsForTestBuilder.cs
@@ -8,7 +8,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public HalibutTimeoutsAndLimits Build()
         {
             var halibutTimeoutAndLimits = HalibutTimeoutsAndLimits.RecommendedValues();
-            halibutTimeoutAndLimits.TcpKeepAliveEnabled = true;
             return halibutTimeoutAndLimits;
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/Legacy/LegacyClientAndTentacleBuilder.cs
@@ -51,7 +51,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.Legacy
             var serverHalibutRuntimeBuilder = new HalibutRuntimeBuilder()
                 .WithServerCertificate(TestCertificates.Server)
                 .WithLegacyContractSupport()
-                .WithHalibutTimeoutsAndLimits(HalibutTimeoutsAndLimits.RecommendedValues())
+                .WithHalibutTimeoutsAndLimits(new HalibutTimeoutsAndLimitsForTestBuilder().Build())
                 .WithLogFactory(BuildClientLogger());
             
             var serverHalibutRuntime = serverHalibutRuntimeBuilder.Build();

--- a/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationObservingPendingRequestQueueFactory.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/PendingRequestQueueHelpers/CancellationObservingPendingRequestQueueFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
+using Octopus.Tentacle.Tests.Integration.Support;
 
 namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
 {
@@ -8,7 +9,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.PendingRequestQueueHelpers
     {
         public IPendingRequestQueue CreateQueue(Uri endpoint)
         {
-            return new CancellationTokenObservingPendingRequestQueueDecorator(new PendingRequestQueueAsync(new HalibutTimeoutsAndLimits(), new LogFactory().ForEndpoint(endpoint)));
+            return new CancellationTokenObservingPendingRequestQueueDecorator(new PendingRequestQueueAsync(new HalibutTimeoutsAndLimitsForTestBuilder().Build(), new LogFactory().ForEndpoint(endpoint)));
         }
     }
 }


### PR DESCRIPTION
so test client halibut settings can be configured from a single place.


Also updates the client halibut to use tcp keepalive, since that is default in places that use the tentacle client.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.