### PR TITLE
Update referenced version of Octopus.Client to 17.0.2288 to correct code signatures. Update global.json to reference 8.0.413 to pick up security fixes for net8 self-contained tentacle

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.303",
+    "version": "8.0.413",
     "rollForward": "latestFeature"
   }
 }

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -53,7 +53,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
-		<PackageReference Include="Octopus.Client" Version="15.2.2240" />
+		<PackageReference Include="Octopus.Client" Version="17.0.2288" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="4.6.2" />


### PR DESCRIPTION
# Background

A customer used a scanning tool to inspect our current release of Tentacle (8.0.3103 at time of writing).

The tool showed

- The `Octopus.Client.dll` bundled with Tentacle had an invalid code signature
- The net8 variant of Tentacle was using version `8.0.7` of the .NET runtime

# Results

The Octopus.Client code signature was corrected in [release 17.0.2288](https://github.com/OctopusDeploy/OctopusClients/releases/tag/17.0.2288)

This PR
- Updates Tentacle to reference the Octopus.Client version 17.0.2288
- Updates the `global.json` file which will cause Tentacle to build with the current `8.0.19` version of the .NET runtime.

[SC-118759]

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:

The PR validation build passed all tests. I manually verified that the bundled .NET runtime is now 8.0.19

<img width="2220" height="526" alt="image" src="https://github.com/user-attachments/assets/716666fc-c023-4fae-a60a-722d7945326d" />


# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.