### PR TITLE
Change NFS CSI driver version to v4.*.*

### DIFF
--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesClusterInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesClusterInstaller.cs
@@ -153,7 +153,7 @@ public class KubernetesClusterInstaller
             "--atomic",
             "--repo https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts",
             "--namespace kube-system",
-            "--version v4.6.0",
+            "--version \"v4.*.*\"",
             $"--kubeconfig \"{KubeConfigPath}\"",
             "csi-driver-nfs",
             "csi-driver-nfs"


### PR DESCRIPTION
# Background

We are changing the default version string in Server to `v4.*.*` so we get the latest version in the `v4` major version range.

# Results

This just updates this to be the same.

Shortcut story: [sc-94493]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.