### PR TITLE
Adjust Kubernetes Tentacle startup to always refresh server comms address registration

### DIFF
--- a/docker/kubernetes-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-and-run.sh
@@ -253,18 +253,19 @@ function registerTentacle() {
 }
 
 function addAdditionalServerInstancesIfRequired() {
-  if [[ -n "$ServerCommsAddress" ]]; then
-    tentacle clear-trusted-servers --keep="{$ServerCommsAddress}"
-  else
-    tentacle clear-trusted-servers --keep="{${SERVER_ADDRESSES[0]}}"
-  fi
-
   if [[ -z "$ServerCommsAddresses" ]]; then
+    clearTrustedServersExcept "$ServerCommsAddress"
     return
   fi
 
   IFS=',' read -ra SERVER_ADDRESSES <<<"$ServerCommsAddresses"
   len=${#SERVER_ADDRESSES[@]}
+
+  if [[ -n "$ServerCommsAddress" ]]; then
+    clearTrustedServersExcept "$ServerCommsAddress"
+  else
+    clearTrustedServersExcept "${SERVER_ADDRESSES[0]}"
+  fi
 
   # If ServerCommsAddress (singular) is not set and ServerCommsAddresses (plural)
   # has only one element return as nothing to do.
@@ -290,6 +291,11 @@ function addAdditionalServerInstancesIfRequired() {
       registerAdditionalServer "$i"
     done
   fi
+}
+
+function clearTrustedServersExcept()
+{
+  tentacle clear-trusted-servers --instance "$instanceName" --keep "$1"
 }
 
 function registerAdditionalServer() {

--- a/docker/kubernetes-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-and-run.sh
@@ -253,6 +253,12 @@ function registerTentacle() {
 }
 
 function addAdditionalServerInstancesIfRequired() {
+  if [[ -n "$ServerCommsAddress" ]]; then
+    tentacle clear-trusted-servers --keep="{$ServerCommsAddress}"
+  else
+    tentacle clear-trusted-servers --keep="{${SERVER_ADDRESSES[0]}}"
+  fi
+
   if [[ -z "$ServerCommsAddresses" ]]; then
     return
   fi
@@ -292,7 +298,7 @@ function registerAdditionalServer() {
   echo "Registering server '${serverCommsAddress}'"
 
   local ARGS=()
-  ARGS+=('poll-server')
+  ARGS+=('poll-server' '--reuse-server-thumbprint')
 
   ARGS+=('--instance' "$instanceName"
     '--server' "$ServerUrl")
@@ -320,6 +326,7 @@ getStatusOfRegistration
 
 if [ "$IS_REGISTERED" == "true" ]; then
   echo "Tentacle is already configured and registered with server."
+  addAdditionalServerInstancesIfRequired
 else
   echo "==============================================="
   echo "Configuring Octopus Deploy Kubernetes Tentacle"

--- a/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
@@ -106,6 +106,12 @@ namespace Octopus.Tentacle.Tests.Commands
             servers = new List<OctopusServerConfiguration>();
         }
 
+        public bool SetTrustedOctopusServers(IEnumerable<OctopusServerConfiguration>? newServers)
+        {
+            servers = newServers?.ToList() ?? new List<OctopusServerConfiguration>();
+            return true;
+        }
+
         public void RemoveTrustedOctopusServersWithThumbprint(string toRemove)
         {
             servers = servers.Where(s => s.Thumbprint != toRemove).ToList();

--- a/source/Octopus.Tentacle/Commands/ClearTrustedServersCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ClearTrustedServersCommand.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Startup;
+
+namespace Octopus.Tentacle.Commands
+{
+    public class ClearTrustedServersCommand : AbstractStandardCommand
+    {
+        readonly Lazy<IWritableTentacleConfiguration> configuration;
+        string[] excludedServerCommsAddresses = Array.Empty<string>();
+
+        public ClearTrustedServersCommand(Lazy<IWritableTentacleConfiguration> configuration, IApplicationInstanceSelector instanceSelector, ISystemLog systemLog, ILogFileOnlyLogger logFileOnlyLogger) : base(instanceSelector, systemLog, logFileOnlyLogger)
+        {
+            this.configuration = configuration;
+            Options.Add("keep=", "A comma separated list of Server Comms Addresses to keep as trusted servers",
+                s => excludedServerCommsAddresses = s.Split(','));
+        }
+
+        protected override void Start()
+        {
+            var serversToKeep = configuration.Value.TrustedOctopusServers
+                .Where(s => excludedServerCommsAddresses.Contains(s.Address.ToString())).ToList();
+
+            configuration.Value.ResetTrustedOctopusServers();
+
+            configuration.Value.SetTrustedOctopusServers(serversToKeep);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Commands/ClearTrustedServersCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ClearTrustedServersCommand.cs
@@ -30,7 +30,7 @@ namespace Octopus.Tentacle.Commands
             // to https: here: RegisterMachineCommandBase<TRegistrationOperationType>.GetActiveTentacleAddress
             // Adjusting the address here to match.
             var adjustedExcludedServerCommsAddresses =
-                excludedServerCommsAddresses.Select(a => a.Replace("http://", "https://")).ToHashSet();
+                excludedServerCommsAddresses.Select(a => new Uri(a.Replace("http://", "https://")).ToString()).ToHashSet();
             var serversToKeep = configuration.Value.TrustedOctopusServers
                 .Where(s => adjustedExcludedServerCommsAddresses.Contains(s.Address.ToString())).ToList();
 

--- a/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
@@ -7,7 +7,6 @@ namespace Octopus.Tentacle.Commands.OptionSets
 {
     public class ApiEndpointOptions : ICommandOptions
     {
-        readonly bool bypassValidate;
         const string ServerAddressNotSpecifiedMessage = "Please specify an Octopus Server, e.g., --server=http://your-octopus-server";
 
         public string Server { get; private set; } = null!;
@@ -20,9 +19,8 @@ namespace Octopus.Tentacle.Commands.OptionSets
 
         public bool Optional { private get; set; }
 
-        public ApiEndpointOptions(OptionSet options, bool bypassValidate = false)
+        public ApiEndpointOptions(OptionSet options)
         {
-            this.bypassValidate = bypassValidate;
             options.Add("server=", "The Octopus Server - e.g., 'http://octopus'", s => Server = s);
             options.Add("apiKey=", "Your API key; you can get this from the Octopus web portal", s => ApiKey = s, sensitive: true);
             options.Add("bearerToken=", "A Bearer Token which has access to your Octopus instance", t => BearerToken = t, sensitive: true);
@@ -39,9 +37,6 @@ namespace Octopus.Tentacle.Commands.OptionSets
 
         public void Validate()
         {
-            if (bypassValidate)
-                return;
-
             var isServerSet = !string.IsNullOrEmpty(Server);
             var isBearerTokenSet = !string.IsNullOrEmpty(BearerToken);
             var isApiKeySet = !string.IsNullOrEmpty(ApiKey);

--- a/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
@@ -7,7 +7,7 @@ namespace Octopus.Tentacle.Commands.OptionSets
 {
     public class ApiEndpointOptions : ICommandOptions
     {
-        readonly bool allowBypass;
+        readonly bool bypassValidate;
         const string ServerAddressNotSpecifiedMessage = "Please specify an Octopus Server, e.g., --server=http://your-octopus-server";
 
         public string Server { get; private set; } = null!;
@@ -20,9 +20,9 @@ namespace Octopus.Tentacle.Commands.OptionSets
 
         public bool Optional { private get; set; }
 
-        public ApiEndpointOptions(OptionSet options, bool allowBypass = false)
+        public ApiEndpointOptions(OptionSet options, bool bypassValidate = false)
         {
-            this.allowBypass = allowBypass;
+            this.bypassValidate = bypassValidate;
             options.Add("server=", "The Octopus Server - e.g., 'http://octopus'", s => Server = s);
             options.Add("apiKey=", "Your API key; you can get this from the Octopus web portal", s => ApiKey = s, sensitive: true);
             options.Add("bearerToken=", "A Bearer Token which has access to your Octopus instance", t => BearerToken = t, sensitive: true);
@@ -39,7 +39,7 @@ namespace Octopus.Tentacle.Commands.OptionSets
 
         public void Validate()
         {
-            if (allowBypass)
+            if (bypassValidate)
                 return;
 
             var isServerSet = !string.IsNullOrEmpty(Server);

--- a/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
+++ b/source/Octopus.Tentacle/Commands/OptionSets/ApiEndpointOptions.cs
@@ -7,6 +7,7 @@ namespace Octopus.Tentacle.Commands.OptionSets
 {
     public class ApiEndpointOptions : ICommandOptions
     {
+        readonly bool allowBypass;
         const string ServerAddressNotSpecifiedMessage = "Please specify an Octopus Server, e.g., --server=http://your-octopus-server";
 
         public string Server { get; private set; } = null!;
@@ -19,8 +20,9 @@ namespace Octopus.Tentacle.Commands.OptionSets
 
         public bool Optional { private get; set; }
 
-        public ApiEndpointOptions(OptionSet options)
+        public ApiEndpointOptions(OptionSet options, bool allowBypass = false)
         {
+            this.allowBypass = allowBypass;
             options.Add("server=", "The Octopus Server - e.g., 'http://octopus'", s => Server = s);
             options.Add("apiKey=", "Your API key; you can get this from the Octopus web portal", s => ApiKey = s, sensitive: true);
             options.Add("bearerToken=", "A Bearer Token which has access to your Octopus instance", t => BearerToken = t, sensitive: true);
@@ -37,6 +39,9 @@ namespace Octopus.Tentacle.Commands.OptionSets
 
         public void Validate()
         {
+            if (allowBypass)
+                return;
+
             var isServerSet = !string.IsNullOrEmpty(Server);
             var isBearerTokenSet = !string.IsNullOrEmpty(BearerToken);
             var isApiKeySet = !string.IsNullOrEmpty(ApiKey);

--- a/source/Octopus.Tentacle/Commands/PollCommand.cs
+++ b/source/Octopus.Tentacle/Commands/PollCommand.cs
@@ -28,6 +28,7 @@ namespace Octopus.Tentacle.Commands
         int? serverCommsPort = null;
         string serverWebSocketAddress = null!;
         string serverCommsAddress = null!;
+        bool reuseThumbprint = false;
 
         public PollCommand(Lazy<IWritableTentacleConfiguration> configuration,
                            ISystemLog log,
@@ -45,11 +46,12 @@ namespace Octopus.Tentacle.Commands
             this.log = log;
             this.selector = selector;
 
-            api = AddOptionSet(new ApiEndpointOptions(Options));
+            api = AddOptionSet(new ApiEndpointOptions(Options, allowBypass: true));
 
             Options.Add("server-comms-address=", "The comms address on the Octopus Server; the address of the Octopus Server will be used if omitted.", s => serverCommsAddress = s);
             Options.Add("server-comms-port=", "The comms port on the Octopus Server; the default is " + DefaultServerCommsPort + ". If specified, this will take precedence over any port number in server-comms-address.", s => serverCommsPort = int.Parse(s));
             Options.Add("server-web-socket=", "When using active communication over websockets, the address of the Octopus Server, eg 'wss://example.com/OctopusComms'. Refer to http://g.octopushq.com/WebSocketComms", s => serverWebSocketAddress = s);
+            Options.Add("reuse-server-thumbprint", "Reuse the Server Thumbprint from the first trusted server instance currently configured", _ => reuseThumbprint = true);
         }
 
         protected override void Start()
@@ -65,6 +67,29 @@ namespace Octopus.Tentacle.Commands
 
             var serverAddress = GetAddress();
 
+            var serverConfiguration = reuseThumbprint ?
+                CreateServerConfigurationFromFirstTrustedServer(serverAddress) :
+                await CreateServerConfigurationViaServerAPI(serverAddress);
+
+            configuration.Value.AddOrUpdateTrustedOctopusServer(serverConfiguration);
+            VoteForRestart();
+
+            log.Info("Polling endpoint configured");
+        }
+
+        OctopusServerConfiguration CreateServerConfigurationFromFirstTrustedServer(Uri serverAddress)
+        {
+            var firstTrustedServer = configuration.Value.TrustedOctopusServers.First();
+            return new OctopusServerConfiguration(firstTrustedServer.Thumbprint)
+            {
+                Address = serverAddress,
+                CommunicationStyle = firstTrustedServer.CommunicationStyle,
+                SubscriptionId = firstTrustedServer.SubscriptionId
+            };
+        }
+
+        async Task<OctopusServerConfiguration> CreateServerConfigurationViaServerAPI(Uri serverAddress)
+        {
             //if we are on a polling tentacle with a polling proxy set up, use the api through that proxy
             var proxyOverride = proxyConfig.ParseToWebProxy(configuration.Value.PollingProxyConfiguration);
 
@@ -72,26 +97,20 @@ namespace Octopus.Tentacle.Commands
 
             log.Info($"Configuring Tentacle to poll the server at {api.ServerUri}");
 
-            using (var client = await octopusClientInitializer.CreateClient(api, proxyOverride))
+            using var client = await octopusClientInitializer.CreateClient(api, proxyOverride);
+
+            var repository = new OctopusAsyncRepository(client);
+
+            var serverThumbprint = await GetServerThumbprint(repository, serverAddress, sslThumbprint);
+
+            var alreadyConfiguredServerInCluster = GetAlreadyConfiguredServerInCluster(serverThumbprint);
+
+            return new OctopusServerConfiguration(serverThumbprint)
             {
-                var repository = new OctopusAsyncRepository(client);
-
-                var serverThumbprint = await GetServerThumbprint(repository, serverAddress, sslThumbprint);
-
-                var alreadyConfiguredServerInCluster = GetAlreadyConfiguredServerInCluster(serverThumbprint);
-
-                var octopusServerConfiguration = new OctopusServerConfiguration(serverThumbprint)
-                {
-                    Address = serverAddress,
-                    CommunicationStyle = CommunicationStyle.TentacleActive,
-                    SubscriptionId = alreadyConfiguredServerInCluster.SubscriptionId
-                };
-
-                configuration.Value.AddOrUpdateTrustedOctopusServer(octopusServerConfiguration);
-                VoteForRestart();
-
-                log.Info("Polling endpoint configured");
-            }
+                Address = serverAddress,
+                CommunicationStyle = CommunicationStyle.TentacleActive,
+                SubscriptionId = alreadyConfiguredServerInCluster.SubscriptionId
+            };
         }
 
         OctopusServerConfiguration GetAlreadyConfiguredServerInCluster(string serverThumbprint)
@@ -141,6 +160,8 @@ namespace Octopus.Tentacle.Commands
 
                 if (string.IsNullOrEmpty(serverCommsAddress))
                 {
+                    if (reuseThumbprint) throw new InvalidOperationException("You must specify either a WebSocketAddress or a ServerCommsAddress");
+
                     serverCommsAddressUri = api.ServerUri;
                     serverCommsPort ??= DefaultServerCommsPort;
                 }

--- a/source/Octopus.Tentacle/Commands/PollCommand.cs
+++ b/source/Octopus.Tentacle/Commands/PollCommand.cs
@@ -46,7 +46,7 @@ namespace Octopus.Tentacle.Commands
             this.log = log;
             this.selector = selector;
 
-            api = AddOptionSet(new ApiEndpointOptions(Options, allowBypass: true));
+            api = AddOptionSet(new ApiEndpointOptions(Options, bypassValidate: true));
 
             Options.Add("server-comms-address=", "The comms address on the Octopus Server; the address of the Octopus Server will be used if omitted.", s => serverCommsAddress = s);
             Options.Add("server-comms-port=", "The comms port on the Octopus Server; the default is " + DefaultServerCommsPort + ". If specified, this will take precedence over any port number in server-comms-address.", s => serverCommsPort = int.Parse(s));

--- a/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
@@ -129,6 +129,8 @@ namespace Octopus.Tentacle.Configuration
         /// </summary>
         void ResetTrustedOctopusServers();
 
+        bool SetTrustedOctopusServers(IEnumerable<OctopusServerConfiguration>? servers);
+
         /// <summary>
         /// Remove the trusted server with the matching thumbprint, if any.
         /// </summary>

--- a/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
@@ -129,6 +129,10 @@ namespace Octopus.Tentacle.Configuration
         /// </summary>
         void ResetTrustedOctopusServers();
 
+        /// <summary>
+        /// Replace all trusted Octopus Servers with the ones provided.
+        /// </summary>
+        /// <returns><see langword="true"/> if successful, else <see langword="false"/></returns>
         bool SetTrustedOctopusServers(IEnumerable<OctopusServerConfiguration>? newServers);
 
         /// <summary>

--- a/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
@@ -129,7 +129,7 @@ namespace Octopus.Tentacle.Configuration
         /// </summary>
         void ResetTrustedOctopusServers();
 
-        bool SetTrustedOctopusServers(IEnumerable<OctopusServerConfiguration>? servers);
+        bool SetTrustedOctopusServers(IEnumerable<OctopusServerConfiguration>? newServers);
 
         /// <summary>
         /// Remove the trusted server with the matching thumbprint, if any.

--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -211,9 +211,9 @@ namespace Octopus.Tentacle.Configuration
             return settings.Set(LastReceivedHandshakeSettingName, setting);
         }
 
-        public bool SetTrustedOctopusServers(IEnumerable<OctopusServerConfiguration>? servers)
+        public bool SetTrustedOctopusServers(IEnumerable<OctopusServerConfiguration>? newServers)
         {
-            return settings.Set(TrustedServersSettingName, servers ?? new OctopusServerConfiguration[0]);
+            return settings.Set(TrustedServersSettingName, newServers ?? Array.Empty<OctopusServerConfiguration>());
         }
 
         bool SetTentacleCertificate(X509Certificate2 certificate)

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -89,6 +89,7 @@ namespace Octopus.Tentacle
             builder.RegisterCommand<ServerCommsCommand>("server-comms", "Configure how the Tentacle communicates with an Octopus Server");
             builder.RegisterCommand<ImportCertificateCommand>("import-certificate", "Replace the certificate that Tentacle uses to authenticate itself");
             builder.RegisterCommand<PollCommand>("poll-server", "Configures an Octopus Server that this Tentacle will poll");
+            builder.RegisterCommand<ClearTrustedServersCommand>("clear-trusted-servers", "Clears trusted servers in the Tentacle Configuration");
             builder.RegisterCommand<ListInstancesCommand>("list-instances", "Lists all installed Tentacle instances");
             builder.RegisterCommand<VersionCommand>("version", "Show the Tentacle version information");
             builder.RegisterCommand<ShowConfigurationCommand>("show-configuration", "Outputs the Tentacle configuration");


### PR DESCRIPTION
# Background

Recently we added the ability to define multiple `ServerCommsAddresses` to the Kubernetes Tentacle so that it could be configured to run with an Octopus Server HA Cluster setup.

The missing functionality was allowing users to adjust this configuration after installation.

# Results

With these changes, it's possible to adjust the configuration by doing a helm update:
```bash
helm upgrade --atomic \
--set agent.serverCommsAddresses="{http://host.docker.internal:10943/,http://host.docker.internal:10942/}" \
--reuse-values \
--create-namespace --namespace octopus-agent-scme \
scme \
/Users/scottmerchant/Documents/dev/helm-charts/charts/kubernetes-agent
```

[sc-75000]