### PR TITLE
Update known latest k8s tools container tags

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
@@ -32,6 +32,9 @@ namespace Octopus.Tentacle.Kubernetes
             new(1, 28),
             new(1, 29),
             new(1, 30),
+            new(1, 31),
+            new(1, 32),
+            new(1, 33),
         };
 
         public async Task<string> GetContainerImageForCluster()


### PR DESCRIPTION
# Background

The Kubernetes agent uses the [octopusdeploy/kubernetes-agent-tools-base](https://github.com/OctopusDeploy/kubernetes-agent-tools-base) container to execute it workloads. We match the version of the tools with the version of the cluster.

However, if we can't retrieve the supported versions, we have a list of known versions/tags to fallback on.

This list got out of date.

# Results

Add Kubernetes 1.31, 1.32 and 1.33 to known versions/tags.

We will add a note to the tools base repo to make sure these are kept up to date when a new k8s version added.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.