### PR TITLE
fix: Systemctl command fallback with sudo

### DIFF
--- a/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
+++ b/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
@@ -46,7 +46,7 @@ namespace Octopus.Tentacle.Util
             // If authentication issue detected, retry with sudo
             if (needsElevation)
             {
-                log.Verbose($"Retrying 'systemctl {command} {serviceName}' with sudo");
+                log.Info($"Permission denied. Retrying 'systemctl {command} {serviceName}' with sudo...");
                 var sudoInvocation = new CommandLineInvocation("/bin/bash", $"-c \"sudo systemctl {command} {serviceName}\"");
                 result = sudoInvocation.ExecuteCommand();
                 if (result.ExitCode == 0) return true;


### PR DESCRIPTION
# Background
 When running Tentacle services with rootless configurations on Linux, the service restart operations fail during upgrades because systemctl commands require elevated privileges. The upgrade script attempts to run systemctl restart without sudo, resulting in an "Interactive authentication required" error. This prevents automatic service restarts after Tentacle upgrades, requiring manual intervention to complete the upgrade process.

Reproduction Steps:
1. Configure a Linux Tentacle with a rootless configuration (Tentacle run with rootless user)
2. Upgrade the Tentacle via Octopus Server
3. Observe that the Tentacle version is not updated because the service did not restart

# Results
[sc-128961]
Fixes #https://github.com/OctopusDeploy/Issues/issues/9758

## Before
- systemctl commands were executed directly without checking for permission requirements
- Service operations (start/stop/restart/enable/disable) would fail for rootless Tentacle configurations
- Users had to manually restart the Tentacle service after upgrades
- Error: "The service could not be restarted" when attempting service operations
<img width="1818" height="260" alt="image" src="https://github.com/user-attachments/assets/5afd0120-5996-47a6-8f95-ba410a1c3ffa" />

## After
- Added an intelligent fallback mechanism in SystemCtlHelper.cs that first attempts systemctl commands without sudo to preserve existing behavior for privileged users, then detects permission-related failures by checking for specific error messages, and automatically retries with sudo prefix when needed while maintaining backward compatibility.Retry
- Service operations work seamlessly for both privileged and unprivileged **rootless and passwordless** configurations
<img width="1772" height="170" alt="image" src="https://github.com/user-attachments/assets/a9ba502a-a002-484b-86b0-d9248bef8429" />

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.