### PR TITLE
Add some more integration tests for Kubernetes Agent

### DIFF
--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
@@ -26,10 +26,22 @@ namespace Octopus.Tentacle.Tests.Integration.Util.Builders
         public ScriptBuilder PrintNTimesWithDelay(string printString, int count, TimeSpan delay)
         {
             // TODO make this a for loop in bash and powershell
-            for (int i = 0; i < count; i++)
+            for (var i = 0; i < count; i++)
             {
                 Sleep(delay);
                 Print(printString);
+            }
+
+            return this;
+        }
+
+        public ScriptBuilder PrintNTimesWithDelay(Func<int, string> outputBuilder, int count, TimeSpan delay)
+        {
+            // TODO make this a for loop in bash and powershell
+            for (var i = 0; i < count; i++)
+            {
+                Sleep(delay);
+                Print(outputBuilder(i));
             }
 
             return this;

--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
@@ -116,5 +116,12 @@ cat {file}
         {
             return bashScript.ToString();
         }
+
+        public ScriptBuilder ExitsWith(int exitCode)
+        {
+            bashScript.AppendLine($"exit {exitCode}");
+            windowsScript.AppendLine($"Exit {exitCode}");
+            return this;
+        }
     }
 }

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgentIntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgentIntegrationTest.cs
@@ -67,6 +67,7 @@ public abstract class KubernetesAgentIntegrationTest
             .ForContext(GetType());
 
         cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(5));
         CancellationToken = cancellationTokenSource.Token;
 
         //each test should get its own tentacle client, so it gets its own builders

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesClusterOneTimeSetUp.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesClusterOneTimeSetUp.cs
@@ -17,25 +17,32 @@ public class KubernetesClusterOneTimeSetUp
         installer = new KubernetesClusterInstaller(KubernetesTestsGlobalContext.Instance.TemporaryDirectory, kindExePath, helmExePath, kubeCtlPath, KubernetesTestsGlobalContext.Instance.Logger);
         await installer.Install();
 
-        //if we are not running in TeamCity, then we need to find the latest local tag and use that if it exists 
-        if (!TeamCityDetection.IsRunningInTeamCity())
-        {
-            var imageLoader = new DockerImageLoader(KubernetesTestsGlobalContext.Instance.TemporaryDirectory, KubernetesTestsGlobalContext.Instance.Logger, kindExePath);
-            KubernetesTestsGlobalContext.Instance.TentacleImageAndTag = imageLoader.LoadMostRecentImageIntoKind(installer.ClusterName);
-        }
-        else
-        {
-            var tag = Environment.GetEnvironmentVariable("KubernetesAgentTests_ImageTag");
-            KubernetesTestsGlobalContext.Instance.TentacleImageAndTag = $"docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:{tag}";
-        }
-
-        if (KubernetesTestsGlobalContext.Instance.TentacleImageAndTag is not null)
-        {
-            KubernetesTestsGlobalContext.Instance.Logger.Information("Using tentacle image: {ImageAndTag}", KubernetesTestsGlobalContext.Instance.TentacleImageAndTag);
-        }
-
+        KubernetesTestsGlobalContext.Instance.TentacleImageAndTag = GetTentacleImageAndTag(kindExePath);
         KubernetesTestsGlobalContext.Instance.SetToolExePaths(helmExePath, kubeCtlPath);
         KubernetesTestsGlobalContext.Instance.KubeConfigPath = installer.KubeConfigPath;
