### PR TITLE
Adding OTEL Traces to TentacleClient

### DIFF
--- a/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
+++ b/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Octopus.Tentacle.Client.Observability;
@@ -110,6 +111,10 @@ namespace Octopus.Tentacle.Client.Execution
             }
             catch (Exception e)
             {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                // We should use activity.AddException here, but need to update the referenced version of System.Diagnostics.DiagnosticSource.
+                // We inherit the reference from Halibut so that would have to change first.
+                activity?.AddTag("exception.message", e.Message); 
                 rpcCallMetricsBuilder.Failure(e, cancellationToken);
                 throw;
             }
@@ -142,6 +147,11 @@ namespace Octopus.Tentacle.Client.Execution
             }
             catch (Exception e)
             {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                // We should use activity.AddException here, but need to update the referenced version of System.Diagnostics.DiagnosticSource.
+                // We inherit the reference from Halibut so that would have to change first.
+                activity?.AddTag("exception.message", e.Message); 
+                
                 rpcCallMetricsBuilder.WithAttempt(TimedOperation.Failure(start, e, cancellationToken));
                 rpcCallMetricsBuilder.Failure(e, cancellationToken);
                 throw;
@@ -175,6 +185,10 @@ namespace Octopus.Tentacle.Client.Execution
             }
             catch (Exception e)
             {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                // We should use activity.AddException here, but need to update the referenced version of System.Diagnostics.DiagnosticSource.
+                // We inherit the reference from Halibut so that would have to change first.
+                activity?.AddTag("exception.message", e.Message); 
                 rpcCallMetricsBuilder.WithAttempt(TimedOperation.Failure(start, e, cancellationToken));
                 rpcCallMetricsBuilder.Failure(e, cancellationToken);
                 throw;

--- a/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
+++ b/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
@@ -56,6 +56,9 @@ namespace Octopus.Tentacle.Client.Execution
             ClientOperationMetricsBuilder clientOperationMetricsBuilder,
             CancellationToken cancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(RpcCallExecutor)}.{nameof(ExecuteWithRetries)}");
+            activity?.AddTag("octopus.tentacle.rpc_call.service", rpcCall.Service);
+            activity?.AddTag("octopus.tentacle.rpc_call.name", rpcCall.Name);
             var rpcCallMetricsBuilder = RpcCallMetricsBuilder.StartWithRetries(rpcCall, rpcCallRetryHandler.RetryTimeout);
 
             try
@@ -125,6 +128,9 @@ namespace Octopus.Tentacle.Client.Execution
             ClientOperationMetricsBuilder clientOperationMetricsBuilder,
             CancellationToken cancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(RpcCallExecutor)}.{nameof(ExecuteWithNoRetries)}");
+            activity?.AddTag("octopus.tentacle.rpc_call.service", rpcCall.Service);
+            activity?.AddTag("octopus.tentacle.rpc_call.name", rpcCall.Name);
             var rpcCallMetricsBuilder = RpcCallMetricsBuilder.StartWithoutRetries(rpcCall);
             var start = DateTimeOffset.UtcNow;
 
@@ -156,6 +162,9 @@ namespace Octopus.Tentacle.Client.Execution
             ClientOperationMetricsBuilder clientOperationMetricsBuilder,
             CancellationToken cancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(RpcCallExecutor)}.{nameof(ExecuteWithNoRetries)}");
+            activity?.AddTag("octopus.tentacle.rpc_call.service", rpcCall.Service);
+            activity?.AddTag("octopus.tentacle.rpc_call.name", rpcCall.Name);
             var rpcCallMetricsBuilder = RpcCallMetricsBuilder.StartWithoutRetries(rpcCall);
             var start = DateTimeOffset.UtcNow;
 

