### PR TITLE
Add a encryption control character to the log lines

### DIFF
--- a/docker/kubernetes-agent-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-agent-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -106,7 +106,8 @@ func Write(stream string, text string, counter *SafeCounter, gcm cipher.AEAD) {
 
 	ciphertext := gcm.Seal(nonce, nonce, []byte(text), nil)
 
-	fmt.Printf("|%d|%s|%x\n", counter.Value, stream, ciphertext)
+	// the |e| indicates the line is encrypted (if we every supported plain, we'd put |p| here)
+	fmt.Printf("|e|%d|%s|%x\n", counter.Value, stream, ciphertext)
 	counter.Value++
 
 	counter.Mutex.Unlock()

--- a/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/PodLogLineParserFixture.cs
@@ -31,6 +31,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             result.Error.Should().Contain("delimited").And.Contain(line);
         }
 
+        [TestCase("1 |e|b|c|d", Reason = "Not a date")]
         [TestCase("1 |b|c|d", Reason = "Not a date")]
         public void FirstPartIsNotALineDate(string line)
         {
@@ -38,22 +39,25 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             result.Error.Should().Contain("log timestamp").And.Contain(line);
         }
 
+        [TestCase("2024-04-03T06:03:10.501025551Z |e|b|c|d", Reason = "Not a line number")]
+        [TestCase("2024-04-03T06:03:10.501025551Z |p|b|c|d", Reason = "Not a line number")]
         [TestCase("2024-04-03T06:03:10.501025551Z |b|c|d", Reason = "Not a line number")]
-        public void SecondPartIsNotALineNumber(string line)
+        [TestCase("2024-04-03T06:03:10.501025551Z |p|1|c|d", Reason = "Not a line number")]
+        public void ThirdPartIsNotALineNumber(string line)
         {
             var result = PodLogLineParser.ParseLine(line, encryptionProvider).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
             result.Error.Should().Contain("line number").And.Contain(line);
         }
 
+        [TestCase("2024-04-03T06:03:10.501025551Z |e|1|c|d", Reason = "Not a valid source")]
         [TestCase("2024-04-03T06:03:10.501025551Z |1|c|d", Reason = "Not a valid source")]
-        public void ThirdPartIsNotAValidSource(string line)
+        public void FourthPartIsNotAValidSource(string line)
         {
             var result = PodLogLineParser.ParseLine(line, encryptionProvider).Should().BeOfType<InvalidPodLogLineParseResult>().Subject;
             result.Error.Should().Contain("log level").And.Contain(line);
         }
 
         [TestCase("2024-04-03T06:03:10.501025551Z |e|123|stdout|This is the message", true)]
-        [TestCase("2024-04-03T06:03:10.501025551Z |p|123|stdout|This is the message", false)]
         //This is the previous log message format where we didn't have the encryption control section
         [TestCase("2024-04-03T06:03:10.501025551Z |123|stdout|This is the message", false)]
         public void SimpleMessage(string line, bool isLogMessageEncrypted)

--- a/source/Octopus.Tentacle/Kubernetes/Crypto/ScriptPodLogEncryptionKeyGenerator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Crypto/ScriptPodLogEncryptionKeyGenerator.cs
@@ -31,7 +31,7 @@ namespace Octopus.Tentacle.Kubernetes.Crypto
             var pdb = new Pkcs5S2ParametersGenerator(new Sha256Digest());
             
             //we use the machine encryption key as the password and the script ticket is the salt
-            pdb.Init(PbeParametersGenerator.Pkcs5PasswordToBytes(Encoding.ASCII.GetChars(machineEncryptionKey)), Encoding.UTF8.GetBytes(scriptTicket.TaskId), 1000);
+            pdb.Init(machineEncryptionKey, Encoding.UTF8.GetBytes(scriptTicket.TaskId), 1000);
             var key = (KeyParameter)pdb.GenerateDerivedMacParameters(keySizeInBytes * 8);
 
             return key.GetKey();

--- a/source/Octopus.Tentacle/Kubernetes/Crypto/ScriptPodLogEncryptionKeyProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Crypto/ScriptPodLogEncryptionKeyProvider.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Kubernetes.Crypto
 {
     public interface IScriptPodLogEncryptionKeyProvider
     {
-        Task WriteEncryptionKeyfileToWorkspace(ScriptTicket scriptTicket, CancellationToken cancellationToken);
+        Task GenerateAndWriteEncryptionKeyfileToWorkspace(ScriptTicket scriptTicket, CancellationToken cancellationToken);
         Task<byte[]> GetEncryptionKey(ScriptTicket scriptTicket, CancellationToken cancellationToken);
         void Delete(ScriptTicket scriptTicket);
     }
@@ -32,7 +32,7 @@ namespace Octopus.Tentacle.Kubernetes.Crypto
             this.log = log;
         }
 
