### PR TITLE
Update k8s agent tests to pull from Artifactory

### DIFF
--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/agent-values.yaml
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/agent-values.yaml
@@ -8,6 +8,17 @@ agent:
   targetEnvironments: ["development"]
   targetRoles: ["testing-cluster"]
   
+  image:
+    repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-agent-tentacle
+  
+persistence:
+  nfs:
+    image:
+      repository: docker.packages.octopushq.com/octopusdeploy/nfs-server
+    watchdog:
+      image:
+        repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-agent-nfs-watchdog  
+  
 testing:
   tentacle:
     configMap:


### PR DESCRIPTION
# Background

Similar to the change made in #973, the kubernetes integration tests are intermittently failing due to docker rate limits.

After discussing with the builds team, they let us know that artifactory will proxy and cache the container pull to docker hub if the container is not in artifactory.

# Results

Updated the agent values file to change all the default container image repositories to be artifactory.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.