+    }
+
+    string? GetTentacleImageAndTag(string kindExePath)
+    {
+        //By default, we don't override the values in the helm chart. This is useful if you are just writing new tests and not changing Tentacle code.
+        string? imageAndTag = null;
+        if (TeamCityDetection.IsRunningInTeamCity())
+        {
+            //In TeamCity, use the tag of the currently building code
+            var tag = Environment.GetEnvironmentVariable("KubernetesAgentTests_ImageTag");
+            imageAndTag = $"docker.packages.octopushq.com/octopusdeploy/kubernetes-tentacle:{tag}";
+        }
+        else if(bool.TryParse(Environment.GetEnvironmentVariable("KubernetesAgentTests_UseLatestLocalImage"), out var useLocal) && useLocal)
+        {
+            //if we should use the latest locally build image, load the tag from docker and load it into kind
+            var imageLoader = new DockerImageLoader(KubernetesTestsGlobalContext.Instance.TemporaryDirectory, KubernetesTestsGlobalContext.Instance.Logger, kindExePath);
+            imageAndTag = imageLoader.LoadMostRecentImageIntoKind(installer.ClusterName);
+        }
+        
+        if(imageAndTag is not null)
+            KubernetesTestsGlobalContext.Instance.Logger.Information("Using tentacle image: {ImageAndTag}", imageAndTag);
+
+        return imageAndTag;
     }
 
     [OneTimeTearDown]

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1AlphaIntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1AlphaIntegrationTest.cs
@@ -13,11 +13,11 @@ namespace Octopus.Tentacle.Kubernetes.Tests.Integration;
 [TestFixture]
 public class KubernetesScriptServiceV1AlphaIntegrationTest : KubernetesAgentIntegrationTest
 {
-    public KubernetesScriptServiceV1AlphaIntegrationTest()
+    protected override TentacleServiceDecoratorBuilder ConfigureTentacleServiceDecoratorBuilder(TentacleServiceDecoratorBuilder builder)
     {
-        TentacleServiceDecoratorBuilder = new TentacleServiceDecoratorBuilder()
+        return builder
             .DecorateCapabilitiesServiceV2With(d => d
-                .DecorateGetCapabilitiesWith((inner, options) => Task.FromResult(new CapabilitiesResponseV2(new List<string> { nameof(IFileTransferService), nameof(IKubernetesScriptServiceV1Alpha) }))));
+            .DecorateGetCapabilitiesWith((inner, options) => Task.FromResult(new CapabilitiesResponseV2(new List<string> { nameof(IFileTransferService), nameof(IKubernetesScriptServiceV1Alpha) }))));
     }
 
     [Test]

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1IntegrationTest.cs
@@ -1,23 +1,34 @@
+using System.Diagnostics;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Octopus.Tentacle.Client.Scripts.Models;
 using Octopus.Tentacle.Client.Scripts.Models.Builders;
 using Octopus.Tentacle.CommonTestUtils;
 using Octopus.Tentacle.CommonTestUtils.Diagnostics;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Contracts.Capabilities;
+using Octopus.Tentacle.Contracts.ClientServices;
 using Octopus.Tentacle.Contracts.KubernetesScriptServiceV1;
 using Octopus.Tentacle.Tests.Integration.Common.Builders.Decorators;
+using Octopus.Tentacle.Kubernetes.Tests.Integration.Util;
+using Octopus.Tentacle.Tests.Integration.Common.Builders.Decorators.Proxies;
 
 namespace Octopus.Tentacle.Kubernetes.Tests.Integration;
 
 [TestFixture]
 public class KubernetesScriptServiceV1IntegrationTest : KubernetesAgentIntegrationTest
 {
-    public KubernetesScriptServiceV1IntegrationTest()
+    IRecordedMethodUsages recordedMethodUsages = null!;
+
+    protected override TentacleServiceDecoratorBuilder ConfigureTentacleServiceDecoratorBuilder(TentacleServiceDecoratorBuilder builder)
     {
-        TentacleServiceDecoratorBuilder = new TentacleServiceDecoratorBuilder()
+        builder.RecordMethodUsages<IAsyncClientKubernetesScriptServiceV1>(out var recordedUsages)
             .DecorateCapabilitiesServiceV2With(d => d
-                .DecorateGetCapabilitiesWith((inner, options) => Task.FromResult(new CapabilitiesResponseV2(new List<string> { nameof(IFileTransferService), nameof(IKubernetesScriptServiceV1) }))));
+                .DecorateGetCapabilitiesWith((_, _) => Task.FromResult(new CapabilitiesResponseV2(new List<string> { nameof(IFileTransferService), nameof(IKubernetesScriptServiceV1) }))));
+
+        recordedMethodUsages = recordedUsages;
+
+        return builder;
     }
 
     [Test]
@@ -26,15 +37,11 @@ public class KubernetesScriptServiceV1IntegrationTest : KubernetesAgentIntegrati
         // Arrange
         var logs = new List<ProcessOutput>();
         var scriptCompleted = false;
-        string scriptBody = @"echo ""Hello World""
-for i in $(seq 1 50);
-do
-    echo $i
-    sleep 0.1
-done
-";
+
         var command = new ExecuteKubernetesScriptCommandBuilder(LoggingUtils.CurrentTestHash())
-            .WithScriptBody(scriptBody)
+            .WithScriptBody(script => script
+                .Print("Hello World")
+                .PrintNTimesWithDelay("Yep", 50, TimeSpan.FromMilliseconds(100)))
             .Build();
 
         //act
