### PR TITLE
Use Artifactory instead of dockerhub to source helm chart

### DIFF
--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
@@ -13,6 +13,7 @@ public class KubernetesAgentInstaller
 {
     //This is the DNS of the localhost Kubernetes Server we add to the cluster in the KubernetesClusterInstaller.SetLocalhostRouting()
     const string LocalhostKubernetesServiceDns = "dockerhost.default.svc.cluster.local";
+    const string ArtifactoryAgentOciRepository = "oci://docker.packages.octopushq.com/kubernetes-agent";
 
     readonly string helmExePath;
     readonly string kubeCtlExePath;
@@ -108,7 +109,7 @@ public class KubernetesAgentInstaller
 
     string BuildAgentInstallArguments(string valuesFilePath, string? tentacleImageAndTag)
     {
-        var (chartVersion, chartRepo) = GetChartVersionAndRepository();
+        var chartVersion = GetChartVersion();
         var args = new[]
         {
             "upgrade",
@@ -121,19 +122,17 @@ public class KubernetesAgentInstaller
             NamespaceFlag,
             KubeConfigFlag,
             AgentName,
-            chartRepo
+            ArtifactoryAgentOciRepository
         };
 
         return string.Join(" ", args.WhereNotNull());
     }
 
-    static (string ChartVersion, string ChartRepo) GetChartVersionAndRepository()
+    static string GetChartVersion()
     {
         var customHelmChartVersion = Environment.GetEnvironmentVariable("KubernetesIntegrationTests_HelmChartVersion");
         
-        return !string.IsNullOrWhiteSpace(customHelmChartVersion) 
-            ? (customHelmChartVersion, "oci://docker.packages.octopushq.com/kubernetes-agent") 
-            : ("1.*.*", "oci://registry-1.docker.io/octopusdeploy/kubernetes-agent");
+        return !string.IsNullOrWhiteSpace(customHelmChartVersion) ? customHelmChartVersion : "1.*.*";
     }
 
     static string? GetImageAndRepository(string? tentacleImageAndTag)


### PR DESCRIPTION
# Background

We've been hitting rate limiting because docker is tightening up their rate limits.

# Results

Instead of doing what we do in server which is to return inconclusive when dockerhub rate limits our request, we are just going to use Artifactory. This will eliminate the rate limiting but could cause failures if artifactory is down. Because this test doesn't have to run on the same scale as server, we don't need to stress too much about this. If it does fail, we can just rerun the test.