### PR TITLE
Use script pod template custom resource to create pods and containers

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesContainerExtensionMethods.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesContainerExtensionMethods.cs
@@ -6,7 +6,7 @@ namespace Octopus.Tentacle.Kubernetes
 {
     public static class KubernetesContainerExtensionMethods
     {
-        [return: NotNullIfNotNull("source")]
+        [return: NotNullIfNotNull(nameof(source))]
         public static V1Container? Clone(this V1Container? source)
         {
             if (source is null)

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesContainerExtensionMethods.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesContainerExtensionMethods.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using k8s;
+using k8s.Models;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public static class KubernetesContainerExtensionMethods
+    {
+        [return: NotNullIfNotNull("source")]
+        public static V1Container? Clone(this V1Container? source)
+        {
+            if (source is null)
+            {
+                return null;
+            }
+            // Use JSON serialization for deep cloning
+            var json = KubernetesJson.Serialize(source);
+            return KubernetesJson.Deserialize<V1Container>(json);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesCustomResourceService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesCustomResourceService.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using k8s;
-using k8s.Autorest;
 using k8s.Models;
 using Octopus.Tentacle.Core.Diagnostics;
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesCustomResourceService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesCustomResourceService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -36,9 +37,10 @@ namespace Octopus.Tentacle.Kubernetes
                         "scriptpodtemplates",
                         cancellationToken: cancellationToken);
                 }
-                catch (HttpOperationException opException)
-                    when (opException.Response.StatusCode == HttpStatusCode.NotFound)
+                catch (Exception ex)
                 {
+                    // we are happy to handle all exceptions here and just fallback
+                    Log.WarnFormat(ex, "Failed to retrieve 'scriptpodtemplates' custom resource");
                     return null;
                 }
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesCustomResourceService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesCustomResourceService.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+using Octopus.Tentacle.Core.Diagnostics;
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public interface IKubernetesCustomResourceService
+    {
+        Task<ScriptPodTemplateCustomResource?> GetOldestScriptPodTemplateCustomResource(CancellationToken cancellationToken);
+    }
+
+    public class KubernetesCustomResourceService : KubernetesService, IKubernetesCustomResourceService
+    {
+        public KubernetesCustomResourceService(IKubernetesClientConfigProvider configProvider, ISystemLog log)
+            : base(configProvider, log)
+        {
+        }
+
+        public async Task<ScriptPodTemplateCustomResource?> GetOldestScriptPodTemplateCustomResource(CancellationToken cancellationToken)
+        {
+            return await RetryPolicy.ExecuteAsync(async () =>
+            {
+                ScriptPodTemplateCustomResourceList resourceList;
+                try
+                {
+                    resourceList = await Client.CustomObjects.ListNamespacedCustomObjectAsync<ScriptPodTemplateCustomResourceList>(
+                        "agent.octopus.com",
+                        "v1beta1",
+                        KubernetesConfig.Namespace,
+                        "scriptpodtemplates",
+                        cancellationToken: cancellationToken);
+                }
+                catch (HttpOperationException opException)
+                    when (opException.Response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return null;
+                }
+
+                return resourceList.Items.OrderBy(r => r.Metadata.CreationTimestamp).FirstOrDefault();
+            });
+        }
+        
+        //These are only ever deserialized from JSON
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+        class ScriptPodTemplateCustomResourceList : KubernetesObject
+        {
+            public V1ListMeta Metadata { get; set; }
+            public List<ScriptPodTemplateCustomResource> Items { get; set; }
+        }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesModule.cs
@@ -34,6 +34,7 @@ namespace Octopus.Tentacle.Kubernetes
             builder.RegisterType<KubernetesPodContainerResolver>().As<IKubernetesPodContainerResolver>().SingleInstance();
             builder.RegisterType<KubernetesConfigMapService>().As<IKubernetesConfigMapService>().SingleInstance();
             builder.RegisterType<KubernetesSecretService>().As<IKubernetesSecretService>().SingleInstance();
+            builder.RegisterType<KubernetesCustomResourceService>().As<IKubernetesCustomResourceService>().SingleInstance();
 
             builder.RegisterType<KubernetesScriptPodCreator>().As<IKubernetesScriptPodCreator>().SingleInstance();
             builder.RegisterType<KubernetesRawScriptPodCreator>().As<IKubernetesRawScriptPodCreator>().SingleInstance();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
@@ -40,19 +40,12 @@ namespace Octopus.Tentacle.Kubernetes
 
         protected override async Task<IList<V1Container>> CreateInitContainers(StartKubernetesScriptCommandV1 command, string podName, string homeDir, string workspacePath, InMemoryTentacleScriptLog tentacleScriptLog, V1Container? containerSpec)
         {
-            V1Container container;
-            if (containerSpec is not null)
-            {
-                // Deep clone the container spec to avoid modifying the original
-                container = containerSpec.Clone()!;
-            }
-            else
-            {
-                container = new V1Container
+            // Deep clone the container spec to avoid modifying the original
+            var container = containerSpec.Clone() ??
+                new V1Container
                 {
                     Resources = GetScriptPodResourceRequirements(tentacleScriptLog)
                 };
-            }
 
             container.Name = $"{podName}-init";
             container.Image = command.PodImageConfiguration?.Image ?? await containerResolver.GetContainerImageForCluster();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
@@ -9,7 +9,7 @@ using Octopus.Tentacle.Contracts.KubernetesScriptServiceV1;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Core.Services.Scripts.Locking;
 using Octopus.Tentacle.Kubernetes.Crypto;
-using Octopus.Tentacle.Scripts;
+using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Kubernetes
 {
@@ -58,7 +58,7 @@ namespace Octopus.Tentacle.Kubernetes
             container.Image = command.PodImageConfiguration?.Image ?? await containerResolver.GetContainerImageForCluster();
             container.ImagePullPolicy = KubernetesConfig.ScriptPodPullPolicy;
             container.Command = new List<string> { "sh", "-c", GetInitExecutionScript("/nfs-mount", homeDir, workspacePath) };
-            container.VolumeMounts = new List<V1VolumeMount> { new("/nfs-mount", "init-nfs-volume"), new(homeDir, "tentacle-home") };
+            container.VolumeMounts.AddRange(new[] { new V1VolumeMount("/nfs-mount", "init-nfs-volume"), new V1VolumeMount(homeDir, "tentacle-home") });
 
             return new List<V1Container> { container };
         }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
@@ -58,7 +58,7 @@ namespace Octopus.Tentacle.Kubernetes
             container.Image = command.PodImageConfiguration?.Image ?? await containerResolver.GetContainerImageForCluster();
             container.ImagePullPolicy = KubernetesConfig.ScriptPodPullPolicy;
             container.Command = new List<string> { "sh", "-c", GetInitExecutionScript("/nfs-mount", homeDir, workspacePath) };
-            container.VolumeMounts.AddRange(new[] { new V1VolumeMount("/nfs-mount", "init-nfs-volume"), new V1VolumeMount(homeDir, "tentacle-home") });
+            container.VolumeMounts = Merge(container.VolumeMounts, new[] { new V1VolumeMount("/nfs-mount", "init-nfs-volume"), new V1VolumeMount(homeDir, "tentacle-home") });
 
             return new List<V1Container> { container };
         }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
@@ -9,7 +9,6 @@ using Octopus.Tentacle.Contracts.KubernetesScriptServiceV1;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Core.Services.Scripts.Locking;
 using Octopus.Tentacle.Kubernetes.Crypto;
-using Octopus.Tentacle.Util;
 
 namespace Octopus.Tentacle.Kubernetes
 {
@@ -44,7 +43,8 @@ namespace Octopus.Tentacle.Kubernetes
             V1Container container;
             if (containerSpec is not null)
             {
-                container = containerSpec;
+                // Deep clone the container spec to avoid modifying the original
+                container = containerSpec.Clone()!;
             }
             else
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesRawScriptPodCreator.cs
@@ -25,6 +25,7 @@ namespace Octopus.Tentacle.Kubernetes
             IKubernetesPodService podService,
             IKubernetesPodMonitor podMonitor,
             IKubernetesSecretService secretService,
+            IKubernetesCustomResourceService customResourceService,
             IKubernetesPodContainerResolver containerResolver,
             IApplicationInstanceSelector appInstanceSelector,
             ISystemLog log,
@@ -33,31 +34,40 @@ namespace Octopus.Tentacle.Kubernetes
             KubernetesPhysicalFileSystem kubernetesPhysicalFileSystem,
             IScriptPodLogEncryptionKeyProvider scriptPodLogEncryptionKeyProvider,
             ScriptIsolationMutex scriptIsolationMutex)
-            : base(podService, podMonitor, secretService, containerResolver, appInstanceSelector, log, scriptLogProvider, homeConfiguration, kubernetesPhysicalFileSystem, scriptPodLogEncryptionKeyProvider, scriptIsolationMutex)
+            : base(podService, podMonitor, secretService, customResourceService, containerResolver, appInstanceSelector, log, scriptLogProvider, homeConfiguration, kubernetesPhysicalFileSystem, scriptPodLogEncryptionKeyProvider, scriptIsolationMutex)
         {
             this.containerResolver = containerResolver;
         }
 
-        protected override async Task<IList<V1Container>> CreateInitContainers(StartKubernetesScriptCommandV1 command, string podName, string homeDir, string workspacePath, InMemoryTentacleScriptLog tentacleScriptLog)
+        protected override async Task<IList<V1Container>> CreateInitContainers(StartKubernetesScriptCommandV1 command, string podName, string homeDir, string workspacePath, InMemoryTentacleScriptLog tentacleScriptLog, V1Container? containerSpec)
         {
-            var container = new V1Container
+            V1Container container;
+            if (containerSpec is not null)
             {
-                Name = $"{podName}-init",
-                Image = command.PodImageConfiguration?.Image ?? await containerResolver.GetContainerImageForCluster(),
-                ImagePullPolicy = KubernetesConfig.ScriptPodPullPolicy,
-                Command = new List<string> { "sh", "-c", GetInitExecutionScript("/nfs-mount", homeDir, workspacePath) },
-                VolumeMounts = new List<V1VolumeMount> { new("/nfs-mount", "init-nfs-volume"), new(homeDir, "tentacle-home") },
-                Resources = GetScriptPodResourceRequirements(tentacleScriptLog)
-            };
+                container = containerSpec;
+            }
+            else
+            {
+                container = new V1Container
+                {
+                    Resources = GetScriptPodResourceRequirements(tentacleScriptLog)
+                };
+            }
+
+            container.Name = $"{podName}-init";
+            container.Image = command.PodImageConfiguration?.Image ?? await containerResolver.GetContainerImageForCluster();
+            container.ImagePullPolicy = KubernetesConfig.ScriptPodPullPolicy;
+            container.Command = new List<string> { "sh", "-c", GetInitExecutionScript("/nfs-mount", homeDir, workspacePath) };
+            container.VolumeMounts = new List<V1VolumeMount> { new("/nfs-mount", "init-nfs-volume"), new(homeDir, "tentacle-home") };
 
             return new List<V1Container> { container };
         }
-        
-        protected override async Task<IList<V1Container>> CreateScriptContainers(StartKubernetesScriptCommandV1 command, string podName, string scriptName, string homeDir, string workspacePath, string[]? scriptArguments, InMemoryTentacleScriptLog tentacleScriptLog)
+
+        protected override async Task<IList<V1Container>> CreateScriptContainers(StartKubernetesScriptCommandV1 command, string podName, string scriptName, string homeDir, string workspacePath, string[]? scriptArguments, InMemoryTentacleScriptLog tentacleScriptLog, ScriptPodTemplateSpec? spec)
         {
             return new List<V1Container>
             {
-                await CreateScriptContainer(command, podName, scriptName, homeDir, workspacePath, scriptArguments, tentacleScriptLog)
+                await CreateScriptContainer(command, podName, scriptName, homeDir, workspacePath, scriptArguments, tentacleScriptLog, spec?.ScriptContainerSpec)
             };
         }
 
@@ -82,7 +92,7 @@ namespace Octopus.Tentacle.Kubernetes
             };
         }
 
-        string GetInitExecutionScript(string nfsVolumeDirectory, string homeDir, string workspacePath)
+        static string GetInitExecutionScript(string nfsVolumeDirectory, string homeDir, string workspacePath)
         {
             var nfsWorkspacePath = Path.Combine(nfsVolumeDirectory, workspacePath);
             var homeWorkspacePath = Path.Combine(homeDir, workspacePath);

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -509,11 +509,11 @@ namespace Octopus.Tentacle.Kubernetes
 
             container.Name = "nfs-watchdog";
             container.Image = KubernetesConfig.NfsWatchdogImage;
-            container.VolumeMounts.AddRange(new List<V1VolumeMount>
+            container.VolumeMounts = Merge(container.VolumeMounts, new List<V1VolumeMount>
             {
                 new(homeDir, "tentacle-home"),
             });
-            container.Env.Add(new V1EnvVar(EnvironmentVariables.NfsWatchdogDirectory, homeDir));
+            container.Env = Merge(container.Env, new[] { new V1EnvVar(EnvironmentVariables.NfsWatchdogDirectory, homeDir) });
 
             return container;
         }

--- a/source/Octopus.Tentacle/Kubernetes/ScriptPodTemplateCustomResource.cs
+++ b/source/Octopus.Tentacle/Kubernetes/ScriptPodTemplateCustomResource.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using k8s;
 using k8s.Models;
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
@@ -20,16 +21,25 @@ namespace Octopus.Tentacle.Kubernetes
     public class ScriptPodTemplateSpec
     {
         [JsonPropertyName("podMetadata")]
-        public V1ObjectMeta? PodMetadata { get; set; }
+        public PodMetadata? PodMetadata { get; set; }
         
         [JsonPropertyName("podSpec")]
-        public V1PodSpec PodSpec { get; set; }
+        public V1PodSpec? PodSpec { get; set; }
 
         [JsonPropertyName("scriptContainerSpec")]
         public V1Container? ScriptContainerSpec { get; set; }
 
         [JsonPropertyName("watchdogContainerSpec")]
         public V1Container? WatchdogContainerSpec { get; set; }
+    }
+
+    public class PodMetadata
+    {
+        [JsonPropertyName("labels")]
+        public IDictionary<string,string>? Labels { get; set; }
+        
+        [JsonPropertyName("annotations")]
+        public IDictionary<string,string>? Annotations { get; set; }
     }
 
     public class ScriptPodTemplateStatus

--- a/source/Octopus.Tentacle/Kubernetes/ScriptPodTemplateCustomResource.cs
+++ b/source/Octopus.Tentacle/Kubernetes/ScriptPodTemplateCustomResource.cs
@@ -1,0 +1,35 @@
+﻿using System.Text.Json.Serialization;
+using k8s;
+using k8s.Models;
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+namespace Octopus.Tentacle.Kubernetes
+{
+    public class ScriptPodTemplateCustomResource : KubernetesObject, IMetadata<V1ObjectMeta>
+    {
+        [JsonPropertyName("metadata")]
+        public V1ObjectMeta Metadata { get; set; }
+
+        [JsonPropertyName("spec")]
+        public ScriptPodTemplateSpec Spec { get; set; }
+        
+        [JsonPropertyName("status")]
+        public ScriptPodTemplateStatus Status { get; set; }
+    }
+
+    public class ScriptPodTemplateSpec
+    {
+        [JsonPropertyName("podSpec")]
+        public V1PodSpec PodSpec { get; set; }
+
+        [JsonPropertyName("scriptContainerSpec")]
+        public V1Container? ScriptContainerSpec { get; set; }
+
+        [JsonPropertyName("watchdogContainerSpec")]
+        public V1Container? WatchdogContainerSpec { get; set; }
+    }
+
+    public class ScriptPodTemplateStatus
+    {
+    }
+}

--- a/source/Octopus.Tentacle/Kubernetes/ScriptPodTemplateCustomResource.cs
+++ b/source/Octopus.Tentacle/Kubernetes/ScriptPodTemplateCustomResource.cs
@@ -19,6 +19,9 @@ namespace Octopus.Tentacle.Kubernetes
 
     public class ScriptPodTemplateSpec
     {
+        [JsonPropertyName("podMetadata")]
+        public V1ObjectMeta? PodMetadata { get; set; }
+        
         [JsonPropertyName("podSpec")]
         public V1PodSpec PodSpec { get; set; }
 

--- a/telepresence-config/launchSettings.template.json
+++ b/telepresence-config/launchSettings.template.json
@@ -9,7 +9,7 @@
         "DefaultLogDirectory": "<telepresence-root>/octopus/logs",
         "BOOTSTRAPRUNNEREXECUTABLEPATH": "/tmp/k8s-agent-debug-vol/bootstrapRunner",
         "TELEPRESENCE_ROOT": "<telepresence-root>",
-        "OCTOPUS_HOME": "<telepresence-root>",
+        "OCTOPUS_HOME": "<telepresence-root>/octopus",
         "OCTOPUS_CONTRIBUTE_ENV_SETTINGS": "true"
       },
       "dotnetRunMessages": true,


### PR DESCRIPTION
# Background

Allows the script pods and containers to have certain fields controlled via a new custom resource, the `scriptpodtemplate.agent.octopus.com`

# Results

When creating the script pod, we now try and read the old custom resource. If this exists, we then use its pod spec, script container and/or the watchdog container spec's to build the base specs/containers.

We then modify these with any additional changes we require for the pods to execute correctly

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.