@@ -46,10 +53,150 @@ done
         result.ExitCode.Should().Be(0);
         result.State.Should().Be(ProcessState.Complete);
 
+        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.StartScriptAsync)).Started.Should().Be(1);
+        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.GetStatusAsync)).Started.Should().BeGreaterThan(2).And.BeLessThan(30);
+        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.CompleteScriptAsync)).Started.Should().Be(1);
+        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.CancelScriptAsync)).Started.Should().Be(0);
+
         return;
 
         void StatusReceived(ScriptExecutionStatus status)
         {
+            logs.AddRange(status.Logs);
+        }
+
+        Task ScriptCompleted(CancellationToken ct)
+        {
+            scriptCompleted = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Test]
+    public async Task TentaclePodIsTerminatedDuringScriptExecution_ShouldRestartAndPickUpPodStatus()
+    {
+        // Arrange
+        var logs = new List<ProcessOutput>();
+        var scriptCompleted = false;
+        const int count = 100;
+        var semaphoreSlim = new SemaphoreSlim(0, 1);
+
+        var command = new ExecuteKubernetesScriptCommandBuilder(LoggingUtils.CurrentTestHash())
+            .WithScriptBody(script => script
+                .Print("Hello World")
+                .Sleep(TimeSpan.FromSeconds(1))
+                .Print("waitingtobestopped")
+                .PrintNTimesWithDelay(i => $"Count: {i}", count, TimeSpan.FromSeconds(1)))
+            .Build();
+
+        var commandResult = await KubeCtl.ExecuteNamespacedCommand("get pods -l app.kubernetes.io/name=octopus-agent -o \"Name\"");
+        var initialPodName = commandResult.StdOut.Single();
+
+        //act
+        var scriptTask = Task.Run(async () => await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken.None));
+
+        //wait for the script to be started, then waiting
+        await semaphoreSlim.WaitAsync(CancellationToken);
+
+        Logger.Information("Deleting tentacle pod");
+        var killTask = await KubeCtl.ExecuteNamespacedCommand("delete pods -l app.kubernetes.io/name=octopus-agent");
+
+        var result = await scriptTask;
+
+        commandResult = await KubeCtl.ExecuteNamespacedCommand("get pods -l app.kubernetes.io/name=octopus-agent -o \"Name\"");
+        var finalPodName = commandResult.StdOut.Single();
+
+        //Assert
+        logs.Should().Contain(po => po.Source == ProcessOutputSource.StdOut && po.Text == "Hello World");
+        logs.Should().Contain(po => po.Source == ProcessOutputSource.StdOut && po.Text == "waitingtobestopped");
+
+        //verify that we are getting all the logs and that the tentacle has been killed
+        using (var scope = new AssertionScope())
+        {
+            scope.FormattingOptions.MaxLines = 200;
+            for (var i = 1; i < count; i++)
+            {
+                var testString = $"Count: {i}";
+                logs.Should().Contain(po => po.Source == ProcessOutputSource.StdOut && po.Text == testString, because: $"the logs should contain all script output. Missing '{testString}'");
+            }
+        }
+
+        scriptCompleted.Should().BeTrue();
+        result.ExitCode.Should().Be(0);
+        result.State.Should().Be(ProcessState.Complete);
+
+        finalPodName.Should().NotBe(initialPodName, because: "the tentacle pod should have been killed and restarted");
+
+        return;
+
+        void StatusReceived(ScriptExecutionStatus status)
+        {
+            if (status.Logs.Any(l => l.Text == "waitingtobestopped"))
+            {
+                semaphoreSlim.Release();
+            }
+
+            logs.AddRange(status.Logs);
+        }
+
+        Task ScriptCompleted(CancellationToken ct)
+        {
+            scriptCompleted = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Test]
+    public async Task WhenALongRunningScriptIsCancelled_TheScriptShouldStop()
+    {
+        // Arrange
+        var logs = new List<ProcessOutput>();
+        var scriptCompleted = false;
+
+        var command = new ExecuteKubernetesScriptCommandBuilder(LoggingUtils.CurrentTestHash())
+            .WithScriptBody(script => script
+                .Print("hello")
+                .Sleep(TimeSpan.FromSeconds(1))
+                .Print("waitingtobestopped")
+                .Sleep(TimeSpan.FromSeconds(100))
+                .Print("i did not stop"))
+            .Build();
+
+        var scriptCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
+        Exception? actualException = null;
+
+        //act
+        try
+        {
+            await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), scriptCancellationTokenSource.Token);
+        }
+        catch (Exception ex)
+        {
+            actualException = ex;
+        }
+
+        //Assert
+        actualException.Should().NotBeNull()
+            .And
+            .BeOfType<OperationCanceledException>()
+            .And
+            .Match<OperationCanceledException>(ex => ex.Message == "Script execution was cancelled");
+
+        logs.Should().NotContain(po => po.Source == ProcessOutputSource.StdOut && po.Text == "i did not stop");
+        scriptCompleted.Should().BeTrue();
+
+        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.StartScriptAsync)).Started.Should().Be(1);
+        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.GetStatusAsync)).Started.Should().BeGreaterThan(1);
+        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.CompleteScriptAsync)).Started.Should().Be(1);
+        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.CancelScriptAsync)).Started.Should().BeGreaterOrEqualTo(1);
+
+        return;
+
+        void StatusReceived(ScriptExecutionStatus status)
+        {
+            if (status.Logs.Any(l => l.Text == "waitingtobestopped"))
+                scriptCancellationTokenSource.Cancel();
+
             logs.AddRange(status.Logs);
         }
 

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1IntegrationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesScriptServiceV1IntegrationTest.cs
@@ -41,11 +41,11 @@ public class KubernetesScriptServiceV1IntegrationTest : KubernetesAgentIntegrati
         var command = new ExecuteKubernetesScriptCommandBuilder(LoggingUtils.CurrentTestHash())
             .WithScriptBody(script => script
                 .Print("Hello World")
-                .PrintNTimesWithDelay("Yep", 50, TimeSpan.FromMilliseconds(100)))
+                .PrintNTimesWithDelay("Yep", 30, TimeSpan.FromMilliseconds(100)))
             .Build();
 
         //act
