### PR TITLE
Introduce OctopusDeploy.Tentacle.SelfContained Chocolatey package 

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -379,23 +379,40 @@ partial class Build
         {
             (ArtifactsDirectory / "chocolatey").CreateDirectory();
 
-            var md5Checksum = (ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}.msi").GetFileHash();
-            Log.Information($"MD5 Checksum: Octopus.Tentacle.msi = {md5Checksum}");
+            var md5ChecksumNetFramework = (ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}.msi").GetFileHash();
+            Log.Information($"MD5 Checksum: Octopus.Tentacle.msi = {md5ChecksumNetFramework}");
 
-            var md5ChecksumX64 = (ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-x64.msi").GetFileHash();
-            Log.Information($"Checksum: Octopus.Tentacle-x64.msi = {md5ChecksumX64}");
+            var md5ChecksumX64NetFramework = (ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-x64.msi").GetFileHash();
+            Log.Information($"Checksum: Octopus.Tentacle-x64.msi = {md5ChecksumX64NetFramework}");
+
+            var md5ChecksumSelfContained = (ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net8.0-windows-win-x86.msi").GetFileHash();
+            Log.Information($"MD5 Checksum: Octopus.Tentacle.msi = {md5ChecksumSelfContained}");
+
+            var md5ChecksumX64SelfContained = (ArtifactsDirectory / "msi" / $"Octopus.Tentacle.{FullSemVer}-net8.0-windows-win-x64.msi").GetFileHash();
+            Log.Information($"Checksum: Octopus.Tentacle-x64.msi = {md5ChecksumX64SelfContained}");
 
             var chocolateyInstallScriptPath = SourceDirectory / "Chocolatey" / "chocolateyInstall.ps1";
             using var chocolateyInstallScriptFile = new ModifiableFileWithRestoreContentsOnDispose(chocolateyInstallScriptPath);
 
             chocolateyInstallScriptFile.ReplaceRegexInFiles("0.0.0", FullSemVer);
-            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksum>", md5Checksum);
-            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksumtype>", "md5");
-            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksum64>", md5ChecksumX64);
-            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksumtype64>", "md5");
+            
+            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksum-net-framework>", md5ChecksumNetFramework);
+            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksumtype-net-framework>", "md5");
+            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksum64-net-framework>", md5ChecksumX64NetFramework);
+            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksumtype64-net-framework>", "md5");
+            
+            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksum-self-contained>", md5ChecksumSelfContained);
+            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksumtype-self-contained>", "md5");
+            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksum64-self-contained>", md5ChecksumX64SelfContained);
+            chocolateyInstallScriptFile.ReplaceRegexInFiles("<checksumtype64-self-contained>", "md5");
 
             ChocolateyTasks.ChocolateyPack(settings => settings
                 .SetPathToNuspec(SourceDirectory / "Chocolatey" / "OctopusDeploy.Tentacle.nuspec")
+                .SetVersion(NuGetVersion)
+                .SetOutputDirectory(ArtifactsDirectory / "chocolatey"));
+            
+            ChocolateyTasks.ChocolateyPack(settings => settings
+                .SetPathToNuspec(SourceDirectory / "Chocolatey" / "OctopusDeploy.Tentacle.SelfContained.nuspec")
                 .SetVersion(NuGetVersion)
                 .SetOutputDirectory(ArtifactsDirectory / "chocolatey"));
         });

--- a/source/Chocolatey/OctopusDeploy.Tentacle.SelfContained.nuspec
+++ b/source/Chocolatey/OctopusDeploy.Tentacle.SelfContained.nuspec
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd" xmlns:octopus="http://octopus.org">
   <metadata>
-    <id>OctopusDeploy.Tentacle</id>
-    <title>Octopus Deploy - Tentacle</title>
+    <id>OctopusDeploy.Tentacle.SelfContained</id>
+    <title>Octopus Deploy - Tentacle (Self-contained)</title>
     <version>0.0.0</version>
     <authors>Octopus Deploy</authors>
-    <summary>Deployment agent for Octopus Deploy, an automated deployment server.</summary>
+    <summary>Deployment agent (self-contained) for Octopus Deploy, an automated deployment server.</summary>
     <description>Octopus Deploy is a Continuous Delivery platform for complex deployments across your entire stack. Deploy with ease to Kubernetes, Linux, Windows virtual machines, Amazon Web Services, Azure, or Google Cloud. If the Octopus Tentacle agent, SSH, command line, or a web service can speak to it, Octopus can deploy to it.
 
-This package installs the Tentacle deployment agent service.</description>
+This package installs the self-contained Tentacle deployment agent service. The .NET Framework is not a pre-requisite.</description>
     <releaseNotes></releaseNotes>
     <language>en-US</language>
     <iconUrl>http://i.octopusdeploy.com/resources/Avatar3-32x32.png</iconUrl>

--- a/source/Chocolatey/chocolateyInstall.ps1
+++ b/source/Chocolatey/chocolateyInstall.ps1
@@ -4,7 +4,18 @@ Install-ChocolateyPackage `
     -SilentArgs '/quiet' `
     -Url 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.0.0.0.msi' `
     -Url64bit 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.0.0.0-x64.msi' `
-    -Checksum '<checksum>' `
-    -ChecksumType '<checksumtype>' `
-    -Checksum64 '<checksum64>' `
-    -ChecksumType64 '<checksumtype64>'
+    -Checksum '<checksum-net-framework>' `
+    -ChecksumType '<checksumtype-net-framework>' `
+    -Checksum64 '<checksum64-net-framework>' `
+    -ChecksumType64 '<checksumtype64-net-framework>'
+Install-ChocolateyPackage `
+    -PackageName 'OctopusDeploy.Tentacle.SelfContained' `
+    -FileType 'msi' `
+    -SilentArgs '/quiet' `
+    -Url 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.0.0.0-net8.0-windows-win-x86.msi' `
+    -Url64bit 'https://download.octopusdeploy.com/octopus/Octopus.Tentacle.0.0.0-net8.0-windows-win-x64.msi' `
+    -Checksum '<checksum-self-contained>' `
+    -ChecksumType '<checksumtype-self-contained>' `
+    -Checksum64 '<checksum64-self-contained>' `
+    -ChecksumType64 '<checksumtype64-self-contained>'
+


### PR DESCRIPTION
# Background

We are introducing the OctopusDeploy.Tentacle.SelfContained package for the public to be able to install the Octopus Self Contained Tentacle on Windows through Chocolatey.

Both should be published on Chocolatey through the internal Tentacle deployment process.

# Results

We will pack two nuspec files rather than one, resulting in two nuget packages being made available:
- OctopusDeploy.Tentacle
- OctopusDeploy.Tentacle.SelfContained

# Testing

Tested on a branch build and seems to be working, and is downloadable publicly
![image](https://github.com/user-attachments/assets/9f4e2cd1-9d38-41f0-b4bb-59c122bc9f72)
