### PR TITLE
Ignore failures when rehashing certs

### DIFF
--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -11,7 +11,7 @@ fi
 # We specifically want to avoid exiting the script if this fails, as it is not critical to the operation of the tentacle
 set +e
 echo "Rehashing SSL/TLS certificates"
-openssl rehash /etc/ssl/certs
+openssl rehash /etc/ssl/certs || true
 set -e
 
 # Tentacle Docker images only support once instance per container. Running multiple instances can be achieved by running multiple containers.


### PR DESCRIPTION
# Background

If the Kubernetes Tentacle container is not running as root, the openssl rehash can fail and thus cause a crash backoff.

# Results

Adds `|| true` which ignores any failures when rehashing

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.