### PR TITLE
pull docker image from artifactory

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -89,9 +89,11 @@ partial class Build
                 packagingScriptsDirectory.GlobFiles("*")
                     .ForEach(x => FileSystemTasks.CopyFileToDirectory(x, debBuildDir / "scripts"));
 
+                const string dockerImage = $"docker.packages.octopushq.com/{dockerToolsContainerImage}";
+                
                 DockerTasks.DockerPull(settings => settings
                     .When(RuntimeInformation.OSArchitecture == Architecture.Arm64, _ => _.SetPlatform("linux/amd64"))
-                    .SetName(dockerToolsContainerImage));
+                    .SetName(dockerImage));
 
                 DockerTasks.DockerRun(settings => settings
                     .When(RuntimeInformation.OSArchitecture == Architecture.Arm64, _ => _.SetPlatform("linux/amd64"))
@@ -108,7 +110,7 @@ partial class Build
                         $"{BuildDirectory / "zip" / "net6.0" / runtimeId / "tentacle"}:/input",
                         $"{debBuildDir / "output"}:/output"
                     )
-                    .SetImage(dockerToolsContainerImage)
+                    .SetImage(dockerImage)
                     .SetCommand("bash")
                     .SetArgs("/scripts/package.sh", runtimeId));
             }

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -89,11 +89,9 @@ partial class Build
                 packagingScriptsDirectory.GlobFiles("*")
                     .ForEach(x => FileSystemTasks.CopyFileToDirectory(x, debBuildDir / "scripts"));
 
-                const string dockerImage = $"docker.packages.octopushq.com/{dockerToolsContainerImage}";
-                
                 DockerTasks.DockerPull(settings => settings
                     .When(RuntimeInformation.OSArchitecture == Architecture.Arm64, _ => _.SetPlatform("linux/amd64"))
-                    .SetName(dockerImage));
+                    .SetName(dockerToolsContainerImage));
 
                 DockerTasks.DockerRun(settings => settings
                     .When(RuntimeInformation.OSArchitecture == Architecture.Arm64, _ => _.SetPlatform("linux/amd64"))
@@ -110,7 +108,7 @@ partial class Build
                         $"{BuildDirectory / "zip" / "net6.0" / runtimeId / "tentacle"}:/input",
                         $"{debBuildDir / "output"}:/output"
                     )
-                    .SetImage(dockerImage)
+                    .SetImage(dockerToolsContainerImage)
                     .SetCommand("bash")
                     .SetArgs("/scripts/package.sh", runtimeId));
             }

--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -62,11 +62,13 @@ partial class Build
 
                     var testScriptsBindMountPoint = RootDirectory / "linux-packages" / "test-scripts";
 
-                    DockerTasks.DockerPull(settings => settings.SetName(testConfiguration.DockerImage));
+                    var dockerImage = $"docker.packages.octopushq.com/{testConfiguration.DockerImage}";
+                    
+                    DockerTasks.DockerPull(settings => settings.SetName(dockerImage));
                     DockerTasks.DockerRun(settings => settings
                         .EnableRm()
                         .EnableTty()
-                        .SetImage(testConfiguration.DockerImage)
+                        .SetImage(dockerImage)
                         .SetEnv(
                             $"VERSION={FullSemVer}",
                             "INPUT_PATH=/input",


### PR DESCRIPTION
# Background

Dockerhub is no longer providing rate-limit exemptions for Azure-hosted services. ([slack thread ref](https://octopusdeploy.slack.com/archives/CDANN5QLT/p1719890200247119)) This leads to failures on the **Test: Linux Packages**.

The [team discussed](https://octopusdeploy.slack.com/archives/C01HH8T16G3/p1719897407362199?thread_ts=1719894614.969379&cid=C01HH8T16G3) and to unblock the build pipeline, we will use Octopus artifactory as a proxy for the docker images needed by the build.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.