### PR TITLE
Fix missing env-vars in k8s debug dockerfile

### DIFF
--- a/docker/kubernetes-agent-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/dev/Dockerfile
@@ -83,6 +83,10 @@ ENV OCTOPUS__K8STENTACLE__DISABLEAUTOPODCLEANUP="False"
 ENV TentacleHome=""
 ENV TentacleApplications=""
 ENV TentacleCertificateBase64=""
+ENV TentaclePollingProxyHost=""
+ENV TentaclePollingProxyPort=""
+ENV TentaclePollingProxyUsername=""
+ENV TentaclePollingProxyPassword=""
 
 ENTRYPOINT [ "/dev-scripts/bootstrap.sh" ] 
 


### PR DESCRIPTION
# Background

The debug container does not work due to these missing env vars

# Results

Adds them back in!
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.