### PR TITLE
Fix: Tentacle wizard emits wrong flag for cloud polling over 443

### DIFF
--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
@@ -909,7 +909,13 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
 
                 if (CommunicationStyle == CommunicationStyle.TentacleActive)
                 {
-                    register = register.Argument("server-comms-port", serverCommsPort);
+                    // On Octopus Cloud (*.octopus.app), polling tentacles connecting over port 443 must use
+                    // the polling subdomain (polling.<instance>.octopus.app) rather than the main server hostname.
+                    // Using --server-comms-port "443" against the main hostname returns 404.
+                    if (serverCommsPort == "443" && Uri.TryCreate(OctopusServerUrl, UriKind.Absolute, out var serverUri) && serverUri.Host.EndsWith("octopus.app", StringComparison.OrdinalIgnoreCase))
+                        register = register.Argument("server-comms-address", $"https://polling.{serverUri.Host}");
+                    else
+                        register = register.Argument("server-comms-port", serverCommsPort);
                 }
 
                 if (!string.IsNullOrWhiteSpace(serverWebSocket))


### PR DESCRIPTION
# Background
When configuring a polling tentacle via the Windows Tentacle Manager wizard against an Octopus Cloud instance, the generated script always emits `--server-comms-port "443"`. This causes the connectivity check to hit `https://<instance>.octopus.app:443` which returns 404. The [documented setup](https://octopus.com/docs/infrastructure/deployment-targets/tentacle/polling-tentacles-over-port-443) requires `--server-comms-address "https://polling.<instance>.octopus.app"` instead.

# Results

The wizard now detects Octopus Cloud URLs (`*.octopus.app`) with port 443 and emits `--server-comms-address` with the polling subdomain instead of `--server-comms-port`.

Fixes [HPY-41](https://linear.app/octopus/issue/HPY-41)
Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/527
## Before
Wizard generates:
```
register-with --server "https://fbkmed.octopus.app" --server-comms-port "443"
```
Connectivity check fails with 404 against `https://fbkmed.octopus.app:443`.

## After
Wizard generates:
```
register-with --server "https://fbkmed.octopus.app" --server-comms-address "https://polling.fbkmed.octopus.app"
```
Connectivity check succeeds against the polling subdomain.

# How to review this PR

Single file change, minimal scope. The condition gates on both port 443 and `*.octopus.app` host suffix so self-hosted and non-443 scenarios are unaffected.

Files changed:
- `source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs` — Added cloud detection in `GenerateScript()` to emit `--server-comms-address` instead of `--server-comms-port` when port is 443 and the server URL matches `*.octopus.app`

# Reducing risk

## Automated Tests
- [x] Run full chain build (PRs targeting `main` `release/*` branches only)

Manual testing required: configure a polling tentacle against a cloud instance with port 443.

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered the [appropriate target version for this PR](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1145896982/Which+versions+should+I+patch#Process).
- [ ] I have considered appropriate testing for my change.
- [ ] I have considered manually testing my changes on a [branch instance](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1262256152/Use+a+Core+Feature+Branch+Instance) to check correctness, stability and performance on Octopus Cloud.
- [ ] I have considered safety nets to reduce any time-to-recovery for my change.