### PR TITLE
Allow the Kubernetes agent to be registered with a pre-install hook

### DIFF
--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -156,6 +156,14 @@ function validateWorkerVariables() {
   echo " - worker pools '$WorkerPools'"
 }
 
+function migrateFromPreinstallScript() {
+  tentacle migrate-preinstalled-k8s-config \
+    --source-config-map-name "tentacle-config-pre" \
+    --source-secret-name "tentacle-secret-pre" \
+    --destination-config-map-name "tentacle-config" \
+    --destination-secret-name "tentacle-secret"
+}
+
 function configureTentacle() {
   tentacle create-instance --instance "$instanceName" --config "$configurationDirectory/tentacle.config" --home "$configurationDirectory"
 
@@ -424,6 +432,7 @@ else
 
   echo "==============================================="
 
+  migrateFromPreinstallScript
   configureTentacle
   registerTentacle
   addAdditionalServerInstancesIfRequired

--- a/docker/kubernetes-agent-tentacle/scripts/register.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/register.sh
@@ -305,138 +305,24 @@ function registerTentacle() {
   tentacle "${ARGS[@]}"
 }
 
-function addAdditionalServerInstancesIfRequired() {
-  if [[ -z "$ServerCommsAddresses" ]]; then
-    clearTrustedServersExcept "$ServerCommsAddress"
-    return
-  fi
-
-  IFS=',' read -ra SERVER_ADDRESSES <<<"$ServerCommsAddresses"
-  len=${#SERVER_ADDRESSES[@]}
-
-  if [[ -n "$ServerCommsAddress" ]]; then
-    clearTrustedServersExcept "$ServerCommsAddress"
-  else
-    clearTrustedServersExcept "${SERVER_ADDRESSES[0]}"
-  fi
-
-  # If ServerCommsAddress (singular) is not set and ServerCommsAddresses (plural)
-  # has only one element return as nothing to do.
-  if [[ -z "$ServerCommsAddress" && len -eq 1 ]]; then
-    return
-  # If ServerCommsAddresses (plural) is empty, return as nothing to do.
-  elif [[ len -eq 0 ]]; then
-    return
-  fi
-
-  echo "Registering additional HA Servers..."
-
-  # If ServerCommsAddress (singular) is not set, skip the first value in
-  # ServerCommsAddresses (plural) as the first value was used for the main
-  # registration.
-  if [[ -z "$ServerCommsAddress" ]]; then
-    # The ":1" skips the first element of the array
-    for i in "${SERVER_ADDRESSES[@]:1}"; do
-      registerAdditionalServer "$i"
-    done
-  else
-    for i in "${SERVER_ADDRESSES[@]}"; do
-      registerAdditionalServer "$i"
-    done
-  fi
-}
-
-function clearTrustedServersExcept()
-{
-  tentacle clear-trusted-servers --instance "$instanceName" --keep "$1"
-}
-
-function registerAdditionalServer() {
-  serverCommsAddress=$1
-
-  echo "Registering server '${serverCommsAddress}'"
-
-  local ARGS=()
-  ARGS+=('poll-server' '--reuse-server-thumbprint')
-
-  ARGS+=('--instance' "$instanceName"
-    '--server' "$ServerUrl")
-
-  if [[ -n "$ServerApiKey" ]]; then
-    echo "Registering Tentacle with API key"
-    ARGS+=('--apiKey' $ServerApiKey)
-  elif [[ -n "$BearerToken" ]]; then
-    echo "Registering Tentacle with Bearer Token"
-    ARGS+=('--bearerToken' "$BearerToken")
-  else
-    echo "Registering Tentacle with username/password"
-    ARGS+=(
-      '--username' "$ServerUsername"
-      '--password' "$ServerPassword")
-  fi
-
-  ARGS+=('--server-comms-address' "$serverCommsAddress")
-
-  tentacle "${ARGS[@]}"
-}
-
-function setPollingProxy() {
-  local ARGS=()
-  ARGS+=('polling-proxy'
-    '--instance' "$instanceName")
-
-  if [[ -n "$TentaclePollingProxyHost" ]]; then
-    echo "Using polling proxy at $TentaclePollingProxyHost:$TentaclePollingProxyPort"
-    ARGS+=(
-      '--proxyEnable' 'true'
-      '--proxyHost' "$TentaclePollingProxyHost"
-      '--proxyPort' "$TentaclePollingProxyPort"
-      '--proxyUsername' "$TentaclePollingProxyUsername"
-      '--proxyPassword' "$TentaclePollingProxyPassword")
-  else
-    echo "Disabling polling proxy"
-        ARGS+=('--proxyEnable' 'false')
-  fi
-
-  tentacle "${ARGS[@]}"
-}
-
-function markAsInitialised() {
-    # There is a startupProbe which checks for this file
-    mkdir -p /etc/octopus && touch /etc/octopus/initialized
-}
-
 setupVariablesForRegistrationCheck
 getStatusOfRegistration
 
-# We expect the tentacle to always be registered due to the new pre-install hook
-# But keeping this here just in case
-# We can remove it in future if we need to
 if [ "$IS_REGISTERED" == "true" ]; then
   echo "Tentacle is already configured and registered with server."
-  addAdditionalServerInstancesIfRequired
-  setPollingProxy
 else
   echo "==============================================="
   echo "Configuring Octopus Deploy Kubernetes Tentacle"
+  echo "==============================================="
 
   validateVariables
 
-  echo "==============================================="
-
   configureTentacle
   registerTentacle
-  addAdditionalServerInstancesIfRequired
-  setPollingProxy
-
   echo "Configuration successful"
 fi
 
-markAsInitialised
-
 echo "==============================================="
-echo "Starting Octopus Deploy Kubernetes Tentacle"
+echo "Finished Configuring Octopus Deploy Kubernetes Tentacle"
 echo "==============================================="
-
-# the exec here means that the host bash process is replaced by the tentacle process
-exec tentacle agent --instance Tentacle --noninteractive
+exit 0

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
@@ -1,0 +1,181 @@
+using System.Text;
+using FluentAssertions;
+using k8s;
+using k8s.Models;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Commands;
+using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Startup;
+
+namespace Octopus.Tentacle.Kubernetes.Tests.Integration.KubernetesAgent;
+
+public class KubernetesAgentMigrateFromPreinstallationTest
+{
+    
+    readonly ISystemLog systemLog = new SystemLog();
+    
+    [Test]
+    public async Task MigrationFromPreinstallHookShouldCopyData()
+    {
+        //Arrange
+        var kubernetesConfigClient = new KubernetesFileWrappedProvider(KubernetesTestsGlobalContext.Instance.KubeConfigPath);
+        var commandToRun = new MigratePreInstalledKubernetesDeploymentTargetCommand(kubernetesConfigClient, systemLog, new LogFileOnlyLogger());
+        var client = new k8s.Kubernetes(kubernetesConfigClient.Get());
+        var commandNamespace = Guid.NewGuid().ToString("N");
+        var validationKey = Guid.NewGuid().ToString("N");
+        var sourceConfigMapData = new Dictionary<string, string>
+        {
+            {"validationKey", validationKey},
+            {"Tentacle.Services.IsRegistered", "true"}
+        };
+        var sourceSecretData = new Dictionary<string, string>
+        {
+            {"machine-iv", "testData"},
+            {"machine-key", validationKey}
+        };
+        const string sourceConfigMapName = "tentacle-config-pre";
+        const string sourceSecretName = "tentacle-secret-pre";
+        const string destinationConfigMapName = "tentacle-config";
+        const string destinationSecretName = "tentacle-secret";
+
+        
+        string[] commandArguments = [
+            $"--source-config-map-name={sourceConfigMapName}", 
+            $"--source-secret-name={sourceSecretName}",
+            $"--destination-config-map-name={destinationConfigMapName}",
+            $"--destination-secret-name={destinationSecretName}",
+            $"--namespace={commandNamespace}"
+        ];
+
+        //Act
+        await CreateCommandNamespace(client, commandNamespace);
+        
+        //Sources
+        await CreateConfigmap(client, sourceConfigMapName, commandNamespace, sourceConfigMapData);
+        await CreateSecret(client, sourceSecretName, commandNamespace, sourceSecretData);
+
+        
+        // Targets
+        await CreateConfigmap(client, destinationConfigMapName, commandNamespace);
+        await CreateSecret(client, destinationSecretName, commandNamespace);
+        
+        commandToRun.Start(commandArguments, new NoninteractiveHost(), []);
+        
+        //Assert
+        var configMap = await client.CoreV1.ReadNamespacedConfigMapAsync(destinationConfigMapName, commandNamespace);
+        var secret = await client.CoreV1.ReadNamespacedSecretAsync(destinationSecretName, commandNamespace);
+
+        configMap.Data.TryGetValue("validationKey", out var validationKeyFromKubernetes);
+        validationKeyFromKubernetes.Should().NotBeNull().And.Be(validationKey);
+        
+        secret.Data.TryGetValue("machine-key", out var hostKeyFromKubernetes);
+        hostKeyFromKubernetes.Should().NotBeNull().And.Equal(Encoding.UTF8.GetBytes(validationKey));
+    }
+    
+    [Test]
+    public async Task MigrationFromPreinstallHookShouldOnlyRunWhenNotRegistered()
+    {
+        //Arrange
+        var kubernetesConfigClient = new KubernetesFileWrappedProvider(KubernetesTestsGlobalContext.Instance.KubeConfigPath);
+        var commandToRun = new MigratePreInstalledKubernetesDeploymentTargetCommand(kubernetesConfigClient, systemLog, new LogFileOnlyLogger());
+        var client = new k8s.Kubernetes(kubernetesConfigClient.Get());
+        var commandNamespace = Guid.NewGuid().ToString("N");
+        var validationKey = Guid.NewGuid().ToString("N");
+        var sourceConfigMapData = new Dictionary<string, string>
+        {
+            {"validationKey", "should-not-be-here"},
+            {"Tentacle.Services.IsRegistered", "true"}
+        };
+        var sourceSecretData = new Dictionary<string, string>
+        {
+            {"machine-iv", "testData"},
+            {"machine-key", validationKey}
+        };
+        var destinationConfigMapData = new Dictionary<string, string>
+        {
+            {"validationKey", validationKey},
+            {"Tentacle.Services.IsRegistered", "true"}
+        };
+
+        const string sourceConfigMapName = "tentacle-config-pre";
+        const string sourceSecretName = "tentacle-secret-pre";
+        const string destinationConfigMapName = "tentacle-config";
+        const string destinationSecretName = "tentacle-secret";
+
+        
+        string[] commandArguments = [
+            $"--source-config-map-name={sourceConfigMapName}", 
+            $"--source-secret-name={sourceSecretName}",
+            $"--destination-config-map-name={destinationConfigMapName}",
+            $"--destination-secret-name={destinationSecretName}",
+            $"--namespace={commandNamespace}"
+        ];
+
+        //Act
+        await CreateCommandNamespace(client, commandNamespace);
+        
+        //Sources
+        await CreateConfigmap(client, sourceConfigMapName, commandNamespace, sourceConfigMapData);
+        await CreateSecret(client, sourceSecretName, commandNamespace, sourceSecretData);
+
+        
+        // Targets
+        await CreateConfigmap(client, destinationConfigMapName, commandNamespace, destinationConfigMapData);
+        await CreateSecret(client, destinationSecretName, commandNamespace);
+        
+        commandToRun.Start(commandArguments, new NoninteractiveHost(), []);
+        
+        //Assert
+        var configMap = await client.CoreV1.ReadNamespacedConfigMapAsync(destinationConfigMapName, commandNamespace);
+        var secret = await client.CoreV1.ReadNamespacedSecretAsync(destinationSecretName, commandNamespace);
+
+        configMap.Data.TryGetValue("validationKey", out var validationKeyFromKubernetes);
+        validationKeyFromKubernetes.Should().NotBeNull().And.Be(validationKey);
+        
+        secret.Data.TryGetValue("machine-key", out var hostKeyFromKubernetes);
+        hostKeyFromKubernetes.Should().BeNullOrEmpty();
+    }
+
+    async Task CreateCommandNamespace(k8s.Kubernetes client, string name)
+    {
+        await client.CoreV1.CreateNamespaceAsync(new V1Namespace
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = name
+            }
+        });
+    }
+    
+    async Task<V1ConfigMap> CreateConfigmap(k8s.Kubernetes client, string name, string ns, Dictionary<string, string>? data = null)
+    {
+        return await client.CoreV1.CreateNamespacedConfigMapAsync(new V1ConfigMap
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = name
+            },
+            Data = data
+        }, ns);
+    }
+    
+    async Task<V1Secret> CreateSecret(k8s.Kubernetes client, string name, string ns, Dictionary<string, string>? data = null)
+    {
+        return await client.CoreV1.CreateNamespacedSecretAsync(new V1Secret
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = name
+            },
+            StringData = data
+        }, ns);
+    }
+
+    class KubernetesFileWrappedProvider(string filename) : IKubernetesClientConfigProvider
+    {
+        public KubernetesClientConfiguration Get()
+        {
+            return KubernetesClientConfiguration.BuildConfigFromConfigFile(filename);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
@@ -19,7 +19,7 @@ public class KubernetesAgentMigrateFromPreinstallationTest
     {
         //Arrange
         var kubernetesConfigClient = new KubernetesFileWrappedProvider(KubernetesTestsGlobalContext.Instance.KubeConfigPath);
-        var commandToRun = new MigratePreInstalledKubernetesDeploymentTargetCommand(kubernetesConfigClient, systemLog, new LogFileOnlyLogger());
+        var commandToRun = new MigratePreInstalledKubernetesDeploymentTargetCommand(new Lazy<IKubernetesClientConfigProvider>(kubernetesConfigClient), systemLog, new LogFileOnlyLogger());
         var client = new k8s.Kubernetes(kubernetesConfigClient.Get());
         var commandNamespace = Guid.NewGuid().ToString("N");
         var validationKey = Guid.NewGuid().ToString("N");
@@ -77,7 +77,7 @@ public class KubernetesAgentMigrateFromPreinstallationTest
     {
         //Arrange
         var kubernetesConfigClient = new KubernetesFileWrappedProvider(KubernetesTestsGlobalContext.Instance.KubeConfigPath);
-        var commandToRun = new MigratePreInstalledKubernetesDeploymentTargetCommand(kubernetesConfigClient, systemLog, new LogFileOnlyLogger());
+        var commandToRun = new MigratePreInstalledKubernetesDeploymentTargetCommand(new Lazy<IKubernetesClientConfigProvider>(kubernetesConfigClient), systemLog, new LogFileOnlyLogger());
         var client = new k8s.Kubernetes(kubernetesConfigClient.Get());
         var commandNamespace = Guid.NewGuid().ToString("N");
         var validationKey = Guid.NewGuid().ToString("N");
@@ -96,6 +96,12 @@ public class KubernetesAgentMigrateFromPreinstallationTest
             {"validationKey", validationKey},
             {"Tentacle.Services.IsRegistered", "true"}
         };
+        var destinationSecretData = new Dictionary<string, string>
+        {
+            {"machine-iv", "testData"},
+            {"machine-key", validationKey}
+        };
+
 
         const string sourceConfigMapName = "tentacle-config-pre";
         const string sourceSecretName = "tentacle-secret-pre";
@@ -121,7 +127,7 @@ public class KubernetesAgentMigrateFromPreinstallationTest
         
         // Targets
         await CreateConfigmap(client, destinationConfigMapName, commandNamespace, destinationConfigMapData);
-        await CreateSecret(client, destinationSecretName, commandNamespace);
+        await CreateSecret(client, destinationSecretName, commandNamespace, destinationSecretData);
         
         commandToRun.Start(commandArguments, new NoninteractiveHost(), []);
         

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
@@ -127,11 +127,11 @@ public class KubernetesAgentMigrateFromPreinstallationTest
         var configMap = await client.CoreV1.ReadNamespacedConfigMapAsync(DestinationConfigMapName, commandNamespace);
         var secret = await client.CoreV1.ReadNamespacedSecretAsync(DestinationSecretName, commandNamespace);
 
-        configMap.Data.TryGetValue("validationKey", out var validationKeyFromKubernetes);
-        validationKeyFromKubernetes.Should().Be(validationKey);
+        configMap.Data.TryGetValue("validationKey", out var validationKeyFromKubernetesConfigMap);
+        validationKeyFromKubernetesConfigMap.Should().Be(validationKey);
         
-        secret.Data.TryGetValue("machine-key", out var hostKeyFromKubernetes);
-        hostKeyFromKubernetes.Should().Equal(Encoding.UTF8.GetBytes(validationKey));
+        secret.Data.TryGetValue("validationKey", out var validationKeyFromKubernetesSecret);
+        validationKeyFromKubernetesSecret.Should().Equal(Encoding.UTF8.GetBytes(validationKey));
     }
 
     async Task CreateCommandNamespace(string name)

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
@@ -19,9 +19,10 @@ public class KubernetesAgentMigrateFromPreinstallationTest
     {
         //Arrange
         var kubernetesConfigClient = new KubernetesFileWrappedProvider(KubernetesTestsGlobalContext.Instance.KubeConfigPath);
+        var commandNamespace = Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(KubernetesConfig.NamespaceVariableName, commandNamespace);
         var commandToRun = new MigratePreInstalledKubernetesDeploymentTargetCommand(new Lazy<IKubernetesClientConfigProvider>(kubernetesConfigClient), systemLog, new LogFileOnlyLogger());
         var client = new k8s.Kubernetes(kubernetesConfigClient.Get());
-        var commandNamespace = Guid.NewGuid().ToString("N");
         var validationKey = Guid.NewGuid().ToString("N");
         var sourceConfigMapData = new Dictionary<string, string>
         {
@@ -77,9 +78,10 @@ public class KubernetesAgentMigrateFromPreinstallationTest
     {
         //Arrange
         var kubernetesConfigClient = new KubernetesFileWrappedProvider(KubernetesTestsGlobalContext.Instance.KubeConfigPath);
+        var commandNamespace = Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(KubernetesConfig.NamespaceVariableName, commandNamespace);
         var commandToRun = new MigratePreInstalledKubernetesDeploymentTargetCommand(new Lazy<IKubernetesClientConfigProvider>(kubernetesConfigClient), systemLog, new LogFileOnlyLogger());
         var client = new k8s.Kubernetes(kubernetesConfigClient.Get());
-        var commandNamespace = Guid.NewGuid().ToString("N");
         var validationKey = Guid.NewGuid().ToString("N");
         var sourceConfigMapData = new Dictionary<string, string>
         {

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
@@ -141,7 +141,7 @@ public class KubernetesAgentMigrateFromPreinstallationTest
         validationKeyFromKubernetes.Should().NotBeNull().And.Be(validationKey);
         
         secret.Data.TryGetValue("machine-key", out var hostKeyFromKubernetes);
-        hostKeyFromKubernetes.Should().BeNullOrEmpty();
+        hostKeyFromKubernetes.Should().NotBeNull().And.Equal(Encoding.UTF8.GetBytes(validationKey));
     }
 
     async Task CreateCommandNamespace(k8s.Kubernetes client, string name)

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/HelmDownloader.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/HelmDownloader.cs
@@ -81,7 +81,7 @@ public class HelmDownloader : ToolDownloader
 
         var exitCode = SilentProcessRunner.ExecuteCommand(
             "tar",
-            $"xzvf {gzArchiveName} -C {destFolder}",
+            $"xzvf \"{gzArchiveName}\" -C \"{destFolder}\"",
             tmp.DirectoryPath,
             Logger.Debug,
             Logger.Information,

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/ToolDownloader.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/ToolDownloader.cs
@@ -44,7 +44,7 @@ public abstract class ToolDownloader : IToolDownloader
         {
             var exitCode = SilentProcessRunner.ExecuteCommand(
                 "chmod",
-                $"+x {downloadFilePath}",
+                $"+x \"{downloadFilePath}\"",
                 targetDirectory,
                 Logger.Debug,
                 Logger.Information,

--- a/source/Octopus.Tentacle.Tests/Commands/MigratePreInstalledKubernetesDeploymentTargetCommandTest.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/MigratePreInstalledKubernetesDeploymentTargetCommandTest.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using k8s.Models;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Tentacle.Commands;
+
+namespace Octopus.Tentacle.Tests.Commands
+{
+    [TestFixture]
+    public class MigratePreInstalledKubernetesDeploymentTargetCommandFixture
+    { 
+        [Test]
+        public void ShouldNotMigrate_ifNoSource()
+        {
+            var targetConfigMap = Substitute.For<V1ConfigMap>();
+            var targetSecret = Substitute.For<V1Secret>();
+            
+            MigratePreInstalledKubernetesDeploymentTargetCommand.ShouldMigrateData(null, null, targetConfigMap, targetSecret).Item1.Should().BeFalse();
+        }
+        
+        [Test]
+        public void ShouldNotMigrate_ifNoDestination()
+        {
+            var sourceConfigMap = Substitute.For<V1ConfigMap>();
+            var sourceSecret = Substitute.For<V1Secret>();
+            
+            MigratePreInstalledKubernetesDeploymentTargetCommand.ShouldMigrateData(sourceConfigMap, sourceSecret, null, null).Item1.Should().BeFalse();
+        }
+        
+        [Test]
+        public void ShouldNotMigrate_ifDestinationRegistered()
+        {
+            var sourceConfigMap = Substitute.For<V1ConfigMap>();
+            var sourceSecret = Substitute.For<V1Secret>();
+            var targetSecret = Substitute.For<V1Secret>();
+            var targetConfigMap = new V1ConfigMap
+            {
+                Data = new Dictionary<string, string>
+                {
+                    {"Tentacle.Services.IsRegistered", "true"}
+                }
+            };
+
+            MigratePreInstalledKubernetesDeploymentTargetCommand.ShouldMigrateData(sourceConfigMap, sourceSecret, targetConfigMap, targetSecret).Item1.Should().BeFalse();
+        }
+
+
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Commands/MigratePreInstalledKubernetesDeploymentTargetCommandTest.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/MigratePreInstalledKubernetesDeploymentTargetCommandTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using k8s.Models;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using Octopus.Tentacle.Commands;
 
@@ -16,12 +17,14 @@ namespace Octopus.Tentacle.Tests.Commands
         {
             var targetConfigMap = Substitute.For<V1ConfigMap>();
             var targetSecret = Substitute.For<V1Secret>();
-            
-            MigratePreInstalledKubernetesDeploymentTargetCommand.ShouldMigrateData(null, null, targetConfigMap, targetSecret).Item1.Should().BeFalse();
+
+            var (shouldMigrate, reason) = MigratePreInstalledKubernetesDeploymentTargetCommand.ShouldMigrateData(null, null, targetConfigMap, targetSecret);
+            shouldMigrate.Should().BeFalse();
+            reason.Should().Be("Source config map or secret not found, skipping migration");
         }
         
         [Test]
-        public void ShouldNotMigrate_ifNoDestination()
+        public void ShouldNotMigrate_IfNoDestination()
         {
             var sourceConfigMap = Substitute.For<V1ConfigMap>();
             var sourceSecret = Substitute.For<V1Secret>();
@@ -30,7 +33,7 @@ namespace Octopus.Tentacle.Tests.Commands
         }
         
         [Test]
-        public void ShouldNotMigrate_ifDestinationRegistered()
+        public void ShouldNotMigrate_IfDestinationRegistered()
         {
             var sourceConfigMap = Substitute.For<V1ConfigMap>();
             var sourceSecret = Substitute.For<V1Secret>();

--- a/source/Octopus.Tentacle.Tests/Commands/MigratePreInstalledKubernetesDeploymentTargetCommandTest.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/MigratePreInstalledKubernetesDeploymentTargetCommandTest.cs
@@ -12,7 +12,7 @@ namespace Octopus.Tentacle.Tests.Commands
     public class MigratePreInstalledKubernetesDeploymentTargetCommandFixture
     { 
         [Test]
-        public void ShouldNotMigrate_ifNoSource()
+        public void ShouldNotMigrate_IfNoSource()
         {
             var targetConfigMap = Substitute.For<V1ConfigMap>();
             var targetSecret = Substitute.For<V1Secret>();

--- a/source/Octopus.Tentacle/Commands/MigratePreInstalledKubernetesDeploymentTargetCommand.cs
+++ b/source/Octopus.Tentacle/Commands/MigratePreInstalledKubernetesDeploymentTargetCommand.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Net;
+using Octopus.Diagnostics;
+using Octopus.Tentacle.Startup;
+using k8s;
+using k8s.Autorest;
+using Octopus.Tentacle.Kubernetes;
+
+namespace Octopus.Tentacle.Commands
+{
+    public class MigratePreInstalledKubernetesDeploymentTargetCommand : AbstractCommand
+    {
+        readonly ISystemLog log;
+        readonly IKubernetesClientConfigProvider configProvider;
+
+        string? sourceConfigMapName;
+        string? sourceSecretName;
+        string? destinationConfigMapName;        
+        string? destinationSecretName;
+
+        public MigratePreInstalledKubernetesDeploymentTargetCommand(IKubernetesClientConfigProvider configProvider, ISystemLog log, ILogFileOnlyLogger logFileOnlyLogger) : base(logFileOnlyLogger)
+        {
+            this.log = log;
+            this.configProvider = configProvider;
+            
+            Options.Add("source-config-map-name=", "The name of the source config map (created by the pre-installation of the agent)", v => sourceConfigMapName = v);
+            Options.Add("source-secret-name=", "The name of the source secret (created by the pre-installation of the agent)", v => sourceSecretName = v);
+            Options.Add("destination-config-map-name=", "The name of the destination config map", v => destinationConfigMapName = v);
+            Options.Add("destination-secret-name=", "The name of the destination secret", v => destinationSecretName = v);
+        }
+        
+        // This command is only used as a way to programatically copy the config map and secret from the pre-installation hook to the new agent
+        // It does not access tentacle configuration so that it doesn't 
+        protected override void Start()
+        {
+            // Check that the sources and destinations are different
+            if (sourceSecretName == destinationSecretName || sourceConfigMapName == destinationConfigMapName)
+            {
+                log.Error("Source and destination names must be different.");
+                return;
+            }
+            
+            var config = configProvider.Get();
+            var client = new k8s.Kubernetes(config);
+            
+            // Check that the sources exist
+            var sourceConfigMap = TryGetCoreV1Object(() => client.CoreV1.ReadNamespacedConfigMap(sourceConfigMapName, KubernetesConfig.Namespace));
+            var sourceSecret = TryGetCoreV1Object(() => client.CoreV1.ReadNamespacedSecret(sourceSecretName, KubernetesConfig.Namespace));
+            if (sourceConfigMap is null || sourceSecret is null)
+            {
+                log.Info("Source config map or secret not found, skipping migration.");
+                return;
+            }
+            
+            // Check if the destinations exist
+            var destinationConfigMap = TryGetCoreV1Object(() => client.CoreV1.ReadNamespacedConfigMap(destinationConfigMapName, KubernetesConfig.Namespace));
+            var destinationSecret = TryGetCoreV1Object(() => client.CoreV1.ReadNamespacedSecret(destinationSecretName, KubernetesConfig.Namespace));
+            if (destinationConfigMap is null || destinationSecret is null)
+            {
+                log.Info("destination config map or secret not found, skipping migration.");
+                return;
+            }
+
+
+            // Check if the destination is already registered
+            if (destinationConfigMap.Data is not null && destinationConfigMap.Data.TryGetValue("Tentacle.Services.IsRegistered", out var isRegistered) && isRegistered == "True")
+            {
+                log.Info("Tentacle is already registered, skipping registration.");
+                return;
+            }
+            
+            // Copy the data from the source to the destination
+            destinationConfigMap.Data = sourceConfigMap.Data;
+            destinationSecret.Data = sourceSecret.Data;
+            client.CoreV1.ReplaceNamespacedConfigMap(destinationConfigMap, destinationConfigMapName, KubernetesConfig.Namespace);
+            client.CoreV1.ReplaceNamespacedSecret(destinationSecret, destinationSecretName, KubernetesConfig.Namespace);
+            
+            // Delete the sources (they are no longer needed)
+            client.CoreV1.DeleteNamespacedConfigMap(sourceConfigMapName, KubernetesConfig.Namespace);
+            client.CoreV1.DeleteNamespacedSecret(sourceSecretName, KubernetesConfig.Namespace);
+            
+            log.Info("Migration complete.");
+        }
+
+        T? TryGetCoreV1Object<T>(Func<T> kubernetesFunc) where T : class
+        {
+            try
+            {
+                return kubernetesFunc();
+            }
+            catch (HttpOperationException ex) when (ex.Response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
+    }
+    
+    
+}

--- a/source/Octopus.Tentacle/Commands/MigratePreInstalledKubernetesDeploymentTargetCommand.cs
+++ b/source/Octopus.Tentacle/Commands/MigratePreInstalledKubernetesDeploymentTargetCommand.cs
@@ -6,6 +6,7 @@ using k8s;
 using k8s.Autorest;
 using k8s.Models;
 using Octopus.Tentacle.Kubernetes;
+using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Commands
 {
@@ -36,6 +37,11 @@ namespace Octopus.Tentacle.Commands
         // It does not access tentacle configuration so that it doesn't 
         protected override void Start()
         {
+            if (!PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
+            {
+                throw new ControlledFailureException("This command can only be run from within a Kubernetes agent.");
+            }
+
             // Check that the sources and destinations are different
             if (sourceSecretName == destinationSecretName || sourceConfigMapName == destinationConfigMapName)
             {

--- a/source/Octopus.Tentacle/Commands/MigratePreInstalledKubernetesDeploymentTargetCommand.cs
+++ b/source/Octopus.Tentacle/Commands/MigratePreInstalledKubernetesDeploymentTargetCommand.cs
@@ -12,7 +12,7 @@ namespace Octopus.Tentacle.Commands
     public class MigratePreInstalledKubernetesDeploymentTargetCommand : AbstractCommand
     {
         readonly ISystemLog log;
-        readonly IKubernetesClientConfigProvider configProvider;
+        readonly Lazy<IKubernetesClientConfigProvider> configProvider;
 
         string? sourceConfigMapName;
         string? sourceSecretName;
@@ -20,7 +20,7 @@ namespace Octopus.Tentacle.Commands
         string? destinationSecretName;
         string? @namespace;
 
-        public MigratePreInstalledKubernetesDeploymentTargetCommand(IKubernetesClientConfigProvider configProvider, ISystemLog log, ILogFileOnlyLogger logFileOnlyLogger) : base(logFileOnlyLogger)
+        public MigratePreInstalledKubernetesDeploymentTargetCommand(Lazy<IKubernetesClientConfigProvider> configProvider, ISystemLog log, ILogFileOnlyLogger logFileOnlyLogger) : base(logFileOnlyLogger)
         {
             this.log = log;
             this.configProvider = configProvider;
@@ -45,7 +45,7 @@ namespace Octopus.Tentacle.Commands
             
             var migrationNamespace = @namespace ?? KubernetesConfig.Namespace;
             
-            var config = configProvider.Get();
+            var config = configProvider.Value.Get();
             var client = new k8s.Kubernetes(config);
             var sourceConfigMap = TryGetCoreV1Object(() => client.CoreV1.ReadNamespacedConfigMap(sourceConfigMapName, migrationNamespace));
             var sourceSecret = TryGetCoreV1Object(() => client.CoreV1.ReadNamespacedSecret(sourceSecretName, migrationNamespace));

--- a/source/Octopus.Tentacle/Kubernetes/ConfigMapNames.cs
+++ b/source/Octopus.Tentacle/Kubernetes/ConfigMapNames.cs
@@ -3,7 +3,6 @@ namespace Octopus.Tentacle.Kubernetes
     public static class ConfigMapNames
     {
         public const string AgentMetrics = "kubernetes-agent-metrics";
-        public const string TentacleConfig = "tentacle-config";
         public const string AgentMetricsConfigMapKey = "metrics";
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/Configuration/ConfigMapKeyValueStore.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Configuration/ConfigMapKeyValueStore.cs
@@ -14,7 +14,7 @@ namespace Octopus.Tentacle.Kubernetes.Configuration
 
         readonly IKubernetesConfigMapService configMapService;
         readonly IKubernetesMachineKeyEncryptor encryptor;
-        const string Name = ConfigMapNames.TentacleConfig;
+        static string Name => KubernetesConfig.TentacleConfigMapName;
 
         readonly Lazy<V1ConfigMap> configMap;
         IDictionary<string, string> ConfigMapData => configMap.Value.Data ??= new Dictionary<string, string>();

--- a/source/Octopus.Tentacle/Kubernetes/Crypto/KubernetesMachineEncryptionKeyProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/Crypto/KubernetesMachineEncryptionKeyProvider.cs
@@ -16,7 +16,7 @@ namespace Octopus.Tentacle.Kubernetes.Crypto
 
     public class KubernetesMachineEncryptionKeyProvider : IKubernetesMachineEncryptionKeyProvider
     {
-        const string SecretName = "tentacle-secret";
+        static string SecretName => KubernetesConfig.TentacleEncryptionSecretName;
         const string MachineKeyName = "machine-key";
         const string MachineIvName = "machine-iv";
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -62,6 +62,12 @@ namespace Octopus.Tentacle.Kubernetes
         public static readonly string PodSecurityContextJsonVariableName = $"{EnvVarPrefix}__PODSECURITYCONTEXTJSON";
         public static string? PodSecurityContextJson => Environment.GetEnvironmentVariable(PodSecurityContextJsonVariableName);
         
+        public static readonly string TentacleConfigMapNameVariableName = $"{EnvVarPrefix}__TENTACLECONFIGMAPNAME";
+        public static string TentacleConfigMapName => GetEnvironmentVariableOrDefault(TentacleConfigMapNameVariableName, "tentacle-config");
+
+        public static readonly string TentacleEncryptionSecretNameVariableName = $"{EnvVarPrefix}__TENTACLEENCRYPTIONSECRETNAME";
+        public static string TentacleEncryptionSecretName => GetEnvironmentVariableOrDefault(TentacleEncryptionSecretNameVariableName, "tentacle-secret");
+
         public static string MetricsEnableVariableName => $"{EnvVarPrefix}__ENABLEMETRICSCAPTURE";
 
         public static bool MetricsIsEnabled
@@ -100,5 +106,8 @@ namespace Octopus.Tentacle.Kubernetes
         static string GetRequiredEnvVar(string variable, string errorMessage)
             => Environment.GetEnvironmentVariable(variable)
                 ?? throw new InvalidOperationException($"{errorMessage} The environment variable '{variable}' must be defined with a non-null value.");
+        
+        static string GetEnvironmentVariableOrDefault(string variable, string defaultValue)
+            => Environment.GetEnvironmentVariable(variable) ?? defaultValue;
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -8,6 +8,7 @@ using Octopus.Tentacle.Kubernetes.Crypto;
 using Octopus.Tentacle.Kubernetes.Diagnostics;
 using Octopus.Tentacle.Kubernetes.Synchronisation;
 using Octopus.Tentacle.Kubernetes.Synchronisation.Internal;
+using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Kubernetes
 {
@@ -15,6 +16,12 @@ namespace Octopus.Tentacle.Kubernetes
     {
         protected override void Load(ContainerBuilder builder)
         {
+            if (!PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
+            {
+                builder.RegisterType<UnimplementedKubernetesConfigProvider>().As<IKubernetesClientConfigProvider>();
+                return;
+            }
+            
             builder.RegisterType<KubernetesPodService>().As<IKubernetesPodService>().SingleInstance();
             builder.RegisterType<KubernetesClusterService>().As<IKubernetesClusterService>().SingleInstance();
 

--- a/source/Octopus.Tentacle/Kubernetes/UnimplementedKubernetesClientConfigProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/UnimplementedKubernetesClientConfigProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using k8s;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    class UnimplementedKubernetesConfigProvider : IKubernetesClientConfigProvider
+    {
+        public KubernetesClientConfiguration Get()
+        {
+            throw new NotImplementedException("This provider is not implemented when running outside of the Kubernetes Agent.");
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -79,6 +79,7 @@ namespace Octopus.Tentacle
 #pragma warning restore CS0618 // Type or member is obsolete
             builder.RegisterCommand<RegisterKubernetesDeploymentTargetCommand>("register-k8s-target", "Registers this kubernetes agent as a deployment target with an Octopus Server");
             builder.RegisterCommand<RegisterKubernetesWorkerCommand>("register-k8s-worker", "Registers this kubernetes agent as a worker with an Octopus Server");
+            builder.RegisterCommand<MigratePreInstalledKubernetesDeploymentTargetCommand>("migrate-preinstalled-k8s-config", "Migrates the configuration from the pre-install hook to the running agent instance");
             builder.RegisterCommand<ExtractCommand>("extract", "Extracts a NuGet package");
             builder.RegisterCommand<DeregisterMachineCommand>("deregister-from", "Deregisters this deployment target from an Octopus Server");
             builder.RegisterCommand<DeregisterWorkerCommand>("deregister-worker", "Deregisters this worker from an Octopus Server");

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -57,11 +57,7 @@ namespace Octopus.Tentacle
             builder.RegisterModule(new ServicesModule());
             builder.RegisterModule(new VersioningModule(GetType().Assembly));
             builder.RegisterModule(new MaintenanceModule());
-
-            if (PlatformDetection.Kubernetes.IsRunningAsKubernetesAgent)
-            {
-                builder.RegisterModule<KubernetesModule>();
-            }
+            builder.RegisterModule(new KubernetesModule());
 
             builder.RegisterCommand<CreateInstanceCommand>("create-instance", "Registers a new instance of the Tentacle service");
             builder.RegisterCommand<DeleteInstanceCommand>("delete-instance", "Deletes an instance of the Tentacle service");


### PR DESCRIPTION
# Background
As a part of the Kubernetes Monitor, we need to have the Kubernetes agent registered prior to the agent registering with server. To do this, we need to run a pre-installation script.

To keep this backwards-compatible, we can't touch any existing resources, or helm may delete files that have data in them.

As such, we have opted for the pre-installation hook to write the configuration to a different configmap and secret, and have created a new command in tentacle to migrate the configuration to the final destination.

# Results

* There's a new command in Tentacle which copies the data from the pre-installation configmap and secret and overwrites the destination data to use it
  * This should only ever happen if the agent _was not registered_ in the existing configmap
* There's a new script that's been added called `register.sh` which only runs the registration commands.

There should be no change to existing behaviour without additional changes to the helm chart to enable it.

I've also fixed up some of the integration tests to escape paths that may have spaces to fix issues running them on MacOS.

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.