### PR TITLE
Remove Debian 11 Build for Kubernetes Tentacle

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -155,8 +155,6 @@ partial class Build
         {
             //Debian 12
             BuildAndPushOrLoadKubernetesTentacleContainerImage(push: true, load: false, KubernetesTentacleContainerRuntimeDepsTag, "docker.packages.octopushq.com");
-            //Debian 11
-            BuildAndPushOrLoadKubernetesTentacleContainerImage(push: true, load: false,  "6.0-bullseye-slim", "docker.packages.octopushq.com", tagSuffix: "bullseye-slim");
         });
 
     [PublicAPI]


### PR DESCRIPTION
# Background

As part of PR #997, Kubernetes Tentacle was updated to use Debian 12 as the default image. In that update, a Debian 11-based version was also built to address compatibility issues with sha1rsa on Windows Server 2012R2, as Debian 11 still uses OpenSSL v1, which works with sha1rsa on that older OS.

However, it was later discovered that while OpenSSL v1 is compatible, it only functions at a security level (SECLEVEL) of 1 or lower. The default SECLEVEL for the Debian base image is 2, meaning the Kubernetes Tentacle wouldn't work on Debian 11 (in this special case) unless the SECLEVEL is manually lowered. The reason for this is that the permitted list of signature hash algorithms at SECLEVEL 2 does not include sha1rsa. More details [here](https://docs.google.com/document/d/1jgApNQDZYYbNWLopsyK-GPAclI1Wjv-6ped3euY5H-s/edit#heading=h.c9lcqi8rpmrc)

As this setup does not meet its original purpose, we will discontinue building the Debian 11 version.

[sc-91578]


# Results

Removes the Debian 11 ("bullseye-slim") build for Kubernetes Tentacle
