### PR TITLE
Link init script pod resource limits to main script pod limits

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -203,7 +203,7 @@ namespace Octopus.Tentacle.Kubernetes
                 },
                 Spec = new V1PodSpec
                 {
-                    InitContainers = await CreateInitContainers(command, podName, homeDir, workspacePath),
+                    InitContainers = await CreateInitContainers(command, podName, homeDir, workspacePath, tentacleScriptLog),
                     Containers = await CreateScriptContainers(command, podName, scriptName, homeDir, workspacePath, workspace.ScriptArguments, tentacleScriptLog),
                     ImagePullSecrets = imagePullSecretNames,
                     ServiceAccountName = serviceAccountName,
@@ -230,7 +230,7 @@ namespace Octopus.Tentacle.Kubernetes
             }.AddIfNotNull(CreateWatchdogContainer(homeDir));
         }
 
-        protected virtual async Task<IList<V1Container>> CreateInitContainers(StartKubernetesScriptCommandV1 command, string podName, string homeDir, string workspacePath)
+        protected virtual async Task<IList<V1Container>> CreateInitContainers(StartKubernetesScriptCommandV1 command, string podName, string homeDir, string workspacePath, InMemoryTentacleScriptLog tentacleScriptLog)
         {
             await Task.CompletedTask;
             return new List<V1Container>();
@@ -346,7 +346,7 @@ namespace Octopus.Tentacle.Kubernetes
             };
         }
 
-        V1ResourceRequirements GetScriptPodResourceRequirements(InMemoryTentacleScriptLog tentacleScriptLog)
+        protected V1ResourceRequirements GetScriptPodResourceRequirements(InMemoryTentacleScriptLog tentacleScriptLog)
         {
             var json = KubernetesConfig.PodResourceJson;
             if (!string.IsNullOrWhiteSpace(json))


### PR DESCRIPTION
# Background
The Kubernetes Agent currently supports setting custom resource limits on main script pods, but not init script pods - they have a fixed value defined in the agent itself.

This PR sets the init script pod resource limits to the values specified for the main script pods.

# Results

I added two agents to my local cluster, one with the old version, one with this version. 
They both had a memory limit set: `--set agent.scriptPods.resources.limits.memory="273Mi"`  

Only this version actually applied that limit.

Left is before, right is after:
![image](https://github.com/user-attachments/assets/28a587f7-c005-46e0-9feb-d85bc788d8d9)

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [X] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [X] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [X] I have considered appropriate testing for my change.