### PR TITLE
Allow configuring proxy when configuring a new tentacle instance

### DIFF
--- a/linux-packages/content/configure-tentacle.sh
+++ b/linux-packages/content/configure-tentacle.sh
@@ -259,14 +259,14 @@ function setupPollingTentacle {
     echo -e "sudo /opt/octopus/tentacle/Tentacle new-certificate --instance \"$instancename\" --if-blank"
     echo -e "sudo /opt/octopus/tentacle/Tentacle configure --instance \"$instancename\" --app \"$applicationpath\" --noListen \"True\" --reset-trust"
 
+    if [ -n "$proxyarg" ]; then
+        echo -e "sudo /opt/octopus/tentacle/Tentacle polling-proxy --instance \"$instancename\" --proxyEnable=\"true\" $proxyargdisplay"
+    fi
+
     if [ $machinetype = 2 ] || [ $machinetype = "worker" ]; then
         echo -e "sudo /opt/octopus/tentacle/Tentacle register-worker --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" $commsAddressOrPortArgs $displayauth --space \"$space\" $workerpoolsstring"
     else
         echo -e "sudo /opt/octopus/tentacle/Tentacle register-with --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" $commsAddressOrPortArgs $displayauth --space \"$space\" $envstring $rolesstring"
-    fi
-
-    if [ -n "$proxyarg" ]; then
-        echo -e "sudo /opt/octopus/tentacle/Tentacle polling-proxy --instance \"$instancename\" --proxyEnable=\"true\" $proxyargdisplay"
     fi
 
     echo -e "sudo /opt/octopus/tentacle/Tentacle service --install --start --instance \"$instancename\"${NC}"
@@ -282,17 +282,17 @@ function setupPollingTentacle {
     eval sudo /opt/octopus/tentacle/Tentacle configure --instance \"$instancename\" --app \"$applicationpath\" --noListen \"True\" --reset-trust
     exitIfCommandFailed 
 
+    if [ -n "$proxyarg" ]; then
+        eval sudo /opt/octopus/tentacle/Tentacle polling-proxy --instance \"$instancename\" --proxyEnable=\"true\" $proxyarg
+        exitIfCommandFailed
+    fi
+
     if [ $machinetype = 2 ] || [ $machinetype = "worker" ]; then
         eval sudo /opt/octopus/tentacle/Tentacle register-worker --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" $commsAddressOrPortArgs $auth --space \"$space\" $workerpoolsstring
     else
         eval sudo /opt/octopus/tentacle/Tentacle register-with --instance \"$instancename\" --server \"$octopusserverurl\" --name \"$displayname\" --comms-style \"TentacleActive\" $commsAddressOrPortArgs $auth --space \"$space\" $envstring $rolesstring
     fi
     exitIfCommandFailed
-
-    if [ -n "$proxyarg" ]; then
-        eval sudo /opt/octopus/tentacle/Tentacle polling-proxy --instance \"$instancename\" --proxyEnable=\"true\" $proxyarg
-        exitIfCommandFailed
-    fi
 
     eval sudo /opt/octopus/tentacle/Tentacle service --install --start --instance \"$instancename\"
     exitIfCommandFailed


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->
The configuration script that ships with the Linux packages does not support configuring a proxy for the Tentacle to use, this prevents users from installing Tentacles on Linux systems that require a proxy.

[sc-126603]

# Results

<!-- Describe the result of the change -->
This PR updates the configuration script to allow specifying a proxy for the Tentacle to use.

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/1161

## Before

<!-- Consider adding a log excerpt or screen capture. -->
No option to configure a proxy when running `configure-tentacle.sh`

## After

<!-- Consider adding a log excerpt or screen capture. -->

### Specifying proxy successfully registers polling tentacle with Octopus

```
root@48b361b2b614:/# /opt/octopus/tentacle/configure-tentacle.sh
Name of Tentacle instance (default Tentacle):
Invalid characters will be ignored, the instance name will be: 'Tentacle'

What kind of Tentacle would you like to configure: 1) Listening or 2) Polling (default 1): 2
Where would you like Tentacle to store log files? (/etc/octopus):
Where would you like Tentacle to install applications to? (/home/Octopus/Applications):
Octopus Server URL (eg. https://octopus-server): http://host.docker.internal:8065
Select auth method: 1) API-Key or 2) Username and Password (default 1): 2
Username: admin
Password:
Select type of Tentacle do you want to setup: 1) Deployment Target or 2) Worker (default 1): 2
What Space would you like to register this Tentacle in? (Default):
What name would you like to register this Tentacle with? (48b361b2b614):
/opt/octopus/tentacle/configure-tentacle.sh: line 196: =1: command not found
Is the comms port on the same domain as the Octopus Server : 1) Yes or 2) No (default 1):
What port is the Octopus Server comms port? (10943):
Enter the worker pools for this Tentacle (comma seperated):
Enter the worker pools for this Tentacle (comma seperated): Default Worker Pool
Should the Tentacle use a proxy to communicate with Octopus? (y/N): y
Enter the proxy Host (eg. http://proxyserver): http://proxy
Enter the proxy Port (eg. 8080): 3128
Enter the proxy Username (leave blank for none):
The following configuration commands will be run to configure Tentacle:
sudo /opt/octopus/tentacle/Tentacle create-instance --instance "Tentacle" --config "/etc/octopus/Tentacle/tentacle-Tentacle.config"
sudo /opt/octopus/tentacle/Tentacle new-certificate --instance "Tentacle" --if-blank
sudo /opt/octopus/tentacle/Tentacle configure --instance "Tentacle" --app "/home/Octopus/Applications" --noListen "True" --reset-trust
sudo /opt/octopus/tentacle/Tentacle polling-proxy --instance "Tentacle" --proxyEnable="true" --proxyHost="http://proxy" --proxyPort="3128"
sudo /opt/octopus/tentacle/Tentacle register-worker --instance "Tentacle" --server "http://host.docker.internal:8065" --name "48b361b2b614" --comms-style "TentacleActive" --server-comms-port "10943" --username "admin" --password "**********" --space "Default" --workerpool "Default Worker Pool"
sudo /opt/octopus/tentacle/Tentacle service --install --start --instance "Tentacle"
Press enter to continue...
Configuration file at /etc/octopus/Tentacle/tentacle-Tentacle.config already exists.
Saving instance: Tentacle
Setting home directory to: /etc/octopus/Tentacle
A certificate already exists, no changes will be applied.
Removing all trusted Octopus Servers...
Application directory set to: /home/Octopus/Applications
Tentacle will not listen on a port
These changes require a restart of the Tentacle.
Proxy port set to: 3128
Using custom proxy at: proxy
Checking connectivity on the server communications port 10943...
Connected successfully
Registering the tentacle with the server at http://host.docker.internal:8065/
Detected automation environment: NoneOrUnknown
Machine registered successfully
These changes require a restart of the Tentacle.
Service installed: Tentacle
```

<img width="1794" height="780" alt="image" src="https://github.com/user-attachments/assets/6e73a637-7492-4514-a069-1595a45fc97b" />

### Not specifying a proxy fails to register polling Tentacle with Octopus

```
root@fe0279ccd871:/# /opt/octopus/tentacle/configure-tentacle.sh
Name of Tentacle instance (default Tentacle):
Invalid characters will be ignored, the instance name will be: 'Tentacle'

What kind of Tentacle would you like to configure: 1) Listening or 2) Polling (default 1): 2
Where would you like Tentacle to store log files? (/etc/octopus):
Where would you like Tentacle to install applications to? (/home/Octopus/Applications):
Octopus Server URL (eg. https://octopus-server): http://host.docker.internal:8065
Select auth method: 1) API-Key or 2) Username and Password (default 1): 2
Username: admin
Password:
Select type of Tentacle do you want to setup: 1) Deployment Target or 2) Worker (default 1): 2
What Space would you like to register this Tentacle in? (Default):
What name would you like to register this Tentacle with? (fe0279ccd871):
/opt/octopus/tentacle/configure-tentacle.sh: line 196: =1: command not found
Is the comms port on the same domain as the Octopus Server : 1) Yes or 2) No (default 1):
What port is the Octopus Server comms port? (10943):
Enter the worker pools for this Tentacle (comma seperated): Default Worker Pool
Should the Tentacle use a proxy to communicate with Octopus? (y/N):
The following configuration commands will be run to configure Tentacle:
sudo /opt/octopus/tentacle/Tentacle create-instance --instance "Tentacle" --config "/etc/octopus/Tentacle/tentacle-Tentacle.config"
sudo /opt/octopus/tentacle/Tentacle new-certificate --instance "Tentacle" --if-blank
sudo /opt/octopus/tentacle/Tentacle configure --instance "Tentacle" --app "/home/Octopus/Applications" --noListen "True" --reset-trust
sudo /opt/octopus/tentacle/Tentacle register-worker --instance "Tentacle" --server "http://host.docker.internal:8065" --name "fe0279ccd871" --comms-style "TentacleActive" --server-comms-port "10943" --username "admin" --password "**********" --space "Default" --workerpool "Default Worker Pool"
sudo /opt/octopus/tentacle/Tentacle service --install --start --instance "Tentacle"
Press enter to continue...
Creating empty configuration file: /etc/octopus/Tentacle/tentacle-Tentacle.config
Saving instance: Tentacle
Setting home directory to: /etc/octopus/Tentacle
A new certificate has been generated and installed. Thumbprint:
5D799C905EC59793FD970CD4B684901C57BB5F19
These changes require a restart of the Tentacle.
Removing all trusted Octopus Servers...
Application directory set to: /home/Octopus/Applications
Tentacle will not listen on a port
These changes require a restart of the Tentacle.
Checking connectivity on the server communications port 10943...
Checking that server communications are open failed with message Resource temporarily unavailable (host.docker.internal:10943). Retrying (1/5) in 00:00:00.7500000.
```

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.