### PR TITLE
fix: bootstrapRunner CVE

### DIFF
--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -1,7 +1,7 @@
 ARG RuntimeDepsTag
 
 
-FROM golang:1.22 as bootstrapRunnerBuilder
+FROM golang:1.26 as bootstrapRunnerBuilder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -1,7 +1,7 @@
 ARG RuntimeDepsTag
 
 
-FROM golang:1.26 as bootstrapRunnerBuilder
+FROM golang:1.25 as bootstrapRunnerBuilder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docker/kubernetes-agent-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/dev/Dockerfile
@@ -1,7 +1,7 @@
 ARG RuntimeDepsTag
 
 
-FROM golang:1.22 as bootstrapRunnerBuilder
+FROM golang:1.26 as bootstrapRunnerBuilder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docker/kubernetes-agent-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/dev/Dockerfile
@@ -1,7 +1,7 @@
 ARG RuntimeDepsTag
 
 
-FROM golang:1.26 as bootstrapRunnerBuilder
+FROM golang:1.25 as bootstrapRunnerBuilder
 
 ARG TARGETARCH
 ARG TARGETOS


### PR DESCRIPTION
# Background

Customer's security scanner hits on https://nvd.nist.gov/vuln/detail/cve-2025-68121. It doesn't look like we are vulnerable but it creates unwanted noise, plus there might be other customer who can't use the image because of the internal policies.

```
CVEs:

pkg:golang/stdlib@1.22.12

    ✗ CRITICAL CVE-2025-68121
      https://scout.docker.com/v/CVE-2025-68121
      Affected range : <1.24.13
      Fixed version  : 1.24.13

    ✗ CRITICAL CVE-2025-22871
      https://scout.docker.com/v/CVE-2025-22871
      Affected range : <1.23.8
      Fixed version  : 1.23.8
```

# Results

<!-- Describe the result of the change -->

Fixes critical CVE-2025-68121 and CVE-2025-22871 that can be found by scanning `octopusdeploy/kubernetes-agent-tentacle` with tools like `docker scout`.

`bootstrapRunner.go` doesn't have any dependencies and using only standard library packages. Minor `go` versions do not include breaking changes so it's safe.
I have ran agent locally with freshly built bootstrapRunner just in case and all looks good.

## Before

```
┌──────────┬───────┐
│ Severity │ Count │
├──────────┼───────┤
│ Critical │ 2     │
├──────────┼───────┤
│ High     │ 12    │
├──────────┼───────┤
│ Medium   │ 19    │
├──────────┼───────┤
│ Low      │ 43    │
└──────────┴───────┘
```

## After

```
┌──────────┬───────┐
│ Severity │ Count │
├──────────┼───────┤
│ Critical │ 0     │
├──────────┼───────┤
│ High     │ 2     │
├──────────┼───────┤
│ Medium   │ 2     │
├──────────┼───────┤
│ Low      │ 41    │
└──────────┴───────┘
```

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.