### PR TITLE
Sast/try cancel script on failure

### DIFF
--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -95,6 +95,9 @@ namespace Octopus.Tentacle.Client.Scripts
                             continue; // Enter cancellation mode.
                         }
                         
+                        // Before giving up, send out an attempt to cancel the inflight script.
+                        // This can work around issues where the RPC retry duration is less than the timeout durations in halibut.
+                        // In cases of short network issues, this means we  have a chance of canceling the in flight script.
                         var _ = Task.Run(() =>
                         {
                             try

--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Halibut.Logging;
 using Octopus.Tentacle.Client.Scripts.Models;
 using Octopus.Tentacle.Contracts;
 
@@ -93,6 +94,18 @@ namespace Octopus.Tentacle.Client.Scripts
                         {
                             continue; // Enter cancellation mode.
                         }
+                        
+                        var _ = Task.Run(() =>
+                        {
+                            try
+                            {
+                                scriptExecutor.CancelScript(lastResult.ContextForNextCommand);
+                            }
+                            catch (Exception)
+                            {
+                                // ignored
+                            }
+                        });
 
                         throw;
                     }

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Halibut.Diagnostics;
 using NUnit.Framework;
 using Octopus.Tentacle.Client;
 using Octopus.Tentacle.CommonTestUtils;
@@ -134,6 +135,75 @@ namespace Octopus.Tentacle.Tests.Integration
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).LastException.Should().NotBeNull();
 
             inMemoryLog.ShouldHaveLoggedRetryAttemptsAndNoRetryFailures();
+        }
+        
+        [Test]
+        [TentacleConfigurations]
+        public async Task WhenANetworkFailureOccurs_DuringGetStatus_AndTheGetStatusCallDoesNotRecover_AnAttemptToCancelTheScriptIsMade(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithPortForwarderDataLogging()
+                .WithRetryDuration(TimeSpan.FromSeconds(10))
+                .WithHalibutTimeoutsAndLimits(new HalibutTimeoutsAndLimits()
+                {
+                    RetryCountLimit = 1,
+                    ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(1),
+                    RetryListeningSleepInterval = TimeSpan.FromSeconds(1),
+                    PollingRequestQueueTimeout = TimeSpan.FromSeconds(5),
+                })
+                .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var recordedUsages)
+                    .DecorateAllScriptServicesWith(u => u
+                        .BeforeGetStatus(
+                            async () =>
+                            {
+                                await Task.CompletedTask;
+                                responseMessageTcpKiller.KillConnectionOnNextResponse();
+                            })
+                    )
+                    
+                    .Build())
+                .Build(CancellationToken);
+
+            await Task.Delay(10000);
+
+            var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
+            var fileCreatedByScript = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "scriptFile");
+
+            var startScriptCommand = new TestExecuteShellScriptCommandBuilder()
+                .SetScriptBody(new ScriptBuilder()
+                    .Print("hello")
+                    .WaitForFileToExist(waitForFile)
+                    .Print("AllDone")
+                    .CreateFile(fileCreatedByScript))
+                .Build();
+
+            var inMemoryLog = new InMemoryLog();
+
+            var execScriptTask = Task.Run(
+                async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog),
+                CancellationToken);
+
+            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).LastException != null,
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("GetStatus did not error"),
+                CancellationToken);
+            
+            // Assert
+            
+            // We should find that the cancel request was sent to tentacle.
+            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).Completed > 0,
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("Cancel script was never called."),
+                CancellationToken);
+
+            // Let the script finish.
+            File.WriteAllText(waitForFile, "");
+            await Task.Delay(TimeSpan.FromSeconds(2)); // It's hard to know if the script was killed or not, if we do the assert below too quickly we will
+                                                       // incorrectly see the script as being cancelled.
+            
+            File.Exists(fileCreatedByScript).Should().BeFalse("A cancel command should have been sent to the script, resulting in the script terminating");
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Halibut.Diagnostics;
 using NUnit.Framework;
 using Octopus.Tentacle.Client;
 using Octopus.Tentacle.CommonTestUtils;
