### PR TITLE
Luke/add option to use async socket listener

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/HalibutTimeoutsAndLimitsForTestBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/HalibutTimeoutsAndLimitsForTestBuilder.cs
@@ -10,6 +10,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var halibutTimeoutAndLimits = HalibutTimeoutsAndLimits.RecommendedValues();
             // Lets dogfood this in our tests.
             halibutTimeoutAndLimits.TcpNoDelay = true;
+            halibutTimeoutAndLimits.UseAsyncListener = true;
             return halibutTimeoutAndLimits;
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleBuilder.cs
@@ -50,6 +50,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
             var env = new Dictionary<string, string>();
             // Dog food our new setting.
             env[EnvironmentVariables.TentacleUseTcpNoDelay] = "true";
+            env[EnvironmentVariables.TentacleUseAsyncListener] = "true";
             return env;
         }
 

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -41,6 +41,14 @@ namespace Octopus.Tentacle.Communications
                     // Default to disabled
                     useTcpNoDelay = false;
                 }
+                
+                if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseAsyncListener), out var useAsyncListener))
+                {
+                    // Default to disabled
+                    useAsyncListener = false;
+                }
+                
+                
 
                 var halibutTimeoutsAndLimits = useRecommendedTimeoutsAndLimits 
                     ? HalibutTimeoutsAndLimits.RecommendedValues() 
@@ -48,6 +56,7 @@ namespace Octopus.Tentacle.Communications
 
                 halibutTimeoutsAndLimits.TcpKeepAliveEnabled = tcpKeepAliveEnabled;
                 halibutTimeoutsAndLimits.TcpNoDelay = useTcpNoDelay;
+                halibutTimeoutsAndLimits.UseAsyncListener = useAsyncListener;
 
                 var halibutRuntime = new HalibutRuntimeBuilder()
                     .WithServiceFactory(services)

--- a/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
+++ b/source/Octopus.Tentacle/Variables/EnvironmentVariables.cs
@@ -26,5 +26,6 @@ namespace Octopus.Tentacle.Variables
         public const string TentaclePollingConnectionCount = "TentaclePollingConnectionCount";
         public const string NfsWatchdogDirectory = "watchdog_directory";
         public static string TentacleUseTcpNoDelay = "TentacleUseTcpNoDelay";
+        public static string TentacleUseAsyncListener = "TentacleUseAsyncListener";
     }
 }


### PR DESCRIPTION
# Background

Adds an option to opt in to use [Improve linux performance when listening on many ports #600](https://github.com/OctopusDeploy/Halibut/pull/600).

This wont show any real world improvements, since its just a little spinlock on every linux tentacle ;D. But moving to this means we can delete the old code in halibut. 

[SC-76274]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.