### PR TITLE
Putting ScriptExecutor functionality into TentacleClient

### DIFF
--- a/source/Octopus.Tentacle.Client/ITentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/ITentacleClient.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut;
 using Halibut.Diagnostics;
+using Octopus.Tentacle.Client.EventDriven;
 using Octopus.Tentacle.Client.Scripts;
 using Octopus.Tentacle.Client.Scripts.Models;
 using Octopus.Tentacle.Contracts;
@@ -16,7 +17,7 @@ namespace Octopus.Tentacle.Client
         Task<DataStream?> DownloadFile(string remotePath, ITentacleClientTaskLog logger, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Execute a script on Tentacle
+        /// Execute a script on Tentacle in its entirety. 
         /// </summary>
         /// <param name="executeScriptCommand">The execute script command</param>
         /// <param name="onScriptStatusResponseReceived"></param>
@@ -31,5 +32,39 @@ namespace Octopus.Tentacle.Client
             OnScriptCompleted onScriptCompleted,
             ITentacleClientTaskLog logger,
             CancellationToken scriptExecutionCancellationToken);
+
+        /// <summary>
+        /// Start the script.
+        /// </summary>
+        /// <returns>The result, which includes the CommandContext for the next command</returns>
+        Task<ScriptOperationExecutionResult> StartScript(ExecuteScriptCommand command,
+            StartScriptIsBeingReAttempted startScriptIsBeingReAttempted,
+            ITentacleClientTaskLog logger,
+            CancellationToken scriptExecutionCancellationToken);
+
+        /// <summary>
+        /// Get the status.
+        /// </summary>
+        /// <param name="commandContext">The CommandContext from the previous command</param>
+        /// <param name="logger"></param>
+        /// <param name="scriptExecutionCancellationToken"></param>
+        /// <returns>The result, which includes the CommandContext for the next command</returns>
+        Task<ScriptOperationExecutionResult> GetStatus(CommandContext commandContext, ITentacleClientTaskLog logger, CancellationToken scriptExecutionCancellationToken);
+
+        /// <summary>
+        /// Cancel the script.
+        /// </summary>
+        /// <param name="commandContext">The CommandContext from the previous command</param>
+        /// <param name="logger"></param>
+        /// <returns>The result, which includes the CommandContext for the next command</returns>
+        Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext, ITentacleClientTaskLog logger);
+
+        /// <summary>
+        /// Complete the script.
+        /// </summary>
+        /// <param name="commandContext">The CommandContext from the previous command</param>
+        /// <param name="logger"></param>
+        /// <param name="scriptExecutionCancellationToken"></param>
+        Task<ScriptStatus?> CompleteScript(CommandContext commandContext, ITentacleClientTaskLog logger, CancellationToken scriptExecutionCancellationToken);
     }
 }

--- a/source/Octopus.Tentacle.Client/ScriptExecutor.cs
+++ b/source/Octopus.Tentacle.Client/ScriptExecutor.cs
@@ -16,7 +16,7 @@ namespace Octopus.Tentacle.Client
     /// <summary>
     /// Executes scripts, on the best available script service. 
     /// </summary>
