### PR TITLE
Timeout downloading tentacles

### DIFF
--- a/source/Octopus.Tentacle.CommonTestUtils/OctopusPackageDownloader.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/OctopusPackageDownloader.cs
@@ -109,7 +109,7 @@ namespace Octopus.Tentacle.CommonTestUtils
             var readTask = contentStream.ReadAsync(buffer, 0, buffer.Length, readCts.Token);
             // Don't trust that cancellation tokens will work on all dotnet versions or OSs we have to test in, so also add Task.Delay ;(
             await Task.WhenAny(Task.Delay(singleReadTimeout, cancellationToken), readTask);
-            if(!readTask.IsCompleted) throw new TimeoutException();
+            if (!readTask.IsCompleted) throw new TimeoutException();
             var read = await readTask;
             return read;
         }

--- a/source/Octopus.Tentacle.CommonTestUtils/OctopusPackageDownloader.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/OctopusPackageDownloader.cs
@@ -72,6 +72,7 @@ namespace Octopus.Tentacle.CommonTestUtils
                             using var readCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                             readCts.CancelAfter(singleReadTimeout); // 60s to read 32k
                             var readTask = contentStream.ReadAsync(buffer, 0, buffer.Length, readCts.Token);
+                            // Don't trust that cancellation tokens will work on all dotnet versions or OSs we have to test in, so also add Task.Delay ;(
                             await Task.WhenAny(Task.Delay(singleReadTimeout, cancellationToken), readTask);
                             if(!readTask.IsCompleted) throw new TimeoutException();
                             var read = await readTask;

--- a/source/Octopus.Tentacle.CommonTestUtils/OctopusPackageDownloader.cs
+++ b/source/Octopus.Tentacle.CommonTestUtils/OctopusPackageDownloader.cs
@@ -67,10 +67,10 @@ namespace Octopus.Tentacle.CommonTestUtils
                         {
 
                             var buffer = new byte[8192*4];
-
-                            var singleReadTimeout = TimeSpan.FromSeconds(60);
+                            var singleReadTimeout = TimeSpan.FromSeconds(60); // 60s to read 32k
+                            
                             using var readCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                            readCts.CancelAfter(singleReadTimeout); // 60s to read 32k
+                            readCts.CancelAfter(singleReadTimeout); 
                             var readTask = contentStream.ReadAsync(buffer, 0, buffer.Length, readCts.Token);
                             // Don't trust that cancellation tokens will work on all dotnet versions or OSs we have to test in, so also add Task.Delay ;(
                             await Task.WhenAny(Task.Delay(singleReadTimeout, cancellationToken), readTask);


### PR DESCRIPTION
# Background

Sometimes the win10 test are hung, looking at the dump we see:

```
[2] 00007ff8616a6588 (0) System.Net.Http.HttpConnection+<ReadAsync>d__87
  [2] 00007ff8616a69c0 (0) System.Net.Http.HttpConnection+ContentLengthReadStream+<ReadAsync>d__3
    [2] 00007ff861485800 (4) Octopus.Tentacle.CommonTestUtils.OctopusPackageDownloader+<AttemptToDownloadPackage>d__1
      [2] 00007ff861485bc8 (0) Octopus.Tentacle.CommonTestUtils.OctopusPackageDownloader+<DownloadPackage>d__0
        [2] 00007ff8614861d8 (1) Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers.NugetTentacleFetcher+<DownloadAndExtractFromUrl>d__4
          [2] 00007ff8614868d0 (0) Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers.NugetTentacleFetcher+<GetTentacleVersion>d__3
            [2] 00007ff861486698 (2) Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers.VersionDependentTentacleFetcher+<GetTentacleVersion>d__2
              [2] 00007ff861486b10 (1) Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers.TentacleBinaryCache+<GetTentacleVersion>d__5
                [2] 00007ff861486dd0 (0) Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers.TentacleFetcher+<GetTentacleVersion>d__0
                  [2] 00007ff861487110 (0) Octopus.Tentacle.Tests.Integration.Support.SetupFixtures.WarmTentacleCache+<GetTentacleVersionWithRuntime>d__3
                    [1] 00007ff8614873e8 (0) Octopus.Tentacle.Tests.Integration.Support.SetupFixtures.WarmTentacleCache+<GetTentacleVersion>d__2
                      [1] 00007ff8613a7838 (1) Octopus.Tentacle.Tests.Integration.Support.SetupFixtures.WarmTentacleCache+<>c__DisplayClass1_1+<<OneTimeSetUp>b__0>d
                        [1] 00007ff860683eb8 System.Threading.Tasks.UnwrapPromise<System.Threading.Tasks.VoidTaskResult>
                          [1] 00007ff86136f958 System.Threading.Tasks.Task+WhenAllPromise
                            [1] 00007ff860689c68 System.Threading.Tasks.Task+SetOnInvokeMres
                    [1] 00007ff8614873e8 (1) Octopus.Tentacle.Tests.Integration.Support.SetupFixtures.WarmTentacleCache+<GetTentacleVersion>d__2
                      [1] 00007ff8613a7838 (1) Octopus.Tentacle.Tests.Integration.Support.SetupFixtures.WarmTentacleCache+<>c__DisplayClass1_1+<<OneTimeSetUp>b__0>d
                        [1] 00007ff860683eb8 System.Threading.Tasks.UnwrapPromise<System.Threading.Tasks.VoidTaskResult>
                          [1] 00007ff86136f958 System.Threading.Tasks.Task+WhenAllPromise
                            [1] 00007ff860689c68 System.Threading.Tasks.Task+SetOnInvokeMres

```

We can see the tests are stuck downloading old versions of tentacles.

The fix here is to add timeouts to each read in a way that will always work.

Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/1099

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.