### PR TITLE
Coerce x64 arch to amd64

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -469,7 +469,7 @@ namespace Octopus.Tentacle.Kubernetes
             var arch = parts[1];
 
             // Server can sometimes erroneously send an architecture of x64.
-            // This is not a supported archin kubernetes, it should be amd64
+            // This is not a supported arch in kubernetes, it should be amd64
             if (arch.Equals("x64", StringComparison.OrdinalIgnoreCase))
             {
                 arch = "amd64";

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -468,6 +468,14 @@ namespace Octopus.Tentacle.Kubernetes
             var os = parts[0];
             var arch = parts[1];
 
+            // Server can sometimes erroneously send an architecture of x64.
+            // This is not a supported archin kubernetes, it should be amd64
+            if (arch.Equals("x64", StringComparison.OrdinalIgnoreCase))
+            {
+                arch = "amd64";
+                platformAffinity = $"{os}-{arch}";
+            }
+
             tentacleScriptLog.Verbose($"Adding node affinity for platform '{platformAffinity}'.");
 
             var affinity = podSpec.Affinity ??= new V1Affinity();


### PR DESCRIPTION
# Background

An issue in Kubernetes agent `2.38.0` meant that pods would have their node affinitiy for arch erroneously set to `x641 by Octopus Server

# Results

This value should be `amd64`, so put in some extra code to coerce this just in case.

Related to MD-1809

## Before

<img width="2065" height="104" alt="image" src="https://github.com/user-attachments/assets/7d9745a0-25f8-410a-a4d8-dea9d02695d0" />

## After

<img width="1738" height="103" alt="image" src="https://github.com/user-attachments/assets/c6ae8372-9b3c-40e2-80c4-6e994880f6d5" />

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.