### PR TITLE
changed proxy config order for k8s agent

### DIFF
--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -434,10 +434,10 @@ else
 
   migrateFromPreinstallScript
   configureTentacle
+  setPollingProxy
   registerTentacle
   addAdditionalServerInstancesIfRequired
-  setPollingProxy
-
+  
   echo "Configuration successful"
 fi
 


### PR DESCRIPTION
# Background

[sc-104721]

For a polling tentacle, the register machine command relies on the polling proxy config to work. In a locked down environment where access to the Octopus instance must go via a proxy, the proxy configuration must be setup prior to registering.

# Results

This PR changes the order so proxy configuration is in place prior to registration.

Fixes #1074 

## Before

## After


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.