### PR TITLE
Use system-defined TLS versions by default

### DIFF
--- a/source/Octopus.Tentacle/EnvironmentOverrides.cs
+++ b/source/Octopus.Tentacle/EnvironmentOverrides.cs
@@ -5,16 +5,12 @@ namespace Octopus.Tentacle
     public static class EnvironmentOverrides
     {
         /// <summary>
-        /// By default, (i.e. with no environment variable set) we will use the legacy explicit SSL
-        /// configuration. For users that choose to opt-in to the new behavior early they can set
-        /// the OCTOPUS_TENTACLE_USE_LEGACY_TLS environment variable to "FALSE".
-        ///
-        /// In the future, the default will change to using the system default, and this flag will
-        /// exist to allow opting back into the legacy behavior by setting the
-        /// OCTOPUS_TENTACLE_USE_LEGACY_TLS environment variable to "TRUE".
+        /// By default, (i.e. with no environment variable set) we will use the system default SSL
+        /// configuration. For users that need to revert to the legacy explicit SSL configuration,
+        /// they can set the OCTOPUS_TENTACLE_USE_LEGACY_TLS environment variable to "TRUE".
         /// </summary>
         public static bool UseLegacyExplicitSslConfiguration =>
-            !bool.FalseString.Equals(
+            bool.TrueString.Equals(
                 Environment.GetEnvironmentVariable("OCTOPUS_TENTACLE_USE_LEGACY_TLS"),
                 StringComparison.OrdinalIgnoreCase
             );


### PR DESCRIPTION
# Background

Operating Systems can be configured to specify the default supported TLS protocol versions. Previously, Tentacle would override these default, enabling TLS 1.0, 1.1, 1.2 and 1.3 explicitly. This allowed systems to use newer TLS versions when they were available, but prevented users from disabling older protocols by removing them from the default set.

In #1170 we added an environment variable to allow users to opt-in to using system-defined TLS protocol versions. In this pull request, we are inverting this behaviour to use system-defined TLS protocol versions by default.

This still allows users to opt-out of system defaults (enabling TLS 1.0, 1.1, 1.2 and 1.3) by setting the `OCTOPUS_TENTACLE_USE_LEGACY_TLS` environment variable to `TRUE`.

Note: although this option attempts to enable TLS protocol versions 1.0, 1.1, 1.2 and 1.3, the actual protocol used may vary depending on the underlying Operating System's support of these protocol versions and the protocol versions available on Octopus Server (Octopus Cloud does not support TLS 1.0 or 1.1).

Example usage:

```bash
❯ : ./Tentacle

# With no environment variable set, will use system configured TLS protocol versions

❯ : OCTOPUS_TENTACLE_USE_LEGACY_TLS="TRUE" ./Tentacle

# Setting to TRUE (case insensitive) will use legacy SSL configuration (previous behavior)

❯ : OCTOPUS_TENTACLE_USE_LEGACY_TLS="FALSE" ./Tentacle

# Setting to FALSE (case insensitive) will use system configured TLS protocol versions (new default)
```

# Results

With the environment variable not set (or set to `FALSE`):

For modern systems, this will result in TLS 1.0 and 1.1 no longer being available. Similarly, TLS 1.3 may also become unavailable if it is not configured by default. Actual behaviour is dependent on the underlying Operating System configuration.

With the environment variable set to `TRUE`:

Previous behaviour will be used, permitting TLS protocol versions 1.0, 1.1, 1.2 and 1.3. Actual protocol version used will depend on underlying Operating System support and protocols supported by the Octopus Server the Tentacle is connecting with.

Resolves #1179

## Before

TLS protocol versions 1.0, 1.1, 1.2 and 1.3 are eligigble for use, depending on the underlying Operating System and Octopus Server the Tentacle is connecting with.

## After

For modern systems, this will result in TLS 1.0 and 1.1 no longer being available. Similarly, TLS 1.3 may also become unavailable if it is not configured by default. Actual behaviour is dependent on the underlying Operating System configuration.

# How to review this PR

Quality :heavy_check_mark:

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.