@@ -135,75 +134,6 @@ namespace Octopus.Tentacle.Tests.Integration
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).LastException.Should().NotBeNull();
 
             inMemoryLog.ShouldHaveLoggedRetryAttemptsAndNoRetryFailures();
-        }
-        
-        [Test]
-        [TentacleConfigurations]
-        public async Task WhenANetworkFailureOccurs_DuringGetStatus_AndTheGetStatusCallDoesNotRecover_AnAttemptToCancelTheScriptIsMade(TentacleConfigurationTestCase tentacleConfigurationTestCase)
-        {
-            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
-                .WithPortForwarderDataLogging()
-                .WithRetryDuration(TimeSpan.FromSeconds(10))
-                .WithHalibutTimeoutsAndLimits(new HalibutTimeoutsAndLimits()
-                {
-                    RetryCountLimit = 1,
-                    ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(1),
-                    RetryListeningSleepInterval = TimeSpan.FromSeconds(1),
-                    PollingRequestQueueTimeout = TimeSpan.FromSeconds(5),
-                })
-                .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)
-                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
-                    .RecordMethodUsages(tentacleConfigurationTestCase, out var recordedUsages)
-                    .DecorateAllScriptServicesWith(u => u
-                        .BeforeGetStatus(
-                            async () =>
-                            {
-                                await Task.CompletedTask;
-                                responseMessageTcpKiller.KillConnectionOnNextResponse();
-                            })
-                    )
-                    
-                    .Build())
-                .Build(CancellationToken);
-
-            await Task.Delay(10000);
-
-            var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
-            var fileCreatedByScript = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "scriptFile");
-
-            var startScriptCommand = new TestExecuteShellScriptCommandBuilder()
-                .SetScriptBody(new ScriptBuilder()
-                    .Print("hello")
-                    .WaitForFileToExist(waitForFile)
-                    .Print("AllDone")
-                    .CreateFile(fileCreatedByScript))
-                .Build();
-
-            var inMemoryLog = new InMemoryLog();
-
-            var execScriptTask = Task.Run(
-                async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog),
-                CancellationToken);
-
-            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).LastException != null,
-                TimeSpan.FromSeconds(60),
-                () => throw new Exception("GetStatus did not error"),
-                CancellationToken);
-            
-            // Assert
-            
-            // We should find that the cancel request was sent to tentacle.
-            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).Completed > 0,
-                TimeSpan.FromSeconds(60),
-                () => throw new Exception("Cancel script was never called."),
-                CancellationToken);
-
-            // Let the script finish.
-            File.WriteAllText(waitForFile, "");
-            await Task.Delay(TimeSpan.FromSeconds(2)); // It's hard to know if the script was killed or not, if we do the assert below too quickly we will
-                                                       // incorrectly see the script as being cancelled.
-            
-            File.Exists(fileCreatedByScript).Should().BeFalse("A cancel command should have been sent to the script, resulting in the script terminating");
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -329,7 +329,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.StartScriptAsync)).Started.Should().Be(1);
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).Started.Should().BeGreaterOrEqualTo(2);
-            recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).Started.Should().Be(0);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).Started.Should().BeInRange(0, 1, "Since a non awaited cancel will be sent");
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CompleteScriptAsync)).Started.Should().Be(0);
 
             // Ensure we actually waited and retried until the timeout policy kicked in
