### PR TITLE
Allow callers too specify the script ticket

### DIFF
--- a/source/Octopus.Tentacle.Client.Tests/ExecuteShellScriptCommandBuilderTests.cs
+++ b/source/Octopus.Tentacle.Client.Tests/ExecuteShellScriptCommandBuilderTests.cs
@@ -1,0 +1,21 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.Client.Scripts.Models.Builders;
+using Octopus.Tentacle.Contracts;
+
+namespace Octopus.Tentacle.Client.Tests
+{
+    [TestFixture]
+    public class ExecuteShellScriptCommandBuilderTests
+    {
+        [Test]
+        public void WhenScriptTicket_ItOverridesTheGeneratedSriptTicket()
+        {
+            var scriptTicket = new ScriptTicket("arealticket");
+            new ExecuteShellScriptCommandBuilder("bob", ScriptIsolationLevel.FullIsolation)
+                .WithScriptTicket(scriptTicket)
+                .Build()
+                .ScriptTicket.Should().Be(scriptTicket);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteScriptCommandBuilder.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/Models/Builders/ExecuteScriptCommandBuilder.cs
@@ -13,7 +13,7 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
         protected Dictionary<ScriptType, string> AdditionalScripts { get; private set; } = new();
         protected StringBuilder ScriptBody { get; private set; } = new(string.Empty);
         protected string TaskId { get; }
-        protected ScriptTicket ScriptTicket { get; }
+        protected ScriptTicket ScriptTicket { get; private set; }
         protected ScriptIsolationConfiguration IsolationConfiguration { get; private set; }
 
         protected ExecuteScriptCommandBuilder(string taskId, ScriptIsolationLevel defaultIsolationLevel)
@@ -27,6 +27,12 @@ namespace Octopus.Tentacle.Client.Scripts.Models.Builders
                 ScriptIsolationConfiguration.NoTimeout);
         }
 
+        public ExecuteScriptCommandBuilder WithScriptTicket(ScriptTicket scriptTicket)
+        {
+            this.ScriptTicket = scriptTicket;
+            return this;
+        }
+        
         public ExecuteScriptCommandBuilder WithScriptBody(string scriptBody)
         {
             ScriptBody = new StringBuilder(scriptBody);


### PR DESCRIPTION
# Background

For resilience we need to be able to specify the ScriptTicket so as to prevent scripts from re-running.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.