### PR TITLE
Allow callers to cancel their request to cancel the script

### DIFF
--- a/source/Octopus.Tentacle.Client/ScriptExecutor.cs
+++ b/source/Octopus.Tentacle.Client/ScriptExecutor.cs
@@ -60,12 +60,12 @@ namespace Octopus.Tentacle.Client
             return await scriptExecutor.GetStatus(commandContext, cancellationToken);
         }
 
-        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
+        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext, CancellationToken cancellationToken)
         {
             var scriptExecutorFactory = CreateScriptExecutorFactory();
             var scriptExecutor = scriptExecutorFactory.CreateScriptExecutor(commandContext.ScripServiceVersionUsed);
 
-            return await scriptExecutor.CancelScript(commandContext);
+            return await scriptExecutor.CancelScript(commandContext, cancellationToken);
         }
         
         public async Task<ScriptStatus?> CompleteScript(CommandContext commandContext, CancellationToken cancellationToken)

--- a/source/Octopus.Tentacle.Client/Scripts/IScriptExecutor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/IScriptExecutor.cs
@@ -30,7 +30,7 @@ namespace Octopus.Tentacle.Client.Scripts
         /// </summary>
         /// <param name="commandContext">The CommandContext from the previous command</param>
         /// <returns>The result, which includes the CommandContext for the next command</returns>
-        Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext);
+        Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext, CancellationToken cancellationToken);
 
         /// <summary>
         /// Complete the script.

--- a/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Executor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Executor.cs
@@ -153,7 +153,7 @@ namespace Octopus.Tentacle.Client.Scripts
             return Map(kubernetesScriptStatusResponseV1);
         }
 
-        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
+        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext, CancellationToken cancellationToken)
         {
             async Task<KubernetesScriptStatusResponseV1> CancelScriptAction(CancellationToken ct)
             {
@@ -173,8 +173,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 CancelScriptAction,
                 logger,
                 clientOperationMetricsBuilder,
-                // We don't want to cancel this operation as it is responsible for stopping the script executing on the Tentacle
-                CancellationToken.None).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
             return Map(kubernetesScriptStatusResponseV1);
         }
 

--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -79,7 +79,8 @@ namespace Octopus.Tentacle.Client.Scripts
             {
                 if (scriptExecutionCancellationToken.IsCancellationRequested)
                 {
-                    lastResult = await scriptExecutor.CancelScript(lastResult.ContextForNextCommand).ConfigureAwait(false);
+                    // We don't want to cancel this operation as it is responsible for stopping the script executing on the Tentacle
+                    lastResult = await scriptExecutor.CancelScript(lastResult.ContextForNextCommand, CancellationToken.None).ConfigureAwait(false);
                 }
                 else
                 {

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Executor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Executor.cs
@@ -106,7 +106,7 @@ namespace Octopus.Tentacle.Client.Scripts
             return Map(scriptStatusResponseV1);
         }
 
-        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
+        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext, CancellationToken cancellationToken)
         {
             var response = await rpcCallExecutor.ExecuteWithNoRetries(
                 RpcCall.Create<IScriptService>(nameof(IScriptService.CancelScript)),
@@ -119,7 +119,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 },
                 logger,
                 clientOperationMetricsBuilder,
-                CancellationToken.None).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
             return Map(response);
         }

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Executor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Executor.cs
@@ -146,7 +146,7 @@ namespace Octopus.Tentacle.Client.Scripts
             return Map(scriptStatusResponseV2);
         }
 
-        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
+        public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext, CancellationToken cancellationToken)
         {
             async Task<ScriptStatusResponseV2> CancelScriptAction(CancellationToken ct)
             {
@@ -166,8 +166,7 @@ namespace Octopus.Tentacle.Client.Scripts
                 CancelScriptAction,
                 logger,
                 clientOperationMetricsBuilder,
-                // We don't want to cancel this operation as it is responsible for stopping the script executing on the Tentacle
-                CancellationToken.None).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
             return Map(scriptStatusResponseV2);
         }
 


### PR DESCRIPTION
# Background

Otherwise callers of the event driven script executor can't bail out on requests to cancel the script.

Which is preventing octopus from shutting down.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.