### PR TITLE
Generating new certificates should be FIPS 140-2 compliant

### DIFF
--- a/source/Octopus.Tentacle.Tests/Certificates/CertificateGeneratorFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Certificates/CertificateGeneratorFixture.cs
@@ -19,8 +19,8 @@ namespace Octopus.Tentacle.Tests.Certificates
             var log = new InMemoryLog();
             var cert = generator.GenerateNew("CN=test");
             cert.Export(X509ContentType.Pkcs12);
-            Assert.That(cert.GetRSAPrivateKey()?.KeySize, Is.EqualTo(2048));
-            Assert.That(cert.GetRSAPublicKey()?.KeySize, Is.EqualTo(2048));
+            Assert.That(cert.GetRSAPrivateKey()?.KeySize, Is.EqualTo(4096));
+            Assert.That(cert.GetRSAPublicKey()?.KeySize, Is.EqualTo(4096));
             if (cert.SignatureAlgorithm.FriendlyName == "sha1RSA")
                 log.GetLog().Should().Contain("WARN: Falling back to SHA1 certificate");
             else

--- a/source/Octopus.Tentacle/Certificates/CertificateGenerator.cs
+++ b/source/Octopus.Tentacle/Certificates/CertificateGenerator.cs
@@ -30,7 +30,7 @@ namespace Octopus.Tentacle.Certificates
 
     public class CertificateGenerator : ICertificateGenerator
     {
-        public const int RecommendedKeyBitLength = 2048;
+        public const int RecommendedKeyBitLength = 4096;
         readonly ISystemLog log;
 
         public CertificateGenerator(ISystemLog log)
@@ -83,7 +83,7 @@ namespace Octopus.Tentacle.Certificates
             certificateGenerator.SetPublicKey(subjectKeyPair.Public);
 
             var issuerKeyPair = subjectKeyPair;
-            const string signatureAlgorithm = "SHA256WithRSA";
+            const string signatureAlgorithm = "SHA512WithRSA";
             var signatureFactory = new Asn1SignatureFactory(signatureAlgorithm, issuerKeyPair.Private);
             var bouncyCert = certificateGenerator.Generate(signatureFactory);
 


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/7802

We don't support 32 bit OS anymore, so I think it should be fine:
https://octopus.com/docs/support/compatibility#operating-system-compatibility

[sc-88505]

# Results
<!-- Describe the result of the change -->

Fixes https://github.com/OctopusDeploy/Issues/issues/7802

See [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) (including [this flowchart](https://whimsical.com/r-d-incoming-work-workflow-aug-21-NsDnGQXcwBLwU66a88Zhue) 
