### PR TITLE
Add option to use tcp_nodelay in tentacle, also use the option in integration tests.

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,8 +28,6 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="7.0.655" />
-    <PackageReference Include="Halibut" Version="7.0.662-pull-610" />
     <PackageReference Include="Halibut" Version="7.0.682" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -29,6 +29,7 @@
   </Choose>
   <ItemGroup>
     <PackageReference Include="Halibut" Version="7.0.655" />
+    <PackageReference Include="Halibut" Version="7.0.662-pull-610" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Halibut" Version="7.0.655" />
     <PackageReference Include="Halibut" Version="7.0.662-pull-610" />
+    <PackageReference Include="Halibut" Version="7.0.682" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Assent" Version="1.8.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="Octopus.TestPortForwarder" Version="6.0.1415" />
+        <PackageReference Include="Octopus.TestPortForwarder" Version="7.0.682" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="Serilog.Sinks.NUnit" Version="1.0.3" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/Octopus.Tentacle.Tests.Integration/Support/HalibutTimeoutsAndLimitsForTestBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/HalibutTimeoutsAndLimitsForTestBuilder.cs
@@ -8,6 +8,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         public HalibutTimeoutsAndLimits Build()
         {
             var halibutTimeoutAndLimits = HalibutTimeoutsAndLimits.RecommendedValues();
+            // Lets dogfood this in our tests.
+            halibutTimeoutAndLimits.TcpNoDelay = true;
             return halibutTimeoutAndLimits;
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -43,7 +43,15 @@ namespace Octopus.Tentacle.Tests.Integration.Support
         bool useDefaultMachineConfigurationHomeDirectory = false;
 
         static readonly Regex ListeningPortRegex = new (@"listen:\/\/.+:(\d+)\/");
-        readonly Dictionary<string, string> runTentacleEnvironmentVariables = new();
+        readonly Dictionary<string, string> runTentacleEnvironmentVariables = BuildDefaultTentacleEnvironmentVariables();
+
+        public static Dictionary<string, string> BuildDefaultTentacleEnvironmentVariables()
+        {
+            var env = new Dictionary<string, string>();
+            // Dog food our new setting.
+            env[EnvironmentVariables.TentacleUseTcpNoDelay] = "true";
+            return env;
+        }
 
         TemporaryDirectory? homeDirectory;
 

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -35,12 +35,19 @@ namespace Octopus.Tentacle.Communications
                 {
                     useRecommendedTimeoutsAndLimits = true;
                 }
+                
+                if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseTcpNoDelay), out var useTcpNoDelay))
+                {
+                    // Default to disabled
+                    useTcpNoDelay = false;
+                }
 
                 var halibutTimeoutsAndLimits = useRecommendedTimeoutsAndLimits 
                     ? HalibutTimeoutsAndLimits.RecommendedValues() 
                     : new HalibutTimeoutsAndLimits();
 
                 halibutTimeoutsAndLimits.TcpKeepAliveEnabled = tcpKeepAliveEnabled;
+                halibutTimeoutsAndLimits.TcpNoDelay = useTcpNoDelay;
 
                 var halibutRuntime = new HalibutRuntimeBuilder()
                     .WithServiceFactory(services)

--- a/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
+++ b/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
@@ -25,5 +25,6 @@ namespace Octopus.Tentacle.Variables
         public const string TentacleMachineConfigurationHomeDirectory = "TentacleMachineConfigurationHomeDirectory";
         public const string TentaclePollingConnectionCount = "TentaclePollingConnectionCount";
         public const string NfsWatchdogDirectory = "watchdog_directory";
+        public static string TentacleUseTcpNoDelay = "TentacleUseTcpNoDelay";
     }
 }


### PR DESCRIPTION
# Background

Background: https://brooker.co.za/blog/2024/05/09/nagle.html

TLDR; TCP_NODELAY=true results in much faster for RPC performance in linux. TCP_NODELAY disables a TCP setting that makes sense when humans type characters into telnet (buffer the chars before sending because humans are slow) but less sense in halibut since when we send a thing we actually would like it to go over the wire now.

This PR adds an option to use: https://github.com/OctopusDeploy/Halibut/pull/610

Additionally TCP_NODELAY is used by default in tests.

[SC-76274]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.