### PR TITLE
Add polling proxy support for kubernetes-agent-tentacle container

### DIFF
--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -81,6 +81,10 @@ ENV OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP="False"
 ENV TentacleHome=""
 ENV TentacleApplications=""
 ENV TentacleCertificateBase64=""
+ENV TentaclePollingProxyHost=""
+ENV TentaclePollingProxyPort=""
+ENV TentaclePollingProxyUsername=""
+ENV TentaclePollingProxyPassword=""
 
 ENTRYPOINT ["/scripts/configure-and-run.sh"]
 

--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -332,6 +332,15 @@ function registerAdditionalServer() {
   tentacle "${ARGS[@]}"
 }
 
+function setPollingProxy() {
+  if [[ -n "$TentaclePollingProxyHost"]]; then
+    tentacle polling-proxy --proxyEnable="true" --instance="$instanceName" --proxyHost="$TentaclePollingProxyHost" --proxyPort="$TentaclePollingProxyPort" --proxyUsername="$TentaclePollingProxyUsername" --proxyPassword="$TentaclePollingProxyPassword"
+  else
+    echo "Disabling polling proxy"
+    tentacle polling-proxy --proxyEnable="false" --instance="$instanceName"
+  fi
+}
+
 function markAsInitialised() {
     # There is a startupProbe which checks for this file
     mkdir -p /etc/octopus && touch /etc/octopus/initialized
@@ -343,6 +352,7 @@ getStatusOfRegistration
 if [ "$IS_REGISTERED" == "true" ]; then
   echo "Tentacle is already configured and registered with server."
   addAdditionalServerInstancesIfRequired
+  setPollingProxy
 else
   echo "==============================================="
   echo "Configuring Octopus Deploy Kubernetes Tentacle"
@@ -354,6 +364,7 @@ else
   configureTentacle
   registerTentacle
   addAdditionalServerInstancesIfRequired
+  setPollingProxy
 
   echo "Configuration successful"
 fi

--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -333,7 +333,7 @@ function registerAdditionalServer() {
 }
 
 function setPollingProxy() {
-  if [[ -n "$TentaclePollingProxyHost"]]; then
+  if [[ -n "$TentaclePollingProxyHost" ]]; then
     echo "Using polling proxy at $TentaclePollingProxyHost:$TentaclePollingProxyPort"
     tentacle polling-proxy --proxyEnable="true" --instance="$instanceName" --proxyHost="$TentaclePollingProxyHost" --proxyPort="$TentaclePollingProxyPort" --proxyUsername="$TentaclePollingProxyUsername" --proxyPassword="$TentaclePollingProxyPassword"
   else

--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -333,13 +333,24 @@ function registerAdditionalServer() {
 }
 
 function setPollingProxy() {
+  local ARGS=()
+  ARGS+=('polling-proxy'
+    '--instance' "$instanceName")
+
   if [[ -n "$TentaclePollingProxyHost" ]]; then
     echo "Using polling proxy at $TentaclePollingProxyHost:$TentaclePollingProxyPort"
-    tentacle polling-proxy --proxyEnable="true" --instance="$instanceName" --proxyHost="$TentaclePollingProxyHost" --proxyPort="$TentaclePollingProxyPort" --proxyUsername="$TentaclePollingProxyUsername" --proxyPassword="$TentaclePollingProxyPassword"
+    ARGS+=(
+      '--proxyEnable' 'true'
+      '--proxyHost' "$TentaclePollingProxyHost"
+      '--proxyPort' "$TentaclePollingProxyPort"
+      '--proxyUsername' "$TentaclePollingProxyUsername"
+      '--proxyPassword' "$TentaclePollingProxyPassword")
   else
     echo "Disabling polling proxy"
-    tentacle polling-proxy --proxyEnable="false" --instance="$instanceName"
+        ARGS+=('--proxyEnable' 'false')
   fi
+
+  tentacle "${ARGS[@]}"
 }
 
 function markAsInitialised() {

--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -334,6 +334,7 @@ function registerAdditionalServer() {
 
 function setPollingProxy() {
   if [[ -n "$TentaclePollingProxyHost"]]; then
+    echo "Using polling proxy at $TentaclePollingProxyHost:$TentaclePollingProxyPort"
     tentacle polling-proxy --proxyEnable="true" --instance="$instanceName" --proxyHost="$TentaclePollingProxyHost" --proxyPort="$TentaclePollingProxyPort" --proxyUsername="$TentaclePollingProxyUsername" --proxyPassword="$TentaclePollingProxyPassword"
   else
     echo "Disabling polling proxy"


### PR DESCRIPTION
# Background

We had a customer ask if we supported the polling proxies in the Kubernetes agent. We didn't, however tentacle does support this via the `polling-proxy`  command. This PR adds support for this in the `configure-and-run.sh` script via environment variables supplied by the helm chart.

# Results

Adds a new method to the `configure-and-run.sh` that calls the `polling-proxy` command.

Shortcut story: [sc-83658]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.