### PR TITLE
Add support for imagePullSecrets to be supplied to script pod

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -37,6 +37,12 @@ namespace Octopus.Tentacle.Kubernetes
         public static string PersistentVolumeFreeBytesVariableName => $"{EnvVarPrefix}__PERSISTENTVOLUMEFREEBYTES";
 
         public const string ServerCommsAddressesVariableName = "ServerCommsAddresses";
+
+        public static IEnumerable<string> PodImagePullSecretNames => Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODIMAGEPULLSECRETNAMES")
+            ?.Split(',')
+            .Select(str => str.Trim())
+            .WhereNotNullOrWhiteSpace()
+            .ToArray() ?? Array.Empty<string>();
         
         public static string MetricsEnableVariableName => $"{EnvVarPrefix}__ENABLEMETRICSCAPTURE";
         public static bool MetricsIsEnabled


### PR DESCRIPTION
# Background

A customer reported that they would like to be able to add an `imagePullSecret` to the script pods as their nodes are dynamically created, so the image is being pulled regularily and they are running into the docker hub rate limiting.

# Results

This PR adds a new environment variable `OCTOPUS__K8STENTACLE__PODIMAGEPULLSECRETNAMES` which is a comma separated list of secret names to be used in the `imagePullSecrets` for the script pods.

Related Helm PR: https://github.com/OctopusDeploy/helm-charts/pull/214

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.