### PR TITLE
Fix flaky test: Remove stray whitespace in expected exception messages.

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/ExceptionContractAssertionBuilder.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/ExceptionContractAssertionBuilder.cs
@@ -29,7 +29,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', before the request could begin: Transport endpoint is not connected",
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', before the request could begin: Connection refused",
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', before the request could begin: Broken pipe",
-                            $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', before the request could begin:  Received an unexpected EOF or 0 bytes from the transport stream",
+                            $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', before the request could begin: Received an unexpected EOF or 0 bytes from the transport stream",
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', before the request could begin: Unable to write data to the transport connection: Broken pipe",
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', before the request could begin: Unable to read data from the transport connection: Broken pipe",
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', before the request could begin: Unable to read data from the transport connection: Connection reset by peer.",
@@ -42,7 +42,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', before the request could begin: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host",
                             
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', after the request began: Broken pipe",
-                            $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', after the request began:  Received an unexpected EOF or 0 bytes from the transport stream",
+                            $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', after the request began: Received an unexpected EOF or 0 bytes from the transport stream",
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', after the request began: Unable to write data to the transport connection: Broken pipe",
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', after the request began: Unable to read data from the transport connection: Broken pipe",
                             $"An error occurred when sending a request to '{clientAndTentacle.ServiceEndPoint}/', after the request began: Attempted to read past the end of the stream.",


### PR DESCRIPTION
# Background

My build failed due to a flaky test:
https://build.octopushq.com/test/-3830879800243621547?currentProjectId=TeamFireAndMotion_OctopusTentacle_TentacleVLatest_net80&expandTestHistoryChartSection=true

It looks like there is stray whitespace in one of the expected exception messages that is causing the test to occasionally fail.

# Results

This PR removes the stray whitespace.

# How to review this PR

Was that whitespace deliberate?
Do we need to cater for messages both with and without the extra space?