-    public class ScriptExecutor : IScriptExecutor
+    class ScriptExecutor : IScriptExecutor
     {
         readonly ITentacleClientTaskLog logger;
         readonly ClientOperationMetricsBuilder operationMetricsBuilder; 
@@ -25,22 +25,6 @@ namespace Octopus.Tentacle.Client
         readonly RpcCallExecutor rpcCallExecutor;
         readonly TimeSpan onCancellationAbandonCompleteScriptAfter;
         
-        public ScriptExecutor(AllClients allClients,
-            ITentacleClientTaskLog logger,
-            ITentacleClientObserver tentacleClientObserver, 
-            TentacleClientOptions clientOptions,
-            TimeSpan onCancellationAbandonCompleteScriptAfter)
-        : this(
-            allClients,
-            logger,
-            tentacleClientObserver,
-            // For now, we do not support operation based metrics when used outside the TentacleClient. So just plug in a builder to discard.
-            ClientOperationMetricsBuilder.Start(),
-            clientOptions,
-            onCancellationAbandonCompleteScriptAfter)
-        {
-        }
-
         internal ScriptExecutor(AllClients allClients,
             ITentacleClientTaskLog logger,
             ITentacleClientObserver tentacleClientObserver,

--- a/source/Octopus.Tentacle.Client/Scripts/IScriptExecutor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/IScriptExecutor.cs
@@ -7,7 +7,7 @@ using Octopus.Tentacle.Contracts;
 
 namespace Octopus.Tentacle.Client.Scripts
 {
-    public interface IScriptExecutor 
+    interface IScriptExecutor 
     {
         /// <summary>
         /// Start the script.

--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -6,7 +6,7 @@ using Octopus.Tentacle.Contracts;
 
 namespace Octopus.Tentacle.Client.Scripts
 {
-    public sealed class ObservingScriptOrchestrator
+    sealed class ObservingScriptOrchestrator
     {
         readonly IScriptObserverBackoffStrategy scriptObserverBackOffStrategy;
         readonly OnScriptStatusResponseReceived onScriptStatusResponseReceived;

--- a/source/Octopus.Tentacle.Client/ServiceHelpers/AllClients.cs
+++ b/source/Octopus.Tentacle.Client/ServiceHelpers/AllClients.cs
@@ -7,19 +7,14 @@ using Octopus.Tentacle.Contracts.ScriptServiceV2;
 
 namespace Octopus.Tentacle.Client.ServiceHelpers
 {
-    public class AllClients
+    class AllClients
     {
         public IAsyncClientScriptService ScriptServiceV1 { get; }
         public IAsyncClientScriptServiceV2 ScriptServiceV2 { get; }
         public IAsyncClientKubernetesScriptServiceV1 KubernetesScriptServiceV1 { get; }
         public IAsyncClientFileTransferService ClientFileTransferServiceV1 { get; }
         public IAsyncClientCapabilitiesServiceV2 CapabilitiesServiceV2 { get; }
-
-        public AllClients(IHalibutRuntime halibutRuntime, ServiceEndPoint serviceEndPoint) : this(halibutRuntime, serviceEndPoint, null)
-        {
-        }
-
-
+        
         internal AllClients(IHalibutRuntime halibutRuntime, ServiceEndPoint serviceEndPoint, ITentacleServiceDecoratorFactory? tentacleServicesDecoratorFactory)
         {
             ScriptServiceV1 = halibutRuntime.CreateAsyncClient<IScriptService, IAsyncClientScriptService>(serviceEndPoint);

--- a/source/Octopus.Tentacle.Client/TentacleClient.cs
+++ b/source/Octopus.Tentacle.Client/TentacleClient.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Halibut;
 using Halibut.ServiceModel;
+using Octopus.Tentacle.Client.EventDriven;
 using Octopus.Tentacle.Client.Execution;
 using Octopus.Tentacle.Client.Observability;
 using Octopus.Tentacle.Client.Scripts;
@@ -185,6 +186,66 @@ namespace Octopus.Tentacle.Client
                 var operationMetrics = operationMetricsBuilder.Build();
                 tentacleClientObserver.ExecuteScriptCompleted(operationMetrics, logger);
             }
+        }
+
+        public async Task<ScriptOperationExecutionResult> StartScript(
+            ExecuteScriptCommand command,
+            StartScriptIsBeingReAttempted startScriptIsBeingReAttempted, 
+            ITentacleClientTaskLog logger, 
+            CancellationToken scriptExecutionCancellationToken)
+        {
+            var scriptExecutor = new ScriptExecutor(
+                allClients,
+                logger,
+                tentacleClientObserver,
+                // For now, we do not support metrics for event-based operations.
+                ClientOperationMetricsBuilder.Start(),
+                clientOptions,
+                OnCancellationAbandonCompleteScriptAfter);
+
+            return await scriptExecutor.StartScript(command, startScriptIsBeingReAttempted, scriptExecutionCancellationToken);
+        }
+
+        public async Task<ScriptOperationExecutionResult> GetStatus(CommandContext commandContext, ITentacleClientTaskLog logger, CancellationToken scriptExecutionCancellationToken)
+        {
+            var scriptExecutor = new ScriptExecutor(
+            allClients,
+                logger,
+                tentacleClientObserver,
+                // For now, we do not support metrics for event-based operations.
+                ClientOperationMetricsBuilder.Start(),
+                clientOptions,
+                OnCancellationAbandonCompleteScriptAfter);
+
+            return await scriptExecutor.GetStatus(commandContext, scriptExecutionCancellationToken);
+        }
+
+        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext, ITentacleClientTaskLog logger)
+        {
+            var scriptExecutor = new ScriptExecutor(
+                allClients,
+                logger,
+                tentacleClientObserver,
+                // For now, we do not support metrics for event-based operations.
+                ClientOperationMetricsBuilder.Start(),
+                clientOptions,
+                OnCancellationAbandonCompleteScriptAfter);
+
+            return await scriptExecutor.CancelScript(commandContext);
+        }
+
+        public async Task<ScriptStatus?> CompleteScript(CommandContext commandContext, ITentacleClientTaskLog logger, CancellationToken scriptExecutionCancellationToken)
+        {
+            var scriptExecutor = new ScriptExecutor(
+                allClients,
+                logger,
+                tentacleClientObserver,
+                // For now, we do not support metrics for event-based operations.
+                ClientOperationMetricsBuilder.Start(),
+                clientOptions,
+                OnCancellationAbandonCompleteScriptAfter);
+
+            return await scriptExecutor.CompleteScript(commandContext, scriptExecutionCancellationToken);
         }
 
         public void Dispose()


### PR DESCRIPTION
# Background

It was decided that exposing the `ScriptExecutor` was not ideal. Instead, we wanted to use the one publicly visible endpoint to be used. That would be the `TentacleClient`.

We have now exposed the operations that the `ScriptExecutor` can do onto the `TentacleClient`, and are calling them through the `TentacleClient` instead.
