### PR TITLE
Fixing bug where script output would appear twice in task logs

### DIFF
--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -59,7 +59,7 @@ namespace Octopus.Tentacle.Client.Scripts
             // but the result to use for other versions is the last observing result.
             if (completeScriptResponse is not null)
             {
-                // Because V1 can actually return a result, needs to handle the response received as well (so the output appears in Octopus Server)
+                // Because V1 can actually return a result, we need to handle the response received as well (so the output appears in Octopus Server)
                 OnScriptStatusResponseReceived(completeScriptResponse);
                 return completeScriptResponse;
             }

--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -57,10 +57,14 @@ namespace Octopus.Tentacle.Client.Scripts
             // V1 can return a result when completing. But other versions do not.
             // The behaviour we are maintaining is that the result to use for V1 is that of "complete"
             // but the result to use for other versions is the last observing result.
-            var scriptStatusResponse = completeScriptResponse ?? observingUntilCompleteResult.ScriptStatus;
-            OnScriptStatusResponseReceived(scriptStatusResponse);
-
-            return scriptStatusResponse;
+            if (completeScriptResponse is not null)
+            {
+                // Because V1 can actually return a result, needs to handle the response received as well (so the output appears in Octopus Server)
+                OnScriptStatusResponseReceived(completeScriptResponse);
+                return completeScriptResponse;
+            }
+            
+            return observingUntilCompleteResult.ScriptStatus;
         }
 
         async Task<ScriptOperationExecutionResult> ObserveUntilComplete(

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionAdditionalScripts.cs
@@ -18,6 +18,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [TentacleConfigurations(testCommonVersions: true)]
         public async Task AdditionalScriptsWork(TentacleConfigurationTestCase tentacleConfigurationTestCase)
         {
+            const string printOutput = "Hello";
             using var tmp = new TemporaryDirectory();
             var path = Path.Combine(tmp.DirectoryPath, "file");
 
@@ -26,7 +27,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var scriptBuilder = new ScriptBuilder()
                 .CreateFile(path) // How files are made are different in bash and powershell, doing this ensures the client and tentacle really are using the correct script.
-                .Print("Hello");
+                .Print(printOutput);
 
             var startScriptCommand = new TestExecuteShellScriptCommandBuilder()
                 .WithAdditionalScriptType(ScriptType.Bash, scriptBuilder.BuildBashScript())
@@ -44,7 +45,10 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var allLogs = logs.JoinLogs();
 
-            allLogs.Should().Contain("Hello");
+            allLogs.Should().Contain(printOutput);
+            allLogs.IndexOf(printOutput, StringComparison.OrdinalIgnoreCase)
+                .Should()
+                .Be(allLogs.LastIndexOf(printOutput, StringComparison.OrdinalIgnoreCase), because: "We should not repeat the script output");
         }
     }
 }


### PR DESCRIPTION
# Background

While testing out the new event driven tentacle client in Octopus Server, we found that E2E tests were failing because log output was coming through twice.

# Results

## Before
When the event driven tentacle client work was done, it maintained a quirk with script service V1. The quirk was that calling "Complete Script" could return output. This output had to be written to the Octopus Server task log, but only script service V1 was doing this.

During the refactor, we ended up maintaining the output logging after "Complete Script", but it was put in a common place which will get run for all service types, not just V1.

## After
Where we call `OnScriptStatusResponseReceived` after we "Complete Script" is the correct location. However, if we do not receive any output (e.g. if we are the V2 or K8s script service), then we simply do not output the results.

We enhanced a test to prove the flaw, and then fixed the test by solving the issue.

# How to review this PR
Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.