### PR TITLE
Isolation mutex is no longer a static

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
@@ -30,6 +30,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         IScriptWorkspace workspace;
         TestScriptLog scriptLog;
         RunningScript runningScript;
+        ScriptIsolationMutex scriptIsolationMutex;
 
         [SetUp]
         public void SetUpLocal()
@@ -59,10 +60,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util
             Console.WriteLine($"Working directory: {workspace.WorkingDirectory}");
             scriptLog = new TestScriptLog();
             cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            scriptIsolationMutex = new ScriptIsolationMutex();
             runningScript = new RunningScript(shell,
                 workspace,
                 scriptLog,
                 taskId,
+                scriptIsolationMutex,
                 cancellationTokenSource.Token,
                 log);
         }
@@ -162,6 +165,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                     workspace,
                     scriptLog,
                     taskId,
+                    scriptIsolationMutex,
                     cts.Token,
                     new InMemoryLog());
 

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceFixture.cs
@@ -33,6 +33,7 @@ namespace Octopus.Tentacle.Tests.Integration
             service = new ScriptService(
                 PlatformDetection.IsRunningOnWindows ? (IShell) new PowerShell() : new Bash(),
                 new ScriptWorkspaceFactory(octopusPhysicalFileSystem, homeConfiguration, new SensitiveValueMasker()),
+                new ScriptIsolationMutex(),
                 Substitute.For<ISystemLog>());
         }
 

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptServiceV2Fixture.cs
@@ -13,7 +13,6 @@ using Octopus.Diagnostics;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Contracts;
-using Octopus.Tentacle.Contracts.Builders;
 using Octopus.Tentacle.Contracts.ScriptServiceV2;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Scripts;
@@ -42,6 +41,7 @@ namespace Octopus.Tentacle.Tests.Integration
                 PlatformDetection.IsRunningOnWindows ? (IShell)new PowerShell() : new Bash(),
                 workspaceFactory,
                 stateStoreFactory,
+                new ScriptIsolationMutex(),
                 Substitute.For<ISystemLog>());
         }
 

--- a/source/Octopus.Tentacle.Tests/Scripts/ScriptIsolationMutexFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Scripts/ScriptIsolationMutexFixture.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
-using Octopus.Diagnostics;
 using Octopus.Tentacle.Contracts;
 using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Tests.Support;
