### PR TITLE
Improving logging around receiving data streams.

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -16,6 +16,7 @@
       <package pattern="NuGet.Common" />
       <package pattern="NuGet.Frameworks" />
       <package pattern="NuGet.Versioning" />
+      <package pattern="Halibut" />
     </packageSource>
     <packageSource key="NuGet.org v3">
       <package pattern="NuGet.Frameworks" />

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="8.1.1942" />
+    <PackageReference Include="Halibut" Version="8.1.1943" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="8.1.1860" />
+    <PackageReference Include="Halibut" Version="8.1.1921" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
+++ b/source/Octopus.Tentacle.Contracts/Octopus.Tentacle.Contracts.csproj
@@ -28,7 +28,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="Halibut" Version="8.1.1921" />
+    <PackageReference Include="Halibut" Version="8.1.1942" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Solution Items\SolutionInfo.cs">

--- a/source/Octopus.Tentacle.Core/Configuration/TentacleHalibutTimeoutAndLimitsFactory.cs
+++ b/source/Octopus.Tentacle.Core/Configuration/TentacleHalibutTimeoutAndLimitsFactory.cs
@@ -1,0 +1,44 @@
+using System;
+using Halibut.Diagnostics;
+using Octopus.Tentacle.Core.Util;
+
+namespace Octopus.Tentacle.Core.Configuration
+{
+    public static class TentacleHalibutTimeoutAndLimitsFactory
+    {
+        public static HalibutTimeoutsAndLimits CreateHalibutTimeoutsAndLimits()
+        {
+            if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled), out var tcpKeepAliveEnabled))
+            {
+                // Default to enabled if the environment variable is not provided
+                tcpKeepAliveEnabled = true;
+            }
+
+            if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleEnableDataStreamLengthChecks), out var enableDataStreamLengthChecks))
+            {
+                // Default to false, since we want to first use the feature in Octopus where it is easier to toggle.
+                enableDataStreamLengthChecks = false;
+            }
+                
+            if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseTcpNoDelay), out var useTcpNoDelay))
+            {
+                // Default to disabled
+                useTcpNoDelay = false;
+            }
+                
+            if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseAsyncListener), out var useAsyncListener))
+            {
+                // Default to disabled
+                useAsyncListener = false;
+            }
+
+            var halibutTimeoutsAndLimits = HalibutTimeoutsAndLimits.RecommendedValues();
+
+            halibutTimeoutsAndLimits.ThrowOnDataStreamSizeMismatch = enableDataStreamLengthChecks;
+            halibutTimeoutsAndLimits.TcpKeepAliveEnabled = tcpKeepAliveEnabled;
+            halibutTimeoutsAndLimits.TcpNoDelay = useTcpNoDelay;
+            halibutTimeoutsAndLimits.UseAsyncListener = useAsyncListener;
+            return halibutTimeoutsAndLimits;
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Core/Util/EnvironmentVariables.cs
+++ b/source/Octopus.Tentacle.Core/Util/EnvironmentVariables.cs
@@ -25,7 +25,7 @@ namespace Octopus.Tentacle.Core.Util
         public const string TentacleProgramDirectoryPath = "TentacleProgramDirectoryPath";
         public const string AgentProgramDirectoryPath = "AgentProgramDirectoryPath";
         public const string TentacleTcpKeepAliveEnabled = "TentacleTcpKeepAliveEnabled";
-        public const string TentacleUseRecommendedTimeoutsAndLimits = "TentacleUseRecommendedTimeoutsAndLimits";
+        public const string TentacleEnableDataStreamLengthChecks = "TentacleEnableDataStreamLengthChecks";
         public const string TentacleMachineConfigurationHomeDirectory = "TentacleMachineConfigurationHomeDirectory";
         public const string TentaclePollingConnectionCount = "TentaclePollingConnectionCount";
         public const string NfsWatchdogDirectory = "watchdog_directory";

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -9,6 +9,7 @@ using Halibut.Diagnostics;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
 using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Core.Configuration;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Core.Util;
 