--- a/source/Octopus.Tentacle.Client/ScriptExecutor.cs
+++ b/source/Octopus.Tentacle.Client/ScriptExecutor.cs
@@ -44,6 +44,8 @@ namespace Octopus.Tentacle.Client
             StartScriptIsBeingReAttempted startScriptIsBeingReAttempted,
             CancellationToken cancellationToken)
         {
+            // Note: This class deliberately does not create OpenTelemetry Trace activities.
+            // It is a facade over other ScriptExecutor services, and the facade doesn't do anything interesting
             var scriptServiceVersionToUse = await DetermineScriptServiceVersionToUse(cancellationToken);
 
             var scriptExecutorFactory = CreateScriptExecutorFactory();

--- a/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Executor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/KubernetesScriptServiceV1Executor.cs
@@ -79,6 +79,8 @@ namespace Octopus.Tentacle.Client.Scripts
             StartScriptIsBeingReAttempted startScriptIsBeingReAttempted,
             CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(KubernetesScriptServiceV1Executor)}.{nameof(StartScript)}");
+            
             var command = Map(executeScriptCommand);
             var startScriptCallsConnectedCount = 0;
             try
@@ -135,6 +137,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         public async Task<ScriptOperationExecutionResult> GetStatus(CommandContext commandContext, CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(KubernetesScriptServiceV1Executor)}.{nameof(GetStatus)}");
             async Task<KubernetesScriptStatusResponseV1> GetStatusAction(CancellationToken ct)
             {
                 var request = new KubernetesScriptStatusRequestV1(commandContext.ScriptTicket, commandContext.NextLogSequence);
@@ -155,6 +158,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(KubernetesScriptServiceV1Executor)}.{nameof(CancelScript)}");
             async Task<KubernetesScriptStatusResponseV1> CancelScriptAction(CancellationToken ct)
             {
                 var request = new CancelKubernetesScriptCommandV1(commandContext.ScriptTicket, commandContext.NextLogSequence);
@@ -180,6 +184,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         public async Task<ScriptStatus?> CompleteScript(CommandContext lastStatusResponse, CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(KubernetesScriptServiceV1Executor)}.{nameof(CompleteScript)}");
             try
             {
                 // Finish performs a best effort cleanup of the Workspace on Tentacle

--- a/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ObservingScriptOrchestrator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Halibut.Logging;
@@ -47,6 +48,10 @@ namespace Octopus.Tentacle.Client.Scripts
             ScriptOperationExecutionResult startScriptResult,
             CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(ObservingScriptOrchestrator)}.{nameof(ObserveUntilCompleteThenFinish)}");
+            activity?.AddTag("octopus.tentacle.script.status.state", startScriptResult.ScriptStatus.State);
+            activity?.AddTag("octopus.tentacle.script.status.exit_code", startScriptResult.ScriptStatus.ExitCode);
+            
             OnScriptStatusResponseReceived(startScriptResult.ScriptStatus);
 
             var observingUntilCompleteResult =  await ObserveUntilComplete(startScriptResult, scriptExecutionCancellationToken).ConfigureAwait(false);

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Executor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV1Executor.cs
@@ -82,6 +82,8 @@ namespace Octopus.Tentacle.Client.Scripts
             StartScriptIsBeingReAttempted startScriptIsBeingReAttempted,
             CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(ScriptServiceV1Executor)}.{nameof(StartScript)}");
