### PR TITLE
Pass PV storage information to script pods as Environment Variables for Calamari package retention

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -29,8 +29,8 @@ namespace Octopus.Tentacle.Kubernetes
         public static string PersistentVolumeSizeVariableName => $"{EnvVarPrefix}__PERSISTENTVOLUMESIZE";
         public static string PersistentVolumeSize => GetRequiredEnvVar(PersistentVolumeSizeVariableName, "Unable to determine Persistent Volume Size");
 
-        public static string PersistentVolumeSizeBytesVariableName => $"{EnvVarPrefix}__PERSISTENVOLUMETOTALBYTES";
-        public static string PersistentVolumeFreeBytesVariableName => $"{EnvVarPrefix}__PERSISTENVOLUMEFREEBYTES";
+        public static string PersistentVolumeSizeBytesVariableName => $"{EnvVarPrefix}__PERSISTENTVOLUMETOTALBYTES";
+        public static string PersistentVolumeFreeBytesVariableName => $"{EnvVarPrefix}__PERSISTENTVOLUMEFREEBYTES";
 
         static string GetRequiredEnvVar(string variable, string errorMessage)
             => Environment.GetEnvironmentVariable(variable)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -29,6 +29,9 @@ namespace Octopus.Tentacle.Kubernetes
         public static string PersistentVolumeSizeVariableName => $"{EnvVarPrefix}__PERSISTENTVOLUMESIZE";
         public static string PersistentVolumeSize => GetRequiredEnvVar(PersistentVolumeSizeVariableName, "Unable to determine Persistent Volume Size");
 
+        public static string PersistentVolumeSizeBytesVariableName => $"{EnvVarPrefix}__PERSISTENVOLUMETOTALBYTES";
+        public static string PersistentVolumeFreeBytesVariableName => $"{EnvVarPrefix}__PERSISTENVOLUMEFREEBYTES";
+
         static string GetRequiredEnvVar(string variable, string errorMessage)
             => Environment.GetEnvironmentVariable(variable)
                 ?? throw new InvalidOperationException($"{errorMessage} The environment variable '{variable}' must be defined with a non-null value.");

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
@@ -10,8 +10,6 @@ namespace Octopus.Tentacle.Kubernetes
         readonly IKubernetesDirectoryInformationProvider directoryInformationProvider;
         ISystemLog Log { get; }
 
-        (ulong freeSpaceBytes, ulong totalSpaceBytes)? storageInformationCache;
-        
         // Set like this for now because we don't have a way to get the home directory from the provider without requiring ourselves
         // DI can be painful when circular dependencies happen with constructed classes :sad-panda:
         // When we can get an Injectable KubernetesConfiguration, we can remove this, alternatively, we can pull apart the configuration stores into different implementations
@@ -50,13 +48,10 @@ namespace Octopus.Tentacle.Kubernetes
             var bytesTotal = directoryInformationProvider.GetPathTotalBytes();
             if (bytesUsed.HasValue && bytesTotal.HasValue)
             {
-                storageInformationCache = (bytesTotal.Value - bytesUsed.Value, bytesTotal.Value);
+                return (bytesTotal.Value - bytesUsed.Value, bytesTotal.Value);
             }
-            else
-            {
-                storageInformationCache = null;
-            }
-            return storageInformationCache;
+
+            return null;
         }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
@@ -26,7 +26,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         public override void EnsureDiskHasEnoughFreeSpace(string directoryPath, long requiredSpaceInBytes)
         {
-            var spaceInformation = GetStorageInformation(useCache: false);
+            var spaceInformation = GetStorageInformation();
             Log.Verbose($"Directory to be checked is {HomeDir}, script directory is {directoryPath}, required space is {requiredSpaceInBytes} bytes");
 
             // If we can't get the free bytes, we just skip the check
@@ -44,18 +44,8 @@ namespace Octopus.Tentacle.Kubernetes
             }
         }
 
-        public (ulong freeSpaceBytes, ulong totalSpaceBytes)? GetCachedStorageInformation()
+        public (ulong freeSpaceBytes, ulong totalSpaceBytes)? GetStorageInformation()
         {
-            return GetStorageInformation(useCache: true);
-        }
-
-        (ulong freeSpaceBytes, ulong totalSpaceBytes)? GetStorageInformation(bool useCache)
-        {
-            if (useCache && storageInformationCache is not null)
-            {
-                return storageInformationCache;
-            }
-
             var bytesUsed = directoryInformationProvider.GetPathUsedBytes(HomeDir);
             var bytesTotal = directoryInformationProvider.GetPathTotalBytes();
             if (bytesUsed.HasValue && bytesTotal.HasValue)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -237,7 +237,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         async Task<V1Container> CreateScriptContainer(StartKubernetesScriptCommandV1 command, IScriptWorkspace workspace, string podName, string scriptName, string homeDir)
         {
-            var spaceInformation = kubernetesPhysicalFileSystem.GetCachedStorageInformation();
+            var spaceInformation = kubernetesPhysicalFileSystem.GetStorageInformation();
             return new V1Container
             {
                 Name = podName,

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -237,7 +237,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         async Task<V1Container> CreateScriptContainer(StartKubernetesScriptCommandV1 command, IScriptWorkspace workspace, string podName, string scriptName, string homeDir)
         {
-            var spaceInformation = kubernetesPhysicalFileSystem.GetCachedSpaceInformation();
+            var spaceInformation = kubernetesPhysicalFileSystem.GetCachedStorageInformation();
             return new V1Container
             {
                 Name = podName,

--- a/source/Octopus.Tentacle/Util/OctopusFileSystemModule.cs
+++ b/source/Octopus.Tentacle/Util/OctopusFileSystemModule.cs
@@ -11,7 +11,7 @@ namespace Octopus.Tentacle.Util
             base.Load(builder);
             if (PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
             {
-                builder.RegisterType<KubernetesPhysicalFileSystem>().As<IOctopusFileSystem>();
+                builder.RegisterType<KubernetesPhysicalFileSystem>().AsSelf().As<IOctopusFileSystem>();
             }
             else
             {


### PR DESCRIPTION
# Background

The Kubernetes Script Pods use a PV mount to get access to the shared file system managed by the Kubernetes Tentacle. When Calamari is acquiring packages, it checks if it should do package cleanup first.

Currently the Calamari implementation cannot do package retention when in the Kubernetes agent because it is not able to calculate the amount of storage on the PV.

[sc-76306]

# Results

This PR gets the Kubernetes Tentacle to add PV storage information (total bytes and free bytes) to the environment variables passed to Script Pods.

There is a Calamari PR () to utilise these variables to correctly calculate if package retention needs to be executed.

# Screen shot:
<img width="903" alt="Screenshot 2024-05-22 at 11 18 00" src="https://github.com/OctopusDeploy/OctopusTentacle/assets/97430840/bb23e3c6-8d82-4a6d-9861-095b5e43f99d">


