### PR TITLE
Support configuring script pod resource requirements

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -43,6 +43,9 @@ namespace Octopus.Tentacle.Kubernetes
             .Select(str => str.Trim())
             .WhereNotNullOrWhiteSpace()
             .ToArray() ?? Array.Empty<string>();
+
+        public static readonly string PodResourceJsonVariableName = $"{EnvVarPrefix}__PODRESOURCEJSON";
+        public static string? PodResourceJson => Environment.GetEnvironmentVariable(PodResourceJsonVariableName);
         
         public static string MetricsEnableVariableName => $"{EnvVarPrefix}__ENABLEMETRICSCAPTURE";
         public static bool MetricsIsEnabled

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
@@ -40,7 +40,7 @@ namespace Octopus.Tentacle.Kubernetes
                 Name = $"{podName}-init",
                 Image = command.PodImageConfiguration?.Image ?? await containerResolver.GetContainerImageForCluster(),
                 Command = new List<string> { "sh", "-c", GetInitExecutionScript("/nfs-mount", homeDir, workspacePath) },
-                VolumeMounts = new List<V1VolumeMount>{new("/nfs-mount", "init-nfs-volume"), new(homeDir, "tentacle-home")},
+                VolumeMounts = new List<V1VolumeMount> { new("/nfs-mount", "init-nfs-volume"), new(homeDir, "tentacle-home") },
                 Resources = new V1ResourceRequirements
                 {
                     Requests = new Dictionary<string, ResourceQuantity>
@@ -54,11 +54,11 @@ namespace Octopus.Tentacle.Kubernetes
             return new List<V1Container> { container };
         }
 
-        protected override async Task<IList<V1Container>> CreateScriptContainers(StartKubernetesScriptCommandV1 command, string podName, string scriptName, string homeDir, string workspacePath, string[]? scriptArguments)
+        protected override async Task<IList<V1Container>> CreateScriptContainers(StartKubernetesScriptCommandV1 command, string podName, string scriptName, string homeDir, string workspacePath, string[]? scriptArguments, InMemoryTentacleScriptLog tentacleScriptLog)
         {
             return new List<V1Container>
             {
-                await CreateScriptContainer(command, podName, scriptName, homeDir, workspacePath, scriptArguments)
+                await CreateScriptContainer(command, podName, scriptName, homeDir, workspacePath, scriptArguments, tentacleScriptLog)
             };
         }
 
@@ -66,17 +66,17 @@ namespace Octopus.Tentacle.Kubernetes
         {
             return new List<V1Volume>
             {
-                new ()
+                new()
                 {
                     Name = "tentacle-home",
                     EmptyDir = new V1EmptyDirVolumeSource()
                 },
-                new ()
+                new()
                 {
                     Name = "init-nfs-volume",
                     PersistentVolumeClaim = new V1PersistentVolumeClaimVolumeSource
                     {
-                    ClaimName = KubernetesConfig.PodVolumeClaimName
+                        ClaimName = KubernetesConfig.PodVolumeClaimName
                     }
                 }
             };

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using k8s;
 using k8s.Models;
 using Newtonsoft.Json;
 using Octopus.Diagnostics;
@@ -43,7 +44,7 @@ namespace Octopus.Tentacle.Kubernetes
             IKubernetesPodContainerResolver containerResolver,
             IApplicationInstanceSelector appInstanceSelector,
             ISystemLog log,
-            ITentacleScriptLogProvider scriptLogProvider, 
+            ITentacleScriptLogProvider scriptLogProvider,
             IHomeConfiguration homeConfiguration,
             KubernetesPhysicalFileSystem kubernetesPhysicalFileSystem)
         {
@@ -159,7 +160,7 @@ namespace Octopus.Tentacle.Kubernetes
         async Task CreatePod(StartKubernetesScriptCommandV1 command, IScriptWorkspace workspace, string? imagePullSecretName, InMemoryTentacleScriptLog tentacleScriptLog, CancellationToken cancellationToken)
         {
             var homeDir = homeConfiguration.HomeDirectory ?? throw new InvalidOperationException("Home directory is not set.");
-            
+
             var podName = command.ScriptTicket.ToKubernetesScriptPodName();
 
             LogVerboseToBothLogs($"Creating Kubernetes Pod '{podName}'.", tentacleScriptLog);
@@ -206,8 +207,8 @@ namespace Octopus.Tentacle.Kubernetes
                     {
                         new(matchExpressions: new List<V1NodeSelectorRequirement>
                         {
-                            new("kubernetes.io/os", "In", new List<string>{"linux"}),
-                            new("kubernetes.io/arch", "In", new List<string>{"arm64","amd64"})
+                            new("kubernetes.io/os", "In", new List<string> { "linux" }),
+                            new("kubernetes.io/arch", "In", new List<string> { "arm64", "amd64" })
                         })
                     })))
                 }
