### PR TITLE
Add k8s 1.36 container support and remove 1.32 testing

### DIFF
--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesClientCompatibilityTests.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesClientCompatibilityTests.cs
@@ -23,8 +23,7 @@ public class KubernetesClientCompatibilityTests
     [
         new object[] {new ClusterVersion(1, 35)},
         new object[] {new ClusterVersion(1, 34)},
-        new object[] {new ClusterVersion(1, 33)},
-        new object[] {new ClusterVersion(1, 32)},
+        new object[] {new ClusterVersion(1, 33)}
     ];
 
     KubernetesTestsGlobalContext? testContext;

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Octopus.Tentacle.Kubernetes.Tests.Integration.csproj
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Octopus.Tentacle.Kubernetes.Tests.Integration.csproj
@@ -57,9 +57,6 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>
       <None Remove="Setup\teamcity-network-routing.yaml" />
-      <EmbeddedResource Include="Setup\KindConfiguration\kind-config-v1-32.yaml">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </EmbeddedResource>
       <EmbeddedResource Include="Setup\KindConfiguration\kind-config-v1-33.yaml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KindConfiguration/kind-config-v1-32.yaml
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KindConfiguration/kind-config-v1-32.yaml
@@ -1,8 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-
-nodes:
-  - role: control-plane
-    image: kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8
-  - role: worker
-    image: kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodContainerResolverTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodContainerResolverTests.cs
@@ -100,7 +100,8 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             result.Should().Be("octopusdeploy/kubernetes-agent-tools-base:latest");
         }
 
-        [TestCase(36, "latest")]
+        [TestCase(37, "latest")]
+        [TestCase(36, "1.36")]
         [TestCase(35, "1.35")]
         [TestCase(34, "1.34")]
         [TestCase(33, "1.33")]

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
@@ -37,6 +37,7 @@ namespace Octopus.Tentacle.Kubernetes
             new(1, 33),
             new(1, 34),
             new(1, 35),
+            new(1, 36),
         };
 
         public async Task<string> GetContainerImageForCluster()


### PR DESCRIPTION
# Background

Kubernetes 1.36 has been released and 1.32 is now deprecated

# Results

Add worker tools 1.36 version supports and remove 1.32 as a tested cluster.

There is no `kind` version that currently supports 1.36, so we can't test against cluster 1.36 yet.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.