@@ -118,8 +116,9 @@ namespace Octopus.Tentacle.Tests.Scripts
             public void AcquireCanBeCancelled()
             {
                 var cancellationToken = new CancellationTokenSource();
+                var scriptIsolationMutex = new ScriptIsolationMutex();
 
-                IDisposable AcquireMutex() => ScriptIsolationMutex.Acquire(ScriptIsolationLevel.FullIsolation,
+                IDisposable AcquireMutex() => scriptIsolationMutex.Acquire(ScriptIsolationLevel.FullIsolation,
                     TimeSpan.FromDays(1),
                     nameof(AcquireCanBeCancelled),
                     _ => { },
@@ -137,19 +136,21 @@ namespace Octopus.Tentacle.Tests.Scripts
             [Test]
             public void LocksBlockOthersThatShareAName()
             {
-                using var lock1 = AcquireNamedLock("Lock 1");
-                Action a = () => AcquireNamedLock("Lock 1");
+                var scriptIsolationMutex = new ScriptIsolationMutex();
+                using var lock1 = AcquireNamedLock(scriptIsolationMutex, "Lock 1");
+                Action a = () => AcquireNamedLock(scriptIsolationMutex, "Lock 1");
                 a.Should().Throw<TimeoutException>();
             }
 
             [Test]
             public void LocksWithDifferentNamesCanBeHeldAtTheSameTime()
             {
-                using var lock1 = AcquireNamedLock("Lock 1");
-                using var lock2 = AcquireNamedLock("Lock 2");
+                var scriptIsolationMutex = new ScriptIsolationMutex();
+                using var lock1 = AcquireNamedLock(scriptIsolationMutex, "Lock 1");
+                using var lock2 = AcquireNamedLock(scriptIsolationMutex, "Lock 2");
             }
 
-            static IDisposable AcquireNamedLock(string name) => ScriptIsolationMutex.Acquire(ScriptIsolationLevel.FullIsolation,
+            static IDisposable AcquireNamedLock(ScriptIsolationMutex scriptIsolationMutex, string name) => scriptIsolationMutex.Acquire(ScriptIsolationLevel.FullIsolation,
                 TimeSpan.FromSeconds(1),
                 name,
                 s =>

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
@@ -2,14 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using k8s;
 using k8s.Models;
 using Octopus.Diagnostics;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Configuration.Instances;
 using Octopus.Tentacle.Contracts.KubernetesScriptServiceV1;
 using Octopus.Tentacle.Kubernetes.Crypto;
-using Octopus.Tentacle.Util;
+using Octopus.Tentacle.Scripts;
 
 namespace Octopus.Tentacle.Kubernetes
 {
@@ -31,8 +30,9 @@ namespace Octopus.Tentacle.Kubernetes
             ITentacleScriptLogProvider scriptLogProvider,
             IHomeConfiguration homeConfiguration,
             KubernetesPhysicalFileSystem kubernetesPhysicalFileSystem,
-            IScriptPodLogEncryptionKeyProvider scriptPodLogEncryptionKeyProvider)
-            : base(podService, podMonitor, secretService, containerResolver, appInstanceSelector, log, scriptLogProvider, homeConfiguration, kubernetesPhysicalFileSystem, scriptPodLogEncryptionKeyProvider)
+            IScriptPodLogEncryptionKeyProvider scriptPodLogEncryptionKeyProvider,
+            ScriptIsolationMutex scriptIsolationMutex)
+            : base(podService, podMonitor, secretService, containerResolver, appInstanceSelector, log, scriptLogProvider, homeConfiguration, kubernetesPhysicalFileSystem, scriptPodLogEncryptionKeyProvider, scriptIsolationMutex)
         {
             this.containerResolver = containerResolver;
         }

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -10,6 +10,7 @@ using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Maintenance;
 using Octopus.Tentacle.Properties;
+using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Services;
 using Octopus.Tentacle.Startup;
 using Octopus.Tentacle.Time;
@@ -58,6 +59,7 @@ namespace Octopus.Tentacle
             builder.RegisterModule(new VersioningModule(GetType().Assembly));
             builder.RegisterModule(new MaintenanceModule());
             builder.RegisterModule(new KubernetesModule());
+            builder.RegisterModule(new ScriptsModule());
 
             builder.RegisterCommand<CreateInstanceCommand>("create-instance", "Registers a new instance of the Tentacle service");
             builder.RegisterCommand<DeleteInstanceCommand>("delete-instance", "Deletes an instance of the Tentacle service");

--- a/source/Octopus.Tentacle/Scripts/RunningScript.cs
+++ b/source/Octopus.Tentacle/Scripts/RunningScript.cs
@@ -15,12 +15,14 @@ namespace Octopus.Tentacle.Scripts
         readonly string taskId;
         readonly CancellationToken token;
         readonly ILog log;
+        readonly ScriptIsolationMutex scriptIsolationMutex;
 
         public RunningScript(IShell shell,
             IScriptWorkspace workspace,
             IScriptStateStore? stateStore,
             IScriptLog scriptLog,
             string taskId,
+            ScriptIsolationMutex scriptIsolationMutex,
             CancellationToken token,
             ILog log)
         {
@@ -30,6 +32,7 @@ namespace Octopus.Tentacle.Scripts
             this.taskId = taskId;
             this.token = token;
             this.log = log;
+            this.scriptIsolationMutex = scriptIsolationMutex;
             this.ScriptLog = scriptLog;
             this.State = ProcessState.Pending;
         }
@@ -38,8 +41,9 @@ namespace Octopus.Tentacle.Scripts
             IScriptWorkspace workspace,
             IScriptLog scriptLog,
             string taskId,
+            ScriptIsolationMutex scriptIsolationMutex,
             CancellationToken token,
-            ILog log) : this(shell, workspace, null, scriptLog, taskId, token, log)
+            ILog log) : this(shell, workspace, null, scriptLog, taskId, scriptIsolationMutex, token, log)
         {
         }
 
@@ -61,7 +65,7 @@ namespace Octopus.Tentacle.Scripts
                 {
                     try
                     {
-                        using (ScriptIsolationMutex.Acquire(workspace.IsolationLevel,
+                        using (scriptIsolationMutex.Acquire(workspace.IsolationLevel,
                                    workspace.ScriptMutexAcquireTimeout,
                                    workspace.ScriptMutexName ?? nameof(RunningScript),
                                    message => writer.WriteOutput(ProcessOutputSource.StdOut, message),

--- a/source/Octopus.Tentacle/Scripts/ScriptIsolationMutex.cs
+++ b/source/Octopus.Tentacle/Scripts/ScriptIsolationMutex.cs
@@ -10,19 +10,19 @@ using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Scripts
 {
-    public static class ScriptIsolationMutex
+    public class ScriptIsolationMutex
     {
         // Reader-writer locks allow multiple readers, but only one writer which blocks readers. This is perfect for our scenario, because
         // we want to allow lots of scripts to run with the 'no' isolation level, but nothing should be running under the 'full' isolation level.
         // NOTE: Changed from ReaderWriterLockSlim to AsyncReaderWriterLock to enable cooperative cancellation whilst waiting for the lock.
         //       Hopefully in a future version of .NET there will be a fully supported ReaderWriterLock with cooperative cancellation support so we can remove this dependency.
-        static readonly ConcurrentDictionary<string, TaskLock> ReaderWriterLocks = new ConcurrentDictionary<string, TaskLock>();
+        readonly ConcurrentDictionary<string, TaskLock> ReaderWriterLocks = new ConcurrentDictionary<string, TaskLock>();
         static readonly TimeSpan InitialWaitTime = TimeSpan.FromMilliseconds(100);
         internal static TimeSpan SubsequentWaitTime = TimeSpan.FromMinutes(10);
 
         public static readonly TimeSpan NoTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
 
-        public static IDisposable Acquire(ScriptIsolationLevel isolation,
+        public IDisposable Acquire(ScriptIsolationLevel isolation,
             TimeSpan mutexAcquireTimeout,
             string lockName,
             Action<string> taskLog,

--- a/source/Octopus.Tentacle/Util/ScriptsModule.cs
+++ b/source/Octopus.Tentacle/Util/ScriptsModule.cs
@@ -1,0 +1,14 @@
+using Autofac;
+using Octopus.Tentacle.Scripts;
+
+namespace Octopus.Tentacle.Util
+{
+    public class ScriptsModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            base.Load(builder);
+            builder.RegisterType<ScriptIsolationMutex>().SingleInstance();
+        }
+    }
+}


### PR DESCRIPTION
# Background

This is a step in the direction of testing tentacle in process.

# Results

## Before

Script isolation was done using a static,
## After

now it is done with a singleton.


# How to review this PR

We already have tests for this.

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.