### PR TITLE
Upgrade WiX Toolset from 3.11.2 to 3.14.1

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageDownload Include="AzureSignTool" Version="[5.0.0]" />
     <PackageDownload Include="Chocolatey" Version="[0.10.14]" />
-    <PackageDownload Include="WiX" Version="[3.11.2]" />
+    <PackageDownload Include="WiX" Version="[3.14.1]" />
     <PackageDownload Include="Octopus.DotNet.Cli" Version="[9.1.7]" />
     <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[0.3.400]" />
   </ItemGroup>


### PR DESCRIPTION
## What

Upgrades WiX Toolset from version 3.11.2 to 3.14.1 to fix build failures in the PackWindowsInstallers target.

## Why

The build was failing with:
```
error MSB4062: The "ResolveWixReferences" task could not be loaded from the assembly wixtasks.dll. 
Could not load file or assembly 'Microsoft.Build.Utilities, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.
```

WiX 3.11.2 is incompatible with modern versions of MSBuild (16.11.6+). It tries to load an ancient version of Microsoft.Build.Utilities (v2.0.0.0) that doesn't exist in modern MSBuild installations.

WiX 3.14.1 includes proper support for MSBuild 15+ and correctly binds to newer versions of Microsoft.Build.Utilities.

## Changes

- Updated WiX package version from 3.11.2 to 3.14.1 in `build/_build.csproj`