### PR TITLE
Run GetStatus check twice when complete on SSV1

### DIFF
--- a/source/Octopus.Tentacle.Client.Tests/ScriptServiceV1ExecutorTests.cs
+++ b/source/Octopus.Tentacle.Client.Tests/ScriptServiceV1ExecutorTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Halibut.ServiceModel;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Tentacle.Client.EventDriven;
+using Octopus.Tentacle.Client.Execution;
+using Octopus.Tentacle.Client.Observability;
+using Octopus.Tentacle.Client.Scripts;
+using Octopus.Tentacle.Contracts;
+using Octopus.Tentacle.Contracts.ClientServices;
+using Octopus.Tentacle.Contracts.Logging;
+using Octopus.Tentacle.Contracts.Observability;
+
+namespace Octopus.Tentacle.Client.Tests
+{
+    [TestFixture]
+    public class ScriptServiceV1ExecutorTests
+    {
+        /// <summary>
+        /// In ScriptServiceV1, it is possible that additional logs may be returned after the
+        /// first call to GetStatus responds with a completed status. The script executor
+        /// mitigates against this by checking a second time if the script is completed.
+        /// </summary>
+        [Test]
+        public async Task GetStatusWillDoubleCheckIfProcessIsCompleted()
+        {
+            // Arrange
+            var scriptService = Substitute.For<IAsyncClientScriptService>();
+            scriptService.GetStatusAsync(Arg.Any<ScriptStatusRequest>(), Arg.Any<HalibutProxyRequestOptions>())
+                .Returns(
+                    x => Task.FromResult(new ScriptStatusResponse(
+                        x.Arg<ScriptStatusRequest>().Ticket,
+                        ProcessState.Complete,
+                        nextLogSequence: 1,
+                        exitCode: 0,
+                        logs: new List<ProcessOutput>
+                        {
+                            new(ProcessOutputSource.StdOut, "First log line"),
+                        })),
+                    x => Task.FromResult(new ScriptStatusResponse(
+                        x.Arg<ScriptStatusRequest>().Ticket,
+                        ProcessState.Complete,
+                        nextLogSequence: 2,
+                        exitCode: 0,
+                        logs: new List<ProcessOutput>
+                        {
+                            new(ProcessOutputSource.StdOut, "Second log line"),
+                        }))
+                );
+
+            var scriptExecutor = new ScriptServiceV1Executor(
+                scriptService,
+                RpcCallExecutorFactory.Create(TimeSpan.Zero, Substitute.For<ITentacleClientObserver>()),
+                ClientOperationMetricsBuilder.Start(),
+                Substitute.For<ITentacleClientTaskLog>()
+            );
+
+
+            var context = new CommandContext(
+                scriptTicket: new ScriptTicket("TestTicket"),
+                nextLogSequence: 0,
+                ScriptServiceVersion.ScriptServiceVersion1
+            );
+
+            // Act
+            var result = await scriptExecutor.GetStatus(context, CancellationToken.None);
+
+            // Assert
+            result.ScriptStatus.Should().NotBeNull();
+            result.ScriptStatus.ExitCode.Should().Be(0);
+            result.ScriptStatus.Logs.Should().HaveCount(2);
+            result.ScriptStatus.Logs[0].Source.Should().Be(ProcessOutputSource.StdOut);
+            result.ScriptStatus.Logs[0].Text.Should().Be("First log line");
+            result.ScriptStatus.Logs[1].Source.Should().Be(ProcessOutputSource.StdOut);
+            result.ScriptStatus.Logs[1].Text.Should().Be("Second log line");
+            result.ScriptStatus.State.Should().Be(ProcessState.Complete);
+        }
+
+        [Test]
+        public async Task GetStatusWillOnlyCheckOnceIfProcessIsNotComplete()
+        {
+            // Arrange
+            var scriptService = Substitute.For<IAsyncClientScriptService>();
+            scriptService.GetStatusAsync(Arg.Any<ScriptStatusRequest>(), Arg.Any<HalibutProxyRequestOptions>())
+                .Returns(
+                    x => Task.FromResult(
+                        new ScriptStatusResponse(
+                            x.Arg<ScriptStatusRequest>().Ticket,
+                            ProcessState.Running,
+                            nextLogSequence: 1,
+                            exitCode: 0,
+                            logs: new List<ProcessOutput>
+                            {
+                                new(ProcessOutputSource.StdOut, "First log line"),
+                            }
+                        )
+                    ),
+                    x => Task.FromResult(
+                        new ScriptStatusResponse(
+                            x.Arg<ScriptStatusRequest>().Ticket,
+                            ProcessState.Complete,
+                            nextLogSequence: 2,
+                            exitCode: 0,
+                            logs: new List<ProcessOutput>
+                            {
+                                new(ProcessOutputSource.StdOut, "This line should not be returned"),
+                            }
+                        )
+                    )
+                );
+            var scriptExecutor = new ScriptServiceV1Executor(
+                scriptService,
+                RpcCallExecutorFactory.Create(TimeSpan.Zero, Substitute.For<ITentacleClientObserver>()),
+                ClientOperationMetricsBuilder.Start(),
+                Substitute.For<ITentacleClientTaskLog>()
+            );
+            var context = new CommandContext(
+                scriptTicket: new ScriptTicket("TestTicket"),
+                nextLogSequence: 0,
+                scripServiceVersionUsed: ScriptServiceVersion.ScriptServiceVersion1
+            );
+
+            // Act
+            var result = await scriptExecutor.GetStatus(context, CancellationToken.None);
+
+            // Assert
+            result.ScriptStatus.Should().NotBeNull();
+            result.ScriptStatus.ExitCode.Should().Be(0);
+            result.ScriptStatus.Logs.Should().HaveCount(1);
+            result.ScriptStatus.Logs[0].Source.Should().Be(ProcessOutputSource.StdOut);
+            result.ScriptStatus.Logs[0].Text.Should().Be("First log line");
+            result.ScriptStatus.State.Should().Be(ProcessState.Running);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/ClientScriptExecutorObservesScriptObserverBackoffStrategy.cs
@@ -32,11 +32,15 @@ namespace Octopus.Tentacle.Tests.Integration
 
             var (_, logs) = await clientTentacle.TentacleClient.ExecuteScript(startScriptCommand, CancellationToken);
 
+            var maxGetStatusCalls = tentacleConfigurationTestCase.ScriptServiceToTest == TentacleConfigurationTestCases.ScriptServiceV1Type
+                ? 4 // When using ScriptServiceV1 we check the final status twice on completion
+                : 3;
+
             recordedUsages.For(nameof(IAsyncClientScriptServiceV2.GetStatusAsync)).Started
                 .Should()
                 .BeGreaterThan(0)
                 .And
-                .BeLessThan(3);
+                .BeLessThan(maxGetStatusCalls);
         }
     }
 }


### PR DESCRIPTION
# Background

For ScriptServiceV1, a call to `GetStatus` may not return the full log
information if the logs have not yet been flushed. This change updates
the client to perform a second GetStatus check to attempt to fetch any
additional logs.

# Results

- Updates the script executor in the Tentacle client for ScriptServiceV1 to run an extra call to `GetStatus` when the process is complete
- Resolves #1117

# How to review this PR

- Quality
- Test Coverage

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
