### PR TITLE
Adds support for ScriptPods having configurable Annotations (#1070)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Currently we can only debug netcore apps running in WSL from VSCode, Visual Stud
 ```
 ## Debugging the Kubernetes Agent Tentacle
 
-The Kubernetes Agent Tentacle is a bit more complex to debug, as it normally runs inside a Kubernetes Pod. To debug it locally, you can run the `setup-k8s-agent-for-local-debug.sh` script in the root of this repo which will guide you through the process of installing a specially configured kind cluster, deploying the agent to it and then scaling back the installed agent so you can run a local copy to take it's place.
+The Kubernetes Agent Tentacle is more complex to debug, as it normally runs inside a Kubernetes Pod. To debug it locally, you can run the `setup-k8s-agent-for-local-debug.sh` script in the root of this repo which will guide you through the process of installing a specially configured kind cluster, deploying the agent to it and then scaling back the installed agent so you can run a local copy to take it's place.
 
 NOTE: This script has only been tested on MacOS so far and requires Docker Desktop, Kubectl, Go CLI and Kind to be installed. It is also only for the Kubernetes Agent Tentacle running as a Deployment Target, not as a Worker.
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -64,7 +64,10 @@ namespace Octopus.Tentacle.Kubernetes
 
         public static readonly string PodSecurityContextJsonVariableName = $"{EnvVarPrefix}__PODSECURITYCONTEXTJSON";
         public static string? PodSecurityContextJson => Environment.GetEnvironmentVariable(PodSecurityContextJsonVariableName);
-        
+
+        public static readonly string PodAnnotationsJsonVariableName = $"{EnvVarPrefix}__PODANNOTATIONSJSON";
+        public static string? PodAnnotationsJson => Environment.GetEnvironmentVariable(PodAnnotationsJsonVariableName);
+
         public static readonly string TentacleConfigMapNameVariableName = $"{EnvVarPrefix}__TENTACLECONFIGMAPNAME";
         public static string TentacleConfigMapName => GetEnvironmentVariableOrDefault(TentacleConfigMapNameVariableName, "tentacle-config");
 
@@ -109,7 +112,7 @@ namespace Octopus.Tentacle.Kubernetes
         static string GetRequiredEnvVar(string variable, string errorMessage)
             => Environment.GetEnvironmentVariable(variable)
                 ?? throw new InvalidOperationException($"{errorMessage} The environment variable '{variable}' must be defined with a non-null value.");
-        
+
         static string GetEnvironmentVariableOrDefault(string variable, string defaultValue)
             => Environment.GetEnvironmentVariable(variable) ?? defaultValue;
     }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -80,7 +80,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 //Write the log encryption key here
                 await scriptPodLogEncryptionKeyProvider.GenerateAndWriteEncryptionKeyfileToWorkspace(command.ScriptTicket, cancellationToken);
-                
+
                 //Possibly create the image pull secret name
                 var imagePullSecretName = await CreateImagePullSecret(command, cancellationToken);
 
@@ -188,7 +188,7 @@ namespace Octopus.Tentacle.Kubernetes
                 .WhereNotNull()
                 .Select(secretName => new V1LocalObjectReference(secretName))
                 .ToList();
-             
+
             var pod = new V1Pod
             {
                 Metadata = new V1ObjectMeta
@@ -199,7 +199,8 @@ namespace Octopus.Tentacle.Kubernetes
                     {
                         ["octopus.com/serverTaskId"] = command.TaskId,
                         ["octopus.com/scriptTicketId"] = command.ScriptTicket.TaskId
-                    }
+                    },
+                    Annotations = ParseScriptPodAnnotations(tentacleScriptLog)
                 },
                 Spec = new V1PodSpec
                 {
@@ -405,6 +406,13 @@ namespace Octopus.Tentacle.Kubernetes
                 KubernetesConfig.PodSecurityContextJson,
                 KubernetesConfig.PodSecurityContextJsonVariableName,
                 "pod security context");
+
+        Dictionary<string, string>? ParseScriptPodAnnotations(InMemoryTentacleScriptLog tentacleScriptLog)
+            => ParseScriptPodJson<Dictionary<string, string>>(
+                tentacleScriptLog,
+                KubernetesConfig.PodAnnotationsJson,
+                KubernetesConfig.PodAnnotationsJsonVariableName,
+                "pod annotations");
 
         [return: NotNullIfNotNull("defaultValue")]
         T? ParseScriptPodJson<T>(InMemoryTentacleScriptLog tentacleScriptLog, string? json, string envVarName, string description, T? defaultValue = null) where T : class


### PR DESCRIPTION
# Background

Adds support for annotations to ScriptPods.

# Results

Fixes [issues/1070](https://github.com/OctopusDeploy/OctopusTentacle/issues/1070)

## Before

```
[POD EVENT] FailedMount | MountVolume.SetUp failed for volume "octopus-agent-octopus-deploy-pvc" : rpc error: code = FailedPrecondition desc = failed to find the sidecar container in Pod spec (Count: 9)
The Kubernetes Pod 'octopus-script-slpfqrh5k2l2ju2gqfseg' is in the 'Pending' phase
```

## After


# How to review this PR

Validate that my understanding of the configuration and JSON parsing pattern is correct as I am unsure about the inline JSON parsing into a `Dictionary<string, string>` pattern.

Quality :heavy_check_mark:
Setting `OCTOPUS__K8STENTACLE__PODANNOTATIONSJSON='{foo: "bar"}'` should be enough to validate that the JSON parsing is correct and validating that any created Script Pods have `foo=bar` in their Pod metadata annotations.

Am also willing to test this in our current cloud instance that we are working on with @mcasperson

# Pre-requisites

- [X] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [X] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [X] I have considered appropriate testing for my change.