### PR TITLE
feat: Add Pod Labels as a configurable option

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -68,6 +68,9 @@ namespace Octopus.Tentacle.Kubernetes
         public static readonly string PodAnnotationsJsonVariableName = $"{EnvVarPrefix}__PODANNOTATIONSJSON";
         public static string? PodAnnotationsJson => Environment.GetEnvironmentVariable(PodAnnotationsJsonVariableName);
 
+        public static readonly string PodLabelsJsonVariableName = $"{EnvVarPrefix}__PODLABELSJSON";
+        public static string? PodLabelsJson => Environment.GetEnvironmentVariable(PodLabelsJsonVariableName);
+        
         public static readonly string TentacleConfigMapNameVariableName = $"{EnvVarPrefix}__TENTACLECONFIGMAPNAME";
         public static string TentacleConfigMapName => GetEnvironmentVariableOrDefault(TentacleConfigMapNameVariableName, "tentacle-config");
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -199,11 +199,7 @@ namespace Octopus.Tentacle.Kubernetes
                 {
                     Name = podName,
                     NamespaceProperty = KubernetesConfig.Namespace,
-                    Labels = new Dictionary<string, string>
-                    {
-                        ["octopus.com/serverTaskId"] = command.TaskId,
-                        ["octopus.com/scriptTicketId"] = command.ScriptTicket.TaskId
-                    },
+                    Labels = GetScriptPodLabels(tentacleScriptLog, command),
                     Annotations = ParseScriptPodAnnotations(tentacleScriptLog)
                 },
                 Spec = new V1PodSpec
@@ -418,6 +414,25 @@ namespace Octopus.Tentacle.Kubernetes
                 KubernetesConfig.PodAnnotationsJson,
                 KubernetesConfig.PodAnnotationsJsonVariableName,
                 "pod annotations");
+
+        Dictionary<string, string>? GetScriptPodLabels(InMemoryTentacleScriptLog tentacleScriptLog, StartKubernetesScriptCommandV1 command)
+        {
+            var labels = new Dictionary<string, string>
+            {
+                ["octopus.com/serverTaskId"] = command.TaskId,
+                ["octopus.com/scriptTicketId"] = command.ScriptTicket.TaskId
+            };
+            var extraLabels = ParseScriptPodJson<Dictionary<string, string>>(
+                tentacleScriptLog,
+                KubernetesConfig.PodLabelsJson,
+                KubernetesConfig.PodLabelsJsonVariableName,
+                "pod labels");
+            labels.AddRange(extraLabels);
+            
+            return labels;
+        }
+
+        
 
         [return: NotNullIfNotNull("defaultValue")]
         T? ParseScriptPodJson<T>(InMemoryTentacleScriptLog tentacleScriptLog, string? json, string envVarName, string description, T? defaultValue = null) where T : class


### PR DESCRIPTION
# Background

This PR adds the ability to define extra labels on the script pods, which is required to support [Entra workload identities](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview?tabs=dotnet#pod-labels).

# Results

<!-- Describe the result of the change -->

Fixes: https://github.com/OctopusDeploy/Issues/issues/9543

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.