@@ -102,7 +103,7 @@ namespace Octopus.Tentacle.Communications
                 log.Info($"Agent will poll Octopus Server at {pollingEndPoint.Address} for subscription {pollingEndPoint.SubscriptionId} expecting thumbprint {pollingEndPoint.Thumbprint}");
                 var halibutProxy = proxyConfigParser.ParseToHalibutProxy(configuration.PollingProxyConfiguration, pollingEndPoint.Address, log);
 
-                var halibutTimeoutsAndLimits = new HalibutTimeoutsAndLimits();
+                var halibutTimeoutsAndLimits = TentacleHalibutTimeoutAndLimitsFactory.CreateHalibutTimeoutsAndLimits();
                 var serviceEndPoint = new ServiceEndPoint(pollingEndPoint.Address, pollingEndPoint.Thumbprint, halibutProxy, halibutTimeoutsAndLimits);
 
                 var connectionCount = GetPollingConnectionCount();

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -7,6 +7,7 @@ using Halibut.ServiceModel;
 using Halibut.Transport;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Contracts.Legacy;
+using Octopus.Tentacle.Core.Configuration;
 using Octopus.Tentacle.Core.Util;
 
 namespace Octopus.Tentacle.Communications
@@ -26,38 +27,7 @@ namespace Octopus.Tentacle.Communications
                 var configuration = c.Resolve<ITentacleConfiguration>();
                 var services = c.Resolve<IServiceFactory>();
 
-                if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleTcpKeepAliveEnabled), out var tcpKeepAliveEnabled))
-                {
-                    // Default to enabled if the environment variable is not provided
-                    tcpKeepAliveEnabled = true;
-                }
-
-                if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseRecommendedTimeoutsAndLimits), out var useRecommendedTimeoutsAndLimits))
-                {
-                    useRecommendedTimeoutsAndLimits = true;
-                }
-                
-                if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseTcpNoDelay), out var useTcpNoDelay))
-                {
-                    // Default to disabled
-                    useTcpNoDelay = false;
-                }
-                
-                if (!bool.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleUseAsyncListener), out var useAsyncListener))
-                {
-                    // Default to disabled
-                    useAsyncListener = false;
-                }
-                
-                
-
-                var halibutTimeoutsAndLimits = useRecommendedTimeoutsAndLimits 
-                    ? HalibutTimeoutsAndLimits.RecommendedValues() 
-                    : new HalibutTimeoutsAndLimits();
-
-                halibutTimeoutsAndLimits.TcpKeepAliveEnabled = tcpKeepAliveEnabled;
-                halibutTimeoutsAndLimits.TcpNoDelay = useTcpNoDelay;
-                halibutTimeoutsAndLimits.UseAsyncListener = useAsyncListener;
+                var halibutTimeoutsAndLimits = TentacleHalibutTimeoutAndLimitsFactory.CreateHalibutTimeoutsAndLimits();
 
                 ISslConfigurationProvider sslConfigurationProvider = EnvironmentOverrides.UseLegacyExplicitSslConfiguration
                     ? new LegacySslConfigurationProvider()


### PR DESCRIPTION
# Background

Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/1203
ref CLOUDPT-11160
ref EFT-3141

Improves the logging around errors when receiving data streams. We will now get errors like:
```
https://localhost:10943/         30  Data stream reading failed, we read zero bytes from the stream which implies EOF.Message ID: IScriptServiceV2::StartScriptAsync[19] / 50341c7e-5c42-4d29-a2f3-4686c137931e, Stream ID: 157e3c22-2b26-4daf-ae9f-172003bbf6a1, Expected length: 3156, Actual bytes read: 5. Total length of all DataStreams to be sent is 3192.
```
When not enough data has been sent. The change is from Halibut, simply updating the version improves the logging.

Note that we do not throw on data stream length miss-match, since we want to try this out in Octopus before enabling on Tentacle. It is configurable by an environment variable.


This updates the version of Halibut to include:
 - https://github.com/OctopusDeploy/Halibut/pull/705
 - https://github.com/OctopusDeploy/Halibut/pull/708
 - https://github.com/OctopusDeploy/Halibut/pull/707
 - https://github.com/OctopusDeploy/Halibut/pull/704
 


Additionally this PR updates the nuget config to allow fetching Halibut from feedz, which is where the pre-release versions are stored.

We also removed the ability to disable recommended TCP settings, since that has been enabled for sometime now.

# Results

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.