### PR TITLE
Allow users to specify multiple Server Comms Addresses to support HA Server configurations

### DIFF
--- a/docker/kubernetes-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-and-run.sh
@@ -203,6 +203,7 @@ function registerTentacle() {
   if [[ -n "$ServerCommsAddress" || -n "$ServerCommsAddresses" || -n "$ServerPort" ]]; then
     ARGS+=('--comms-style' 'TentacleActive')
 
+    # If ServerCommsAddress (singular) is not set, use the first value in ServerCommsAddresses (plural)
     if [[ -n "$ServerCommsAddress" ]]; then
       ARGS+=('--server-comms-address' "$ServerCommsAddress")
     elif [[ -n "$ServerCommsAddresses" ]]; then
@@ -259,13 +260,22 @@ function addAdditionalServerInstancesIfRequired() {
   IFS=',' read -ra SERVER_ADDRESSES <<<"$ServerCommsAddresses"
   len=${#SERVER_ADDRESSES[@]}
 
+  # If ServerCommsAddress (singular) is not set and ServerCommsAddresses (plural)
+  # has only one element return as nothing to do.
   if [[ -z "$ServerCommsAddress" && len -eq 1 ]]; then
+    return
+  # If ServerCommsAddresses (plural) is empty, return as nothing to do.
+  elif [[ len -eq 0 ]]; then
     return
   fi
 
   echo "Registering additional HA Servers..."
 
+  # If ServerCommsAddress (singular) is not set, skip the first value in
+  # ServerCommsAddresses (plural) as the first value was used for the main
+  # registration.
   if [[ -z "$ServerCommsAddress" ]]; then
+    # The ":1" skips the first element of the array
     for i in "${SERVER_ADDRESSES[@]:1}"; do
       registerAdditionalServer "$i"
     done

--- a/docker/kubernetes-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-and-run.sh
@@ -252,28 +252,28 @@ function registerTentacle() {
 }
 
 function addAdditionalServerInstancesIfRequired() {
-    if [[ -z "$ServerCommsAddresses" ]]; then
-      return;
-    fi
+  if [[ -z "$ServerCommsAddresses" ]]; then
+    return
+  fi
 
-    IFS=',' read -ra SERVER_ADDRESSES <<<"$ServerCommsAddresses"
-    len=${#SERVER_ADDRESSES[@]}
+  IFS=',' read -ra SERVER_ADDRESSES <<<"$ServerCommsAddresses"
+  len=${#SERVER_ADDRESSES[@]}
 
-    if [[ -z "$ServerCommsAddress" && len -eq 1 ]]; then
-      return;
-    fi
+  if [[ -z "$ServerCommsAddress" && len -eq 1 ]]; then
+    return
+  fi
 
-    echo "Registering additional HA Servers..."
+  echo "Registering additional HA Servers..."
 
-    if [[ -z "$ServerCommsAddress" ]]; then
-      for i in "${SERVER_ADDRESSES[@]:1}"; do
-        registerAdditionalServer "$i"
-      done
-    else
-      for i in "${SERVER_ADDRESSES[@]}"; do
-        registerAdditionalServer "$i"
-      done
-    fi
+  if [[ -z "$ServerCommsAddress" ]]; then
+    for i in "${SERVER_ADDRESSES[@]:1}"; do
+      registerAdditionalServer "$i"
+    done
+  else
+    for i in "${SERVER_ADDRESSES[@]}"; do
+      registerAdditionalServer "$i"
+    done
+  fi
 }
 
 function registerAdditionalServer() {
@@ -285,19 +285,19 @@ function registerAdditionalServer() {
   ARGS+=('poll-server')
 
   ARGS+=('--instance' "$instanceName"
-         '--server' "$ServerUrl")
+    '--server' "$ServerUrl")
 
   if [[ -n "$ServerApiKey" ]]; then
-      echo "Registering Tentacle with API key"
-      ARGS+=('--apiKey' $ServerApiKey)
+    echo "Registering Tentacle with API key"
+    ARGS+=('--apiKey' $ServerApiKey)
   elif [[ -n "$BearerToken" ]]; then
-      echo "Registering Tentacle with Bearer Token"
-      ARGS+=('--bearerToken' "$BearerToken")
+    echo "Registering Tentacle with Bearer Token"
+    ARGS+=('--bearerToken' "$BearerToken")
   else
-      echo "Registering Tentacle with username/password"
-      ARGS+=(
-          '--username' "$ServerUsername"
-          '--password' "$ServerPassword")
+    echo "Registering Tentacle with username/password"
+    ARGS+=(
+      '--username' "$ServerUsername"
+      '--password' "$ServerPassword")
   fi
 
   ARGS+=('--server-comms-address' "$serverCommsAddress")
@@ -320,7 +320,7 @@ else
 
   configureTentacle
   registerTentacle
-    addAdditionalServerInstancesIfRequired
+  addAdditionalServerInstancesIfRequired
 
   echo "Configuration successful"
 fi

--- a/docker/kubernetes-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-and-run.sh
@@ -67,11 +67,14 @@ function validateVariables() {
   echo " - server endpoint '$ServerUrl'"
   echo " - api key '##########'"
 
-  if [[ -n "$ServerCommsAddress" || -n "$ServerPort" ]]; then
+  if [[ -n "$ServerCommsAddress" || -n "$ServerCommsAddresses" || -n "$ServerPort" ]]; then
     echo " - communication mode 'Kubernetes' (Polling)"
 
     if [[ -n "$ServerCommsAddress" ]]; then
       echo " - server comms address $ServerCommsAddress"
+    fi
+    if [[ -n "$ServerCommsAddresses" ]]; then
+      echo " - HA server comms addresses $ServerCommsAddresses"
     fi
     if [[ -n "$ServerPort" ]]; then
       echo " - server port $ServerPort"
@@ -118,7 +121,7 @@ function configureTentacle() {
   tentacle configure --instance "$instanceName" --app "$applicationsDirectory"
 
   echo "Configuring communication type ..."
-  if [[ -n "$ServerCommsAddress" || -n "$ServerPort" ]]; then
+  if [[ -n "$ServerCommsAddress" || -n "$ServerCommsAddresses" || -n "$ServerPort" ]]; then
     tentacle configure --instance "$instanceName" --noListen "True"
   else
     tentacle configure --instance "$instanceName" --port $internalListeningPort --noListen "False"
@@ -197,11 +200,14 @@ function registerTentacle() {
     '--space' "$Space"
     '--policy' "$MachinePolicy")
 
-  if [[ -n "$ServerCommsAddress" || -n "$ServerPort" ]]; then
+  if [[ -n "$ServerCommsAddress" || -n "$ServerCommsAddresses" || -n "$ServerPort" ]]; then
     ARGS+=('--comms-style' 'TentacleActive')
 
     if [[ -n "$ServerCommsAddress" ]]; then
-      ARGS+=('--server-comms-address' $ServerCommsAddress)
+      ARGS+=('--server-comms-address' "$ServerCommsAddress")
+    elif [[ -n "$ServerCommsAddresses" ]]; then
+      IFS=',' read -ra SERVER_ADDRESSES <<<"$ServerCommsAddresses"
+      ARGS+=('--server-comms-address' "${SERVER_ADDRESSES[0]}")
     fi
 
     if [[ -n "$ServerPort" ]]; then
@@ -245,6 +251,60 @@ function registerTentacle() {
   tentacle "${ARGS[@]}"
 }
 
+function addAdditionalServerInstancesIfRequired() {
+    if [[ -z "$ServerCommsAddresses" ]]; then
+      return;
+    fi
+
+    IFS=',' read -ra SERVER_ADDRESSES <<<"$ServerCommsAddresses"
+    len=${#SERVER_ADDRESSES[@]}
+
+    if [[ -z "$ServerCommsAddress" && len -eq 1 ]]; then
+      return;
+    fi
+
+    echo "Registering additional HA Servers..."
+
+    if [[ -z "$ServerCommsAddress" ]]; then
+      for i in "${SERVER_ADDRESSES[@]:1}"; do
+        registerAdditionalServer "$i"
+      done
+    else
+      for i in "${SERVER_ADDRESSES[@]}"; do
+        registerAdditionalServer "$i"
+      done
+    fi
+}
+
+function registerAdditionalServer() {
+  serverCommsAddress=$1
+
+  echo "Registering server '${serverCommsAddress}'"
+
+  local ARGS=()
+  ARGS+=('poll-server')
+
+  ARGS+=('--instance' "$instanceName"
+         '--server' "$ServerUrl")
+
+  if [[ -n "$ServerApiKey" ]]; then
+      echo "Registering Tentacle with API key"
+      ARGS+=('--apiKey' $ServerApiKey)
+  elif [[ -n "$BearerToken" ]]; then
+      echo "Registering Tentacle with Bearer Token"
+      ARGS+=('--bearerToken' "$BearerToken")
+  else
+      echo "Registering Tentacle with username/password"
+      ARGS+=(
+          '--username' "$ServerUsername"
+          '--password' "$ServerPassword")
+  fi
+
+  ARGS+=('--server-comms-address' "$serverCommsAddress")
+
+  tentacle "${ARGS[@]}"
+}
+
 setupVariablesForRegistrationCheck
 getStatusOfRegistration
 
@@ -260,6 +320,7 @@ else
 
   configureTentacle
   registerTentacle
+    addAdditionalServerInstancesIfRequired
 
   echo "Configuration successful"
 fi


### PR DESCRIPTION
# Background

We need to allow users to specify multiple server comms addresses to support Octopus Server running in an HA configuration.

[sc-75000]

# Results

Fortunately, there is already a command in Tentacle that we can leverage to register extra server instances (`poll-server`) so I just added an extra variable which can have multiple values, one for each additional server to register.

To make things backwards compatible, I've kept the original variable and now support both in the following way:
If `ServerCommsAddress` (singular) is set, it will use that for the initial registration. In this case, if `ServerCommsAddresses` (plural) is also set, all those values will be registered via `poll-server`.

If `ServerCommsAddress` is **not** set, the first value of `ServerCommsAddresses` will be used instead, and the remaining values (if any) in `ServerCommsAddresses` will be registered via `poll-server`.

Related Helm Chart PR: https://github.com/OctopusDeploy/helm-charts/pull/160