### PR TITLE
Allow the script services to supply env vars to scripts

### DIFF
--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
@@ -97,7 +97,7 @@ ForEach ($arg in $args){
 printenv
 ");
             windowsScript.AppendLine(@"
-dir env:
+Get-ChildItem env: | Format-List
 ");
             return this;
         }

--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
@@ -90,6 +90,17 @@ ForEach ($arg in $args){
 ");
             return this;
         }
+        
+        public ScriptBuilder PrintEnv()
+        {
+            bashScript.AppendLine(@"
+printenv
+");
+            windowsScript.AppendLine(@"
+SET
+");
+            return this;
+        }
 
         public ScriptBuilder PrintFileContents(string file)
         {

--- a/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/Builders/ScriptBuilder.cs
@@ -97,7 +97,7 @@ ForEach ($arg in $args){
 printenv
 ");
             windowsScript.AppendLine(@"
-SET
+dir env:
 ");
             return this;
         }

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptsAreGivenRequiredEnvironmentVariables.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptsAreGivenRequiredEnvironmentVariables.cs
@@ -40,7 +40,6 @@ namespace Octopus.Tentacle.Tests.Integration
             var scriptOutput = scriptResult.ProcessOutput.Select(p => p.Text).StringJoin("\r\n");
 
             scriptOutput.Should().Contain("TentacleHome");
-            scriptOutput.Should().Contain("CalamariPackageRetentionJournalPath");
             scriptOutput.Should().Contain("TentacleJournal");
         }
     }

--- a/source/Octopus.Tentacle.Tests.Integration/ScriptsAreGivenRequiredEnvironmentVariables.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ScriptsAreGivenRequiredEnvironmentVariables.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Client.Extensions;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Tests.Integration.Common.Builders.Decorators;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Util;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [IntegrationTestTimeout]
+    public class ScriptsAreGivenRequiredEnvironmentVariables : IntegrationTest
+    {
+        [Test]
+        [TentacleConfigurations(testPolling: false)]
+        public async Task EnsureEnvironmentVariablesAreSetForScripts(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var recordedUsages)
+                    .Build())
+                .Build(CancellationToken);
+
+            var script = new TestExecuteShellScriptCommandBuilder()
+                .SetScriptBody(new ScriptBuilder()
+                    .PrintEnv())
+                .Build();
+            
+            var tentacleClient = clientTentacle.TentacleClient;
+            var scriptResult = await tentacleClient.ExecuteScript(script, CancellationToken);
+
+            var scriptOutput = scriptResult.ProcessOutput.Select(p => p.Text).StringJoin("\r\n");
+
+            scriptOutput.Should().Contain("TentacleHome");
+            scriptOutput.Should().Contain("CalamariPackageRetentionJournalPath");
+            scriptOutput.Should().Contain("TentacleJournal");
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/RunningScriptFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using FluentAssertions;
@@ -67,6 +68,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                 taskId,
                 scriptIsolationMutex,
                 cancellationTokenSource.Token,
+                new Dictionary<string, string>(),
                 log);
         }
 
@@ -167,6 +169,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                     taskId,
                     scriptIsolationMutex,
                     cts.Token,
+                    new Dictionary<string, string>(),
                     new InMemoryLog());
 
                 workspace.BootstrapScript($"echo Starting\n{sleepCommand} 30\necho Finito");

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
@@ -49,7 +49,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                     cts.Token);
 
                 exitCode.Should().Be(99, "our custom exit code should be reflected");
-                debugMessages.ToString().Should().ContainEquivalentOf($"Starting {command} in working directory '' using '{SilentProcessRunner.EncodingDetector.GetOEMEncoding().EncodingName}' encoding running as '{TestEnvironmentHelper.CurrentUserName}'");
+                
+                // It seems the encoding can change during the lifetime of the OS so don't expect it wont change in tests.
+                debugMessages.ToString().Should().ContainEquivalentOf($"Starting {command} in working directory '' using '");
+                debugMessages.ToString().Should().ContainEquivalentOf($"' encoding running as '{TestEnvironmentHelper.CurrentUserName}'");
+                
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
                 infoMessages.ToString().Should().BeEmpty("no messages should be written to stdout");
             }

--- a/source/Octopus.Tentacle/Scripts/RunningScript.cs
+++ b/source/Octopus.Tentacle/Scripts/RunningScript.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Diagnostics;
@@ -14,6 +15,7 @@ namespace Octopus.Tentacle.Scripts
         readonly IShell shell;
         readonly string taskId;
         readonly CancellationToken token;
+        readonly IReadOnlyDictionary<string, string> environmentVariables;
         readonly ILog log;
         readonly ScriptIsolationMutex scriptIsolationMutex;
 
@@ -24,6 +26,7 @@ namespace Octopus.Tentacle.Scripts
             string taskId,
             ScriptIsolationMutex scriptIsolationMutex,
             CancellationToken token,
+            IReadOnlyDictionary<string, string> environmentVariables,
             ILog log)
         {
             this.shell = shell;
@@ -31,6 +34,7 @@ namespace Octopus.Tentacle.Scripts
             this.stateStore = stateStore;
             this.taskId = taskId;
             this.token = token;
+            this.environmentVariables = environmentVariables;
             this.log = log;
             this.scriptIsolationMutex = scriptIsolationMutex;
             this.ScriptLog = scriptLog;
@@ -43,7 +47,8 @@ namespace Octopus.Tentacle.Scripts
             string taskId,
             ScriptIsolationMutex scriptIsolationMutex,
             CancellationToken token,
-            ILog log) : this(shell, workspace, null, scriptLog, taskId, scriptIsolationMutex, token, log)
+            IReadOnlyDictionary<string, string> environmentVariables,
+            ILog log) : this(shell, workspace, null, scriptLog, taskId, scriptIsolationMutex, token, environmentVariables, log)
         {
         }
 
