### PR TITLE
Introduce "Green-means-go" Renovate PR Messages

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -52,17 +52,7 @@ module.exports = {
     {
       // These packages use a custom fork of NuGet which we still rely on.
       groupName: 'NuGet Libraries',
-      matchPackageNames: [
-        'NuGet.Common',
-        'NuGet.Configuration',
-        'NuGet.Frameworks',
-        'NuGet.Packaging',
-        'NuGet.Packaging.Core',
-        'NuGet.Packaging.Core.Types',
-        'NuGet.Protocol.Core.Types',
-        'NuGet.Protocol.Core.v3',
-        'NuGet.Versioning',
-      ],
+      matchPackageNames: ['NuGet.Packaging'],
       enabled: false,
     },
     // Keep the rest of the packages in alphabetical order (of package name). However, non-greenMeansGo packages should be placed before greenMeansGo packages 
@@ -72,9 +62,6 @@ module.exports = {
       prBodyNotes: [
         'Autofac is very important to Octopus. We need to be careful upgrading this package.',
         'Review release notes to ensure there are no breaking changes.',
-        'Create a public issue regarding the upgrade.',
-        "Merge the upgrade and take note of which release it's included in.",
-        'Monitor memory usage in deploy to ensure there are no significant changes.',
       ],
     },
     // greenMeansGo packages

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,4 +1,5 @@
-// Several parts of this config have been duplicated from the Octopus Server renovate.config
+// Several parts of this config such as the excludeList, preCannedPrNotes and some packageRules have been duplicated from the Octopus Server renovate.config as they also apply to Tentacle
+// https://github.com/OctopusDeploy/OctopusDeploy/blob/main/renovate-config.js
 
 const excludeList = [
   'dotnet-sdk', // The dotnet SDK update is a non-trivial piece of work.

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -60,7 +60,7 @@ module.exports = {
     {
       matchPackageNames: ['Autofac'],
       prBodyNotes: [
-        'Autofac is very important to Octopus. We need to be careful upgrading this package.',
+        'Autofac is very important to Tentacle. We need to be careful upgrading this package.',
         'Review release notes to ensure there are no breaking changes.',
       ],
     },

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,43 +1,92 @@
+// Several parts of this config have been duplicated from the Octopus Server renovate.config
+
 const excludeList = [
-    "dotnet-sdk", // The dotnet SDK update is a non-trivial piece of work.
-    "FluentAssertions", // FluentAssertions 8 and above introduced potential fees for developers
-];
+  'dotnet-sdk', // The dotnet SDK update is a non-trivial piece of work.
+  'FluentAssertions', // FluentAssertions 8 and above introduced potential fees for developers
+]
+
+const preCannedPrNotes = {
+  greenMeansGo: [
+    'Green means go. Any issues in this PR should be caught as part of our tests and/or builds.',
+  ],
+}
 
 module.exports = {
+  timezone: 'Australia/Brisbane',
+  requireConfig: 'optional',
+  onboarding: false,
+  ignoreDeps: excludeList,
+  enabledManagers: ['nuget'],
 
-    timezone: "Australia/Brisbane",
-    requireConfig: "optional",
-    onboarding: false,
+  // Full list of built-in presets: https://docs.renovatebot.com/presets-default/
+  extends: [
+    'config:base',
+    'group:monorepos',
+    'group:recommended',
+    ':rebaseStalePrs',
+    ':automergeRequireAllStatusChecks',
+  ],
 
-    ignoreDeps: excludeList,
-    enabledManagers: ["nuget"],
+  // Renovate will create a new issue in the repository.
+  // This issue has a "dashboard" where you can get an overview of the status of all updates.
+  // https://docs.renovatebot.com/key-concepts/dashboard/
+  dependencyDashboard: true,
+  dependencyDashboardTitle: 'Tentacle Dependency Dashboard',
 
-    // Full list of built-in presets: https://docs.renovatebot.com/presets-default/
-    extends: [
-        "config:base",
-        "group:monorepos",
-        "group:recommended",
-		":rebaseStalePrs",
-        ":automergeRequireAllStatusChecks",
-    ],
+  platform: 'github',
+  repositories: ['OctopusDeploy/OctopusTentacle'],
+  reviewers: ['OctopusDeploy/team-server-at-scale'],
+  labels: ['dependencies', 'Tentacle'],
+  branchPrefix: 'renovate-dotnet/',
 
-    // Renovate will create a new issue in the repository.
-    // This issue has a "dashboard" where you can get an overview of the status of all updates.
-    // https://docs.renovatebot.com/key-concepts/dashboard/
-    dependencyDashboard: true,
-    dependencyDashboardTitle: "Tentacle Dependency Dashboard",
+  // Limit the amount of PRs created
+  prConcurrentLimit: 2,
+  prHourlyLimit: 1,
 
-    platform: "github",
-    repositories: ["OctopusDeploy/OctopusTentacle"],
-    reviewers: ["OctopusDeploy/team-server-at-scale"],
-    labels: ["dependencies", "Tentacle"],
-    branchPrefix: "renovate-dotnet/",
+  // If set to false, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.
+  // https://docs.renovatebot.com/configuration-options/#separatemajorminor
+  separateMajorMinor: false,
 
-    // Limit the amount of PRs created
-    prConcurrentLimit: 2,
-    prHourlyLimit: 1,
-
-    // If set to false, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.
-    // https://docs.renovatebot.com/configuration-options/#separatemajorminor
-    separateMajorMinor: false,
-};
+  packageRules: [
+    {
+      // These packages use a custom fork of NuGet which we still rely on.
+      groupName: 'NuGet Libraries',
+      matchPackageNames: [
+        'NuGet.Common',
+        'NuGet.Configuration',
+        'NuGet.Frameworks',
+        'NuGet.Packaging',
+        'NuGet.Packaging.Core',
+        'NuGet.Packaging.Core.Types',
+        'NuGet.Protocol.Core.Types',
+        'NuGet.Protocol.Core.v3',
+        'NuGet.Versioning',
+      ],
+      enabled: false,
+    },
+    {
+      matchPackageNames: ['Nsubstitute'],
+      prBodyNotes: [
+        ...preCannedPrNotes.greenMeansGo,
+        'Used extensively throughout tests.',
+      ],
+    },
+    {
+      matchPackageNames: ['Autofac'],
+      prBodyNotes: [
+        'Autofac is very important to Octopus. We need to be careful upgrading this package.',
+        'Review release notes to ensure there are no breaking changes.',
+        'Create a public issue regarding the upgrade.',
+        "Merge the upgrade and take note of which release it's included in.",
+        'Monitor memory usage in deploy to ensure there are no significant changes.',
+      ],
+    },
+    {
+      matchPackageNames: ['Polly'],
+      prBodyNotes: [
+        ...preCannedPrNotes.greenMeansGo,
+        'Used extensively in the codebase. Any breaking changes are likely to be surfaced in the test suite.',
+      ],
+    },
+  ],
+}

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -65,13 +65,8 @@ module.exports = {
       ],
       enabled: false,
     },
