### PR TITLE
Making ExitCode not nullable, plus renaming command context parameter

### DIFF
--- a/source/Octopus.Tentacle.Client/ScriptExecutor.cs
+++ b/source/Octopus.Tentacle.Client/ScriptExecutor.cs
@@ -68,28 +68,28 @@ namespace Octopus.Tentacle.Client
             return await scriptExecutor.StartScript(executeScriptCommand, startScriptIsBeingReAttempted, cancellationToken);
         }
 
-        public async Task<ScriptOperationExecutionResult> GetStatus(CommandContext ticketForNextNextStatus, CancellationToken cancellationToken)
+        public async Task<ScriptOperationExecutionResult> GetStatus(CommandContext commandContext, CancellationToken cancellationToken)
         {
             var scriptExecutorFactory = CreateScriptExecutorFactory();
-            var scriptExecutor = scriptExecutorFactory.CreateScriptExecutor(ticketForNextNextStatus.ScripServiceVersionUsed);
+            var scriptExecutor = scriptExecutorFactory.CreateScriptExecutor(commandContext.ScripServiceVersionUsed);
 
-            return await scriptExecutor.GetStatus(ticketForNextNextStatus, cancellationToken);
+            return await scriptExecutor.GetStatus(commandContext, cancellationToken);
         }
 
-        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext ticketForNextNextStatus)
+        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
         {
             var scriptExecutorFactory = CreateScriptExecutorFactory();
-            var scriptExecutor = scriptExecutorFactory.CreateScriptExecutor(ticketForNextNextStatus.ScripServiceVersionUsed);
+            var scriptExecutor = scriptExecutorFactory.CreateScriptExecutor(commandContext.ScripServiceVersionUsed);
 
-            return await scriptExecutor.CancelScript(ticketForNextNextStatus);
+            return await scriptExecutor.CancelScript(commandContext);
         }
         
-        public async Task<ScriptStatus?> CompleteScript(CommandContext ticketForNextNextStatus, CancellationToken cancellationToken)
+        public async Task<ScriptStatus?> CompleteScript(CommandContext commandContext, CancellationToken cancellationToken)
         {
             var scriptExecutorFactory = CreateScriptExecutorFactory();
-            var scriptExecutor = scriptExecutorFactory.CreateScriptExecutor(ticketForNextNextStatus.ScripServiceVersionUsed);
+            var scriptExecutor = scriptExecutorFactory.CreateScriptExecutor(commandContext.ScripServiceVersionUsed);
 
-            return await scriptExecutor.CompleteScript(ticketForNextNextStatus, cancellationToken);
+            return await scriptExecutor.CompleteScript(commandContext, cancellationToken);
         }
         
         ScriptExecutorFactory CreateScriptExecutorFactory()

--- a/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Executor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Executor.cs
@@ -153,11 +153,11 @@ namespace Octopus.Tentacle.Client.Scripts
             return Map(kubernetesScriptStatusResponseV1);
         }
 
-        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext lastStatusResponse)
+        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
         {
             async Task<KubernetesScriptStatusResponseV1> CancelScriptAction(CancellationToken ct)
             {
-                var request = new CancelKubernetesScriptCommandV1(lastStatusResponse.ScriptTicket, lastStatusResponse.NextLogSequence);
+                var request = new CancelKubernetesScriptCommandV1(commandContext.ScriptTicket, commandContext.NextLogSequence);
                 var result = await clientKubernetesScriptServiceV1.CancelScriptAsync(request, new HalibutProxyRequestOptions(ct));
 
                 return result;

--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -39,7 +39,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 throw new OperationCanceledException("Script execution was cancelled");
             }
 
-            return new ScriptExecutionResult(scriptStatus.State, scriptStatus.ExitCode!.Value);
+            return new ScriptExecutionResult(scriptStatus.State, scriptStatus.ExitCode);
         }
 
         async Task<ScriptStatus> ObserveUntilCompleteThenFinish(

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptOperationExecutionResult.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptOperationExecutionResult.cs
@@ -21,7 +21,7 @@ namespace Octopus.Tentacle.Client.Scripts
         /// </summary>
         internal static ScriptOperationExecutionResult CreateScriptStartedResult(ScriptTicket scriptTicket, ScriptServiceVersion scripServiceVersionUsed)
         {
-            var scriptStatus = new ScriptStatus(ProcessState.Pending, null, new List<ProcessOutput>());
+            var scriptStatus = new ScriptStatus(ProcessState.Pending, 0, new List<ProcessOutput>());
             var contextForNextCommand = new CommandContext(scriptTicket, 0, scripServiceVersionUsed);
             return new(scriptStatus, contextForNextCommand);
         }

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Executor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Executor.cs
@@ -106,13 +106,13 @@ namespace Octopus.Tentacle.Client.Scripts
             return Map(scriptStatusResponseV1);
         }
 
-        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext lastStatusResponse)
+        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
         {
             var response = await rpcCallExecutor.ExecuteWithNoRetries(
                 RpcCall.Create<IScriptService>(nameof(IScriptService.CancelScript)),
                 async ct =>
                 {
-                    var request = new CancelScriptCommand(lastStatusResponse.ScriptTicket, lastStatusResponse.NextLogSequence);
+                    var request = new CancelScriptCommand(commandContext.ScriptTicket, commandContext.NextLogSequence);
                     var result = await clientScriptServiceV1.CancelScriptAsync(request, new HalibutProxyRequestOptions(ct));
 
                     return result;

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Executor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Executor.cs
@@ -146,11 +146,11 @@ namespace Octopus.Tentacle.Client.Scripts
             return Map(scriptStatusResponseV2);
         }
 
-        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext lastStatusResponse)
+        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
         {
             async Task<ScriptStatusResponseV2> CancelScriptAction(CancellationToken ct)
             {
-                var request = new CancelScriptCommandV2(lastStatusResponse.ScriptTicket, lastStatusResponse.NextLogSequence);
+                var request = new CancelScriptCommandV2(commandContext.ScriptTicket, commandContext.NextLogSequence);
                 var result = await clientScriptServiceV2.CancelScriptAsync(request, new HalibutProxyRequestOptions(ct));
 
                 return result;

--- a/source/Octopus.Tentacle.Contracts/ScriptStatus.cs
+++ b/source/Octopus.Tentacle.Contracts/ScriptStatus.cs
@@ -5,10 +5,10 @@ namespace Octopus.Tentacle.Contracts
     public class ScriptStatus
     {
         public ProcessState State { get; }
-        public int? ExitCode { get; }
+        public int ExitCode { get; }
         public List<ProcessOutput> Logs { get; }
         
-        public ScriptStatus(ProcessState state, int? exitCode, List<ProcessOutput> logs)
+        public ScriptStatus(ProcessState state, int exitCode, List<ProcessOutput> logs)
         {
             State = state;
             ExitCode = exitCode;


### PR DESCRIPTION
# Background

Exit code is always an integer in the response. It makes it easier to work with in Octopus Server as well. So let's just make it not nullable for now to make life easier in Octopus Server, and we can deal with the entire situation later.

Also, we had a parameter name that was incorrect. That is being fixed here as well.
