### PR TITLE
Kubernetes agent - Allow basic raw scripts with no dependencies to run without a volume mount

### DIFF
--- a/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Orchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Orchestrator.cs
@@ -70,7 +70,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 kubernetesScriptCommand.ScriptPodServiceAccountName,
                 kubernetesScriptCommand.Scripts,
                 kubernetesScriptCommand.Files.ToArray(),
-                kubernetesScriptCommand.IsRawScriptWithNoDependencies);
+                kubernetesScriptCommand.ReadonlyWorkspaceOnly);
         }
 
         protected override ScriptExecutionStatus MapToStatus(KubernetesScriptStatusResponseV1 response)

--- a/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Orchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Orchestrator.cs
@@ -70,7 +70,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 kubernetesScriptCommand.ScriptPodServiceAccountName,
                 kubernetesScriptCommand.Scripts,
                 kubernetesScriptCommand.Files.ToArray(),
-                kubernetesScriptCommand.ReadonlyWorkspaceOnly);
+                kubernetesScriptCommand.IsRawScript);
         }
 
         protected override ScriptExecutionStatus MapToStatus(KubernetesScriptStatusResponseV1 response)

--- a/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Orchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Orchestrator.cs
@@ -69,7 +69,8 @@ namespace Octopus.Tentacle.Client.Scripts
                 podImageConfiguration,
                 kubernetesScriptCommand.ScriptPodServiceAccountName,
                 kubernetesScriptCommand.Scripts,
-                kubernetesScriptCommand.Files.ToArray());
+                kubernetesScriptCommand.Files.ToArray(),
+                kubernetesScriptCommand.IsRawScriptWithNoDependencies);
         }
 
         protected override ScriptExecutionStatus MapToStatus(KubernetesScriptStatusResponseV1 response)

--- a/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteKubernetesScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteKubernetesScriptCommandBuilder.cs
@@ -7,7 +7,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
     {
         KubernetesImageConfiguration? configuration;
         string? scriptPodServiceAccountName;
-        bool readonlyWorkspaceOnly;
+        bool isRawScript;
 
         public ExecuteKubernetesScriptCommandBuilder(string taskId)
             : base(taskId, ScriptIsolationLevel.NoIsolation) //Kubernetes Agents don't need isolation since the scripts won't clash with each other (it won't clash more than Workers anyway)
@@ -26,9 +26,9 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
             return this;
         }
 
-        public ExecuteKubernetesScriptCommandBuilder AsReadonlyWorkspaceOnly()
+        public ExecuteKubernetesScriptCommandBuilder IsRawScript()
         {
-            readonlyWorkspaceOnly = true;
+            isRawScript = true;
             return this;
         }
 
@@ -43,7 +43,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
                 Files.ToArray(),
                 configuration,
                 scriptPodServiceAccountName,
-                readonlyWorkspaceOnly
+                isRawScript
             );
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteKubernetesScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteKubernetesScriptCommandBuilder.cs
@@ -7,6 +7,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
     {
         KubernetesImageConfiguration? configuration;
         string? scriptPodServiceAccountName;
+        bool isRawScriptWithNoDependencies;
 
         public ExecuteKubernetesScriptCommandBuilder(string taskId)
             : base(taskId, ScriptIsolationLevel.NoIsolation) //Kubernetes Agents don't need isolation since the scripts won't clash with each other (it won't clash more than Workers anyway)
@@ -25,6 +26,12 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
             return this;
         }
 
+        public ExecuteKubernetesScriptCommandBuilder AsRawScriptWithNoDependencies()
+        {
+            isRawScriptWithNoDependencies = true;
+            return this;
+        }
+
         public override ExecuteScriptCommand Build()
             => new ExecuteKubernetesScriptCommand(
                 ScriptTicket,
@@ -35,7 +42,8 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
                 AdditionalScripts,
                 Files.ToArray(),
                 configuration,
-                scriptPodServiceAccountName
+                scriptPodServiceAccountName,
+                isRawScriptWithNoDependencies
             );
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteKubernetesScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteKubernetesScriptCommandBuilder.cs
@@ -7,7 +7,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
     {
         KubernetesImageConfiguration? configuration;
         string? scriptPodServiceAccountName;
-        bool isRawScriptWithNoDependencies;
+        bool readonlyWorkspaceOnly;
 
         public ExecuteKubernetesScriptCommandBuilder(string taskId)
             : base(taskId, ScriptIsolationLevel.NoIsolation) //Kubernetes Agents don't need isolation since the scripts won't clash with each other (it won't clash more than Workers anyway)
@@ -26,9 +26,9 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
             return this;
         }
 
-        public ExecuteKubernetesScriptCommandBuilder AsRawScriptWithNoDependencies()
+        public ExecuteKubernetesScriptCommandBuilder AsReadonlyWorkspaceOnly()
         {
-            isRawScriptWithNoDependencies = true;
+            readonlyWorkspaceOnly = true;
             return this;
         }
 
@@ -43,7 +43,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
                 Files.ToArray(),
                 configuration,
                 scriptPodServiceAccountName,
-                isRawScriptWithNoDependencies
+                readonlyWorkspaceOnly
             );
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/Models/ExecuteKubernetesScriptCommand.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/ExecuteKubernetesScriptCommand.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models
 
         public string? ScriptPodServiceAccountName { get;}
 
-        public bool IsRawScriptWithNoDependencies { get; }
+        public bool ReadonlyWorkspaceOnly { get; }
 
         public ExecuteKubernetesScriptCommand(
             ScriptTicket scriptTicket,
@@ -22,12 +22,12 @@ namespace Octopus.Tentacle.Client.Scripts.Models
             ScriptFile[] additionalFiles,
             KubernetesImageConfiguration? imageConfiguration, 
             string? scriptPodServiceAccountName,
-            bool isRawScriptWithNoDependencies)
+            bool readonlyWorkspaceOnly)
             : base(scriptTicket, taskId, scriptBody, arguments, isolationConfiguration, additionalScripts, additionalFiles)
         {
             ImageConfiguration = imageConfiguration;
             ScriptPodServiceAccountName = scriptPodServiceAccountName;
-            IsRawScriptWithNoDependencies = isRawScriptWithNoDependencies;
+            ReadonlyWorkspaceOnly = readonlyWorkspaceOnly;
         }
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/Models/ExecuteKubernetesScriptCommand.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/ExecuteKubernetesScriptCommand.cs
@@ -10,6 +10,8 @@ namespace Octopus.Tentacle.Client.Scripts.Models
 
         public string? ScriptPodServiceAccountName { get;}
 
