### PR TITLE
Add ServerCommsAddresses as env var to script pods

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Kubernetes
 {
     public static class KubernetesConfig
     {
+        const string ServerCommsAddressVariableName = "ServerCommsAddress";
         const string EnvVarPrefix = "OCTOPUS__K8STENTACLE";
 
         public static string NamespaceVariableName => $"{EnvVarPrefix}__NAMESPACE";
@@ -31,6 +35,24 @@ namespace Octopus.Tentacle.Kubernetes
 
         public static string PersistentVolumeSizeBytesVariableName => $"{EnvVarPrefix}__PERSISTENTVOLUMETOTALBYTES";
         public static string PersistentVolumeFreeBytesVariableName => $"{EnvVarPrefix}__PERSISTENTVOLUMEFREEBYTES";
+
+        public const string ServerCommsAddressesVariableName = "ServerCommsAddresses";
+
+        public static string[] ServerCommsAddresses {
+            get {
+                var addresses = new List<string>();
+                if (Environment.GetEnvironmentVariable(ServerCommsAddressVariableName) is { Length: > 0 } addressString)
+                {
+                    addresses.Add(addressString);
+                }
+                if (Environment.GetEnvironmentVariable(ServerCommsAddressesVariableName) is {} addressesString)
+                {
+                    addresses.AddRange(addressesString.Split(',').Where(a => !a.IsNullOrEmpty()));
+                }
+                return addresses.ToArray();
+            }
+
+        }
 
         static string GetRequiredEnvVar(string variable, string errorMessage)
             => Environment.GetEnvironmentVariable(variable)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -258,6 +258,7 @@ namespace Octopus.Tentacle.Kubernetes
                     new(KubernetesConfig.NamespaceVariableName, KubernetesConfig.Namespace),
                     new(KubernetesConfig.HelmReleaseNameVariableName, KubernetesConfig.HelmReleaseName),
                     new(KubernetesConfig.HelmChartVersionVariableName, KubernetesConfig.HelmChartVersion),
+                    new(KubernetesConfig.ServerCommsAddressesVariableName, string.Join(",", KubernetesConfig.ServerCommsAddresses)),
                     new(KubernetesConfig.PersistentVolumeFreeBytesVariableName, spaceInformation?.freeSpaceBytes.ToString()),
                     new(KubernetesConfig.PersistentVolumeSizeBytesVariableName, spaceInformation?.totalSpaceBytes.ToString()),
                     new(EnvironmentVariables.TentacleHome, homeDir),


### PR DESCRIPTION
# Background

As part of adding Kubernetes Agent support for HA clusters, we want to allow health checks to check if the agent is configured correctly with the right number of ServerCommsAddresses.

[sc-80605]

# Results

This partners with a Server change which will compare the number of nodes to the number of configured ServerCommsAddresses and fail if the number is not the same. For backwards compatibility, if the value isn't set, it will be ignored on Server.

Related server change: https://github.com/OctopusDeploy/OctopusDeploy/pull/25129
Related documentation change: https://github.com/OctopusDeploy/docs/pull/2323