### PR TITLE
Add ability to set script pod security contexts

### DIFF
--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -49,8 +49,9 @@ RUN chgrp -R 0 /opt /usr /.dotnet && \
 
 # The same as above, but we shouldn't recursively own /etc, as it would add
 # ownership to system files like /etc/passwd
-RUN chgrp 0 /etc && \
-    chmod g=u /etc
+# We own /etc/ssl/certs so we can do a rehash
+RUN chgrp 0 /etc /etc/ssl/certs && \
+    chmod g=u /etc /etc/ssl/certs
 
 ENV BOOTSTRAPRUNNEREXECUTABLEPATH=/bootstrapRunner
 ENV OCTOPUS_RUNNING_IN_CONTAINER=Y

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -57,6 +57,9 @@ namespace Octopus.Tentacle.Kubernetes
         public static readonly string PodTolerationsJsonVariableName = $"{EnvVarPrefix}__PODTOLERATIONSJSON";
         public static string? PodTolerationsJson => Environment.GetEnvironmentVariable(PodTolerationsJsonVariableName);
 
+        public static readonly string PodSecurityContextJsonVariableName = $"{EnvVarPrefix}__PODSECURITYCONTEXTJSON";
+        public static string? PodSecurityContextJson => Environment.GetEnvironmentVariable(PodSecurityContextJsonVariableName);
+        
         public static string MetricsEnableVariableName => $"{EnvVarPrefix}__ENABLEMETRICSCAPTURE";
 
         public static bool MetricsIsEnabled


### PR DESCRIPTION
# Background

Customers have asked if they are configure the Kubernetes agent pods to not run as the root user. K8s has this capability via the pod `securityContext` values (and `runAsUser`).

# Results

This PR exposes a new environment variable `OCTOPUS_K8STENTACLE_PODSECURITYCONTEXTJSON` that is provided by the Helm chart that is then deserialized and set on the script pod.

Shortcut story: [sc-87998]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.