+        public bool IsRawScriptWithNoDependencies { get; }
+
         public ExecuteKubernetesScriptCommand(
             ScriptTicket scriptTicket,
             string taskId,
@@ -19,11 +21,13 @@ namespace Octopus.Tentacle.Client.Scripts.Models
             Dictionary<ScriptType, string>? additionalScripts,
             ScriptFile[] additionalFiles,
             KubernetesImageConfiguration? imageConfiguration, 
-            string? scriptPodServiceAccountName)
+            string? scriptPodServiceAccountName,
+            bool isRawScriptWithNoDependencies)
             : base(scriptTicket, taskId, scriptBody, arguments, isolationConfiguration, additionalScripts, additionalFiles)
         {
             ImageConfiguration = imageConfiguration;
             ScriptPodServiceAccountName = scriptPodServiceAccountName;
+            IsRawScriptWithNoDependencies = isRawScriptWithNoDependencies;
         }
     }
 }

--- a/source/Octopus.Tentacle.Client/Scripts/Models/ExecuteKubernetesScriptCommand.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/ExecuteKubernetesScriptCommand.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models
 
         public string? ScriptPodServiceAccountName { get;}
 
-        public bool ReadonlyWorkspaceOnly { get; }
+        public bool IsRawScript { get; }
 
         public ExecuteKubernetesScriptCommand(
             ScriptTicket scriptTicket,
@@ -22,12 +22,12 @@ namespace Octopus.Tentacle.Client.Scripts.Models
             ScriptFile[] additionalFiles,
             KubernetesImageConfiguration? imageConfiguration, 
             string? scriptPodServiceAccountName,
-            bool readonlyWorkspaceOnly)
+            bool isRawScript)
             : base(scriptTicket, taskId, scriptBody, arguments, isolationConfiguration, additionalScripts, additionalFiles)
         {
             ImageConfiguration = imageConfiguration;
             ScriptPodServiceAccountName = scriptPodServiceAccountName;
-            ReadonlyWorkspaceOnly = readonlyWorkspaceOnly;
+            IsRawScript = isRawScript;
         }
     }
 }

--- a/source/Octopus.Tentacle.Contracts/KubernetesScriptServiceV1/StartKubernetesScriptCommandV1.cs
+++ b/source/Octopus.Tentacle.Contracts/KubernetesScriptServiceV1/StartKubernetesScriptCommandV1.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1
             string? scriptPodServiceAccountName,
             Dictionary<ScriptType, string>? additionalScripts,
             ScriptFile[]? additionalFiles,
-            bool isRawScriptWithNoDependencies)
+            bool readonlyWorkspaceOnly)
         {
             Arguments = arguments;
             TaskId = taskId;
@@ -29,7 +29,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1
             IsolationMutexName = isolationMutexName;
             PodImageConfiguration = podImageConfiguration;
             ScriptPodServiceAccountName = scriptPodServiceAccountName;
-            IsRawScriptWithNoDependencies = isRawScriptWithNoDependencies;
+            ReadonlyWorkspaceOnly = readonlyWorkspaceOnly;
 
             if (additionalFiles != null)
                 Files.AddRange(additionalFiles);
@@ -43,7 +43,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1
             }
         }
 
-        public bool IsRawScriptWithNoDependencies { get; }
+        public bool ReadonlyWorkspaceOnly { get; }
         public string ScriptBody { get; }
         public string TaskId { get; }
         public ScriptTicket ScriptTicket { get; }

--- a/source/Octopus.Tentacle.Contracts/KubernetesScriptServiceV1/StartKubernetesScriptCommandV1.cs
+++ b/source/Octopus.Tentacle.Contracts/KubernetesScriptServiceV1/StartKubernetesScriptCommandV1.cs
@@ -17,7 +17,8 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1
             PodImageConfigurationV1? podImageConfiguration, 
             string? scriptPodServiceAccountName,
             Dictionary<ScriptType, string>? additionalScripts,
-            ScriptFile[]? additionalFiles)
+            ScriptFile[]? additionalFiles,
+            bool isRawScriptWithNoDependencies)
         {
             Arguments = arguments;
             TaskId = taskId;
@@ -28,6 +29,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1
             IsolationMutexName = isolationMutexName;
             PodImageConfiguration = podImageConfiguration;
             ScriptPodServiceAccountName = scriptPodServiceAccountName;
+            IsRawScriptWithNoDependencies = isRawScriptWithNoDependencies;
 
             if (additionalFiles != null)
                 Files.AddRange(additionalFiles);
@@ -41,6 +43,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1
             }
         }
 
+        public bool IsRawScriptWithNoDependencies { get; }
         public string ScriptBody { get; }
         public string TaskId { get; }
         public ScriptTicket ScriptTicket { get; }

--- a/source/Octopus.Tentacle.Contracts/KubernetesScriptServiceV1/StartKubernetesScriptCommandV1.cs
+++ b/source/Octopus.Tentacle.Contracts/KubernetesScriptServiceV1/StartKubernetesScriptCommandV1.cs
@@ -18,7 +18,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1
             string? scriptPodServiceAccountName,
             Dictionary<ScriptType, string>? additionalScripts,
             ScriptFile[]? additionalFiles,
-            bool readonlyWorkspaceOnly)
+            bool isRawScript)
         {
             Arguments = arguments;
             TaskId = taskId;
@@ -29,7 +29,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1
             IsolationMutexName = isolationMutexName;
             PodImageConfiguration = podImageConfiguration;
             ScriptPodServiceAccountName = scriptPodServiceAccountName;
-            ReadonlyWorkspaceOnly = readonlyWorkspaceOnly;
+            IsRawScript = isRawScript;
 
             if (additionalFiles != null)
                 Files.AddRange(additionalFiles);
@@ -43,7 +43,7 @@ namespace Octopus.Tentacle.Contracts.KubernetesScriptServiceV1
             }
         }
 
