### PR TITLE
Don't fail mkdir if directory already exists

### DIFF
--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -334,7 +334,7 @@ function registerAdditionalServer() {
 
 function markAsInitialised() {
     # There is a startupProbe which checks for this file
-    mkdir /etc/octopus && touch /etc/octopus/initialized
+    mkdir -p /etc/octopus && touch /etc/octopus/initialized
 }
 
 setupVariablesForRegistrationCheck


### PR DESCRIPTION
# Background

When diagnosing issues with a customers agent installation, their logs indicated that the `mkdir` call was failing 

`mkdir: cannot create directory '/etc/octopus': File exists`

# Results

Adding the `-p` flag suppresses the error if the directory already exists. I'm not 100% _why_ the directory already exists. My initial suspicion is maybe something to do with Logs being written during registration and creating that directory before the `markAsInitialised` is called

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.`