### PR TITLE
Lobs communication spike

### DIFF
--- a/docker/kubernetes-tentacle/Dockerfile
+++ b/docker/kubernetes-tentacle/Dockerfile
@@ -18,6 +18,8 @@ ARG TARGETOS
 ARG TARGETVARIANT
 
 EXPOSE 10933
+EXPOSE 5001
+EXPOSE 5002
 
 COPY docker/kubernetes-tentacle/scripts/* /scripts/
 COPY --from=bootstrapRunnerBuilder bootstrapRunner/bin/bootstrapRunner /bootstrapRunner

--- a/installer/Octopus.Tentacle.Installer/Product.wxs
+++ b/installer/Octopus.Tentacle.Installer/Product.wxs
@@ -14,7 +14,7 @@
     - Product/Version      : Change this every major build
     - Product/UpgradeCode  : Never change this
   -->
-  <Product Id="*" Name="Octopus Deploy Tentacle" Language="1033" Version="8.1.1518" Manufacturer="Octopus Deploy Pty. Ltd." UpgradeCode="1B32E04F-49C2-4907-8879-A556986F7F16">
+  <Product Id="*" Name="Octopus Deploy Tentacle" Language="1033" Version="8.1.1693" Manufacturer="Octopus Deploy Pty. Ltd." UpgradeCode="1B32E04F-49C2-4907-8879-A556986F7F16">
     <Package InstallerVersion="200" Compressed="yes" Description="Octopus Deploy Tentacle" Platform="$(var.Platform)" InstallScope="perMachine" />
     <Media Id="1" Cabinet="Files.cab" EmbedCab="yes" />
     <Property Id="MSIFASTINSTALL" Value="3" />

--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -123,7 +123,7 @@
     <Resource Include="Resources\Images\warning.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.2" />
+    <PackageReference Include="Autofac" Version="6.2.0" />
     <PackageReference Include="FluentValidation" Version="7.2.1" />
     <PackageReference Include="MaterialDesignColors" Version="2.1.4" />
     <PackageReference Include="MaterialDesignThemes" Version="4.9.0" />

--- a/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RunAgentCommandFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Autofac;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Diagnostics;
@@ -60,7 +61,8 @@ namespace Octopus.Tentacle.Tests.Commands
                 Substitute.For<IWindowsLocalAdminRightsChecker>(),
                 new AppVersion(GetType().Assembly),
                 Substitute.For<ILogFileOnlyLogger>(),
-                backgroundTasks.Select(bt => new Lazy<IBackgroundTask>(() => bt)).ToList());
+                backgroundTasks.Select(bt => new Lazy<IBackgroundTask>(() => bt)).ToList(),
+                new ContainerBuilder().Build());
 
             selector.Current.Returns(new ApplicationInstanceConfiguration("MyTentacle", null, null, null));
         }

--- a/source/Octopus.Tentacle/Communications/IEchoService.cs
+++ b/source/Octopus.Tentacle/Communications/IEchoService.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Octopus.Tentacle.Communications
+{
+    public interface IMyEchoService
+    {
+        string SayHello(string name);
+    }
+
+    public interface IAsyncClientMyEchoService
+    {
+        Task<string> SayHelloAsync(string name);
+    }
+
+    public interface IAsyncMyEchoService
+    {
+        Task<string> SayHelloAsync(string name, CancellationToken cancellationToken);
+    }
+}

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -17,7 +17,7 @@ namespace Octopus.Tentacle.Communications
             base.Load(builder);
 
             builder.RegisterType<ProxyConfigParser>().As<IProxyConfigParser>();
-            builder.RegisterType<HalibutInitializer>().As<IHalibutInitializer>();
+            builder.RegisterType<HalibutInitializer>().As<IHalibutInitializer>().SingleInstance();
             builder.RegisterType<AutofacServiceFactory>().AsImplementedInterfaces().SingleInstance();
 
             builder.Register(c =>

--- a/source/Octopus.Tentacle/Communications/gRPC/GreeterService.cs
+++ b/source/Octopus.Tentacle/Communications/gRPC/GreeterService.cs
@@ -1,0 +1,37 @@
+#if !NETFRAMEWORK
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Halibut;
+
+namespace Octopus.Tentacle.Communications.gRPC
+{
+    public class GreeterService: Greeter.GreeterBase
+    {
+        readonly HalibutRuntime halibut;
+
+        public GreeterService(HalibutRuntime halibut)
+        {
+            this.halibut = halibut;
+        }
+        
+        
+        public override Task<HelloReply> SayHello(
+            HelloRequest request, ServerCallContext context)
+        {
+            var client = halibut.CreateAsyncClient<IMyEchoService, IAsyncClientMyEchoService>(HalibutInitializer.ServiceEndPoints.First());
+            
+            Task.Run(async () =>
+            {
+                await client.SayHelloAsync("Hello from: " + request.Name);
+            });
+            
+            return Task.FromResult(new HelloReply
+            {
+                Message = "Hello " + request.Name
+            });
+        }
+    }
+}
+#endif

--- a/source/Octopus.Tentacle/Configuration/ConfigurationModule.cs
+++ b/source/Octopus.Tentacle/Configuration/ConfigurationModule.cs
@@ -67,6 +67,7 @@ namespace Octopus.Tentacle.Configuration
                 .As<IApplicationInstanceManager>()
                 .SingleInstance();
 
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
             builder.Register(c =>
                 {
                     var selector = c.Resolve<IApplicationInstanceSelector>();
@@ -82,6 +83,7 @@ namespace Octopus.Tentacle.Configuration
                 })
                 .As<IWritableKeyValueStore>()
                 .SingleInstance();
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
 
             builder.RegisterType<HomeConfiguration>()
                 .As<IHomeConfiguration>()

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -50,12 +50,21 @@
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net6.0-windows'">
 		<PackageReference Include="KubernetesClient" Version="13.0.26" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="Google.Protobuf" Version="3.27.0" />
+		<PackageReference Include="Grpc.AspNetCore" Version="2.62.0"/>
+		<PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.62.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.64.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Octopus.Client" Version="14.3.1389" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Autofac" Version="4.6.2" />
+		<PackageReference Include="Autofac" Version="6.2.0" />
+		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
 		<PackageReference Include="NuGet.Common" Version="3.6.0-octopus-58692" />
 		<PackageReference Include="NuGet.Frameworks" Version="3.6.0-octopus-58692" />
 		<PackageReference Include="NuGet.Packaging" Version="3.6.0-octopus-58692" />
@@ -126,5 +135,14 @@
 	  <EmbeddedResource Include="Startup\PathsToDeleteOnStartup.core.txt" />
 	  <EmbeddedResource Include="Startup\PathsToDeleteOnStartup.netfx.txt" />
 	  <None Remove="Kubernetes\bootstrapRunner.sh" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Reference Include="Microsoft.Extensions.Hosting" />
+	</ItemGroup>
+	<ItemGroup>
+		<Protobuf Include="Protos\greet.proto" GrpcServices="Server"/>
 	</ItemGroup>
 </Project>

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -92,6 +92,8 @@ namespace Octopus.Tentacle
             builder.RegisterCommand<ListInstancesCommand>("list-instances", "Lists all installed Tentacle instances");
             builder.RegisterCommand<VersionCommand>("version", "Show the Tentacle version information");
             builder.RegisterCommand<ShowConfigurationCommand>("show-configuration", "Outputs the Tentacle configuration");
+            
+            builder.RegisterModule(new CommandModule());
 
             return builder.Build();
         }

--- a/source/Octopus.Tentacle/Protos/greet.proto
+++ b/source/Octopus.Tentacle/Protos/greet.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/source/Octopus.Tentacle/Startup/OctopusProgram.cs
+++ b/source/Octopus.Tentacle/Startup/OctopusProgram.cs
@@ -605,11 +605,11 @@ namespace Octopus.Tentacle.Startup
 
         protected virtual void RegisterAdditionalModules(IContainer builtContainer)
         {
-            var builder = new ContainerBuilder();
-            builder.RegisterModule(new CommandModule());
-#pragma warning disable 618
-            builder.Update(builtContainer);
-#pragma warning restore 618
+            // var builder = new ContainerBuilder();
+//             builder.RegisterModule(new CommandModule());
+// #pragma warning disable 618
+//             builder.Update(builtContainer);
+// #pragma warning restore 618
         }
 
         static string ParseCommandName(string[] args)


### PR DESCRIPTION
# Description 
This is a POC to evaluate ways of handling communication between processes for live kubernetes object status

Includes changes from https://github.com/OctopusDeploy/OctopusTentacle/compare/main...robe/reverse-tentacle
Octopus Server side: https://github.com/OctopusDeploy/OctopusDeploy/compare/robe/reverse-tentacle 

# What it does 
- Configures a kestrel server to run when the tentacle process is running to handle gRPC requests
- Creates a basic gRPC service that forwards along a message to Octopus server using existing Halibut polling connections

# Example with simple Go App hitting the gRPC service in Tentacle all running in a cluster
https://github.com/OctopusDeploy/OctopusTentacle/assets/3272176/f618d078-8d25-4f2f-a6fe-5cc9ee8f0fa6