### PR TITLE
Create Octopus.Tentacle.CrossPlatformBundle.Server nuget package

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,9 +4,22 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <packageSources>
+    <clear />
     <add key="NuGet.org v3" value="https://api.nuget.org/v3/index.json" />
-    <add key="NuGet.org" value="https://www.nuget.org/api/v2/" />
     <add key="feedz.io" value="https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json" />
-    <add key="nuget.packages.octopushq.com" value="https://nuget.packages.octopushq.com/" />
   </packageSources>
+  <packageSourceMapping>
+    <clear />
+    <packageSource key="feedz.io">
+      <package pattern="Octopus.Time" />
+      <package pattern="NuGet.Packaging*" />
+      <package pattern="NuGet.Common" />
+      <package pattern="NuGet.Frameworks" />
+      <package pattern="NuGet.Versioning" />
+    </packageSource>
+    <packageSource key="NuGet.org v3">
+      <package pattern="NuGet.Frameworks" />
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/build/NuGet.Config
+++ b/build/NuGet.Config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSourceMapping>
+    <clear />
+    <packageSource key="NuGet.org v3">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
# Background
<!-- Why does this PR exist? -->

This PR introduces a new slimmer, sleeker cross platform bundle called `Octopus.Tentacle.CrossPlatformBundle.Server`, which only contains the Tentacle build artifacts depended on directly by Octopus Server. 

## What is the Tentacle CrossPlatformBundle?

The `Octopus.Tentacle.CrossPlatformBundle` nuget package contains _all_ the installers, packages, and archives that are produced by the Tentacle build process. This currently includes:

- MSI installers for .NET 4.8 on Windows (x86 and x64)
- MSI installers for .NET 8.0 on Windows (x86 and x64), includes Tentacle Manager
- MSI installers for .NET 8.0 on Windows (x86 and x64), excludes Tentacle Manager
- Zip archives for all Windows builds listed above
- MSI installers for Octopus Tentacle Upgrader (.NET 4.8, .NET 8.0 x86, .NET 8.0 x64)
- DEB and RPM packages for Linux package managers
- Tar archives for Linux builds (x64, MUSL, ARM, ARM64) 
- Tar archives for MacOS builds (x64 and ARM64)

In total, there are **26** separate builds in this package, totalling a whopping **919MB**! 😵

## What is it used for?
The primary purpose of this bundle is to enable Octopus Server to remotely upgrade connected Tentacles, thereby saving users the need to upgrade each one manually.

There are multiple secondary usages, such as:
- Setup and configure Tentacles in Integration and E2E tests
- Setup and configure Tentacles in a local dev environment via the environment setup CLI

## What is the problem?
It's bloody massive, that's what the problem is.

Including such a huge dependency in Octopus Server significantly contributes to the size of the installer and Docker images, which can have many knock-on effects on the duration and reliability of downloading artifacts and upgrading Octopus Server.

##  Can we reduce the size of this behemoth?
Yes! Sort of!

It turns out that since 2022, [Octopus Server only sends the specific build required to the Tentacle being upgraded](https://github.com/OctopusDeploy/OctopusDeploy/pull/13090). This heavily reduced the amount of unnecessary data being transferred between Octopus Server and Tentacle, but also had the added benefit of _explicitly defining_ which particular Tentacle builds were required by Octopus Server as part of the 'Upgrade Tentacle' feature.

Octopus Server only explicitly depends on a handful of the available Tentacle builds, rather than the complete set of 26.

As mentioned above, there are other secondary usages of the cross platform bundle that do depend on the wider set of build artifacts, so removing artifacts not needed by Octopus Server from the existing cross platform bundle would require significant rework of these usages.

The chosen alternative solution is to create a new cross platform bundle, specifically created for use by Octopus Server, that only contains a minimal subset of artifacts and therefore reduces the overall size of Octopus Server installer and Docker images.

# Results
<!-- Describe the result of the change -->

`Octopus.Tentacle.CrossPlatformBundle.Server` is only **236MB** which is ~25% the size of the original! 🎉 

This PR adds a new NUKE build target called 'PackCrossPlatformBundleForServer', which is mostly the same as the original 'PackCrossPlatformBundle' target except it excludes the unnecessary artifacts from the nuget package.

It also does a little bit of formatting, commenting, and cleaning up, but those changes are negligible.

Once this PR is merged, we will be able to do the following:
- ~~Update the Tentacle TeamCity build chain to build the new package and push it to Artifactory~~ Done!
- ~~Update the Tentacle deployment process to push the new package to feedz.io~~ Done!

Then later on, as it is significantly more work, we will be able to:
- Update Octopus Server to depend on the new package
- Update the Octopus Server NUKE configuration and TeamCity build chain so that the integration and E2E still run using the full-size bundle, but Octopus Server only depends on the new slim bundle.

# How to review this PR
<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.