### PR TITLE
Add activity traces for retries

### DIFF
--- a/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
+++ b/source/Octopus.Tentacle.Client/Execution/RpcCallExecutor.cs
@@ -71,7 +71,7 @@ namespace Octopus.Tentacle.Client.Execution
                             using var attemptActivity = TentacleClient.ActivitySource.StartActivity($"{nameof(RpcCallExecutor)}.{nameof(ExecuteWithRetries)} - Attempt");
                             attemptActivity?.AddTag("octopus.tentacle.rpc_call.service", rpcCall.Service);
                             attemptActivity?.AddTag("octopus.tentacle.rpc_call.name", rpcCall.Name);
-                            attemptActivity?.AddTag("octopus.tentacle.rpc_call.attempt_number", attemptNumber.ToString());
+                            attemptActivity?.AddTag("octopus.tentacle.rpc_call.attempt_number", attemptNumber);
                             attemptNumber++;
                             
                             var start = DateTimeOffset.UtcNow;


### PR DESCRIPTION
# Background

Tracking was added in #1148 , but it did not include retries.  This information is needed to diagnose more gnarly connection issues.

# Results

Adds traces for each retry attempt, including
* A child span for each retry attempt
* Events for each retry callback

See the linked PR above for earlier traces.

Note this is a minimal example taken from an integration test, so it's not a very deep trace.

<img width="804" height="101" alt="image" src="https://github.com/user-attachments/assets/4a9aa02b-ee95-4a3c-83eb-bed14b2a7f40" />

# How to review this PR

Are the tags / events sensible? I wanted to cover all avenues of the retry for most visibility.

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.