### PR TITLE
Add script state store test, test reading old files

### DIFF
--- a/source/Octopus.Tentacle.Tests/Scripts/ScriptStateStoreTests.cs
+++ b/source/Octopus.Tentacle.Tests/Scripts/ScriptStateStoreTests.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Scripts;
+using Octopus.Tentacle.Tests.Support;
+using Octopus.Tentacle.Util;
+using InMemoryLog = Octopus.Tentacle.CommonTestUtils.Diagnostics.InMemoryLog;
+
+namespace Octopus.Tentacle.Tests.Scripts
+{
+    [TestFixture]
+    public class ScriptStateStoreTests
+    {
+        [Test]
+        public void WeCanRoundTrip()
+        {
+            var octopusFileSystem = new OctopusPhysicalFileSystem(new InMemoryLog());
+            using var tmpDir = new TemporaryDirectory(octopusFileSystem);
+            var scriptStateStore = new ScriptStateStore(octopusFileSystem, s => Path.Combine(tmpDir.DirectoryPath, s));
+            var scriptState = scriptStateStore.Create();
+            scriptState.Start();
+            scriptState.Complete(99, true);
+            
+            scriptStateStore.Save(scriptState);
+
+            var loaded = scriptStateStore.Load();
+
+            loaded.Should().BeEquivalentTo(scriptState);
+        }
+
+        const string OldScriptState = @"{""Created"":""2025-04-09T23:24:03.683243+00:00"",""Started"":""2025-04-09T23:24:03.731068+00:00"",""Completed"":""2025-04-09T23:24:03.731175+00:00"",""State"":2,""ExitCode"":99,""RanToCompletion"":true}";
+        
+        [Test]
+        public void WeCanReadOldScriptStates()
+        {
+            var octopusFileSystem = new OctopusPhysicalFileSystem(new InMemoryLog());
+            using var tmpDir = new TemporaryDirectory(octopusFileSystem);
+            var scriptStateStore = new ScriptStateStore(octopusFileSystem, s => Path.Combine(tmpDir.DirectoryPath, s));
+            
+            File.WriteAllText(Path.Combine(tmpDir.DirectoryPath, "scriptstate.json"), OldScriptState);
+            
+            var loaded = scriptStateStore.Load();
+
+            loaded.RanToCompletion.Should().BeTrue();
+            loaded.ExitCode.Should().Be(99);
+            loaded.State.Should().Be(ProcessState.Complete);
+        }
+    }
+}


### PR DESCRIPTION
# Background

We should have a test that we can read previously written versions of the state store, and now we do.

fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/1095
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.