### PR TITLE
Better prompt message for Tentacle files directory

### DIFF
--- a/linux-packages/content/configure-tentacle.sh
+++ b/linux-packages/content/configure-tentacle.sh
@@ -47,7 +47,7 @@ function setupListeningTentacle {
     applicationpath="/home/Octopus/Applications"
     port="10933"
     
-    read -p "Where would you like Tentacle to store log files? ($logpath):" inputlogpath
+    read -p "Where would you like Tentacle to store configuration, logs, and working files? ($logpath):" inputlogpath
     logpath=$(assignNonEmptyValue "$inputlogpath" $logpath)
     
     read -p "Where would you like Tentacle to install applications to? ($applicationpath):" inputapplicationpath


### PR DESCRIPTION
# Background
Customer are confused on the script's prompt is misleading.  When the script asks "Where would you like Tentacle to store log files?", it's not just setting the log location. That path becomes the location for:
- Configuration file (tentacle.config)
- Log files (Logs/)
- Working directories (Work/)
- Deployment journals

Update the script to prompt like "Where would you like Tentacle to store configuration, logs, and working files?"

# Result
[sc-126012](https://app.shortcut.com/octopusdeploy/story/126012/sev-2-linux-tentacle-the-logpath-param-also-seems-to-change-the-config-directory-requested-by-jonathan-vermeulen)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.