### PR TITLE
Upgraded Tentacle's "NuGet.Packaging" dependency to the latest re-fork

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -57,7 +57,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="4.6.2" />
-		<PackageReference Include="NuGet.Packaging" Version="3.6.0-octopus-58692" />
+		<PackageReference Include="NuGet.Packaging" Version="6.14.1-release.3901" />
 		<PackageReference Include="Octopus.Time" Version="1.1.339" />
 		<PackageReference Include="TaskScheduler" Version="2.7.2" />
 		<PackageReference Include="Nito.AsyncEx" Version="5.0.0" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -59,6 +59,7 @@
 		<PackageReference Include="Autofac" Version="4.6.2" />
 		<PackageReference Include="NuGet.Packaging" Version="6.14.1-release.3901" />
 		<PackageReference Include="Octopus.Time" Version="1.1.339" />
+		<PackageReference Include="Octopus.Versioning" Version="5.1.883" />
 		<PackageReference Include="TaskScheduler" Version="2.7.2" />
 		<PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
 		<PackageReference Include="NLog" Version="5.0.4" />

--- a/source/Octopus.Tentacle/Properties/OctopusTentacle.cs
+++ b/source/Octopus.Tentacle/Properties/OctopusTentacle.cs
@@ -1,8 +1,7 @@
 using System.Reflection;
-using Octopus.Client.Model;
 using Octopus.Tentacle.Util;
 using Octopus.Tentacle.Versioning;
-using AssemblyExtensions = Octopus.Tentacle.Versioning.AssemblyExtensions;
+using Octopus.Versioning.Semver;
 
 namespace Octopus.Tentacle.Properties
 {
@@ -10,8 +9,8 @@ namespace Octopus.Tentacle.Properties
     {
         public static readonly Assembly Assembly = typeof (OctopusTentacle).Assembly;
         public static readonly string InformationalVersion = Assembly.GetInformationalVersion() ?? "0.0.0";
-        public static readonly SemanticVersionInfo SemanticVersionInfo = new SemanticVersionInfo(Assembly);
-        public static readonly SemanticVersion Version = new SemanticVersion(SemanticVersionInfo.NuGetVersion);
+        public static readonly SemanticVersionInfo SemanticVersionInfo = new(Assembly);
+        public static readonly SemanticVersion Version = SemanticVersionInfo.SemanticVersion;
         public static readonly string[] EnvironmentInformation = EnvironmentHelper.SafelyGetEnvironmentInformation();
     }
 }

--- a/source/Octopus.Tentacle/Versioning/SemanticVersionInfo.cs
+++ b/source/Octopus.Tentacle/Versioning/SemanticVersionInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
-using NuGet.Versioning;
+using Octopus.Versioning;
+using Octopus.Versioning.Semver;
 
 namespace Octopus.Tentacle.Versioning
 {
@@ -11,7 +12,7 @@ namespace Octopus.Tentacle.Versioning
     {
         public SemanticVersionInfo(Assembly assembly)
         {
-            SemanticVersion = SemanticVersion.Parse(assembly.GetInformationalVersion() ?? "0.0.0");
+            SemanticVersion = SemVerFactory.Parse(assembly.GetInformationalVersion() ?? "0.0.0");
             MajorMinorPatch = SemanticVersion.ToString("V", new VersionFormatter());
             BranchName = assembly.GetCustomAttribute<AssemblyGitBranchAttribute>()!.BranchName;
             NuGetVersion = assembly.GetCustomAttribute<AssemblyNuGetVersionAttribute>()!.NuGetVersion;


### PR DESCRIPTION
# Background

With the release of the re-fork of the [Octopus Nuget.Clients](https://github.com/OctopusDeploy/NuGet.Client/tree/release/release-6.14.x)  we want to update all our usages to use the new and latest version. 

Tentacle depends on it in two places:

1. [Package Extraction](https://github.com/OctopusDeploy/OctopusTentacle/blob/168cc9756e6510169861e02f2332547d08682204/source/Octopus.Tentacle/Packages/NuGetPackageInstaller.cs#L32)
2.  [Versioning](https://github.com/OctopusDeploy/OctopusTentacle/blob/168cc9756e6510169861e02f2332547d08682204/source/Octopus.Tentacle/Versioning/SemanticVersionInfo.cs#L3)  (via transitive dependency)

We can remove the dependency on `Nuget.Versioning.SemanticVersion` by replacing it with the new `[Octopus.Versioning.SemanticVersion](https://github.com/OctopusDeploy/Versioning/blob/main/source/Octopus.Versioning/Semver/SemanticVersion.cs)` that was modeled off the original fork.

We can update the `PackageExtractor.ExtractPackage` to instead call the new 6.14.x async only `PackageExtractor.ExtractPackageAsync`

# Results

This PR has removed the transitive dependency on `NuGet.Versioning` and has updated the package extractor to use the new async variant.

There are further improvements to consider:

- Making package extractor async
- Removing all usages of the string version of the `NuGetVersion` in favor of `SemanticVersion`

There are still many places that use the string version of `NuGetVersion`

## Before

<!-- Consider adding a log excerpt or screen capture. -->

![Before](https://user-images.githubusercontent.com/5088479/120727281-72762180-c51d-11eb-9776-85363dc084e2.png)

## After

<!-- Consider adding a log excerpt or screen capture. -->

![After](https://user-images.githubusercontent.com/5088479/120727258-67bb8c80-c51d-11eb-8d2a-e047095b2d01.png)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.