### PR TITLE
Replace IE fallback with explorer.exe and enable shell execute for browser opening

### DIFF
--- a/source/Octopus.Manager.Tentacle/Util/BrowserHelper.cs
+++ b/source/Octopus.Manager.Tentacle/Util/BrowserHelper.cs
@@ -10,11 +10,11 @@ namespace Octopus.Manager.Tentacle.Util
         {
             try
             {
-                Process.Start(new ProcessStartInfo(uri.AbsoluteUri));
+                Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
             }
             catch (Win32Exception)
             {
-                Process.Start(new ProcessStartInfo("IExplore.exe", uri.AbsoluteUri));
+                Process.Start(new ProcessStartInfo("explorer.exe", uri.AbsoluteUri));
             }
         }
     }


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->
The `BrowserHelper` was falling back to `IExplore.exe` (Internet Explorer) when the default browser failed to open, and was launching URIs without `UseShellExecute=true`.

Fixes FD-186

# Results

<!-- Describe the result of the change -->

IE has been retired and removed from Windows since 2022, so the fallback now uses `explorer.exe` instead. Adding  `UseShellExecute=true` is also required on .NET Core+ for launching URLs via `ProcessStartInfo`, as the default changed from .NET Framework behaviour.

Fixes https://github.com/OctopusDeploy/Issues/issues/9953

## Before

<!-- Consider adding a log excerpt or screen capture. -->
Exception thrown when clicking the link to learn more about choosing a communication style.

https://github.com/user-attachments/assets/58a3e869-9884-4561-a802-1519fa7bfc43

## After

<!-- Consider adding a log excerpt or screen capture. -->
No exception thrown when clicking the link to learn more about choosing a communication style and the link is opened in the users browser.

https://github.com/user-attachments/assets/1177c2eb-8af9-4527-9cc5-22470c3bfa8d

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.