### PR TITLE
Add the 1.30 tag to the known Script pod container tags

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerRegistry.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerRegistry.cs
@@ -25,6 +25,7 @@ namespace Octopus.Tentacle.Kubernetes
             new(1, 27),
             new(1, 28),
             new(1, 29),
+            new(1, 30),
         };
 
         public async Task<string> GetContainerImageForCluster()


### PR DESCRIPTION
# Background

We published the `1.30` tag for the `kubernetes-agent-tools-base` image, but forgot to update the known tags in the resolver. In practice it doesn't really matter because running on a 1.30 cluster, it defaults to `latest`, which is the `1.30` tag anyway, but still :)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.