### PR TITLE
Fix k8s worker running as non-root

### DIFF
--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -48,8 +48,8 @@ RUN mkdir /.dotnet
 # By default, OpenShift uses random UIDs 
 # This introduces support for it as per
 # https://docs.openshift.com/container-platform/4.15/openshift_images/create-images.html#use-uid_create-images
-RUN chgrp -R 0 /opt /usr /.dotnet && \
-    chmod -R g=u /opt /usr /.dotnet
+RUN chgrp -R 0 /opt /usr /.dotnet /root && \
+    chmod -R g=u /opt /usr /.dotnet /root
 
 # The same as above, but we shouldn't recursively own /etc, as it would add
 # ownership to system files like /etc/passwd


### PR DESCRIPTION
# Background

When the kubernetes agent runs as a worker, a secret for helm is mounted into the `/root/agent_upgrade/` folder. The `/root` folder has a default ownership of `700`, which means that when running as a non-root user (I.E. in OpenShift), the agent upgrade and health check would fail with `EACCESS` whenever attempting to run helm.

# Results

This fixes this bug, making the `/root` folder accessible by the root _group_ as well.