-        var result = await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken.None);
+        var result = await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken);
 
         //Assert
         logs.Should().Contain(po => po.Source == ProcessOutputSource.StdOut && po.Text == "Hello World");
@@ -54,7 +54,7 @@ public class KubernetesScriptServiceV1IntegrationTest : KubernetesAgentIntegrati
         result.State.Should().Be(ProcessState.Complete);
 
         recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.StartScriptAsync)).Started.Should().Be(1);
-        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.GetStatusAsync)).Started.Should().BeGreaterThan(2).And.BeLessThan(30);
+        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.GetStatusAsync)).Started.Should().BeGreaterThan(1);
         recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.CompleteScriptAsync)).Started.Should().Be(1);
         recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.CancelScriptAsync)).Started.Should().Be(0);
 
@@ -86,18 +86,13 @@ public class KubernetesScriptServiceV1IntegrationTest : KubernetesAgentIntegrati
             .Build();
 
         //act
-        var result = await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken.None);
+        var result = await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken);
 
         //Assert
         logs.Should().Contain(po => po.Source == ProcessOutputSource.StdOut && po.Text == "Hello World");
         scriptCompleted.Should().BeTrue();
         result.ExitCode.Should().Be(1);
         result.State.Should().Be(ProcessState.Complete);
-
-        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.StartScriptAsync)).Started.Should().Be(1);
-        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.GetStatusAsync)).Started.Should().BeGreaterThan(2).And.BeLessThan(30);
-        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.CompleteScriptAsync)).Started.Should().Be(1);
-        recordedMethodUsages.For(nameof(IAsyncClientKubernetesScriptServiceV1.CancelScriptAsync)).Started.Should().Be(0);
 
         return;
 
@@ -130,7 +125,7 @@ public class KubernetesScriptServiceV1IntegrationTest : KubernetesAgentIntegrati
             .Build();
 
         //act
-        var scriptTask = Task.Run(async () => await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken.None));
+        var scriptTask = Task.Run(async () => await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken));
 
         //wait for the script to be started, then waiting
         await semaphoreSlim.WaitAsync(CancellationToken);
@@ -192,7 +187,7 @@ public class KubernetesScriptServiceV1IntegrationTest : KubernetesAgentIntegrati
         var initialPodName = commandResult.StdOut.Single();
 
         //act
-        var scriptTask = Task.Run(async () => await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken.None));
+        var scriptTask = Task.Run(async () => await TentacleClient.ExecuteScript(command, StatusReceived, ScriptCompleted, new InMemoryLog(), CancellationToken));
 
         //wait for the script to be started, then waiting
         await semaphoreSlim.WaitAsync(CancellationToken);

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
@@ -35,7 +35,7 @@ public class KubernetesAgentInstaller
 
     public string AgentName { get; }
 
