### PR TITLE
Update Halibut to 8.1.1860

### DIFF
--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="8.1.1707" />
+    <PackageReference Include="Halibut" Version="8.1.1860" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">


### PR DESCRIPTION
## Summary
- Updates Halibut package version from 8.1.1707 to 8.1.1860

No change to Tentacle, brings in the latest Halibut which has support for RPCs over the queue e.g. RPC over redis. 

## Test plan
- Run the tests, because we have confidence in the tests.