-        public bool ReadonlyWorkspaceOnly { get; }
+        public bool IsRawScript { get; }
         public string ScriptBody { get; }
         public string TaskId { get; }
         public ScriptTicket ScriptTicket { get; }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -20,6 +20,7 @@ namespace Octopus.Tentacle.Kubernetes
             builder.RegisterType<KubernetesSecretService>().As<IKubernetesSecretService>().SingleInstance();
 
             builder.RegisterType<KubernetesScriptPodCreator>().As<IKubernetesScriptPodCreator>().SingleInstance();
+            builder.RegisterType<KubernetesRawScriptPodCreator>().As<IKubernetesRawScriptPodCreator>().SingleInstance();
             builder.RegisterType<KubernetesPodLogService>().As<IKubernetesPodLogService>().SingleInstance();
             builder.RegisterType<ScriptPodSinceTimeStore>().As<IScriptPodSinceTimeStore>().SingleInstance();
             builder.RegisterType<TentacleScriptLogProvider>().As<ITentacleScriptLogProvider>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -26,7 +26,6 @@ namespace Octopus.Tentacle.Kubernetes
     {
         IList<ITrackedScriptPod> GetAllTrackedScriptPods();
         ITrackedScriptPod? TryGetTrackedScriptPod(ScriptTicket scriptTicket);
-        Task WaitForScriptPodToStart(ScriptTicket scriptTicket, CancellationToken cancellationToken);
     }
 
     public class KubernetesPodMonitor : IKubernetesPodMonitor, IKubernetesPodStatusProvider
@@ -36,8 +35,6 @@ namespace Octopus.Tentacle.Kubernetes
         readonly ITentacleScriptLogProvider scriptLogProvider;
         readonly IClock clock;
 
-        event EventHandler<V1Pod>? PodUpdatedEvent;
-        
         ConcurrentDictionary<ScriptTicket, TrackedScriptPod> podStatusLookup = new();
         
         //Prevent giving false results when we are still loading for the first time 
@@ -189,8 +186,6 @@ namespace Octopus.Tentacle.Kubernetes
                             log.Warn($"Received watch event type {type} for pod {pod.Name()}. Ignoring as we don't need it");
                             break;
                     }
-
-                    PodUpdatedEvent?.Invoke(this, pod);
                 }
                 catch (Exception e)
                 {
@@ -211,36 +206,6 @@ namespace Octopus.Tentacle.Kubernetes
             WaitForInitialLoadToFinish();
             var found = podStatusLookup.TryGetValue(scriptTicket, out var status);
             return found ? status : null;
-        }
-
-        public async Task WaitForScriptPodToStart(ScriptTicket scriptTicket, CancellationToken cancellationToken)
-        {
-            using var semaphore = new SemaphoreSlim(0);
-            var onPodUpdated = (EventHandler<V1Pod>)OnPodUpdated;
-            PodUpdatedEvent += onPodUpdated;
-            try
-            {
-                if (TryGetTrackedScriptPod(scriptTicket) is null or {State: {Phase: TrackedScriptPodPhase.Pending}})
-                {
-                    await semaphore.WaitAsync(cancellationToken);
-                }
-            }
-            finally
-            {
-                PodUpdatedEvent -= onPodUpdated;
-            }
-
-            void OnPodUpdated(object? _, V1Pod pod)
-            {
-                if (pod.GetScriptTicket() != scriptTicket) return;
-
-                var trackedPod = TryGetTrackedScriptPod(scriptTicket);
-                if (trackedPod is {State: {Phase: not TrackedScriptPodPhase.Pending}} &&
-                    pod.Status.ContainerStatuses.All(s => s.State.Waiting is null))
-                {
-                    semaphore.Release();
-                }
-            }
         }
 
         void WaitForInitialLoadToFinish()

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using ICSharpCode.SharpZipLib.Tar;
 using k8s;
 using k8s.Models;
 using Octopus.Diagnostics;

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Net;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.Tar;
 using k8s;
-using k8s.Autorest;
 using k8s.Models;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
@@ -18,6 +18,7 @@ namespace Octopus.Tentacle.Kubernetes
         Task WatchAllPods(string initialResourceVersion, Func<WatchEventType, V1Pod, CancellationToken, Task> onChange, Action<Exception> onError, CancellationToken cancellationToken);
         Task<V1Pod> Create(V1Pod pod, CancellationToken cancellationToken);
         Task DeleteIfExists(ScriptTicket scriptTicket, CancellationToken cancellationToken);
+        Task<int> CopyFileToPodAsync(V1Pod pod, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken, string? container = null);
     }
 
     public class KubernetesPodService : KubernetesService, IKubernetesPodService
@@ -85,5 +86,116 @@ namespace Octopus.Tentacle.Kubernetes
 
         public async Task DeleteIfExists(ScriptTicket scriptTicket, CancellationToken cancellationToken)
             => await TryExecuteAsync(async () => await Client.DeleteNamespacedPodAsync(scriptTicket.ToKubernetesScriptPodName(), KubernetesConfig.Namespace, cancellationToken: cancellationToken));