+            
             // Script Service v1 is not idempotent, do not allow it to be re-attempted as it may run a second time.
             if (startScriptIsBeingReAttempted == StartScriptIsBeingReAttempted.PossiblyBeingReAttempted)
             {
@@ -106,6 +108,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         public async Task<ScriptOperationExecutionResult> GetStatus(CommandContext commandContext, CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(ScriptServiceV1Executor)}.{nameof(GetStatus)}");
             var scriptStatusResponseV1 = await GetStatusV1(commandContext, scriptExecutionCancellationToken).ConfigureAwait(false);
 
             if (scriptStatusResponseV1.State != ProcessState.Complete)
@@ -125,6 +128,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         async Task<ScriptStatusResponse> GetStatusV1(CommandContext commandContext, CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(ScriptServiceV1Executor)}.{nameof(GetStatusV1)}");
             var scriptStatusResponseV1 = await rpcCallExecutor.ExecuteWithNoRetries(
                 RpcCall.Create<IScriptService>(nameof(IScriptService.GetStatus)),
                 async ct =>
@@ -142,6 +146,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(ScriptServiceV1Executor)}.{nameof(CancelScript)}");
             var response = await rpcCallExecutor.ExecuteWithNoRetries(
                 RpcCall.Create<IScriptService>(nameof(IScriptService.CancelScript)),
                 async ct =>
@@ -160,6 +165,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         public async Task<ScriptStatus?> CompleteScript(CommandContext lastStatusResponse, CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(ScriptServiceV1Executor)}.{nameof(CompleteScript)}");
             var response = await rpcCallExecutor.ExecuteWithNoRetries(
                 RpcCall.Create<IScriptService>(nameof(IScriptService.CompleteScript)),
                 async ct =>

--- a/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Executor.cs
+++ b/source/Octopus.Tentacle.Client/Scripts/ScriptServiceV2Executor.cs
@@ -128,6 +128,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         public async Task<ScriptOperationExecutionResult> GetStatus(CommandContext commandContext, CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(ScriptServiceV2Executor)}.{nameof(GetStatus)}");
             async Task<ScriptStatusResponseV2> GetStatusAction(CancellationToken ct)
             {
                 var request = new ScriptStatusRequestV2(commandContext.ScriptTicket, commandContext.NextLogSequence);
@@ -148,6 +149,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         public async Task<ScriptOperationExecutionResult> CancelScript(CommandContext commandContext)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(ScriptServiceV2Executor)}.{nameof(CancelScript)}");
             async Task<ScriptStatusResponseV2> CancelScriptAction(CancellationToken ct)
             {
                 var request = new CancelScriptCommandV2(commandContext.ScriptTicket, commandContext.NextLogSequence);
@@ -173,6 +175,7 @@ namespace Octopus.Tentacle.Client.Scripts
 
         public async Task<ScriptStatus?> CompleteScript(CommandContext lastStatusResponse, CancellationToken scriptExecutionCancellationToken)
         {
+            using var activity = TentacleClient.ActivitySource.StartActivity($"{nameof(ScriptServiceV2Executor)}.{nameof(CompleteScript)}");
             try
             {
                 // Finish performs a best effort cleanup of the Workspace on Tentacle


### PR DESCRIPTION
# Background

[whimsical](https://whimsical.com/adding-tracing-to-tentacleclient-DghPwsZpzqU6rAsrBi4EXR)

We would like more visibility into what Octopus Server is doing when it communicates with tentacles.

# Results

Adds traces to TentacleClient

Previously this trace would have just shown the toplevel TentacleExecutionTarget.Execute, with no child spans to explain what Execute is actually doing. Now, we can see that it's doing two RPC calls, then polling on GetStatus until CompleteScript.

(Note: Ignore the "Octopus.Tests" tree node names, they only appear because I'm capturing these traces from an integration test because it's convenient. If this was running in the real server they'd say Octopus.Server)

<img width="822" height="235" alt="image" src="https://github.com/user-attachments/assets/cfa4e3a2-24fb-4d82-9827-77b9fa6562d6" />

We can expand the Rpc calls and discover that the slow Rpc call was ICapbilitiesServiceV2.GetCapabilities

<img width="1460" height="461" alt="image" src="https://github.com/user-attachments/assets/e4dae079-3697-4f6b-a104-2f0ef2ac1a59" />

# How to review this PR

The attribute names and values are somewhat arbitrary. I tried to make a best-guess at what might be useful to capture, based on what I could see in the surrounding code, but I've never worked in the TentacleClient codebase before so I'm really just guessing.

Also please consider this as a first start; we can always iterate and tweak it over time.

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.