### PR TITLE
Create a single method that supplies the min set of env vars Tentacle passes to scripts, to simplify In Processes Tentacle And Tentacle Simulator.

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
@@ -30,8 +30,6 @@ namespace Octopus.Tentacle.Tests.Commands
         public string ApplicationDirectory { get; set; } = null!;
         public string PackagesDirectory { get; private set; } = null!;
         public string LogsDirectory { get; private set; } = null!;
-        public string JournalFilePath { get; private set; } = null!;
-        public string PackageRetentionJournalPath { get; private set; } = null!;
         public X509Certificate2 TentacleCertificate { get; set; } = null!;
         public string? ListenIpAddress { get; set; } = null!;
         public bool NoListen { get; set; }

--- a/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
@@ -43,16 +43,6 @@ namespace Octopus.Tentacle.Configuration
         string PackagesDirectory { get; }
 
         /// <summary>
-        /// Gets the file where deployment entries should be added.
-        /// </summary>
-        string JournalFilePath { get; }
-
-        /// <summary>
-        /// Gets the file where package usages should be stored.
-        /// </summary>
-        string PackageRetentionJournalPath { get; }
-
-        /// <summary>
         /// Gets or sets the X509 certificate used by the Tentacle.
         /// </summary>
         X509Certificate2? TentacleCertificate { get; }

--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -122,9 +122,6 @@ namespace Octopus.Tentacle.Configuration
             get { return Path.Combine(ApplicationDirectory, "Packages"); }
         }
 
-        public string JournalFilePath => Path.Combine(home.HomeDirectory ?? ".", "DeploymentJournal.xml");
-        public string PackageRetentionJournalPath => Path.Combine(home.HomeDirectory ?? ".", "PackageRetentionJournal.json");
-
         public X509Certificate2? TentacleCertificate
         {
             get


### PR DESCRIPTION
# Background

One of the pains in creating an in process tentacle is setting the environment variables that are passed to scripts.

With this change we now have a method to call which will set all of those environment variables for us. This method takes care of deriving variables which means we don't need to do that work in out tests or in tentacle simulator.

# How to review this PR

This PR should make no change to how Tentacle currently works.

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.