### PR TITLE
fix: update outdated dev scripts

### DIFF
--- a/k8s-agent-debug-cluster-config/launchSettings.template.json
+++ b/k8s-agent-debug-cluster-config/launchSettings.template.json
@@ -20,7 +20,7 @@
         "OCTOPUS__K8STENTACLE__PERSISTENTVOLUMESIZE": "10Gi",
         "KUBECONFIG": "<kube-config>",
         "DefaultLogDirectory": "/tmp/k8s-agent-debug-vol/logs",
-        "BOOTSTRAPRUNNEREXECUTABLEPATH": "/tmp/k8s-agent-debug-vol/bootstrapRunner",
+        "BOOTSTRAPRUNNEREXECUTABLEDIRECTORY": "/tmp/k8s-agent-debug-vol",
         "OCTOPUS__K8STENTACLE__PODRESOURCEJSON": "{\"requests\":{\"cpu\":\"25m\",\"memory\":\"100Mi\"}}"
       }
     }

--- a/setup-k8s-agent-for-local-debug.sh
+++ b/setup-k8s-agent-for-local-debug.sh
@@ -43,7 +43,17 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "🏗️  - Building bootstrap runner"
-env GOOS=linux go build -C docker/kubernetes-agent-tentacle/bootstrapRunner -ldflags "-s -w" -o "/tmp/k8s-agent-debug-vol/bootstrapRunner"
+case "$(uname -m)" in
+    x86_64)             GOARCH="amd64" ;;
+    aarch64|arm64)      GOARCH="arm64" ;;
+    i386|i686)          GOARCH="386" ;;
+    armv7l|armv6l)      GOARCH="arm" ;;
+    *)
+        echo "❗  - Unsupported architecture: $(uname -m). Aborting."
+        exit 1
+        ;;
+esac
+env GOOS=linux go build -C docker/kubernetes-agent-tentacle/bootstrapRunner -ldflags "-s -w" -o "/tmp/k8s-agent-debug-vol/bootstrapRunner-linux-${GOARCH}"
 
 if [ $? -ne 0 ]; then
   echo ""
@@ -51,6 +61,9 @@ if [ $? -ne 0 ]; then
   echo "❗  - Failed to build bootstrap runner. Aborting."
   exit -1
 fi
+
+echo "🏗️  - Coping bootstrap runner executor"
+cp docker/kubernetes-agent-tentacle/bootstrapRunner/execute-bootstrapRunner.sh /tmp/k8s-agent-debug-vol
 
 echo ""
 echo ""

--- a/setup-k8s-agent-for-local-debug.sh
+++ b/setup-k8s-agent-for-local-debug.sh
@@ -46,8 +46,6 @@ echo "🏗️  - Building bootstrap runner"
 case "$(uname -m)" in
     x86_64)             GOARCH="amd64" ;;
     aarch64|arm64)      GOARCH="arm64" ;;
-    i386|i686)          GOARCH="386" ;;
-    armv7l|armv6l)      GOARCH="arm" ;;
     *)
         echo "❗  - Unsupported architecture: $(uname -m). Aborting."
         exit 1


### PR DESCRIPTION
Fixes outdate dev scripts and configurations after: 
* `BOOTSTRAPRUNNEREXECUTABLEPATH` renamed to `BOOTSTRAPRUNNEREXECUTABLEDIRECTORY`
* `bootstrapRunner/execute-bootstrapRunner.sh` was added