### PR TITLE
Add support for custom script pod affinity & tolerations

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -50,6 +50,12 @@ namespace Octopus.Tentacle.Kubernetes
 
         public static readonly string PodResourceJsonVariableName = $"{EnvVarPrefix}__PODRESOURCEJSON";
         public static string? PodResourceJson => Environment.GetEnvironmentVariable(PodResourceJsonVariableName);
+
+        public static readonly string PodAffinityJsonVariableName = $"{EnvVarPrefix}__PODAFFINITYJSON";
+        public static string? PodAffinityJson => Environment.GetEnvironmentVariable(PodResourceJsonVariableName);
+
+        public static readonly string PodTolerationsJsonVariableName = $"{EnvVarPrefix}__PODTOLERATIONSJSON";
+        public static string? PodTolerationsJson => Environment.GetEnvironmentVariable(PodResourceJsonVariableName);
         
         public static string MetricsEnableVariableName => $"{EnvVarPrefix}__ENABLEMETRICSCAPTURE";
         public static bool MetricsIsEnabled

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -15,7 +15,7 @@ namespace Octopus.Tentacle.Kubernetes
         public static string PodServiceAccountName => GetRequiredEnvVar($"{EnvVarPrefix}__PODSERVICEACCOUNTNAME", "Unable to determine Kubernetes Pod service account name.");
         public static string PodVolumeClaimName => GetRequiredEnvVar($"{EnvVarPrefix}__PODVOLUMECLAIMNAME", "Unable to determine Kubernetes Pod persistent volume claim name.");
 
-        public static int PodMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODMONITORTIMEOUT"), out var podMonitorTimeout) ? podMonitorTimeout : 10*60; //10min
+        public static int PodMonitorTimeoutSeconds => int.TryParse(Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODMONITORTIMEOUT"), out var podMonitorTimeout) ? podMonitorTimeout : 10 * 60; //10min
         public static string NfsWatchdogImageVariableName => $"{EnvVarPrefix}__NFSWATCHDOGIMAGE";
         public static string? NfsWatchdogImage => Environment.GetEnvironmentVariable(NfsWatchdogImageVariableName);
 
@@ -52,39 +52,44 @@ namespace Octopus.Tentacle.Kubernetes
         public static string? PodResourceJson => Environment.GetEnvironmentVariable(PodResourceJsonVariableName);
 
         public static readonly string PodAffinityJsonVariableName = $"{EnvVarPrefix}__PODAFFINITYJSON";
-        public static string? PodAffinityJson => Environment.GetEnvironmentVariable(PodResourceJsonVariableName);
+        public static string? PodAffinityJson => Environment.GetEnvironmentVariable(PodAffinityJsonVariableName);
 
         public static readonly string PodTolerationsJsonVariableName = $"{EnvVarPrefix}__PODTOLERATIONSJSON";
-        public static string? PodTolerationsJson => Environment.GetEnvironmentVariable(PodResourceJsonVariableName);
-        
+        public static string? PodTolerationsJson => Environment.GetEnvironmentVariable(PodTolerationsJsonVariableName);
+
         public static string MetricsEnableVariableName => $"{EnvVarPrefix}__ENABLEMETRICSCAPTURE";
+
         public static bool MetricsIsEnabled
         {
-             get
-             {
-                 var envContent = Environment.GetEnvironmentVariable(MetricsEnableVariableName);
-                if(bool.TryParse(envContent, out var result))
+            get
+            {
+                var envContent = Environment.GetEnvironmentVariable(MetricsEnableVariableName);
+                if (bool.TryParse(envContent, out var result))
                 {
                     return result;
                 }
+
                 return true;
             }
         }
 
-        public static string[] ServerCommsAddresses {
-            get {
+        public static string[] ServerCommsAddresses
+        {
+            get
+            {
                 var addresses = new List<string>();
                 if (Environment.GetEnvironmentVariable(ServerCommsAddressVariableName) is { Length: > 0 } addressString)
                 {
                     addresses.Add(addressString);
                 }
-                if (Environment.GetEnvironmentVariable(ServerCommsAddressesVariableName) is {} addressesString)
+
+                if (Environment.GetEnvironmentVariable(ServerCommsAddressesVariableName) is { } addressesString)
                 {
                     addresses.AddRange(addressesString.Split(',').Where(a => !a.IsNullOrEmpty()));
                 }
+
                 return addresses.ToArray();
             }
-
         }
 
         static string GetRequiredEnvVar(string variable, string errorMessage)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -360,7 +360,7 @@ namespace Octopus.Tentacle.Kubernetes
                 }
                 catch (Exception e)
                 {
-                    var message = $"Failed to deserialize env.{KubernetesConfig.PodTolerationsJson} into valid pod tolerations.{Environment.NewLine}JSON value: {json}{Environment.NewLine}Using no tolerations for script pod.";
+                    var message = $"Failed to deserialize env.{KubernetesConfig.PodTolerationsJsonVariableName} into valid pod tolerations.{Environment.NewLine}JSON value: {json}{Environment.NewLine}Using no tolerations for script pod.";
                     //if we can't parse the JSON, fall back to the defaults below and warn the user
                     log.WarnFormat(e, message);
                     //write a verbose message to the script log. 


### PR DESCRIPTION
# Background

A customer would like to set affinity and tolerations on the script pods. This allows customers to set affinity & tolerations to force the script pods to only schedule on specific nodes.

This should allow customers who are running EKS with BottleRocket to avoid scheduling script pods on BottleRocket nodes

# Results

Shortcut story: [sc-86605]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.