### PR TITLE
Add extra mount for agent upgrade

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -327,7 +327,8 @@ namespace Octopus.Tentacle.Kubernetes
                 VolumeMounts = new List<V1VolumeMount>
                 {
                     new(homeDir, "tentacle-home"),
-                    new ("/root/agent_upgrade/", "agent-upgrade")
+                    new ("/root/agent_upgrade/", "agent-upgrade"),
+                    new ("/tmp/agent_upgrade/", "agent-upgrade")
                 },
                 Env = new List<V1EnvVar>
                 {


### PR DESCRIPTION
# Background

When the kubernetes agent runs as a worker, a secret for helm is mounted into the `/root/agent_upgrade/` folder. The `/root` folder has a default ownership of `700`, which means that when running as a non-root user (I.E. in OpenShift), the agent upgrade and health check would fail with `EACCESS` whenever attempting to run helm.

# Results

This fixes the bug by adding an additional mount in `/tmp`, a more reasonable place. A change to the upgrade script will need to be made to point to the new location (if it exists) as well.