@@ -171,6 +176,7 @@ namespace Octopus.Tentacle.Scripts
                     output => writer.WriteOutput(ProcessOutputSource.Debug, output),
                     output => writer.WriteOutput(ProcessOutputSource.StdOut, output),
                     output => writer.WriteOutput(ProcessOutputSource.StdErr, output),
+                    environmentVariables,
                     token);
 
                 return exitCode;

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Diagnostics;
@@ -86,7 +87,7 @@ namespace Octopus.Tentacle.Services.Scripts
 
         RunningScript LaunchShell(ScriptTicket ticket, string serverTaskId, IScriptWorkspace workspace, CancellationTokenSource cancel)
         {
-            var runningScript = new RunningScript(shell, workspace, workspace.CreateLog(), serverTaskId, scriptIsolationMutex, cancel.Token, log);
+            var runningScript = new RunningScript(shell, workspace, workspace.CreateLog(), serverTaskId, scriptIsolationMutex, cancel.Token, new Dictionary<string, string>(), log);
             var thread = new Thread(runningScript.Execute) { Name = "Executing PowerShell script for " + ticket.TaskId };
             thread.Start();
             return runningScript;

--- a/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/ScriptServiceV2.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,19 +22,31 @@ namespace Octopus.Tentacle.Services.Scripts
         readonly ISystemLog log;
         readonly ScriptIsolationMutex scriptIsolationMutex;
         readonly ConcurrentDictionary<ScriptTicket, RunningScriptWrapper> runningScripts = new();
+        readonly IReadOnlyDictionary<string, string> environmentVariables;
 
         public ScriptServiceV2(
             IShell shell,
             IScriptWorkspaceFactory workspaceFactory,
             IScriptStateStoreFactory scriptStateStoreFactory,
             ScriptIsolationMutex scriptIsolationMutex,
-            ISystemLog log)
+            ISystemLog log, 
+            IReadOnlyDictionary<string, string> environmentVariables)
         {
             this.shell = shell;
             this.workspaceFactory = workspaceFactory;
             this.scriptStateStoreFactory = scriptStateStoreFactory;
             this.log = log;
+            this.environmentVariables = environmentVariables;
             this.scriptIsolationMutex = scriptIsolationMutex;
+        }
+
+        public ScriptServiceV2(
+            IShell shell,
+            IScriptWorkspaceFactory workspaceFactory,
+            IScriptStateStoreFactory scriptStateStoreFactory,
+            ScriptIsolationMutex scriptIsolationMutex,
+            ISystemLog log) : this(shell, workspaceFactory, scriptStateStoreFactory, scriptIsolationMutex, log, new Dictionary<string, string>())
+        {
         }
 
         public async Task<ScriptStatusResponseV2> StartScriptAsync(StartScriptCommandV2 command, CancellationToken cancellationToken)
@@ -130,7 +143,7 @@ namespace Octopus.Tentacle.Services.Scripts
 
         RunningScript LaunchShell(ScriptTicket ticket, string serverTaskId, IScriptWorkspace workspace, IScriptStateStore stateStore, CancellationToken cancellationToken)
         {
-            var runningScript = new RunningScript(shell, workspace, stateStore, workspace.CreateLog(), serverTaskId, scriptIsolationMutex, cancellationToken, log);
+            var runningScript = new RunningScript(shell, workspace, stateStore, workspace.CreateLog(), serverTaskId, scriptIsolationMutex, cancellationToken, environmentVariables, log);
             var thread = new Thread(runningScript.Execute) { Name = "Executing PowerShell runningScript for " + ticket.TaskId };
             thread.Start();
             return runningScript;

--- a/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
@@ -171,7 +171,7 @@ namespace Octopus.Tentacle.Util
 
                     if (customEnvironmentVariables != null && customEnvironmentVariables.Any())
                     {
-                        // Note this will add to the environment variables and not replace them.
+                        // Note this will add to the environment variables, potentially replacing existing ones.
                         foreach (var variable in customEnvironmentVariables)
                         {
                             process.StartInfo.EnvironmentVariables[variable.Key] = variable.Value;

--- a/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle/Util/SilentProcessRunner.cs
@@ -84,6 +84,7 @@ namespace Octopus.Tentacle.Util
                 LogFileOnlyLogger.Current.Info,
                 info,
                 error,
+                customEnvironmentVariables: null,
                 cancel: cancel);
 
         public static int ExecuteCommand(
@@ -95,7 +96,7 @@ namespace Octopus.Tentacle.Util
             Action<string> error,
             CancellationToken cancel)
         {
-            return ExecuteCommand(executable, arguments, workingDirectory, debug, info, error, cancel: cancel);
+            return ExecuteCommand(executable, arguments, workingDirectory, debug, info, error, customEnvironmentVariables: null, cancel: cancel);
         }
 
         public static int ExecuteCommand(


### PR DESCRIPTION
# Background

This is a step in the direction of testing tentacle in process

Since we will need to provide env vars per script service rather than CLR wide.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.