### PR TITLE
Fix tentacle hostname resolution on non-domain-joined machines

### DIFF
--- a/docker/windows/Scripts/configure-tentacle.ps1
+++ b/docker/windows/Scripts/configure-tentacle.ps1
@@ -60,7 +60,14 @@ function Get-PublicHostName
   elseif ($publicHostNameConfiguration -eq "FQDN")
   {
     $computer = Get-CimInstance win32_computersystem
-    $publicHostName = "$($computer.DNSHostName).$($computer.Domain)"
+    # On domain-joined machines, DNSHostName is the short name and Domain is the DNS suffix.
+    # On non-domain-joined machines (e.g. EC2), DNSHostName is already fully qualified and
+    # Domain is empty or a non-DNS workgroup name, so use DNSHostName as-is.
+    if ($computer.DNSHostName.Contains('.') -or [string]::IsNullOrEmpty($computer.Domain)) {
+      $publicHostName = $computer.DNSHostName
+    } else {
+      $publicHostName = "$($computer.DNSHostName).$($computer.Domain)"
+    }
   }
   elseif ($publicHostNameConfiguration -eq "ComputerName")
   {


### PR DESCRIPTION
# Background

A customer running the Windows Tentacle container in ECS on EC2 reported that their Tentacle was being registered in
Octopus with an invalid URL. They had configured `PublicHostNameConfiguration=FQDN` so the container would register
using its internal EC2 DNS hostname (e.g. `ip-xxx-xx-x-x.ec2.internal`). This seems to be the right configuration when the Octopus server and the ECS task are in the same VPC, so should be supported.

Fixes HPY-1292

# Results

The `configure-tentacle.ps1` script constructs the FQDN by concatenating `DNSHostName` and `Domain`. On a domain-joined machine this is correct (`DNSHostName` is the short name and `Domain `is the DNS suffix). However, on a non-domain-joined machine like an EC2 instance, `DNSHostName` is already fully qualified and `Domain` is empty.

This PR adds a conditional to check if `DNSHostName `already contains a dot or `Domain` is empty before attempting to join them.

# How to review this PR

- Main risk here is regressions. The conditional is intentionally restrictive to reduce the risk of changing desired existing behaviour, but the risk is still there.

Quality :heavy_check_mark:

- Unit testing this area is difficult, and adding an integration test for this use-case feels a bit disproportionate.
- If there are concerns, I can do some manual testing against a real EC2 instance (but again, time cost is high vs. the value of this change).

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.