### PR TITLE
Add file to indicate when tentacle is initialised

### DIFF
--- a/docker/kubernetes-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-and-run.sh
@@ -327,6 +327,11 @@ function registerAdditionalServer() {
   tentacle "${ARGS[@]}"
 }
 
+function markAsInitialised() {
+    # There is a startupProbe which checks for this file
+    touch /scripts/initialised
+}
+
 setupVariablesForRegistrationCheck
 getStatusOfRegistration
 
@@ -347,6 +352,8 @@ else
 
   echo "Configuration successful"
 fi
+
+markAsInitialised
 
 echo "==============================================="
 echo "Starting Octopus Deploy Kubernetes Tentacle"

--- a/docker/kubernetes-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-tentacle/scripts/configure-and-run.sh
@@ -329,7 +329,7 @@ function registerAdditionalServer() {
 
 function markAsInitialised() {
     # There is a startupProbe which checks for this file
-    touch /scripts/initialised
+    mkdir /etc/octopus && touch /etc/octopus/initialized
 }
 
 setupVariablesForRegistrationCheck


### PR DESCRIPTION
# Background

Currently you can run the helm upgrade command for a Kubernetes agent and it will install and helm will be happy even if there is no server running to connect to.

When the tentacle starts up, Kubernetes sees the container running and helm just thinks it's good to go, even though the configuration/initialisation hasn't completed yet. This can put the agent in a situation where the Tentacle container is constantly bootlooping, unable to do anything while the helm chart returned happy.

# Results

This change is coupled with another change in the helm-chart (https://github.com/OctopusDeploy/helm-charts/pull/167) to add a startup probe. This change simply adds an empty file to the `/scripts/` folder to indicate that the initialisation is complete. The startup probe checks if the file exists, as soon as it does, the container is marked as ready and the helm chart command can complete successfully.

If the startup probe continues to fail, the helm chart will timeout and uninstall itself after the specified timeout (default 5mins).

[sc-80003]
