### PR TITLE
Indicate disabled tenants in setup dropdown

### DIFF
--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
@@ -777,7 +777,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
                 AreTenantsSupported = spaceSpecificData.AreTenantsSupported;
                 PotentialTenantTags = spaceSpecificData.TenantTags.SelectMany(tt => tt.Tags.Select(t => t.CanonicalTagName)).ToArray();
                 UpdateSelection(SelectedTenantTags, PotentialTenantTags);
-                PotentialTenants = spaceSpecificData.Tenants.Select(tt => tt.Name).ToArray();
+                PotentialTenants = spaceSpecificData.Tenants.Select(tt => tt.IsDisabled ? $"{tt.Name} (disabled)" : tt.Name).ToArray();
                 UpdateSelection(SelectedTenants, PotentialTenants);
                 AreTenantsAvailable = PotentialTenants.Any();
             }


### PR DESCRIPTION

# Background

[sc-https://app.shortcut.com/octopusdeploy/story/104616/sev-3-disabled-tenants-appearing-on-tentacle-setup-page-requested-by-lewis-johnson]

# Results

<!-- Describe the result of the change -->

Fixes https://github.com/OctopusDeploy/Issues/issues/9273.

## Before

<!-- Consider adding a log excerpt or screen capture. -->

TODO.

## After

<!-- Consider adding a log excerpt or screen capture. -->

TODO.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.