### PR TITLE
Fix CVE vulnerabilities in transitive NuGet dependencies (#1204)

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -105,6 +105,18 @@
 		<PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
 		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
 	</ItemGroup>
+	<!-- Pin transitive dependencies to fix known CVEs (net6.0+ only, these packages don't support net48) -->
+	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
+		<PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" />
+	</ItemGroup>
+	<!-- Pin transitive dependencies to fix known CVEs (all frameworks) -->
+	<ItemGroup>
+		<PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Private.Uri" Version="4.3.2" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
 		<PackageReference Include="System.Runtime" Version="4.3.0" />
 		<Reference Include="System.Security" />


### PR DESCRIPTION
**_Are you a customer of Octopus Deploy? Please contact [our support team](https://octopus.com/support) so we can triage your PR, so that we can make sure it's handled appropriately._**

# Background

#1204

The `octopusdeploy/tentacle` container image bundles transitive NuGet dependencies with known CVEs in `/opt/octopus/tentacle/Tentacle.deps.json`. These are flagged by container vulnerability scanners (Azure Defender for Cloud, Trivy, Snyk, etc.) and cannot be remediated by image consumers.

This PR pins 6 vulnerable transitive dependencies to their fixed versions by adding explicit `PackageReference` entries to `Octopus.Tentacle.csproj`.

# Results

| CVE | Severity | Package | Before | After |
|-----|----------|---------|--------|-------|
| CVE-2024-38095 | High | System.Formats.Asn1 | 6.0.0 | 6.0.1 |
| CVE-2023-29331 | High | System.Security.Cryptography.Pkcs | 6.0.1 | 6.0.3 |
| CVE-2017-11770 | High | System.Security.Cryptography.X509Certificates | 4.1.0 | 4.3.2 |
| CVE-2018-8292 | Medium | System.Net.Http | 4.1.0 | 4.3.4 |
| CVE-2019-0657, CVE-2019-0980, CVE-2019-0981 | Medium | System.Private.Uri | 4.3.0 | 4.3.2 |
| CVE-2019-0820 | Medium | System.Text.RegularExpressions | 4.3.0 | 4.3.1 |

## Before

Container vulnerability scanners flag 8 CVEs (3 High, 5 Medium) from `/opt/octopus/tentacle/Tentacle.deps.json`.

## After

All 8 CVEs resolved. No functional changes — only transitive dependency version pins.

# How to review this PR

This is a low-risk dependency pin change. The packages are already present as transitive dependencies; we are only overriding their versions to pick up security fixes.

Key points to verify:
- `System.Formats.Asn1` and `System.Security.Cryptography.Pkcs` are conditioned on `'$(TargetFrameworkIdentifier)' != '.NETFramework'` because they only target netstandard2.1/net6.0+ and would break the net48 build
- The remaining 4 packages support all target frameworks and are unconditional
- `System.Security.Cryptography.X509Certificates` is pinned to 4.3.2 (not the NVD-listed 4.1.2) because `System.Net.Http 4.3.4` depends on `>= 4.3.0`

Quality :heavy_check_mark:
Build all target frameworks (net48, net8.0, net8.0-windows) and run the existing test suite.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG)
