### PR TITLE
Fix bug to allow spaces in Kubernetes agent target tags

### DIFF
--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -204,10 +204,51 @@ function registerTentacle() {
 
   if [[ "$DeploymentTargetEnabled" == "true" ]]; then
     ARGS+=('register-k8s-target')
-    ARGS+=($(getTentacleAsDeploymentTargetRegistrationArgs))
+  
+    if [[ -n "$TargetEnvironment" ]]; then
+      IFS=',' read -ra ENVIRONMENTS <<<"$TargetEnvironment"
+      for i in "${ENVIRONMENTS[@]}"; do
+        ARGS+=('--environment' "$i")
+      done
+    fi
+
+    if [[ -n "$TargetRole" ]]; then
+      IFS=',' read -ra ROLES <<<"$TargetRole"
+      for i in "${ROLES[@]}"; do
+        ARGS+=('--role' "$i")
+      done
+    fi
+
+    if [[ -n "$TargetTenant" ]]; then
+      IFS=',' read -ra TENANTS <<<"$TargetTenant"
+      for i in "${TENANTS[@]}"; do
+        ARGS+=('--tenant' "$i")
+      done
+    fi
+
+    if [[ -n "$TargetTenantTag" ]]; then
+      IFS=',' read -ra TENANTTAGS <<<"$TargetTenantTag"
+      for i in "${TENANTTAGS[@]}"; do
+        ARGS+=('--tenanttag' "$i")
+      done
+    fi
+
+    if [[ -n "$TargetTenantedDeploymentParticipation" ]]; then
+      ARGS+=('--tenanted-deployment-participation' "$TargetTenantedDeploymentParticipation")
+    fi
+
+    if [[ -n "$DefaultNamespace" ]]; then
+      ARGS+=('--default-namespace' "$DefaultNamespace")
+    fi
   elif [[ "$WorkerEnabled" == "true" ]]; then
     ARGS+=('register-k8s-worker')
-    ARGS+=($(getTentacleAsWorkerRegistrationArgs))
+
+    if [[ -n "$WorkerPools" ]]; then
+      IFS=',' read -ra WORKERPOOLS <<<"$WorkerPools"
+      for i in "${WORKERPOOLS[@]}"; do
+        ARGS+=('--workerpool' "$i")
+      done
+    fi
   fi
 
   ARGS+=(
@@ -262,61 +303,6 @@ function registerTentacle() {
   fi
 
   tentacle "${ARGS[@]}"
-}
-
-function getTentacleAsDeploymentTargetRegistrationArgs() {
-  local ARGS=()
-
-  if [[ -n "$TargetEnvironment" ]]; then
-    IFS=',' read -ra ENVIRONMENTS <<<"$TargetEnvironment"
-    for i in "${ENVIRONMENTS[@]}"; do
-      ARGS+=('--environment' "$i")
-    done
-  fi
-
-  if [[ -n "$TargetRole" ]]; then
-    IFS=',' read -ra ROLES <<<"$TargetRole"
-    for i in "${ROLES[@]}"; do
-      ARGS+=('--role' "$i")
-    done
-  fi
-
-  if [[ -n "$TargetTenant" ]]; then
-    IFS=',' read -ra TENANTS <<<"$TargetTenant"
-    for i in "${TENANTS[@]}"; do
-      ARGS+=('--tenant' "$i")
-    done
-  fi
-
-  if [[ -n "$TargetTenantTag" ]]; then
-    IFS=',' read -ra TENANTTAGS <<<"$TargetTenantTag"
-    for i in "${TENANTTAGS[@]}"; do
-      ARGS+=('--tenanttag' "$i")
-    done
-  fi
-
-  if [[ -n "$TargetTenantedDeploymentParticipation" ]]; then
-    ARGS+=('--tenanted-deployment-participation' "$TargetTenantedDeploymentParticipation")
-  fi
-
-  if [[ -n "$DefaultNamespace" ]]; then
-    ARGS+=('--default-namespace' "$DefaultNamespace")
-  fi
-
-  echo "${ARGS[@]}"
-}
-
-function getTentacleAsWorkerRegistrationArgs() {
-  local ARGS=()
-
-  if [[ -n "$WorkerPools" ]]; then
-    IFS=',' read -ra WORKERPOOLS <<<"$WorkerPools"
-    for i in "${WORKERPOOLS[@]}"; do
-      ARGS+=('--workerpool' "$i")
-    done
-  fi
-
-  echo "${ARGS[@]}"
 }
 
 function addAdditionalServerInstancesIfRequired() {

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/agent-values.yaml
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/agent-values.yaml
@@ -6,7 +6,7 @@ agent:
   bearerToken: "this-is-a-fake-bearer-token"
   space: "Default"
   targetEnvironments: ["development"]
-  targetRoles: ["testing-cluster"]
+  targetRoles: ["Testing Cluster", "another-testing-cluster"]
   
   image:
     repository: docker.packages.octopushq.com/octopusdeploy/kubernetes-agent-tentacle


### PR DESCRIPTION
# Background

There is currently a [bug](https://octopus.zendesk.com/agent/tickets/196514) in the `configure-and-run.sh` script of the Kubernetes Tentacle that causes the registration to fail if a space is included in the target tag string.

This is caused by the bash script incorrectly interpreting the space inside the tag string as a delimiter, and thereby passing an extra token to the tentacle executable.

# Results

Fixes the bug by [reverting back](https://github.com/OctopusDeploy/OctopusTentacle/pull/969/files#diff-6dfa40bcf0d67e7161ca980e8437fbda23940d37b92e1645ca31d1cecdbdc637L170) to having a single bash function that performs the tentacle registration. 

The reason that this single function approach works is because it builds a local ARGS array, adds elements to it (which may include strings with whitespaces in them), and expands the array using the `${ARGS[@]}` notation which importantly preserves the items even if they include a whitespace. 

This is in contrast with how the array is currently built using sub-functions that pass the result around using `echo` (as an effort to avoid setting global array objects). `echo` "stringifies" the array and this causes it to lose information about whitespacing because whitespace is the default delimiter of bash arrays. One other way around this is to explicitly choose a new `IFS` character to delimit the array e.g. `IFS='^'`, and expand using the `${ARGS[*]}` notation which inserts the delimiter. However, this means we have effectively reserved the special character such that if the user were to type that into their tag then the program will fail because the script sees that character as the new delimiter.

Therefore, it is easiest to simply revert to the single function, as we are only losing a small amount of readability in the process. It is also very worth considering moving away from bash to a testable language as this logic becomes increasingly complex and hard to reason about.