### PR TITLE
Update Halibut to support SSL configuration

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="8.1.1681" />
+    <PackageReference Include="Halibut" Version="8.1.1707" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -4,6 +4,7 @@ using Autofac;
 using Halibut;
 using Halibut.Diagnostics;
 using Halibut.ServiceModel;
+using Halibut.Transport;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Contracts.Legacy;
 using Octopus.Tentacle.Variables;
@@ -63,6 +64,7 @@ namespace Octopus.Tentacle.Communications
                     .WithServerCertificate(configuration.TentacleCertificate!)
                     .WithMessageSerializer(serializerBuilder => serializerBuilder.WithLegacyContractSupport())
                     .WithHalibutTimeoutsAndLimits(halibutTimeoutsAndLimits)
+                    .WithSslConfigurationProvider(new LegacySslConfigurationProvider())
                     .Build();
 
                 halibutRuntime.SetFriendlyHtmlPageContent(FriendlyHtmlPageContent);


### PR DESCRIPTION
# Background

To support deprecation of TLS 1.0 and 1.1 support in Octopus Server, Halibut has been updated to allow configuring the supported SSL protocols. This pull request updates Halibut while maintaining the existing behaviour in Tentacle.

# Results

- Updates Halibut to the version supporting custom SSL configuration
- Ensures that Tentacle continues to use the current SSL configuration. Switching to the default configuration can be done separately.

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.
