### PR TITLE
Octopus Client - Enable K8s Agent Update Blocking

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -53,7 +53,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
-		<PackageReference Include="Octopus.Client" Version="17.13.2388" />
+		<PackageReference Include="Octopus.Client" Version="17.15.2394" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="4.6.2" />


### PR DESCRIPTION
# Background

An update to the Octopus Server API to enable a flag blocking k8s Agent upgrades requires a new version of the Octopus Client to be deployed within Tentacle

# Results

This PR updates to the required version of OctoClient. 

There will exist a very small window where the Change will be live in Server but not yet live for tentacle, so this PR is being managed on a time sensitive basis in na attemtp to minimise any disruption.



# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.