### PR TITLE
Make running K8S Agent locally a little easier

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesConfig.cs
@@ -10,6 +10,8 @@ namespace Octopus.Tentacle.Kubernetes
         const string ServerCommsAddressVariableName = "ServerCommsAddress";
         const string EnvVarPrefix = "OCTOPUS__K8STENTACLE";
 
+        public static string KubeContextVariableName = $"{EnvVarPrefix}__KUBECONTEXT";
+        
         public static string NamespaceVariableName => $"{EnvVarPrefix}__NAMESPACE";
         public static string Namespace => GetRequiredEnvVar(NamespaceVariableName, "Unable to determine Kubernetes namespace.");
         public static string PodServiceAccountName => GetRequiredEnvVar($"{EnvVarPrefix}__PODSERVICEACCOUNTNAME", "Unable to determine Kubernetes Pod service account name.");


### PR DESCRIPTION
When running the agent locally, ill often have any number of different kubectl contexts and namespaces that I want the agent to connect with.

This PR adds a little more configuration support based on env variables