+
+        public async Task<int> CopyFileToPodAsync(V1Pod pod, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken, string? container = null)
+        {
+            // All other parameters are being validated by MuxedStreamNamespacedPodExecAsync called by NamespacedPodExecAsync
+            ValidatePathParameters(sourceFilePath, destinationFilePath);
+
+            // The callback which processes the standard input, standard output and standard error of exec method
+            var handler = new ExecAsyncCallback(async (stdIn, stdOut, stdError) =>
+            {
+                var stdInTask = ProcessStdIn(stdIn, cancellationToken);
+                var stdOutTask = ProcessStdOut(stdOut, cancellationToken);
+                var stdErrorTask = ProcessStdError(stdError, cancellationToken);
+
+                await Task.WhenAll(stdInTask, stdOutTask, stdErrorTask);
+            });
+
+            async Task ProcessStdOut(Stream stdOut, CancellationToken ct)
+            {
+                using var streamReader = new StreamReader(stdOut);
+                while (streamReader.EndOfStream == false)
+                {
+                    var output = await streamReader.ReadLineAsync();
+                    if (output is not null)
+                    {
+                        Log.Verbose($"SEND FILE OUT: {output}");
+                    }
+                }
+            }
+
+            async Task ProcessStdError(Stream stdError, CancellationToken ct)
+            {
+                using var streamReader = new StreamReader(stdError);
+                while (streamReader.EndOfStream == false)
+                {
+                    var error = await streamReader.ReadLineAsync();
+                    if (error is not null)
+                    {
+                        Log.Verbose($"SEND FILE ERR: {error}");
+                    }
+                }
+            }
+
+            async Task ProcessStdIn(Stream stdIn, CancellationToken ct)
+            {
+                var fileInfo = new FileInfo(destinationFilePath);
+                try
+                {
+                    using var memoryStream = new MemoryStream();
+                    await using (var inputFileStream = File.OpenRead(sourceFilePath))
+                    await using (var tarOutputStream = new TarOutputStream(memoryStream, Encoding.Default))
+                    {
+                        tarOutputStream.IsStreamOwner = false;
+                        var fileSize = inputFileStream.Length;
+                        var entry = TarEntry.CreateTarEntry(fileInfo.Name);
+                        entry.Size = fileSize;
+                        tarOutputStream.PutNextEntry(entry);
+                        await inputFileStream.CopyToAsync(tarOutputStream, ct);
+                        tarOutputStream.CloseEntry();
+                    }
+                    memoryStream.Position = 0;
+                    const int bufferSize = 31 * 1024 * 1024; // must be lower than 32 * 1024 * 1024
+                    var localBuffer = new byte[bufferSize];
+                    while (true)
+                    {
+                        var numRead = await memoryStream.ReadAsync(localBuffer, ct);
+                        if (numRead <= 0)
+                        {
+                            break;
+                        }
+                        await stdIn.WriteAsync(localBuffer.AsMemory(0, numRead), ct);
+                    }
+                    await stdIn.FlushAsync(ct);
+                }
+                catch (Exception ex)
+                {
+                    throw new IOException($"Copy command failed: {ex.Message}");
+                }
+            }
+
+            var destinationFolder = GetFolderName(destinationFilePath);
+
+            return await Client.NamespacedPodExecAsync(
+                pod.Name(),
+                pod.Namespace(),
+                container ?? pod.Spec.Containers.First().Name,
+                new[] { "sh", "-c", $"mkdir -p {destinationFolder} && tar xmf - -C {destinationFolder}" },
+                false,
+                handler,
+                cancellationToken);
+        }
+
+        static void ValidatePathParameters(string sourcePath, string destinationPath)
+        {
+            if (string.IsNullOrWhiteSpace(sourcePath))
+            {
+                throw new ArgumentException($"{nameof(sourcePath)} cannot be null or whitespace");
+            }
+
+            if (string.IsNullOrWhiteSpace(destinationPath))
+            {
+                throw new ArgumentException($"{nameof(destinationPath)} cannot be null or whitespace");
+            }
+
+        }
+
+        static string GetFolderName(string filePath)
+        {
+            var folderName = Path.GetDirectoryName(filePath);
+
+            return string.IsNullOrEmpty(folderName) ? "." : folderName;
+        }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
@@ -18,7 +18,6 @@ namespace Octopus.Tentacle.Kubernetes
         Task WatchAllPods(string initialResourceVersion, Func<WatchEventType, V1Pod, CancellationToken, Task> onChange, Action<Exception> onError, CancellationToken cancellationToken);
         Task<V1Pod> Create(V1Pod pod, CancellationToken cancellationToken);
         Task DeleteIfExists(ScriptTicket scriptTicket, CancellationToken cancellationToken);
-        Task<int> CopyFileToPodAsync(V1Pod pod, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken, string? container = null);
     }
 
     public class KubernetesPodService : KubernetesService, IKubernetesPodService
@@ -86,116 +85,5 @@ namespace Octopus.Tentacle.Kubernetes
 
         public async Task DeleteIfExists(ScriptTicket scriptTicket, CancellationToken cancellationToken)
             => await TryExecuteAsync(async () => await Client.DeleteNamespacedPodAsync(scriptTicket.ToKubernetesScriptPodName(), KubernetesConfig.Namespace, cancellationToken: cancellationToken));
