### PR TITLE
Fix running Integration Tests on OSX

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
@@ -64,7 +64,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             Action<string> log = s => logger.Information(s);
             var exitCode = SilentProcessRunner.ExecuteCommand(
                 "tar",
-                $"xzvf {gzArchiveName} -C {destFolder}",
+                $"xzvf \"{gzArchiveName}\" -C \"{destFolder}\"",
                 tmp.DirectoryPath,
                 log,
                 log,

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/NugetTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/NugetTentacleFetcher.cs
@@ -73,13 +73,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
 
         public string[] TentacleArtifactNames(Version version, TentacleRuntime runtime)
         {
+            // Tentacle 8.2 is/was built on .NET8, previous versions were built on .NET6
+            string runtimeForVersion = version.Major >= 8 && version.Minor >= 2
+                ? RuntimeDetection.DotNet8
+                : RuntimeDetection.DotNet6;
             if (PlatformDetection.IsRunningOnWindows)
             {
-                // Tentacle 8.2 is/was built on .NET8, previous versions were built on .NET6
-                string runtimeForVersion = version.Major >= 8 && version.Minor >= 2
-                    ? RuntimeDetection.DotNet8
-                    : RuntimeDetection.DotNet6;
-
                 var net48ArtifactNames = new[] {"tentacle-net48-win.zip"};
                 var dotnetArtifactNames = Architectures()
                     .Select(a => $"tentacle-{runtimeForVersion}-win-{a}.zip")
@@ -98,14 +97,14 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             if (PlatformDetection.IsRunningOnMac)
             {
                 return Architectures()
-                    .Select(a => $"tentacle-{RuntimeDetection.GetCurrentRuntime()}-osx-{a}.tar.gz")
+                    .Select(a => $"tentacle-{runtimeForVersion}-osx-{a}.tar.gz")
                     .ToArray();
             }
 
             if (PlatformDetection.IsRunningOnNix)
             {
                 return Architectures()
-                    .Select(a => $"tentacle-{RuntimeDetection.GetCurrentRuntime()}-linux-{a}.tar.gz")
+                    .Select(a => $"tentacle-{runtimeForVersion}-linux-{a}.tar.gz")
                     .ToArray();
             }
 


### PR DESCRIPTION
# Background

- Fixing the tar command where the path contains spaces.
- Fixes downloading older tentacles. The issue was it was trying to use net8 versions of old version of tentacle which did not exist.


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.