### PR TITLE
Use newer debian retro for tests

### DIFF
--- a/build/Build.Tests.cs
+++ b/build/Build.Tests.cs
@@ -84,7 +84,7 @@ partial class Build
             
             List<TestConfigurationOnLinuxDistribution> testOnLinuxDistributions = new()
             {
-                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian:bullseye", "deb"),
+                new TestConfigurationOnLinuxDistribution(NetCore, "linux-x64", "debian", "deb"),
 
                 // Debian dist oldoldstable appears to have been removed on 23/4/2023, maybe temporarily whilst a new stable release is created. 
                 // TODO: Revisit this when/if the dist becomes available again and reinstate if possible.


### PR DESCRIPTION
# Background

[Slack thread](https://octopusdeploy.slack.com/archives/C01HH8T16G3/p1753661962547059)

Tentacle nightly build has recently been failing when running `apt-get update` with the error.

> E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.

Thanks to team build's help, we found out that the image `debian:buster` that we use as a distro to run our tests is no longer compatible with `apt-get update`. The image for the retro has its LTS ended a while ago.

Discussed with the team and we don't think there are any particular reasons we want to runs the tests on `debian:buster`.

This PR update the the build process of the project to use the `latest` version of debian (Debian 11 “[Bullseye](https://wiki.debian.org/LTS/Bullseye)”)  which we have confrimed to work with `apt-get update`.

# Results

## Before
<img width="1110" height="282" alt="image" src="https://github.com/user-attachments/assets/b8ca8e88-92cb-42a1-8a1b-2f74c499532a" />


## After
<img width="1127" height="395" alt="image" src="https://github.com/user-attachments/assets/c6b6af62-9f1b-40a8-b2ed-6004293fc5ad" />

# How to review this PR
Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.