### PR TITLE
fix: Add octopus user

### DIFF
--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -21,6 +21,13 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG TARGETVARIANT
 
+RUN groupadd -g 999 octopus \
+    && useradd -m -u 999 -g octopus octopus \
+    && mkdir -p -m 0700 /run/user/999 \
+    && chown octopus:octopus /run/user/999 \
+    && echo 'octopus:265536:65536' >> /etc/subuid \
+    && echo 'octopus:265536:65536' >> /etc/subgid
+
 EXPOSE 10933
 
 COPY docker/kubernetes-agent-tentacle/scripts/* /scripts/


### PR DESCRIPTION
**_Are you a customer of Octopus Deploy? Please contact [our support team](https://octopus.com/support) so we can triage your PR, so that we can make sure it's handled appropriately._**

Tasks were failing when specifying a non-root user to execute tasks as.


# Results

This updates the Docker file for base tools to add the Octopus user used elsewhere in Octopus images

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.