-        public async Task WriteEncryptionKeyfileToWorkspace(ScriptTicket scriptTicket, CancellationToken cancellationToken)
+        public async Task GenerateAndWriteEncryptionKeyfileToWorkspace(ScriptTicket scriptTicket, CancellationToken cancellationToken)
         {
             if (encryptionKeyCache.ContainsKey(scriptTicket))
             {

--- a/source/Octopus.Tentacle/Kubernetes/InMemoryTentacleScriptLog.cs
+++ b/source/Octopus.Tentacle/Kubernetes/InMemoryTentacleScriptLog.cs
@@ -27,6 +27,16 @@ namespace Octopus.Tentacle.Kubernetes
                 logs.Add(new ProcessOutput(ProcessOutputSource.StdErr, message));
         }
 
+        public void Warning(string message)
+        {
+            lock (logs)
+            {
+                logs.Add(new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-warning]"));
+                logs.Add(new ProcessOutput(ProcessOutputSource.StdOut, message));
+                logs.Add(new ProcessOutput(ProcessOutputSource.StdOut, "##octopus[stdout-default]"));
+            }
+        }
+
         public IReadOnlyCollection<ProcessOutput> PopLogs()
         {
             lock (logs)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodLogService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodLogService.cs
@@ -105,7 +105,7 @@ namespace Octopus.Tentacle.Kubernetes
                 {
                     //if we can't read the pod log encryption key for a while
                     var message = $"Failed to read pod log encryption key. No new pod logs will be read.";
-                    tentacleScriptLog.Verbose(message);
+                    tentacleScriptLog.Warning(message);
                     Log.Warn(ex, message);
 
                     return (new List<ProcessOutput>(), lastLogSequence, null);

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -79,7 +79,7 @@ namespace Octopus.Tentacle.Kubernetes
                        log))
             {
                 //Write the log encryption key here
-                await scriptPodLogEncryptionKeyProvider.WriteEncryptionKeyfileToWorkspace(command.ScriptTicket, cancellationToken);
+                await scriptPodLogEncryptionKeyProvider.GenerateAndWriteEncryptionKeyfileToWorkspace(command.ScriptTicket, cancellationToken);
                 
                 //Possibly create the image pull secret name
                 var imagePullSecretName = await CreateImagePullSecret(command, cancellationToken);

--- a/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
@@ -63,6 +63,10 @@ namespace Octopus.Tentacle.Kubernetes
         public static PodLogLineParseResult ParseLine(string line, IPodLogEncryptionProvider encryptionProvider)
         {
             var initialParts = line.Split(new[] { '|' }, 2);
+            if (initialParts.Length != 2)
+            {
+                return new InvalidPodLogLineParseResult($"Pod log line is not correctly pipe-delimited: '{line}'");
+            }
 
             var datePart = initialParts[0];
 

--- a/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
+++ b/source/Octopus.Tentacle/Kubernetes/PodLogLineParser.cs
@@ -77,10 +77,9 @@ namespace Octopus.Tentacle.Kubernetes
 
             var isEncryptedMessage = false;
             //there is an encryption control part at the start of the remaining message
-            if (encryptionControl.Equals("e|", StringComparison.Ordinal) ||
-                encryptionControl.Equals("p|", StringComparison.Ordinal))
+            if (encryptionControl.Equals("e|", StringComparison.Ordinal))
             {
-                isEncryptedMessage = encryptionControl[0] == 'e';
+                isEncryptedMessage = true;
 
                 //we slice the encryption control from the start of the message, then parse as normal
                 remainingMessage = remainingMessage.Substring(2);


### PR DESCRIPTION
# Background

We identified an issue with #1047 where an automated upgrade would fail as the script pod would be created by an non-pod log encryption Tentacle, but then after the upgrade the pod log encryption Tentacle would fail as it expects all pod logs to be encrypted.

# Results

We have added a new `e` to the log lines generated by the bootstrap runner. This control character indicates the line is encrypted. An absence of this control char (or being set to `p`) indicates that the line is in plaintext and should not be decrypted

This PR also include minor nit changes from the review of #1047 

Shortcut story: [sc-98480]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.