### PR TITLE
Use existing helper to kill the connection at the right time

### DIFF
--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransferRetriesTimeout.cs
@@ -49,7 +49,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (methodUsages.For(nameof(IAsyncClientFileTransferService.UploadFileAsync)).LastException is null)
                                 {
                                     // Ensure there is an active connection so it can be killed correctly
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
                                 else
@@ -63,7 +63,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                     else
                                     {
                                         // Ensure there is an active connection so it can be killed correctly
-                                        await tcpConnectionUtilities.RestartTcpConnection();
+                                        await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                         // Pause the port forwarder so the next requests are in-flight when retries timeout
                                         responseMessageTcpKiller.PauseConnectionOnNextResponse();
                                     }
@@ -114,7 +114,7 @@ namespace Octopus.Tentacle.Tests.Integration
                         .BeforeUploadFile(
                             async () =>
                             {
-                                await tcpConnectionUtilities.RestartTcpConnection();
+                                await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                 // Sleep to make the initial RPC call take longer than the allowed retry duration
                                 await Task.Delay(retryDuration + TimeSpan.FromSeconds(1));
@@ -160,7 +160,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (recordedUsages.For(nameof(IAsyncClientFileTransferService.DownloadFileAsync)).LastException is null)
                                 {
                                     // Ensure there is an active connection so it can be killed correctly
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
                                 else
@@ -175,7 +175,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                     else
                                     {
                                         // Ensure there is an active connection so it can be killed correctly
-                                        await tcpConnectionUtilities.RestartTcpConnection();
+                                        await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                         // Pause the port forwarder so the next requests are in-flight when retries timeout
                                         responseMessageTcpKiller.PauseConnectionOnNextResponse();
                                     }
@@ -226,7 +226,7 @@ namespace Octopus.Tentacle.Tests.Integration
                         .BeforeDownloadFile(
                             async () =>
                             {
-                                await tcpConnectionUtilities.RestartTcpConnection();
+                                await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                 // Sleep to make the initial RPC call take longer than the allowed retry duration
                                 await Task.Delay(retryDuration + TimeSpan.FromSeconds(1));

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreNotRetriedWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreNotRetriedWhenRetriesAreDisabled.cs
@@ -31,7 +31,7 @@ namespace Octopus.Tentacle.Tests.Integration
                         .BeforeUploadFile(
                             async () =>
                             {
-                                await tcpConnectionUtilities.RestartTcpConnection();
+                                await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                 // Only kill the connection the first time, causing the upload
                                 // to succeed - and therefore failing the test - if retries are attempted
@@ -69,7 +69,7 @@ namespace Octopus.Tentacle.Tests.Integration
                         .BeforeDownloadFile(
                             async () =>
                             {
-                                await tcpConnectionUtilities.RestartTcpConnection();
+                                await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                 // Only kill the connection the first time, causing the upload
                                 // to succeed - and therefore failing the test - if retries are attempted

--- a/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientFileTransfersAreRetriedWhenRetriesAreEnabled.cs
@@ -32,7 +32,7 @@ namespace Octopus.Tentacle.Tests.Integration
                         .BeforeUploadFile(
                             async () =>
                             {
-                                await tcpConnectionUtilities.RestartTcpConnection();
+                                await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                 // Only kill the connection the first time, causing the upload
                                 // to succeed - and therefore failing the test - if retries are attempted
@@ -75,7 +75,7 @@ namespace Octopus.Tentacle.Tests.Integration
                         .BeforeDownloadFile(
                             async () =>
                             {
-                                await tcpConnectionUtilities.RestartTcpConnection();
+                                await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                 // Only kill the connection the first time, causing the upload
                                 // to succeed - and therefore failing the test - if retries are attempted

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreDisabled.cs
@@ -59,7 +59,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (!hasPausedOrStoppedPortForwarder)
                                 {
                                     hasPausedOrStoppedPortForwarder = true;
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                     PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
                                     if (rpcCallStage == RpcCallStage.Connecting)
@@ -129,7 +129,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (!hasPausedOrStoppedPortForwarder)
                                 {
                                     hasPausedOrStoppedPortForwarder = true;
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
                                     if (rpcCallStage == RpcCallStage.Connecting)
                                     {
@@ -225,7 +225,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (!hasPausedOrStoppedPortForwarder)
                                 {
                                     hasPausedOrStoppedPortForwarder = true;
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
                                     if (rpcCallStage == RpcCallStage.Connecting)
                                     {
@@ -309,7 +309,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (!hasPausedOrStoppedPortForwarder)
                                 {
                                     hasPausedOrStoppedPortForwarder = true;
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
                                     if (rpcCallStage == RpcCallStage.Connecting)
                                     {

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanBeCancelledWhenRetriesAreEnabled.cs
@@ -64,7 +64,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (rpcCall == RpcCall.RetryingCall &&
                                     recordedUsages.ForGetCapabilitiesAsync().LastException == null)
                                 {
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                     // Kill the first GetCapabilities call to force the rpc call into retries
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
@@ -72,7 +72,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 else if (!hasPausedOrStoppedPortForwarder)
                                 {
                                     hasPausedOrStoppedPortForwarder = true;
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                     await PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
                                     if (rpcCallStage == RpcCallStage.Connecting && tentacleConfigurationTestCase.TentacleType == TentacleType.Polling)
@@ -160,7 +160,7 @@ namespace Octopus.Tentacle.Tests.Integration
                             {
                                 if (rpcCall == RpcCall.RetryingCall && recordedUsages.ForStartScriptAsync().LastException is null)
                                 {
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     // Kill the first StartScript call to force the rpc call into retries
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
@@ -169,7 +169,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                     if (!hasPausedOrStoppedPortForwarder)
                                     {
                                         hasPausedOrStoppedPortForwarder = true;
-                                        await tcpConnectionUtilities.RestartTcpConnection();
+                                        await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                         await PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
                                         if (rpcCallStage == RpcCallStage.Connecting)
                                         {
@@ -429,7 +429,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (rpcCall == RpcCall.RetryingCall &&
                                     recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).LastException is null)
                                 {
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     // Kill the first StartScript call to force the rpc call into retries
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
@@ -438,7 +438,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                     if (!hasPausedOrStoppedPortForwarder)
                                     {
                                         hasPausedOrStoppedPortForwarder = true;
-                                        await tcpConnectionUtilities.RestartTcpConnection();
+                                        await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                         await PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
                                         if (rpcCallStage == RpcCallStage.Connecting)
                                         {
@@ -536,7 +536,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (!hasPausedOrStoppedPortForwarder)
                                 {
                                     hasPausedOrStoppedPortForwarder = true;
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     await PauseOrStopPortForwarder(rpcCallStage, portForwarder.Value, responseMessageTcpKiller, rpcCallHasStarted);
                                     if (rpcCallStage == RpcCallStage.Connecting)
                                     {

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionCanRecoverFromNetworkIssues.cs
@@ -277,7 +277,7 @@ namespace Octopus.Tentacle.Tests.Integration
                             {
                                 if (recordedUsages.For(nameof(IAsyncClientCapabilitiesServiceV2.GetCapabilitiesAsync)).LastException == null)
                                 {
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionRetriesTimeout.cs
@@ -47,7 +47,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (capabilitiesMethodUsages.For(nameof(IAsyncClientCapabilitiesServiceV2.GetCapabilitiesAsync)).LastException is null)
                                 {
                                     // Ensure there is an active connection so it can be killed correctly
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
                                 else
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                     else
                                     {
                                         // Ensure there is an active connection so it can be killed correctly
-                                        await tcpConnectionUtilities.RestartTcpConnection();
+                                        await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                         // Pause the port forwarder so the next requests are in-flight when retries timeout
                                         responseMessageTcpKiller.PauseConnectionOnNextResponse();
                                     }
@@ -114,7 +114,7 @@ namespace Octopus.Tentacle.Tests.Integration
                         .BeforeGetCapabilities(
                             async () =>
                             {
-                                await tcpConnectionUtilities.RestartTcpConnection();
+                                await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                 // Sleep to make the initial RPC call take longer than the allowed retry duration
                                 await Task.Delay(retryDuration + TimeSpan.FromSeconds(1));
@@ -163,7 +163,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (recordedUsages.For(nameof(IAsyncClientScriptServiceV2.StartScriptAsync)).LastException == null)
                                 {
                                     // Ensure there is an active connection so it can be killed correctly
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
                                 else
@@ -177,7 +177,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                     else
                                     {
                                         // Ensure there is an active connection so it can be killed correctly
-                                        await tcpConnectionUtilities.RestartTcpConnection();
+                                        await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                         // Pause the port forwarder so the next requests are in-flight when retries timeout
                                         responseMessageTcpKiller.PauseConnectionOnNextResponse();
                                     }
@@ -283,7 +283,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).LastException == null)
                                 {
                                     // Ensure there is an active connection so it can be killed correctly
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
                                 else
@@ -297,7 +297,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                     else
                                     {
                                         // Ensure there is an active connection so it can be killed correctly
-                                        await tcpConnectionUtilities.RestartTcpConnection();
+                                        await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                         // Pause the port forwarder so the next requests are in-flight when retries timeout
                                         responseMessageTcpKiller.PauseConnectionOnNextResponse();
                                     }
@@ -408,7 +408,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 if (recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).LastException == null)
                                 {
                                     // Ensure there is an active connection so it can be killed correctly
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
                                 else
@@ -422,7 +422,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                     else
                                     {
                                         // Ensure there is an active connection so it can be killed correctly
-                                        await tcpConnectionUtilities.RestartTcpConnection();
+                                        await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                         // Pause the port forwarder so the next requests are in-flight when retries timeout
                                         responseMessageTcpKiller.PauseConnectionOnNextResponse();
                                     }

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceNonV1IsNotRetriedWhenRetriesAreDisabled.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutionScriptServiceNonV1IsNotRetriedWhenRetriesAreDisabled.cs
@@ -41,7 +41,7 @@ namespace Octopus.Tentacle.Tests.Integration
                                 // use a different service to ensure Tentacle is connected to Server.
                                 // Otherwise, the response to the 'ensure connection' will get cached
                                 // and any subsequent calls will succeed w/o using the network.
-                                await tcpConnectionUtilities.RestartTcpConnection();
+                                await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
 
                                 if (capabilitiesRecordedUsages.For(nameof(IAsyncClientCapabilitiesServiceV2.GetCapabilitiesAsync)).LastException is null)
                                 {
@@ -210,7 +210,7 @@ namespace Octopus.Tentacle.Tests.Integration
                             {
                                 if (recordedUsages.For(nameof(IAsyncClientScriptServiceV2.CancelScriptAsync)).LastException is null)
                                 {
-                                    await tcpConnectionUtilities.RestartTcpConnection();
+                                    await tcpConnectionUtilities.EnsureConnectionIsSetupBeforeKillingIt();
                                     responseMessageTcpKiller.KillConnectionOnNextResponse();
                                 }
                             }))

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/ListeningResponseMessageTcpKiller.cs
@@ -38,22 +38,8 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 
         public IDataTransferObserver DataTransferObserver()
         {
-            int numberOfWritesFromTentacleSeen = 0;
             return new DataTransferObserverBuilder().WithWritingDataObserver((tcpPump, dataFromTentacle) =>
             {
-                numberOfWritesFromTentacleSeen++;
-                if (pauseConnection || killConnection)
-                {
-                    // For listening tentacle to be connected to, it must first send some ssl stuff, then a MX control message to
-                    // register itself.
-                    // In practice, it is not until the 4th write that we could be processing a message.
-                    if (numberOfWritesFromTentacleSeen <= 3)
-                    {
-                        logger.Information("Too few writes ({WriteCount} seen from tentacle the connection is not setup.", numberOfWritesFromTentacleSeen);
-                        return;
-                    }
-                }
-                
                 // It seems messages around 45 and below are control messages - except for
                 // Windows Server 2012, where the max size seems to be ~85.
                 // So anything bigger must be the interesting one.

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/PollingResponseMessageTcpKiller.cs
@@ -50,23 +50,8 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 
         public IDataTransferObserver DataTransferObserver()
         {
-            int numberOfWritesFromTentacleSeen = 0;
             return new DataTransferObserverBuilder().WithWritingDataObserver((tcpPump, dataFromTentacle) =>
             {
-                numberOfWritesFromTentacleSeen++;
-
-                if (pauseConnection || killConnection)
-                {
-                    // For polling tentacle to connect it first sends some sort of "open" connection data,
-                    // then some ssl stuff, then a MX control message to register itself.
-                    // In practice, it is not until the 4th write that we could be processing a message.
-                    if (numberOfWritesFromTentacleSeen <= 4)
-                    {
-                        logger.Information("Too few writes seen from tentacle the connection is not setup.");
-                        return;
-                    }
-                }
-                
                 //logger.Information($"Received: {size} from tentacle");
                 if (pauseConnection)
                 {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/TcpConnectionUtilities.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/TcpTentacleHelpers/TcpConnectionUtilities.cs
@@ -26,7 +26,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
             this.serviceEndPoint = serviceEndPoint;
         }
 
-        public async Task RestartTcpConnection()
+        public async Task EnsureConnectionIsSetupBeforeKillingIt()
         {
             logger.Information("Call DownloadFile to work around an issue where the tcp killer kills setup of new connections");
             await ExecuteDownloadFile(new HalibutProxyRequestOptions(CancellationToken.None));
@@ -60,7 +60,7 @@ namespace Octopus.Tentacle.Tests.Integration.Util.TcpTentacleHelpers
 
     public interface ITcpConnectionUtilities
     {
-        Task RestartTcpConnection();
+        Task EnsureConnectionIsSetupBeforeKillingIt();
         Task EnsurePollingQueueWontSendMessageToDisconnectedTentacles();
     }
 }


### PR DESCRIPTION
# Background

We already head something that sets up the connection to be killed at just the right time.

Lets use that instead of trying to see when the connection is setup from the port forwarder.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.