### PR TITLE
Add support for Kubernetes agent script pod proxies secret

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -42,6 +42,7 @@ namespace Octopus.Tentacle.Kubernetes
         public static string? ScriptPodContainerImage => Environment.GetEnvironmentVariable($"{EnvVarPrefix}__SCRIPTPODIMAGE");
         public static string ScriptPodContainerImageTag => Environment.GetEnvironmentVariable($"{EnvVarPrefix}__SCRIPTPODIMAGETAG") ?? "latest";
         public static string? ScriptPodPullPolicy => Environment.GetEnvironmentVariable($"{EnvVarPrefix}__SCRIPTPODPULLPOLICY");
+        public static string? ScriptPodProxiesSecretName => Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODPROXIESSECRETNAME");
 
         public static IEnumerable<string> PodImagePullSecretNames => Environment.GetEnvironmentVariable($"{EnvVarPrefix}__PODIMAGEPULLSECRETNAMES")
             ?.Split(',')


### PR DESCRIPTION
# Background

A customer needs support for making outbound connections via a HTTP/S proxy in script pods.

# Results

To support this, we need to set the `http_proxy`/`HTTP_PROXY`, `https_proxy`/`HTTPS_PROXY` and `no_proxy`/`NO_PROXY` environment variables in the pod. This is being set in a new secret being added in https://github.com/OctopusDeploy/helm-charts/pull/329

We use a secret as the proxy URI might have authentication credentials in it

This PR just sets the `envFrom` on the script pods to a `secretRef` with the name of the proxies secret created when set

Shortcut story: [sc-95481]

![image](https://github.com/user-attachments/assets/78447e25-9397-4524-8a40-f77e1933e171)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.