@@ -381,7 +381,7 @@ namespace Octopus.Tentacle.Tests.Integration
 
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.StartScriptAsync)).Started.Should().Be(1);
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).Started.Should().Be(1);
-            recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).Started.Should().Be(0);
+            recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).Started.Should().BeInRange(0, 1, "Since a non awaited cancel will be sent");
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CompleteScriptAsync)).Started.Should().Be(0);
 
             inMemoryLog.ShouldHaveLoggedRetryFailureAndNoRetryAttempts();

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWillAttemptACancelCallWhenGetStatusFails.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionWillAttemptACancelCallWhenGetStatusFails.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.Diagnostics;
+using NUnit.Framework;
+using Octopus.Tentacle.CommonTestUtils.Diagnostics;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Tests.Integration.Common.Builders.Decorators;
+using Octopus.Tentacle.Tests.Integration.Support;
+using Octopus.Tentacle.Tests.Integration.Util;
+using Octopus.Tentacle.Tests.Integration.Util.Builders;
+using Octopus.Tentacle.Tests.Integration.Util.Builders.Decorators;
+using Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers;
+
+namespace Octopus.Tentacle.Tests.Integration
+{
+    [IntegrationTestTimeout]
+    public class ClientScriptExecutionWillAttemptACancelCallWhenGetStatusFails : IntegrationTest
+    {
+        [Test]
+        [TentacleConfigurations]
+        public async Task WhenANetworkFailureOccurs_DuringGetStatus_AndTheGetStatusCallDoesNotRecover_AnAttemptToCancelTheScriptIsMade(TentacleConfigurationTestCase tentacleConfigurationTestCase)
+        {
+            await using var clientTentacle = await tentacleConfigurationTestCase.CreateBuilder()
+                .WithPortForwarderDataLogging()
+                .WithRetryDuration(TimeSpan.FromSeconds(10))
+                .WithHalibutTimeoutsAndLimits(new HalibutTimeoutsAndLimits
+                {
+                    RetryCountLimit = 1,
+                    ConnectionErrorRetryTimeout = TimeSpan.FromSeconds(1),
+                    RetryListeningSleepInterval = TimeSpan.FromSeconds(1),
+                    PollingRequestQueueTimeout = TimeSpan.FromSeconds(5)
+                })
+                .WithResponseMessageTcpKiller(out var responseMessageTcpKiller)
+                .WithTentacleServiceDecorator(new TentacleServiceDecoratorBuilder()
+                    .RecordMethodUsages(tentacleConfigurationTestCase, out var recordedUsages)
+                    .DecorateAllScriptServicesWith(u => u
+                        .BeforeGetStatus(
+                            async () =>
+                            {
+                                await Task.CompletedTask;
+                                responseMessageTcpKiller.KillConnectionOnNextResponse();
+                            })
+                    )
+                    .Build())
+                .Build(CancellationToken);
+
+            var waitForFile = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "waitforme");
+            var fileCreatedByScript = Path.Combine(clientTentacle.TemporaryDirectory.DirectoryPath, "scriptFile");
+
+            var startScriptCommand = new TestExecuteShellScriptCommandBuilder()
+                .SetScriptBody(new ScriptBuilder()
+                    .Print("hello")
+                    .WaitForFileToExist(waitForFile)
+                    .Print("AllDone")
+                    .CreateFile(fileCreatedByScript))
+                .Build();
+
+            var inMemoryLog = new InMemoryLog();
+
+            var execScriptTask = Task.Run(
+                async () => await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken, null, inMemoryLog),
+                CancellationToken);
+
+            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).LastException != null,
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("GetStatus did not error"),
+                CancellationToken);
+
+            // Assert
+
+            // We should find that the cancel request was sent to tentacle.
+            await Wait.For(() => recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).Completed > 0,
+                TimeSpan.FromSeconds(60),
+                () => throw new Exception("Cancel script was never called."),
+                CancellationToken);
+
+            // Let the script finish.
+            File.WriteAllText(waitForFile, "");
+            await Task.Delay(TimeSpan.FromSeconds(2)); // It's hard to know if the script was killed or not, if we do the assert below too quickly we will
+            // incorrectly see the script as being cancelled.
+
+            File.Exists(fileCreatedByScript).Should().BeFalse("A cancel command should have been sent to the script, resulting in the script terminating");
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
@@ -38,8 +38,22 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 
         public IDataTransferObserver DataTransferObserver()
         {
+            int numberOfWritesFromTentacleSeen = 0;
             return new DataTransferObserverBuilder().WithWritingDataObserver((tcpPump, dataFromTentacle) =>
             {
+                numberOfWritesFromTentacleSeen++;
+                if (pauseConnection || killConnection)
+                {
+                    // For listening tentacle to be connected to, it must first send some ssl stuff, then a MX control message to
+                    // register itself and finally a control PROCEED message. This means it is not until the 4th
+                    // write that we could be processing a message.
+                    if (numberOfWritesFromTentacleSeen <= 3)
+                    {
+                        logger.Information("Too few writes ({WriteCount} seen from tentacle the connection is not setup.", numberOfWritesFromTentacleSeen);
+                        return;
+                    }
+                }
+                
                 // It seems messages around 45 and below are control messages - except for
                 // Windows Server 2012, where the max size seems to be ~85.
                 // So anything bigger must be the interesting one.

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
@@ -45,8 +45,8 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
                 if (pauseConnection || killConnection)
                 {
                     // For listening tentacle to be connected to, it must first send some ssl stuff, then a MX control message to
-                    // register itself and finally a control PROCEED message. This means it is not until the 4th
-                    // write that we could be processing a message.
+                    // register itself.
+                    // In practice, it is not until the 4th write that we could be processing a message.
                     if (numberOfWritesFromTentacleSeen <= 3)
                     {
                         logger.Information("Too few writes ({WriteCount} seen from tentacle the connection is not setup.", numberOfWritesFromTentacleSeen);

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
@@ -50,9 +50,20 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 
         public IDataTransferObserver DataTransferObserver()
         {
+            int numberOfWritesFromTentacleSeen = 0;
             return new DataTransferObserverBuilder().WithWritingDataObserver((tcpPump, dataFromTentacle) =>
             {
-                var size = dataFromTentacle.Length;
+                numberOfWritesFromTentacleSeen++;
+
+                if (pauseConnection || killConnection)
+                {
+                    if (numberOfWritesFromTentacleSeen <= 4)
+                    {
+                        logger.Information("Too few writes seen from tentacle the connection is not setup.");
+                        return;
+                    }
+                }
+                
                 //logger.Information($"Received: {size} from tentacle");
                 if (pauseConnection)
                 {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
@@ -57,9 +57,9 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 
                 if (pauseConnection || killConnection)
                 {
-                    // For polling tentacle to connect it first sends some ssl stuff, then a MX control message to
-                    // register itself and finally a control PROCEED message. This means it is not until the 4th
-                    // write that we could be processing a message.
+                    // For polling tentacle to connect it first sends some sort of "open" connection data,
+                    // then some ssl stuff, then a MX control message to register itself.
+                    // In practice, it is not until the 4th write that we could be processing a message.
                     if (numberOfWritesFromTentacleSeen <= 4)
                     {
                         logger.Information("Too few writes seen from tentacle the connection is not setup.");

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
@@ -57,6 +57,9 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 
                 if (pauseConnection || killConnection)
                 {
+                    // For polling tentacle to connect it first sends some ssl stuff, then a MX control message to
+                    // register itself and finally a control PROCEED message. This means it is not until the 4th
+                    // write that we could be processing a message.
                     if (numberOfWritesFromTentacleSeen <= 4)
                     {
                         logger.Information("Too few writes seen from tentacle the connection is not setup.");


### PR DESCRIPTION
# Background

We are seeing that short network issues are resulting in non recoverable timeouts when communicating with polling tentacles. This is then resulting in scripts which continue to execute on the tentacle, while Octopus claims the server task is failed. This executing script can prevent further tasks from executing on the tentacle. The executing script can not be killed other than either waiting for the script to complete OR restarting the tentacle (killing the in-flight scripts).

The issue is that the network dies in a way that is only detectable by timeout from the client. Ordinarily this is fine, however unfortunately we are frequently seeing the issue occur at the [5 minute timeout](https://github.com/OctopusDeploy/Halibut/blob/main/source/Halibut/Diagnostics/HalibutTimeoutsAndLimits.cs#L51) when the response is being waited for by the client. The timeout is high so as to allow the client time to execute the request.

Additionally the test utility of interrupting a response message from a polling tentacle is updated to no longer interrupt the set up of a connection between polling tentacle and client. Instead we now only kill/pause the connection once we know the connection from polling tentacle is setup.

# Results

This PR attempts to solve the problem of the script continuing to execute. This is done by sending a non awaited cancel request to the  tentacle, when calls to get status fail.

## Before

Short network issues might result in a failed ServerTask, while the script continues to execute on tentacle preventing further ServerTasks from progressing.

## After

An attempt to cancel the inflight script is made, which for short lived network failures should result in the script being cancelled on tentacle. This will allow further ServerTasks to execute on the tentacle.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.