### PR TITLE
Remove Net60ClientNet48Service test category

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleTestCaseSourceAttribute.cs
@@ -43,7 +43,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
     {
         private readonly NUnitTestCaseBuilder _builder = new();
         
-        public const string Net60ClientNet48Service = nameof(Net60ClientNet48Service);
         public const string Net80ClientNet48Service = nameof(Net80ClientNet48Service);
 
         /// <summary>
@@ -170,7 +169,6 @@ namespace Octopus.Tentacle.Tests.Integration.Support
                         #if !NETFRAMEWORK
                         if (item is TentacleConfigurationTestCase {TentacleRuntime: TentacleRuntime.Framework48} testCase)
                         {
-                            parms.Properties.Add(PropertyNames.Category, Net60ClientNet48Service);
                             parms.Properties.Add(PropertyNames.Category, Net80ClientNet48Service);
                         }
                         #endif


### PR DESCRIPTION
# Background

The `Net60ClientNet48Service` test category is no longer used in build configurations and can be removed.

Instead, the newer `Net80ClientNet48Service` test category should be used instead.

# Results

Tests should run as before

# How to review this PR

- Quality :heavy_check_mark:
- TeamCity tests, especially integration tests on Windows that use this category

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
