### PR TITLE
Makes --proxy added in #46 available to Docker containers

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -49,6 +49,7 @@ ENV DISABLE_DIND=N
 ENV ListeningPort=""
 ENV MachinePolicy="Default Machine Policy"
 ENV PublicHostNameConfiguration="ComputerName"
+ENV ProxyName=""
 ENV ServerApiKey=""
 ENV ServerPassword=""
 ENV ServerCommsAddress=""

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -214,9 +214,9 @@ function registerTentacle() {
         if [[ ! -z "$ListeningPort" && "$ListeningPort" != "$internalListeningPort" ]]; then
             ARGS+=('--tentacle-comms-port' $ListeningPort)
         fi
-		if [[ ! -z "$ProxyName" ]]; then
+        if [[ ! -z "$ProxyName" ]]; then
             ARGS+=('--proxy' "$ProxyName")
-		fi
+        fi
     fi
 
     if [[ ! -z "$ServerApiKey" ]]; then

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -90,9 +90,9 @@ function validateVariables() {
             echo " - communication mode 'Listening' (Passive)"
         fi
         echo " - registered port $ListeningPort"
-    if [[ ! -z "$ProxyName" ]]; then
-      echo " - proxy '$ProxyName'"
-    fi
+        if [[ ! -z "$ProxyName" ]]; then
+            echo " - proxy '$ProxyName'"
+        fi
     fi
     if [[ ! -z "$TargetWorkerPool" ]]; then
         echo " - worker pool '$TargetWorkerPool'"
@@ -215,7 +215,7 @@ function registerTentacle() {
             ARGS+=('--tentacle-comms-port' $ListeningPort)
         fi
 		if [[ ! -z "$ProxyName" ]]; then
-		  ARGS+=('--proxy' $ProxyName)
+            ARGS+=('--proxy' "$ProxyName")
 		fi
     fi
 

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -90,6 +90,9 @@ function validateVariables() {
             echo " - communication mode 'Listening' (Passive)"
         fi
         echo " - registered port $ListeningPort"
+    if [[ ! -z "$ProxyName" ]]; then
+      echo " - proxy '$ProxyName'"
+    fi
     fi
     if [[ ! -z "$TargetWorkerPool" ]]; then
         echo " - worker pool '$TargetWorkerPool'"
@@ -211,6 +214,9 @@ function registerTentacle() {
         if [[ ! -z "$ListeningPort" && "$ListeningPort" != "$internalListeningPort" ]]; then
             ARGS+=('--tentacle-comms-port' $ListeningPort)
         fi
+		if [[ ! -z "$ProxyName" ]]; then
+		  ARGS+=('--proxy' $ProxyName)
+		fi
     fi
 
     if [[ ! -z "$ServerApiKey" ]]; then

--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -133,7 +133,7 @@ function Validate-Variables() {
       Write-Log " - communication mode 'Listening' (Passive)"
     }
     Write-Log " - registered port $ListeningPort"
-    if($null -ne $ProxyName) {
+    if ($null -ne $ProxyName) {
       Write-Log " - proxy '$ProxyName'"
     }
   }

--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -25,6 +25,7 @@ $ServerPort=$env:ServerPort;
 $Space=$env:Space;
 $MachinePolicy=$env:MachinePolicy;
 $AsKubernetesTentacle=$env:AsKubernetesTentacle;
+$ProxyName=$env:ProxyName;
 
 $TentacleExe=$Exe
 
@@ -132,6 +133,9 @@ function Validate-Variables() {
       Write-Log " - communication mode 'Listening' (Passive)"
     }
     Write-Log " - registered port $ListeningPort"
+    if($null -ne $ProxyName) {
+      Write-Log " - proxy '$ProxyName'"
+    }
   }
   if ($null -ne $TargetWorkerPool) {
     Write-Log " - worker pool '$TargetWorkerPool'"
@@ -253,6 +257,10 @@ function Register-Tentacle(){
     if (($null -ne $ListeningPort) -and ($ListeningPort -ne $InternalListeningPort)) {
       $arg += "--tentacle-comms-port"
       $arg += $ListeningPort
+    }
+    if ($null -ne $ProxyName) {
+      $arg += "--proxy"
+      $arg += $ProxyName
     }
   }
 


### PR DESCRIPTION
# Background

https://github.com/OctopusDeploy/OctopusTentacle/pull/46 added the `--proxy` CLI arg. This change adds the ability to pass the value for that token as an environment variable into the container.

# Results

- Shortcut: [SC-90394]
- Resolves #996

## After

Specifying `ProxyName` as an environment variable to the container will add it as the value of the  `--proxy` CLI flag.

## Testing

This has been running in production for approximately a year. We're trying to unwind our customizations on top of the upstream image.