@@ -256,6 +257,9 @@ namespace Octopus.Tentacle.Kubernetes
         protected async Task<V1Container> CreateScriptContainer(StartKubernetesScriptCommandV1 command, string podName, string scriptName, string homeDir, string workspacePath, string[]? scriptArguments)
         {
             var spaceInformation = kubernetesPhysicalFileSystem.GetStorageInformation();
+
+            var resourceRequirements = GetScriptPodResourceRequirements();
+
             return new V1Container
             {
                 Name = podName,
@@ -267,7 +271,7 @@ namespace Octopus.Tentacle.Kubernetes
                         Path.Combine(homeDir, workspacePath, scriptName)
                     }.Concat(scriptArguments ?? Array.Empty<string>())
                     .ToList(),
-                VolumeMounts = new List<V1VolumeMount>{new(homeDir, "tentacle-home")},
+                VolumeMounts = new List<V1VolumeMount> { new(homeDir, "tentacle-home") },
                 Env = new List<V1EnvVar>
                 {
                     new(KubernetesConfig.NamespaceVariableName, KubernetesConfig.Namespace),
@@ -284,14 +288,33 @@ namespace Octopus.Tentacle.Kubernetes
 
                     //We intentionally exclude setting "TentacleJournal" since it doesn't make sense to keep a Deployment Journal for Kubernetes deployments
                 },
-                Resources = new V1ResourceRequirements
+                Resources = resourceRequirements
+            };
+        }
+
+        V1ResourceRequirements GetScriptPodResourceRequirements()
+        {
+            var json = KubernetesConfig.PodResourceJson;
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                try
                 {
-                    //set resource requests to be quite low for now as the scripts tend to run fairly quickly
-                    Requests = new Dictionary<string, ResourceQuantity>
-                    {
-                        ["cpu"] = new("25m"),
-                        ["memory"] = new("100Mi")
-                    }
+                    return KubernetesJson.Deserialize<V1ResourceRequirements>(json);
+                }
+                catch (Exception e)
+                {
+                    //if we can't parse the JSON, fall back to the defaults below and warn the user
+                    log.WarnFormat(e, $"Failed to deserialize env.{KubernetesConfig.PodResourceJsonVariableName} into valid pod resource requirements. Using default values. Value: {json}");
+                }
+            }
+
+            return new V1ResourceRequirements
+            {
+                //set resource requests to be quite low for now as the scripts tend to run fairly quickly
+                Requests = new Dictionary<string, ResourceQuantity>
+                {
+                    ["cpu"] = new("25m"),
+                    ["memory"] = new("100Mi")
                 }
             };
         }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -304,7 +304,7 @@ namespace Octopus.Tentacle.Kubernetes
                 catch (Exception e)
                 {
                     //if we can't parse the JSON, fall back to the defaults below and warn the user
-                    log.WarnFormat(e, $"Failed to deserialize env.{KubernetesConfig.PodResourceJsonVariableName} into valid pod resource requirements. Using default values. Value: {json}");
+                    log.WarnFormat(e, $"Failed to deserialize env.{KubernetesConfig.PodResourceJsonVariableName} into valid pod resource requirements.{Environment.NewLine}JSON value: {json}{Environment.NewLine}Using default values.");
                 }
             }
 


### PR DESCRIPTION
# Background

A customer appears to be having resource contention with a large number of script pods. They would like to be able to modify the resource requirements of script pods.

# Results

Adds support for a new environment variable `OCTOPUS__K8STENTACLE__PODRESOURCEJSON` which contains the serialized resource requirements provided by the helm chart in https://github.com/OctopusDeploy/helm-charts/pull/225

We then deserialize this to a `V1ResourceRequirements` and use it

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.