### PR TITLE
Add xxd to the Dockerfile dependencies

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
         dos2unix \
         jq \
         sudo \
+        xxd \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->
We added a feature in Server to be able to enumerate the variable set in a bash script. To make this performant it relies on the `xxd` cli tool.

[sc-125804]

# Results

<!-- Describe the result of the change -->

This PR adds that tool to our Linux Tentacle image.

Related to https://github.com/OctopusDeploy/Calamari/pull/1441

# Before

```bash
# xxd -v
/bin/sh: 1: xxd: not found
```

# After

```bash
# xxd -v
xxd V1.10 27oct98 by Juergen Weigert
```
# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.