### PR TITLE
Increase the maximum buffer size of the Kubernetes agent bootstrapRunner's stream readers

### DIFF
--- a/docker/kubernetes-agent-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-agent-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -20,6 +20,12 @@ type SafeCounter struct {
 	Value int
 }
 
+const (
+	// MaxScanTokenSize 10Mi Max token size
+	// 10Mi is the maximum default size of a pod's log file
+	MaxScanTokenSize = 10 * 1024 * 1024
+)
+
 // The bootstrapRunner applet is designed to execute a script in a specific folder
 // and format the script's output from stdout and stderr into the following format:
 // <line number>|<RFC3339Nano date time>|<"stdout" or "stderr">|<original string>
@@ -47,6 +53,11 @@ func main() {
 
 	stdOutScanner := bufio.NewScanner(stdOutCmdReader)
 	stdErrScanner := bufio.NewScanner(stdErrCmdReader)
+
+	// Create an initial buffer to be used by the scanners
+	buffer := make([]byte, 64*1024) // 64K initial buffer
+	stdOutScanner.Buffer(buffer, MaxScanTokenSize)
+	stdErrScanner.Buffer(buffer, MaxScanTokenSize)
 
 	doneStd := make(chan bool)
 	doneErr := make(chan bool)

--- a/docker/kubernetes-agent-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-agent-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -94,7 +94,7 @@ func reader(readCloser io.ReadCloser, stream string, done *chan bool, counter *S
 	scanner := bufio.NewScanner(readCloser)
 
 	// Create an initial buffer to be used by the scanners
-	buffer := make([]byte, 4096) // 4Ki initial buffer
+	buffer := make([]byte, 4096) // 4Ki initial buffer https://github.com/golang/go/blob/master/src/bufio/scan.go#L84
 	scanner.Buffer(buffer, MaxScanTokenSize)
 
 	for scanner.Scan() {

--- a/docker/kubernetes-agent-tentacle/bootstrapRunner/bootstrapRunner.go
+++ b/docker/kubernetes-agent-tentacle/bootstrapRunner/bootstrapRunner.go
@@ -22,7 +22,7 @@ type SafeCounter struct {
 
 const (
 	// MaxScanTokenSize 10Mi Max token size
-	// 10Mi is the maximum default size of a pod's log file
+	// 10Mi is the default maximum size of a Kubernetes container's log file
 	MaxScanTokenSize = 10 * 1024 * 1024
 )
 
@@ -48,22 +48,14 @@ func main() {
 		panic(err)
 	}
 
-	stdOutCmdReader, _ := cmd.StdoutPipe()
-	stdErrCmdReader, _ := cmd.StderrPipe()
-
-	stdOutScanner := bufio.NewScanner(stdOutCmdReader)
-	stdErrScanner := bufio.NewScanner(stdErrCmdReader)
-
-	// Create an initial buffer to be used by the scanners
-	buffer := make([]byte, 64*1024) // 64K initial buffer
-	stdOutScanner.Buffer(buffer, MaxScanTokenSize)
-	stdErrScanner.Buffer(buffer, MaxScanTokenSize)
+	stdOutCmdReadCloser, _ := cmd.StdoutPipe()
+	stdErrCmdReadCloser, _ := cmd.StderrPipe()
 
 	doneStd := make(chan bool)
 	doneErr := make(chan bool)
 
-	go reader(stdOutScanner, "stdout", &doneStd, &lineCounter, gcm)
-	go reader(stdErrScanner, "stderr", &doneErr, &lineCounter, gcm)
+	go reader(stdOutCmdReadCloser, "stdout", &doneStd, &lineCounter, gcm)
+	go reader(stdErrCmdReadCloser, "stderr", &doneErr, &lineCounter, gcm)
 
 	Write("stdout", "##octopus[stdout-verbose]", &lineCounter, gcm)
 	Write("stdout", "Kubernetes Script Pod started", &lineCounter, gcm)
@@ -98,10 +90,25 @@ func main() {
 	os.Exit(exitCode)
 }
 
-func reader(scanner *bufio.Scanner, stream string, done *chan bool, counter *SafeCounter, gcm cipher.AEAD) {
+func reader(readCloser io.ReadCloser, stream string, done *chan bool, counter *SafeCounter, gcm cipher.AEAD) {
+	scanner := bufio.NewScanner(readCloser)
+
+	// Create an initial buffer to be used by the scanners
+	buffer := make([]byte, 4096) // 4Ki initial buffer
+	scanner.Buffer(buffer, MaxScanTokenSize)
+
 	for scanner.Scan() {
 		Write(stream, scanner.Text(), counter, gcm)
 	}
+
+	err := readCloser.Close()
+	if scanner.Err() != nil {
+		fmt.Fprintln(os.Stderr, "bootstrapRunner.go: Error reading from scanner", scanner.Err())
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bootstrapRunner.go: Failed to close the command's %s pipe: %v\n", stream, err)
+	}
+
 	*done <- true
 }
 


### PR DESCRIPTION
# Background

Part of https://github.com/OctopusDeploy/Issues/issues/9202

This PR addresses an issue where long text cannot be written to Octopus output variables when deploying via the Octopus Kubernetes Agent. The problem is caused by the default max buffer size of the `bufio.Scanner `in the bootstrap runner, which is limited to 64 KiB. This causes large outputs (e.g., from Terraform plans) to not be written to service message logs.

[sc-100196]

# Results

- The max buffer size for the Scanner has been increased to allow larger outputs, with the maximum size set to 10 MiB, which aligns with Kubernetes' default max container log size.

- Ensures the reader is closed after scanning (regardless of error) to properly close the pipe, allowing the command process to terminate without hanging while waiting for the pipe to clear before writing stdout.