### PR TITLE
Update Halibut to version 8.1.1514

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="8.1.1503" />
+    <PackageReference Include="Halibut" Version="8.1.1514" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">


### PR DESCRIPTION
This PR updates the Halibut package from version 8.1.1503 to 8.1.1514 in the Octopus.Tentacle.Contracts project.

Adds a minor fix to Redis message stream wrappers, where the stream was not disposed before using the result of the stream. Does not affect tentacle.