-    {
-      matchPackageNames: ['Nsubstitute'],
-      prBodyNotes: [
-        ...preCannedPrNotes.greenMeansGo,
-        'Used extensively throughout tests.',
-      ],
-    },
+    // Keep the rest of the packages in alphabetical order (of package name). However, non-greenMeansGo packages should be placed before greenMeansGo packages 
+    // Non-greenMeansGo packages
     {
       matchPackageNames: ['Autofac'],
       prBodyNotes: [
@@ -80,6 +75,14 @@ module.exports = {
         'Create a public issue regarding the upgrade.',
         "Merge the upgrade and take note of which release it's included in.",
         'Monitor memory usage in deploy to ensure there are no significant changes.',
+      ],
+    },
+    // greenMeansGo packages
+    {
+      matchPackageNames: ['Nsubstitute'],
+      prBodyNotes: [
+        ...preCannedPrNotes.greenMeansGo,
+        'Used extensively throughout tests.',
       ],
     },
     {

--- a/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
+++ b/source/Octopus.Manager.Tentacle/Octopus.Manager.Tentacle.csproj
@@ -126,12 +126,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3" />
     <PackageReference Include="NLog" Version="5.0.4" />
-    <PackageReference Include="NuGet.Common" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Frameworks" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Packaging" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
     <PackageReference Include="TaskScheduler" Version="2.7.2" />
   </ItemGroup>

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -57,12 +57,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="4.6.2" />
-		<PackageReference Include="NuGet.Common" Version="3.6.0-octopus-58692" />
-		<PackageReference Include="NuGet.Frameworks" Version="3.6.0-octopus-58692" />
 		<PackageReference Include="NuGet.Packaging" Version="3.6.0-octopus-58692" />
-		<PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
-		<PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
-		<PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
 		<PackageReference Include="Octopus.Diagnostics" Version="2.1.285" />
 		<PackageReference Include="Octopus.Time" Version="1.1.339" />
 		<PackageReference Include="Polly" Version="7.2.2" />


### PR DESCRIPTION
# Background

We have a significant backlog of dependency update PRs accumulating in the Tentacle repository since Renovate was enabled last year. These PRs are currently rate-limited, and it is important for us to prevent the backlog from growing further. It's clear that we need to stay on top of dependency updates.

To address this issue, we are establishing [a structured dependency update process](https://whimsical.com/dependency-updates-process-AvRrJa2scNomVv7gq2Rz3N) for both the Tentacle and Halibut repositories. As part of this initiative, we will introduce a "Green-means-go" PR message, similar to the dependency update procedures used in Octopus Server. This will allow developers to approve certain dependencies with minimal scrutiny, while ensuring that other dependencies receive the appropriate level of review.

# Results

When a Renovate PR is created, the PR message will inform the developer if it is relatively safe to merge. This applies only to packages with good test coverage, ensuring any issues are easily detected during TeamCity builds.

The process enables developers to add new "Green-means-go" rules. For example:
```
{
  matchPackageNames: ['Nsubstitute'],
  prBodyNotes: [
    ...preCannedPrNotes.greenMeansGo,
    'Used extensively throughout tests.',
  ],
}
```

[Relevant Halibut PR](https://github.com/OctopusDeploy/Halibut/pull/658)


# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.