### PR TITLE
Change Kubernetes script cancellation to better handle pod deletion

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -327,6 +327,14 @@ namespace Octopus.Tentacle.Kubernetes
             };
         }
 
+        public static TrackedScriptPodState Canceling()
+        {
+            return new TrackedScriptPodState()
+            {
+                Phase = TrackedScriptPodPhase.Canceling
+            };
+        }
+
         public static TrackedScriptPodState Succeeded(int exitCode, DateTimeOffset finishedAt)
         {
             return new TrackedScriptPodState()
@@ -356,6 +364,7 @@ namespace Octopus.Tentacle.Kubernetes
     {
         Pending,
         Running,
+        Canceling,
         Succeeded,
         Failed
     }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodMonitor.cs
@@ -327,14 +327,6 @@ namespace Octopus.Tentacle.Kubernetes
             };
         }
 
-        public static TrackedScriptPodState Canceling()
-        {
-            return new TrackedScriptPodState()
-            {
-                Phase = TrackedScriptPodPhase.Canceling
-            };
-        }
-
         public static TrackedScriptPodState Succeeded(int exitCode, DateTimeOffset finishedAt)
         {
             return new TrackedScriptPodState()
@@ -364,7 +356,6 @@ namespace Octopus.Tentacle.Kubernetes
     {
         Pending,
         Running,
-        Canceling,
         Succeeded,
         Failed
     }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodService.cs
@@ -15,7 +15,7 @@ namespace Octopus.Tentacle.Kubernetes
         Task WatchAllPods(string initialResourceVersion, Func<WatchEventType, V1Pod, CancellationToken, Task> onChange, Action<Exception> onError, CancellationToken cancellationToken);
         Task<V1Pod> Create(V1Pod pod, CancellationToken cancellationToken);
         Task DeleteIfExists(ScriptTicket scriptTicket, CancellationToken cancellationToken);
-        Task CancelScriptPod(ScriptTicket scriptTicket, ITrackedScriptPod trackedPod, CancellationToken cancellationToken);
+        Task DeleteIfExists(ScriptTicket scriptTicket, TimeSpan gracePeriod, CancellationToken cancellationToken);
     }
 
     public class KubernetesPodService : KubernetesService, IKubernetesPodService
@@ -84,14 +84,10 @@ namespace Octopus.Tentacle.Kubernetes
         public async Task DeleteIfExists(ScriptTicket scriptTicket, CancellationToken cancellationToken)
             => await DeleteIfExistsInternal(scriptTicket, null, cancellationToken);
 
-        public async Task CancelScriptPod(ScriptTicket scriptTicket, ITrackedScriptPod trackedPod, CancellationToken cancellationToken)
-        {
-            await DeleteIfExistsInternal(scriptTicket, 0, cancellationToken);
-            //if this is a cancellation, mark it as completed with the cancel exit code
-            trackedPod.MarkAsCompleted(ScriptExitCodes.CanceledExitCode, DateTimeOffset.UtcNow);
-        }
+        public async Task DeleteIfExists(ScriptTicket scriptTicket, TimeSpan gracePeriod, CancellationToken cancellationToken) 
+            => await DeleteIfExistsInternal(scriptTicket, (long)Math.Floor(gracePeriod.TotalSeconds), cancellationToken);
 
-        async Task DeleteIfExistsInternal(ScriptTicket scriptTicket, int? gracePeriodSeconds, CancellationToken cancellationToken)
+        async Task DeleteIfExistsInternal(ScriptTicket scriptTicket, long? gracePeriodSeconds, CancellationToken cancellationToken)
             => await TryExecuteAsync(async () => await Client.DeleteNamespacedPodAsync(scriptTicket.ToKubernetesScriptPodName(), KubernetesConfig.Namespace, new V1DeleteOptions(gracePeriodSeconds: gracePeriodSeconds), cancellationToken: cancellationToken));
     }
 }


### PR DESCRIPTION
# Background

Kubernetes script pod cancellation takes into account the grace seconds of the script pod. Which means that after cancellation, the pod can run for up to 30s before termination. This PR changes this logic to delete the pod with `0` grace seconds, it also returns a completed state from the `CancelScript` call so that the script observation stops calling `CancelScript` multiple times.

# Results

Script execution is now forced to not have a grace period. We also immediately mark the task as completed, which then stops the script observation loop from calling `CancelScript` again, which can result in an erroneous error as the pod has been removed.

This is also consistent with the normal shell scripts, which return complete & the canceled error code as soon as the cancellation token is marked as canceled.

<img width="825" alt="image" src="https://github.com/user-attachments/assets/67e90ff1-f9f3-4796-908a-d5ccc2d17db6">

Old code, note the multiple CancelScript calls
<img width="857" alt="image" src="https://github.com/user-attachments/assets/7046fb93-998b-40cf-9508-8b4e9e5d1438">

New code, note single CancelScript call
<img width="860" alt="image" src="https://github.com/user-attachments/assets/70cd075d-4319-4c81-8530-40139e223031">

Shortcut story: [sc-70002]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.