### PR TITLE
Automatically update credits file with latest licence information

### DIFF
--- a/credits/credits.md.template
+++ b/credits/credits.md.template
@@ -1,0 +1,19 @@
+﻿---
+title: Credits
+description: Tentacle is made possible thanks to many great third-party products.
+position: 200
+---
+
+Tentacle is made possible thanks to the following great third-party products.
+
+|                      Package                      |                         Authors and/or maintainers                        |                                                                                                        Find it at...                                                                                                        |                                                       License                                                       |
+| ------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+{{ for dependency in dependencies ~}}
+| {{ dependency.id | string.pad_right 49 }} | {{ dependency.authors | string.pad_right 73}} | {{ "[" + dependency.project_url + "]" + "(" + dependency.project_url + ")" | string.pad_right 219 }} | {{ for descriptor in dependency.licenses.descriptors }}{{ "[" + descriptor.name + "]" + "(" + descriptor.url + ")" | string.pad_right 115 }}{{ end }} |
+{{~ end }}
+
+Each project listed here is the property of its respective copyright owner.
+
+:::div{.hint}
+Have we missed something from this list? Typos or inaccuracies? Please let us know via our [support forum](https://octopus.com/support) so that we can fix it. Thanks!
+:::

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -20,7 +20,6 @@
     <package id="Octopus.Diagnostics" version="1.3.0" targetFramework="net48" />
     <package id="Octopus.Shared" version="5.1.14" targetFramework="net48" />
     <package id="Octopus.Time" version="1.1.6" targetFramework="net48" />
-    <package id="Polly" version="5.3.1" targetFramework="net48" />
     <package id="Portable.BouncyCastle" version="1.8.10" targetFramework="net48" />
     <package id="System.Collections" version="4.3.0" targetFramework="net48" />
     <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net48" />

--- a/source/Octopus.Manager.Tentacle/packages.config
+++ b/source/Octopus.Manager.Tentacle/packages.config
@@ -20,6 +20,7 @@
     <package id="Octopus.Diagnostics" version="1.3.0" targetFramework="net48" />
     <package id="Octopus.Shared" version="5.1.14" targetFramework="net48" />
     <package id="Octopus.Time" version="1.1.6" targetFramework="net48" />
+    <package id="Polly" version="7.2.2" targetFramework="net48" />
     <package id="Portable.BouncyCastle" version="1.8.10" targetFramework="net48" />
     <package id="System.Collections" version="4.3.0" targetFramework="net48" />
     <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net48" />


### PR DESCRIPTION
This is an automated update of the credits / license attribution file, based on the latest code in https://github.com/OctopusDeploy/OctopusDeploy.

Please review for

- syntactical correctness (ie, markdown looks correct)
- logical correctness (ie, when reading it, it makes sense)
- license conformance (we agree with the license in question and we are able to redistribute it)

This pull request was created by TeamCity project Spikes_Bec_AutomatedDocumentationUpdates build 14842312