### PR TITLE
Remove Example Octopus API Key

### DIFF
--- a/docker/readme.md
+++ b/docker/readme.md
@@ -29,7 +29,7 @@ On a Windows Server 2016 server, or on Windows 10, run:
 docker run --publish 10931:10933 `
            --tty --interactive `
            --env ListeningPort="10931" `
-           --env ServerApiKey="API-WZ27UDXXAPCKUPZSH1WTG8YC80G" `
+           --env ServerApiKey="API-xxx" `
            --env TargetEnvironment="Test" `
            --env TargetRole="app-server" `
            --env ServerUrl="https://octopus.example.com" `


### PR DESCRIPTION
# Background

Octopus is a [GitHub secret scanning partner](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partner-program), and this means we receive alerts when GitHub detects an Octopus API key in a public GitHub repository.

The `docker/README.md` file in this repository contains an example Octopus API key that is triggering an alert because it matches the same pattern as an actual Octopus API key. In this PR, I've replaced it with `API-xxx`.

# Results

After this PR is merged, GitHub will stop notifying us that an "exposed" API key is in this repository.

## Before

N/A

## After

N/A

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.