### PR TITLE
Add polling proxy to register script

### DIFF
--- a/docker/kubernetes-agent-tentacle/scripts/register.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/register.sh
@@ -199,6 +199,27 @@ function getStatusOfRegistration() {
     cut -d'"' -f4)
 }
 
+function setPollingProxy() {
+  local ARGS=()
+  ARGS+=('polling-proxy'
+    '--instance' "$instanceName")
+
+  if [[ -n "$TentaclePollingProxyHost" ]]; then
+    echo "Using polling proxy at $TentaclePollingProxyHost:$TentaclePollingProxyPort"
+    ARGS+=(
+      '--proxyEnable' 'true'
+      '--proxyHost' "$TentaclePollingProxyHost"
+      '--proxyPort' "$TentaclePollingProxyPort"
+      '--proxyUsername' "$TentaclePollingProxyUsername"
+      '--proxyPassword' "$TentaclePollingProxyPassword")
+  else
+    echo "Disabling polling proxy"
+        ARGS+=('--proxyEnable' 'false')
+  fi
+
+  tentacle "${ARGS[@]}"
+}
+
 function registerTentacle() {
   echo "Registering with server ..."
 
@@ -320,6 +341,7 @@ else
   validateVariables
 
   configureTentacle
+  setPollingProxy
   registerTentacle
   echo "Configuration successful"
 fi


### PR DESCRIPTION
# Background
When we split out the register/run scripts for the agent pre-registration pod, we didn't add the proxy configuration to the registration script, causing the registration to fail in some instances.

# Results

Fixes https://github.com/OctopusDeploy/Issues/issues/9580

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.