### PR TITLE
Rename the setup fixture to tell users it is slow to run and clicking it will show logs

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/ShowOneTimeSetupLogInfo.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/SetupFixtures/ShowOneTimeSetupLogInfo.cs
@@ -13,8 +13,8 @@ namespace Octopus.Tentacle.Tests.Integration.Support.SetupFixtures
         [Test]
         public void ShowOneTimeSetupLogInfoTest()
         {
-            this.Logger.Information(TentacleIntegrationSetupFixtures.OneTimeSetupLogOutput);
-            TentacleIntegrationSetupFixtures.OneTimeSetupLogOutput = null;
+            this.Logger.Information(TentacleIntegrationSetupCanBeLongRunningClickHereToSeeLogsFixtures.OneTimeSetupLogOutput);
+            TentacleIntegrationSetupCanBeLongRunningClickHereToSeeLogsFixtures.OneTimeSetupLogOutput = null;
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleIntegrationSetupCanBeLongRunningClickHereToSeeLogsFixtures.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleIntegrationSetupCanBeLongRunningClickHereToSeeLogsFixtures.cs
@@ -15,7 +15,7 @@ namespace Octopus.Tentacle.Tests.Integration
     /// 
     /// </summary>
     [SetUpFixture] // Must be the one and only. 
-    public class TentacleIntegrationSetupFixtures
+    public class TentacleIntegrationSetupCanBeLongRunningClickHereToSeeLogsFixtures
     {
         private ISetupFixture[] setupFixtures = new ISetupFixture[]
         {
@@ -33,7 +33,7 @@ namespace Octopus.Tentacle.Tests.Integration
             var logger = new SerilogLoggerBuilder()
                 .WithLoggingToStringBuilder(sb)
                 .Build()
-                .ForContext<TentacleIntegrationSetupFixtures>();
+                .ForContext<TentacleIntegrationSetupCanBeLongRunningClickHereToSeeLogsFixtures>();
             foreach (var setupFixture in setupFixtures)
             {
                 setupFixture.OneTimeSetUp(logger.ForContext(setupFixture.GetType()));
@@ -45,7 +45,7 @@ namespace Octopus.Tentacle.Tests.Integration
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            var logger = new SerilogLoggerBuilder().Build().ForContext<TentacleIntegrationSetupFixtures>();
+            var logger = new SerilogLoggerBuilder().Build().ForContext<TentacleIntegrationSetupCanBeLongRunningClickHereToSeeLogsFixtures>();
             var exceptions = new List<Exception>();
             foreach (var setupFixture in setupFixtures.Reverse())
             {


### PR DESCRIPTION
# Background

Some devs are left wondering what on earth is happening the first time Integration tests run locally.

What happens is we download potentially GBs of data to download  tentacle for testing.

The Fixture which does that is renamed to hint it could be slow and how to view progress:

![image](https://github.com/user-attachments/assets/4c159122-3c36-4b06-a4a7-f798ebef1ba7)
 

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.