-
-        public async Task<int> CopyFileToPodAsync(V1Pod pod, string sourceFilePath, string destinationFilePath, CancellationToken cancellationToken, string? container = null)
-        {
-            // All other parameters are being validated by MuxedStreamNamespacedPodExecAsync called by NamespacedPodExecAsync
-            ValidatePathParameters(sourceFilePath, destinationFilePath);
-
-            // The callback which processes the standard input, standard output and standard error of exec method
-            var handler = new ExecAsyncCallback(async (stdIn, stdOut, stdError) =>
-            {
-                var stdInTask = ProcessStdIn(stdIn, cancellationToken);
-                var stdOutTask = ProcessStdOut(stdOut, cancellationToken);
-                var stdErrorTask = ProcessStdError(stdError, cancellationToken);
-
-                await Task.WhenAll(stdInTask, stdOutTask, stdErrorTask);
-            });
-
-            async Task ProcessStdOut(Stream stdOut, CancellationToken ct)
-            {
-                using var streamReader = new StreamReader(stdOut);
-                while (streamReader.EndOfStream == false)
-                {
-                    var output = await streamReader.ReadLineAsync();
-                    if (output is not null)
-                    {
-                        Log.Verbose($"SEND FILE OUT: {output}");
-                    }
-                }
-            }
-
-            async Task ProcessStdError(Stream stdError, CancellationToken ct)
-            {
-                using var streamReader = new StreamReader(stdError);
-                while (streamReader.EndOfStream == false)
-                {
-                    var error = await streamReader.ReadLineAsync();
-                    if (error is not null)
-                    {
-                        Log.Verbose($"SEND FILE ERR: {error}");
-                    }
-                }
-            }
-
-            async Task ProcessStdIn(Stream stdIn, CancellationToken ct)
-            {
-                var fileInfo = new FileInfo(destinationFilePath);
-                try
-                {
-                    using var memoryStream = new MemoryStream();
-                    await using (var inputFileStream = File.OpenRead(sourceFilePath))
-                    await using (var tarOutputStream = new TarOutputStream(memoryStream, Encoding.Default))
-                    {
-                        tarOutputStream.IsStreamOwner = false;
-                        var fileSize = inputFileStream.Length;
-                        var entry = TarEntry.CreateTarEntry(fileInfo.Name);
-                        entry.Size = fileSize;
-                        tarOutputStream.PutNextEntry(entry);
-                        await inputFileStream.CopyToAsync(tarOutputStream, ct);
-                        tarOutputStream.CloseEntry();
-                    }
-                    memoryStream.Position = 0;
-                    const int bufferSize = 31 * 1024 * 1024; // must be lower than 32 * 1024 * 1024
-                    var localBuffer = new byte[bufferSize];
-                    while (true)
-                    {
-                        var numRead = await memoryStream.ReadAsync(localBuffer, ct);
-                        if (numRead <= 0)
-                        {
-                            break;
-                        }
-                        await stdIn.WriteAsync(localBuffer.AsMemory(0, numRead), ct);
-                    }
-                    await stdIn.FlushAsync(ct);
-                }
-                catch (Exception ex)
-                {
-                    throw new IOException($"Copy command failed: {ex.Message}");
-                }
-            }
-
-            var destinationFolder = GetFolderName(destinationFilePath);
-
-            return await Client.NamespacedPodExecAsync(
-                pod.Name(),
-                pod.Namespace(),
-                container ?? pod.Spec.Containers.First().Name,
-                new[] { "sh", "-c", $"mkdir -p {destinationFolder} && tar xmf - -C {destinationFolder}" },
-                false,
-                handler,
-                cancellationToken);
-        }
-
-        static void ValidatePathParameters(string sourcePath, string destinationPath)
-        {
-            if (string.IsNullOrWhiteSpace(sourcePath))
-            {
-                throw new ArgumentException($"{nameof(sourcePath)} cannot be null or whitespace");
-            }
-
-            if (string.IsNullOrWhiteSpace(destinationPath))
-            {
-                throw new ArgumentException($"{nameof(destinationPath)} cannot be null or whitespace");
-            }
-
-        }
-
-        static string GetFolderName(string filePath)
-        {
-            var folderName = Path.GetDirectoryName(filePath);
-
-            return string.IsNullOrEmpty(folderName) ? "." : folderName;
-        }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using k8s.Models;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Contracts.KubernetesScriptServiceV1;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesRawScriptPodCreator : IKubernetesScriptPodCreator
+    {
+    }
+
+    public class KubernetesRawScriptPodCreator : KubernetesScriptPodCreator, IKubernetesRawScriptPodCreator
+    {
+        readonly IKubernetesPodContainerResolver containerResolver;
+
+        public KubernetesRawScriptPodCreator(
+            IKubernetesPodService podService,
+            IKubernetesPodMonitor podMonitor,
+            IKubernetesSecretService secretService,
+            IKubernetesPodContainerResolver containerResolver,
+            IApplicationInstanceSelector appInstanceSelector,
+            ISystemLog log,
+            ITentacleScriptLogProvider scriptLogProvider,
+            IHomeConfiguration homeConfiguration,
+            KubernetesPhysicalFileSystem kubernetesPhysicalFileSystem)
+            : base(podService, podMonitor, secretService, containerResolver, appInstanceSelector, log, scriptLogProvider, homeConfiguration, kubernetesPhysicalFileSystem)
+        {
+            this.containerResolver = containerResolver;
+        }
+
+        protected override async Task<IList<V1Container>> CreateInitContainers(StartKubernetesScriptCommandV1 command, string podName, string homeDir, string workspacePath)
+        {
+            var container = new V1Container
+            {
+                Name = $"{podName}-init",
+                Image = command.PodImageConfiguration?.Image ?? await containerResolver.GetContainerImageForCluster(),
+                Command = new List<string> { "sh", "-c", GetInitExecutionScript("/nfs-mount", homeDir, workspacePath) },
+                VolumeMounts = new List<V1VolumeMount>{new("/nfs-mount", "init-nfs-volume"), new(homeDir, "tentacle-home")},
+                Resources = new V1ResourceRequirements
+                {
+                    Requests = new Dictionary<string, ResourceQuantity>
+                    {
+                        ["cpu"] = new("25m"),
+                        ["memory"] = new("100Mi")
+                    }
+                }
+            };
+
+            return new List<V1Container> { container };
+        }
+
+        protected override async Task<IList<V1Container>> CreateScriptContainers(StartKubernetesScriptCommandV1 command, string podName, string scriptName, string homeDir, string workspacePath, string[]? scriptArguments)
+        {
+            return new List<V1Container>
+            {
+                await CreateScriptContainer(command, podName, scriptName, homeDir, workspacePath, scriptArguments)
+            };
+        }
+
+        protected override IList<V1Volume> CreateVolumes(StartKubernetesScriptCommandV1 command)
+        {
+            return new List<V1Volume>
+            {
+                new ()
+                {
+                    Name = "tentacle-home",
+                    EmptyDir = new V1EmptyDirVolumeSource()
+                },
+                new ()
+                {
+                    Name = "init-nfs-volume",
+                    PersistentVolumeClaim = new V1PersistentVolumeClaimVolumeSource
+                    {
+                    ClaimName = KubernetesConfig.PodVolumeClaimName
+                    }
+                }
+            };
+        }
+
+        string GetInitExecutionScript(string nfsVolumeDirectory, string homeDir, string workspacePath)
+        {
+            var nfsWorkspacePath = Path.Combine(nfsVolumeDirectory, workspacePath);
+            var homeWorkspacePath = Path.Combine(homeDir, workspacePath);
+            return $@"
+                    mkdir -p ""{homeWorkspacePath}"" && cp -r ""{nfsWorkspacePath}""/* ""{homeWorkspacePath}"";
+                    ";
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -220,7 +220,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         async Task<IList<V1Container>> CreateInitContainers(StartKubernetesScriptCommandV1 command, string podName, string homeDir, string workspacePath)
         {
-            if (!command.IsRawScriptWithNoDependencies)
+            if (!command.ReadonlyWorkspaceOnly)
             {
                 return new List<V1Container>();
             }
@@ -249,7 +249,7 @@ namespace Octopus.Tentacle.Kubernetes
         {
             var homeVolume = new V1Volume("tentacle-home");
             var volumes = new List<V1Volume> { homeVolume };
-            if (command.IsRawScriptWithNoDependencies)
+            if (command.ReadonlyWorkspaceOnly)
             {
                 homeVolume.EmptyDir = new V1EmptyDirVolumeSource();
                 var initVolume = new V1Volume("init-nfs-volume")
@@ -332,7 +332,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         V1Container? CreateWatchdogContainer(StartKubernetesScriptCommandV1 command, string homeDir)
         {
-            if (command.IsRawScriptWithNoDependencies || KubernetesConfig.NfsWatchdogImage is null)
+            if (command.ReadonlyWorkspaceOnly || KubernetesConfig.NfsWatchdogImage is null)
             {
                 return null;
             }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -27,7 +27,6 @@ namespace Octopus.Tentacle.Kubernetes
     {
         readonly IKubernetesPodService podService;
         readonly IKubernetesPodMonitor podMonitor;
-        readonly IKubernetesPodStatusProvider podStatusProvider;
         readonly IKubernetesSecretService secretService;
         readonly IKubernetesPodContainerResolver containerResolver;
         readonly IApplicationInstanceSelector appInstanceSelector;
@@ -39,7 +38,6 @@ namespace Octopus.Tentacle.Kubernetes
         public KubernetesScriptPodCreator(
             IKubernetesPodService podService,
             IKubernetesPodMonitor podMonitor,
-            IKubernetesPodStatusProvider podStatusProvider,
             IKubernetesSecretService secretService,
             IKubernetesPodContainerResolver containerResolver,
             IApplicationInstanceSelector appInstanceSelector,
@@ -50,7 +48,6 @@ namespace Octopus.Tentacle.Kubernetes
         {
             this.podService = podService;
             this.podMonitor = podMonitor;
-            this.podStatusProvider = podStatusProvider;
             this.secretService = secretService;
             this.containerResolver = containerResolver;
             this.appInstanceSelector = appInstanceSelector;
@@ -166,15 +163,10 @@ namespace Octopus.Tentacle.Kubernetes
 
             LogVerboseToBothLogs($"Creating Kubernetes Pod '{podName}'.", tentacleScriptLog);
 
-            if (!command.IsRawScriptWithNoDependencies)
-            {
-                //write the bootstrap runner script to the workspace
-                workspace.CopyFile(KubernetesConfig.BootstrapRunnerExecutablePath, "bootstrapRunner", true);
-            }
+            workspace.CopyFile(KubernetesConfig.BootstrapRunnerExecutablePath, "bootstrapRunner", true);
 
             var scriptName = Path.GetFileName(workspace.BootstrapScriptFilePath);
-            var taskWorkDirectory = $"{homeDir}/Work/{workspace.ScriptTicket.TaskId}";
-            var bootstrapRunnerExecutablePath = $"{homeDir}/Work/{workspace.ScriptTicket.TaskId}/bootstrapRunner";
+            var workspacePath = Path.Combine("Work", workspace.ScriptTicket.TaskId);
 
             var serviceAccountName = !string.IsNullOrWhiteSpace(command.ScriptPodServiceAccountName)
                 ? command.ScriptPodServiceAccountName
@@ -194,10 +186,10 @@ namespace Octopus.Tentacle.Kubernetes
                 },
                 Spec = new V1PodSpec
                 {
-                    // Containers = await CreateRequiredContainers(command, workspace, podName, scriptName),
+                    InitContainers = await CreateInitContainers(command, podName, homeDir, workspacePath),
                     Containers = new List<V1Container>
                     {
-                        await CreateScriptContainer(command, podName, bootstrapRunnerExecutablePath, taskWorkDirectory, scriptName, workspace.ScriptArguments, homeDir)
+                        await CreateScriptContainer(command, podName, scriptName, homeDir, workspacePath, workspace.ScriptArguments)
                     }.AddIfNotNull(CreateWatchdogContainer(command, homeDir)),
                     //only include the image pull secret name if it's actually been defined
                     ImagePullSecrets = imagePullSecretName is not null
@@ -223,37 +215,61 @@ namespace Octopus.Tentacle.Kubernetes
 
             var createdPod = await podService.Create(pod, cancellationToken);
             podMonitor.AddPendingPod(command.ScriptTicket, createdPod);
-            if (command.IsRawScriptWithNoDependencies)
-            {
-                log.Verbose("Waiting for script pod to start");
-                await podStatusProvider.WaitForScriptPodToStart(command.ScriptTicket, cancellationToken);
-                // log.Verbose("Waiting a bit more time...");
-                // await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
-                log.Verbose("Copying files");
-                await podService.CopyFileToPodAsync(createdPod, workspace.BootstrapScriptFilePath, workspace.BootstrapScriptFilePath, cancellationToken);
-                await podService.CopyFileToPodAsync(createdPod, KubernetesConfig.BootstrapRunnerExecutablePath, bootstrapRunnerExecutablePath, cancellationToken);
-            }
             LogVerboseToBothLogs($"Executing script in Kubernetes Pod '{podName}'.", tentacleScriptLog);
+        }
+
+        async Task<IList<V1Container>> CreateInitContainers(StartKubernetesScriptCommandV1 command, string podName, string homeDir, string workspacePath)
+        {
+            if (!command.IsRawScriptWithNoDependencies)
+            {
+                return new List<V1Container>();
+            }
+
+            var container = new V1Container
+            {
+                Name = $"{podName}-init",
+                Image = command.PodImageConfiguration?.Image ?? await containerResolver.GetContainerImageForCluster(),
+                Command = new List<string> { "sh", "-c", GetInitExecutionScript("/nfs-mount", homeDir, workspacePath) },
+                VolumeMounts = new List<V1VolumeMount>{new("/nfs-mount", "init-nfs-volume"), new(homeDir, "tentacle-home")},
+                Resources = new V1ResourceRequirements
+                {
+                    //set resource requests to be quite low for now as the scripts tend to run fairly quickly
+                    Requests = new Dictionary<string, ResourceQuantity>
+                    {
+                        ["cpu"] = new("25m"),
+                        ["memory"] = new("100Mi")
+                    }
+                }
+            };
+
+            return new List<V1Container> { container };
         }
 
         static IList<V1Volume> CreateVolumes(StartKubernetesScriptCommandV1 command)
         {
+            var homeVolume = new V1Volume("tentacle-home");
+            var volumes = new List<V1Volume> { homeVolume };
             if (command.IsRawScriptWithNoDependencies)
             {
-                return new List<V1Volume>();
-            }
-
-            return new List<V1Volume>
-            {
-                new()
+                homeVolume.EmptyDir = new V1EmptyDirVolumeSource();
+                var initVolume = new V1Volume("init-nfs-volume")
                 {
-                    Name = "tentacle-home",
                     PersistentVolumeClaim = new V1PersistentVolumeClaimVolumeSource
                     {
                         ClaimName = KubernetesConfig.PodVolumeClaimName
                     }
-                }
-            };
+                };
+                volumes.Add(initVolume);
+            }
+            else
+            {
+                homeVolume.PersistentVolumeClaim = new V1PersistentVolumeClaimVolumeSource
+                {
+                    ClaimName = KubernetesConfig.PodVolumeClaimName
+                };
+            }
+
+            return volumes;
         }
 
         void LogVerboseToBothLogs(string message, InMemoryTentacleScriptLog tentacleScriptLog)
@@ -262,15 +278,21 @@ namespace Octopus.Tentacle.Kubernetes
             tentacleScriptLog.Verbose(message);
         }
 
-        async Task<V1Container> CreateScriptContainer(StartKubernetesScriptCommandV1 command, string podName, string bootstrapperExecutablePath, string taskWorkDirectory, string scriptName, string[]? scriptArguments, string homeDir)
+        async Task<V1Container> CreateScriptContainer(StartKubernetesScriptCommandV1 command, string podName, string scriptName, string homeDir, string workspacePath, string[]? scriptArguments)
         {
             var spaceInformation = kubernetesPhysicalFileSystem.GetStorageInformation();
             return new V1Container
             {
                 Name = podName,
                 Image = command.PodImageConfiguration?.Image ?? await containerResolver.GetContainerImageForCluster(),
-                Command = new List<string> { "sh", "-c", GetExecutionScript(bootstrapperExecutablePath, taskWorkDirectory, scriptName, scriptArguments) },
-                VolumeMounts = CreateVolumeMounts(command, homeDir),
+                Command = new List<string> { $"{homeDir}/Work/{command.ScriptTicket.TaskId}/bootstrapRunner" },
+                Args = new List<string>
+                    {
+                        Path.Combine(homeDir, workspacePath),
+                        Path.Combine(homeDir, workspacePath, scriptName)
+                    }.Concat(scriptArguments ?? Array.Empty<string>())
+                    .ToList(),
+                VolumeMounts = new List<V1VolumeMount>{new(homeDir, "tentacle-home")},
                 Env = new List<V1EnvVar>
                 {
                     new(KubernetesConfig.NamespaceVariableName, KubernetesConfig.Namespace),
@@ -299,34 +321,13 @@ namespace Octopus.Tentacle.Kubernetes
             };
         }
 
-        IList<V1VolumeMount> CreateVolumeMounts(StartKubernetesScriptCommandV1 command, string homeDir)
+        string GetInitExecutionScript(string nfsVolumeDirectory, string homeDir, string workspacePath)
         {
-            if (command.IsRawScriptWithNoDependencies)
-            {
-                return new List<V1VolumeMount>();
-            }
-
-            return new List<V1VolumeMount>
-            {
-                new(homeDir, "tentacle-home"),
-            };
-        }
-
-        string GetExecutionScript(string bootstrapperExecutablePath, string taskWorkDirectory, string scriptName, string[]? scriptArguments)
-        {
-            scriptArguments ??= Array.Empty<string>();
-            return @$"
-                     ready=false;
-                     while ! ""$ready""; do
-                         if [ -e {bootstrapperExecutablePath} ]; then
-                             ready=true;
-                         else
-                             sleep 0.1;
-                         fi
-                     done
-
-                     {bootstrapperExecutablePath} {taskWorkDirectory} {taskWorkDirectory}/{scriptName} {string.Join(" ", scriptArguments)}
-                     ";
+            var nfsWorkspacePath = Path.Combine(nfsVolumeDirectory, workspacePath);
+            var homeWorkspacePath = Path.Combine(homeDir, workspacePath);
+            return $@"
+                    mkdir -p ""{homeWorkspacePath}"" && cp -r ""{nfsWorkspacePath}""/* ""{homeWorkspacePath}"";
+                    ";
         }
 
         V1Container? CreateWatchdogContainer(StartKubernetesScriptCommandV1 command, string homeDir)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -220,7 +220,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         async Task<IList<V1Container>> CreateInitContainers(StartKubernetesScriptCommandV1 command, string podName, string homeDir, string workspacePath)
         {
-            if (!command.ReadonlyWorkspaceOnly)
+            if (!command.IsRawScript)
             {
                 return new List<V1Container>();
             }
@@ -249,7 +249,7 @@ namespace Octopus.Tentacle.Kubernetes
         {
             var homeVolume = new V1Volume("tentacle-home");
             var volumes = new List<V1Volume> { homeVolume };
-            if (command.ReadonlyWorkspaceOnly)
+            if (command.IsRawScript)
             {
                 homeVolume.EmptyDir = new V1EmptyDirVolumeSource();
                 var initVolume = new V1Volume("init-nfs-volume")
@@ -332,7 +332,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         V1Container? CreateWatchdogContainer(StartKubernetesScriptCommandV1 command, string homeDir)
         {
-            if (command.ReadonlyWorkspaceOnly || KubernetesConfig.NfsWatchdogImage is null)
+            if (command.IsRawScript || KubernetesConfig.NfsWatchdogImage is null)
             {
                 return null;
             }

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -66,6 +66,7 @@
 		<PackageReference Include="Octopus.Time" Version="1.1.339" />
 		<PackageReference Include="Polly" Version="7.2.2" />
 		<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+		<PackageReference Include="SharpZipLib" Version="1.3.3" />
 		<PackageReference Include="System.Management" Version="4.7.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 		<PackageReference Include="System.Net.Primitives" Version="4.3.1" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -66,7 +66,6 @@
 		<PackageReference Include="Octopus.Time" Version="1.1.339" />
 		<PackageReference Include="Polly" Version="7.2.2" />
 		<PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-		<PackageReference Include="SharpZipLib" Version="1.3.3" />
 		<PackageReference Include="System.Management" Version="4.7.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 		<PackageReference Include="System.Net.Primitives" Version="4.3.1" />

--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
@@ -21,7 +21,8 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
         readonly IKubernetesPodService podService;
         readonly IScriptWorkspaceFactory workspaceFactory;
         readonly IKubernetesPodStatusProvider podStatusProvider;
-        readonly IKubernetesScriptPodCreator podCreator;
+        readonly IKubernetesScriptPodCreator scriptPodCreator;
+        readonly IKubernetesRawScriptPodCreator rawScriptPodCreator;
         readonly IKubernetesPodLogService podLogService;
         readonly ITentacleScriptLogProvider scriptLogProvider;
         readonly IScriptPodSinceTimeStore scriptPodSinceTimeStore;
@@ -31,7 +32,8 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
             IKubernetesPodService podService,
             IScriptWorkspaceFactory workspaceFactory,
             IKubernetesPodStatusProvider podStatusProvider,
-            IKubernetesScriptPodCreator podCreator,
+            IKubernetesScriptPodCreator scriptPodCreator,
+            IKubernetesRawScriptPodCreator rawScriptPodCreator,
             IKubernetesPodLogService podLogService,
             ITentacleScriptLogProvider scriptLogProvider,
             IScriptPodSinceTimeStore scriptPodSinceTimeStore,
@@ -40,7 +42,8 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
             this.podService = podService;
             this.workspaceFactory = workspaceFactory;
             this.podStatusProvider = podStatusProvider;
-            this.podCreator = podCreator;
+            this.scriptPodCreator = scriptPodCreator;
+            this.rawScriptPodCreator = rawScriptPodCreator;
             this.podLogService = podLogService;
             this.scriptLogProvider = scriptLogProvider;
             this.scriptPodSinceTimeStore = scriptPodSinceTimeStore;
@@ -151,7 +154,14 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
         
         async Task<IReadOnlyCollection<ProcessOutput>> CreatePodAndWaitForLogs(StartKubernetesScriptCommandV1 command, IScriptWorkspace workspace, CancellationToken cancellationToken)
         {
-            await podCreator.CreatePod(command, workspace, cancellationToken);
+            if (command.IsRawScript)
+            {
+                await rawScriptPodCreator.CreatePod(command, workspace, cancellationToken);
+            }
+            else
+            {
+                await scriptPodCreator.CreatePod(command, workspace, cancellationToken);
+            }
 
             var (logs, _) = await podLogService.GetLogs(command.ScriptTicket, 0, cancellationToken);
             return logs;

--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
@@ -208,7 +208,7 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
                 command.ScriptPodServiceAccountName,
                 command.Scripts,
                 command.Files.ToArray(),
-                isRawScriptWithNoDependencies: false
+                readonlyWorkspaceOnly: false
             );
         }
 

--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
@@ -207,7 +207,8 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
                 command.PodImageConfiguration?.ToV1(),
                 command.ScriptPodServiceAccountName,
                 command.Scripts,
-                command.Files.ToArray()
+                command.Files.ToArray(),
+                isRawScriptWithNoDependencies: false
             );
         }
 

--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
@@ -208,7 +208,7 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
                 command.ScriptPodServiceAccountName,
                 command.Scripts,
                 command.Files.ToArray(),
-                readonlyWorkspaceOnly: false
+                isRawScript: false
             );
         }
 


### PR DESCRIPTION
# Background

There is a known issue with Server running the upgrade script on the Kubernetes agent where if the helm chart has changed in such a way that an NFS Pod restart is required, the script pod doing the upgrade will be forcefully killed by the nfs watchdog. This is reported to server as a failure so the upgrade fails and there is no follow up health check to get the latest version details. The upgrade itself might actually succeed, but because the task fails in server, it requires the user to do a health check before they can use it.

# Results

~To just fix the issue above, we could just disable the NFS watchdog for scripts that don't need it (raw scripts with no dependencies). However thinking about this holistically, I thought it might be even better to remove the volume mount requirement all together for those pods. The only hurdle for that is how to get the files onto the pod if it we can't use the volume mount. It turns out we can use `tar` with `Client.NamespacedPodExecAsync()` as per this example: https://github.com/kubernetes-client/csharp/pull/962~

After discussion with the team, we've opted for a lighter-weight solution which still acts as you would expect. We're using an init container which mounts the volume and then copies the files to an empty dir shared with the main container. Then the main container runs completely without a mount. This way we don't have to send files manually using the approach above but it still makes sense because the main container does not rely on the volume mount once the init container is complete.

https://github.com/OctopusDeploy/OctopusDeploy/pull/25256
~https://github.com/OctopusDeploy/helm-charts/pull/173~ <- this is no longer necessary with the new approach.

[sc-76765]