### PR TITLE
Call openssl rehash in Kubernetes agent startup script

### DIFF
--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -6,6 +6,11 @@ if [[ "$ACCEPT_EULA" != "Y" ]]; then
   exit 1
 fi
 
+# In the scenario where a customer is using a custom certificate (which is mounted via a config map), we need to rehash the certificates
+# We just do this all the time because there is no downside
+echo "Rehashing SSL/TLS certificates"
+openssl rehash /etc/ssl/certs
+
 # Tentacle Docker images only support once instance per container. Running multiple instances can be achieved by running multiple containers.
 instanceName=Tentacle
 internalListeningPort=10933


### PR DESCRIPTION
# Background

To support customers with custom certificates, a new helm-chart PR has been created
https://github.com/OctopusDeploy/helm-charts/pull/188

Debian requires that the certificate be hashed (which creates a symlink to the original file, but with a hashed filename) to be used.

Rather than stuff around with init-containers or lifecycle events, we are including this rehash at the start of the `configure-and-run.sh` script as it's fast and safe.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.