-    string Namespace => $"octopus-agent-{AgentName}";
+    public string Namespace => $"octopus-agent-{AgentName}";
 
     public Uri SubscriptionId { get; } = PollingSubscriptionId.Generate();
 

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Tooling/KubeCtlTool.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Tooling/KubeCtlTool.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Text;
+using Octopus.Tentacle.CommonTestUtils;
+using Octopus.Tentacle.CommonTestUtils.Logging;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Kubernetes.Tests.Integration.Tooling;
+
+public class KubeCtlTool
+{
+    readonly TemporaryDirectory temporaryDirectory;
+    readonly string kubeCtlExePath;
+    readonly string kubeConfigPath;
+    readonly string ns;
+    readonly ILogger logger;
+
+    public KubeCtlTool(TemporaryDirectory temporaryDirectory, string kubeCtlExePath, string kubeConfigPath, string ns, ILogger logger)
+    {
+        this.temporaryDirectory = temporaryDirectory;
+        this.kubeCtlExePath = kubeCtlExePath;
+        this.kubeConfigPath = kubeConfigPath;
+        this.ns = ns;
+        this.logger = logger;
+    }
+
+    public Task<KubeCtlCommandResult> ExecuteNamespacedCommand(string command, CancellationToken cancellationToken = default)
+    {
+        return Task.Run(() => ExecuteCommand($"{command} --namespace {ns}", cancellationToken), cancellationToken);
+    }
+
+    KubeCtlCommandResult ExecuteCommand(string command, CancellationToken cancellationToken = default)
+    {
+        var sb = new StringBuilder();
+        var sprLogger = new LoggerConfiguration()
+            .WriteTo.Logger(logger)
+            .WriteTo.StringBuilder(sb)
+            .MinimumLevel.Debug()
+            .CreateLogger();
+
+        var stdOut = new List<string>();
+        var stdErr = new List<string>();
+
+        var exitCode = SilentProcessRunner.ExecuteCommand(
+            kubeCtlExePath,
+            $"{command} --kubeconfig=\"{kubeConfigPath}\"",
+            temporaryDirectory.DirectoryPath,
+            sprLogger.Debug,
+            x =>
+            {
+                sprLogger.Information(x);
+                stdOut.Add(x);
+            },
+            y =>
+            {
+                sprLogger.Error(y);
+                stdErr.Add(y);
+            },
+            cancellationToken);
+
+        return new (exitCode, stdOut, stdErr);
+    }
+
+    public record KubeCtlCommandResult(int ExitCode, IEnumerable<string> StdOut, IEnumerable<string> StdError);
+}

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Util/ExecuteKubernetesScriptCommandBuilderExtensionMethods.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Util/ExecuteKubernetesScriptCommandBuilderExtensionMethods.cs
@@ -1,0 +1,18 @@
+﻿using Octopus.Tentacle.Client.Scripts.Models.Builders;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+
+namespace Octopus.Tentacle.Kubernetes.Tests.Integration.Util;
+
+public static class ExecuteKubernetesScriptCommandBuilderExtensionMethods
+{
+    public static ExecuteKubernetesScriptCommandBuilder WithScriptBody(this ExecuteKubernetesScriptCommandBuilder builder, Action<ScriptBuilder> scriptBuilderFunc)
+    {
+        var scriptBuilder = new ScriptBuilder();
+        scriptBuilderFunc(scriptBuilder);
+
+        return builder.WithScriptBody(scriptBuilder);
+    }
+
+    public static ExecuteKubernetesScriptCommandBuilder WithScriptBody(this ExecuteKubernetesScriptCommandBuilder builder, ScriptBuilder scriptBuilder)
+        => (ExecuteKubernetesScriptCommandBuilder)builder.WithScriptBody(scriptBuilder.BuildBashScript());
+}


### PR DESCRIPTION
# Background

We need some more test overage for the `KubernetesScriptServiceV1` and it's interactions with `TentacleClient`. This PR does that 😄 

# Results

Adds 4 more tests:
- `TentaclePodIsTerminatedDuringScriptExecution_ShouldRestartAndPickUpPodStatus` which tests that when the tentacle pod is terminated, that the script continues running and that a new tentacle pod is created and continues reading the logs
- `WhenALongRunningScriptIsCancelled_TheScriptShouldStop` which tests that cancellation
- `SimpleScriptExitsWithErrorCode_ScriptFails`  which tests that when a script explicitly exits with an error code, that it is reflected
- `ScriptPodIsTerminatedDuringScriptExecution_ScriptFails` which tests when the script pod deleted that the script exits with an error

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.