### PR TITLE
Update FluentAssertions to v7 and lock

### DIFF
--- a/.github/workflows/approve-renovate-pull-request.yml
+++ b/.github/workflows/approve-renovate-pull-request.yml
@@ -1,3 +1,5 @@
+# Derived from https://github.com/OctopusDeploy/OctopusDeploy/blob/main/.github/workflows/portal-update-pull-request-automation.yml
+
 name: "Approve Renovate Pull Request"
 
 on:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,3 +1,5 @@
+# Derived from https://github.com/OctopusDeploy/OctopusDeploy/blob/main/.github/workflows/update-dependencies.yml
+
 name: Renovate update dependencies
 on:
   schedule:

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,5 +1,6 @@
 const excludeList = [
     "dotnet-sdk", // The dotnet SDK update is a non-trivial piece of work.
+    "FluentAssertions", // FluentAssertions 8 and above introduced potential fees for developers
 ];
 
 module.exports = {

--- a/source/Octopus.Manager.Tentacle.Tests/Octopus.Manager.Tentacle.Tests.csproj
+++ b/source/Octopus.Manager.Tentacle.Tests/Octopus.Manager.Tentacle.Tests.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/Octopus.Tentacle.Client.Tests/Octopus.Tentacle.Client.Tests.csproj
+++ b/source/Octopus.Tentacle.Client.Tests/Octopus.Tentacle.Client.Tests.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/source/Octopus.Tentacle.CommonTestUtils/Octopus.Tentacle.CommonTestUtils.csproj
+++ b/source/Octopus.Tentacle.CommonTestUtils/Octopus.Tentacle.CommonTestUtils.csproj
@@ -27,7 +27,7 @@
       <ProjectReference Include="..\Octopus.Tentacle\Octopus.Tentacle.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="FluentAssertions" Version="6.7.0" />
+      <PackageReference Include="FluentAssertions" Version="7.0.0" />
       <PackageReference Include="NUnit" Version="3.13.3" />
       <PackageReference Include="Serilog" Version="2.12.0" />
     </ItemGroup>

--- a/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Tests.Integration/Octopus.Tentacle.Tests.Integration.csproj
@@ -28,7 +28,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />                       
         <PackageReference Include="NetCoreStack.DispatchProxyAsync" Version="2.2.0" />
         <PackageReference Include="NSubstitute" Version="4.4.0" />
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="FluentAssertions" Version="7.0.0" />
         <PackageReference Include="Assent" Version="1.8.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="Octopus.TestPortForwarder" Version="7.0.682" />

--- a/source/Octopus.Tentacle.Tests/DependenciesTest.cs
+++ b/source/Octopus.Tentacle.Tests/DependenciesTest.cs
@@ -1,0 +1,19 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Octopus.Tentacle.Tests
+{
+    public class DependenciesTest
+    {
+        [Test]
+        public void FluentAssertionsIsVersion7()
+        {
+            typeof(AssertionOptions).Assembly.GetName().Version!.Major
+                .Should()
+                .Be(
+                    7,
+                    "We want to keep using the FOSS version of FluentAssertions, which changed in v8."
+                );
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
+++ b/source/Octopus.Tentacle.Tests/Octopus.Tentacle.Tests.csproj
@@ -43,7 +43,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Assent" Version="1.8.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />


### PR DESCRIPTION
# Background

Prevent the FluentAssertions version from auto-updating as [v8 upwards is not FOSS](https://github.com/fluentassertions/fluentassertions/pull/2943).

[sc-102264]

# Results

Renovate will not generate PRs relating to FluentAssertion updates. 


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.