### PR TITLE
Add bootstrap runner exe to the debug tentacle image

### DIFF
--- a/docker/kubernetes-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-tentacle/dev/Dockerfile
@@ -1,3 +1,14 @@
+FROM golang:1.22 as bootstrapRunnerBuilder
+
+ARG TARGETARCH
+ARG TARGETOS
+
+COPY docker/kubernetes-tentacle/bootstrapRunner/* /bootstrapRunner/
+WORKDIR /bootstrapRunner
+
+# Note: the given ldflags remove debug symbols
+RUN go build -ldflags "-s -w" -o "bin/bootstrapRunner"
+
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0
 
 ARG BUILD_NUMBER
@@ -13,6 +24,7 @@ EXPOSE 10933
 EXPOSE 7777
 
 COPY docker/kubernetes-tentacle/scripts/* /scripts/
+COPY --from=bootstrapRunnerBuilder bootstrapRunner/bin/bootstrapRunner /bootstrapRunner
 RUN chmod +x /scripts/*.sh
 
 COPY docker/kubernetes-tentacle/dev/scripts/* /dev-scripts/
@@ -38,6 +50,7 @@ RUN \
 # We know this won't reduce the image size at all. It's just to make the filesystem a little tidier.
 RUN rm -rf /tmp/*
 
+ENV BOOTSTRAPRUNNEREXECUTABLEPATH=/bootstrapRunner
 ENV OCTOPUS_RUNNING_IN_CONTAINER=Y
 ENV ACCEPT_EULA=N
 ENV CustomPublicHostName=""


### PR DESCRIPTION
# Background

The dev Dockerfile is used to build the image of tentacle for remote debugging. This has not been kept up to date as it is missing the bootstrap runner executable.

# Results

The PR brings the debug tentacle image up to date with the prod one (at least in terms of the bootstrap runner part).
