### PR TITLE
Re-sync dotnet-install.ps1 to remove azureedge.net

### DIFF
--- a/dotnet-install.ps1
+++ b/dotnet-install.ps1
@@ -75,14 +75,12 @@
 .PARAMETER Verbose
     Displays diagnostics information.
 .PARAMETER AzureFeed
-    Default: https://dotnetcli.azureedge.net/dotnet
+    Default: https://builds.dotnet.microsoft.com/dotnet
     For internal use only.
     Allows using a different storage to download SDK archives from.
-    This parameter is only used if $NoCdn is false.
 .PARAMETER UncachedFeed
     For internal use only.
     Allows using a different storage to download SDK archives from.
-    This parameter is only used if $NoCdn is true.
 .PARAMETER ProxyAddress
     If set, the installer will use the proxy when making web requests
 .PARAMETER ProxyUseDefaultCredentials
@@ -93,8 +91,6 @@
 .PARAMETER SkipNonVersionedFiles
     Default: false
     Skips installing non-versioned files if they already exist, such as dotnet.exe.
-.PARAMETER NoCdn
-    Disable downloading from the Azure CDN, and use the uncached feed directly.
 .PARAMETER JSonFile
     Determines the SDK version from a user specified global.json file
     Note: global.json must have a value for 'SDK:Version'
@@ -133,7 +129,6 @@ param(
     [switch]$ProxyUseDefaultCredentials,
     [string[]]$ProxyBypassList = @(),
     [switch]$SkipNonVersionedFiles,
-    [switch]$NoCdn,
     [int]$DownloadTimeout = 1200,
     [switch]$KeepZip,
     [string]$ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName()),
@@ -1148,24 +1143,15 @@ function Get-AkaMsLink-And-Version([string] $NormalizedChannel, [string] $Normal
 function Get-Feeds-To-Use() {
     $feeds = @(
         "https://builds.dotnet.microsoft.com/dotnet"
-        "https://dotnetcli.azureedge.net/dotnet"
         "https://ci.dot.net/public"
-        "https://dotnetbuilds.azureedge.net/public"
     )
 
     if (-not [string]::IsNullOrEmpty($AzureFeed)) {
         $feeds = @($AzureFeed)
     }
 
-    if ($NoCdn) {
-        $feeds = @(
-            "https://dotnetcli.blob.core.windows.net/dotnet",
-            "https://dotnetbuilds.blob.core.windows.net/public"
-        )
-
-        if (-not [string]::IsNullOrEmpty($UncachedFeed)) {
+    if (-not [string]::IsNullOrEmpty($UncachedFeed)) {
             $feeds = @($UncachedFeed)
-        }
     }
 
     Write-Verbose "Initialized feeds: $feeds"


### PR DESCRIPTION
# Background

The azureedge.net domain is no longer used to provide the .NET SDK. This PR synchronises our forked version of the dotnet-install.ps1 script with the upstream version.

# Results

- References to azureedge.net have been removed
- The `NoCdn` parameter of the script has been removed (as per upstream)

# How to review this PR

This PR primarily changes the old references to domains that are no longer used to serve the dotnet SDK. This keeps the changes relatively constrained following the most recent synchronisation:

- #1053

To compare with the current version upstream, the following command can be run (tested in bash):

```
diff --color=auto --strip-trailing-cr <(curl --location https://dot.net/v1/dotnet-install.ps1) dotnet-install.ps1
```

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
