### PR TITLE
If the test process wont die, don't fail the build just ignore it and proceed

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -19,6 +19,10 @@ using Nuke.Common.Utilities.Collections;
 using Serilog;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
+// macOS build agents are persistent (non-ephemeral), so compiler server processes must be cleaned up between builds.
+#if MACOS
+[ShutdownDotNetAfterServerBuild]
+#endif
 partial class Build : NukeBuild
 {
     /// Support plugins are available for:
@@ -322,11 +326,4 @@ partial class Build : NukeBuild
     }
 
     public static int Main() => Execute<Build>(x => x.Default);
-
-    protected override void OnBuildFinished()
-    {
-        base.OnBuildFinished();
-        if (OperatingSystem.IsMacOS())
-            DotNetBuildServerShutdown();
-    }
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Xml;
 using JetBrains.Annotations;
@@ -323,18 +322,4 @@ partial class Build : NukeBuild
     }
 
     public static int Main() => Execute<Build>(x => x.Default);
-
-    protected override void OnBuildFinished()
-    {
-        base.OnBuildFinished();
-        try
-        {
-            var process = Process.Start("dotnet", "build-server shutdown");
-            process?.WaitForExit(10_000);
-        }
-        catch (Exception e)
-        {
-            Log.Warning(e, "Failed to shut down dotnet build server — ignoring");
-        }
-    }
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Xml;
 using JetBrains.Annotations;
@@ -19,7 +20,6 @@ using Nuke.Common.Utilities.Collections;
 using Serilog;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
-[ShutdownDotNetAfterServerBuild]
 partial class Build : NukeBuild
 {
     /// Support plugins are available for:
@@ -323,4 +323,18 @@ partial class Build : NukeBuild
     }
 
     public static int Main() => Execute<Build>(x => x.Default);
+
+    protected override void OnBuildFinished()
+    {
+        base.OnBuildFinished();
+        try
+        {
+            var process = Process.Start("dotnet", "build-server shutdown");
+            process?.WaitForExit(10_000);
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Failed to shut down dotnet build server — ignoring");
+        }
+    }
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -19,7 +19,7 @@ using Nuke.Common.Utilities.Collections;
 using Serilog;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
-// macOS build agents are persistent (non-ephemeral), so compiler server processes must be cleaned up between builds.
+// macOS build agents are persistent (non-ephemeral), so compiler server processes may need to be cleaned up between builds.
 #if MACOS
 [ShutdownDotNetAfterServerBuild]
 #endif

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -322,4 +322,11 @@ partial class Build : NukeBuild
     }
 
     public static int Main() => Execute<Build>(x => x.Default);
+
+    protected override void OnBuildFinished()
+    {
+        base.OnBuildFinished();
+        if (OperatingSystem.IsMacOS())
+            DotNetBuildServerShutdown();
+    }
 }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -8,6 +8,7 @@
     <NukeScriptDirectory>..</NukeScriptDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
     <Nullable>enable</Nullable>
+    <DefineConstants Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(DefineConstants);MACOS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Background

Fixes: EFT-3259
**AI summary:**
  The [ShutdownDotNetAfterServerBuildAttribute] runs dotnet build-server shutdown after every build. On the Windows 2012 build agent this process hangs, causing Nuke to throw an unhandled
  exception and exit with code 255 — even when all tests pass.

  macOS build agents are persistent (non-ephemeral) so the shutdown is still needed there to prevent compiler server processes accumulating between builds. Windows and Linux agents are
  ephemeral so processes are cleaned up when the agent tears down.

  Replaces the attribute with an OnBuildFinished override that calls DotNetBuildServerShutdown() on macOS only.

This should fix the issue seen at:

https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacle_TentacleVLatest_net80_IntegrationTestNet80onWindows2012net48service/22113648?buildTab=tests

where all the tests pass but we could not shutdown correctly.

# Results

<!-- Describe the result of the change -->

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/... _(optional public issue)_

See [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) (including [this flowchart](https://whimsical.com/r-d-incoming-work-workflow-aug-21-NsDnGQXcwBLwU66a88Zhue) 

## Before

<!-- Consider adding a log excerpt or screen capture. -->

## After

<!-- Consider adding a log excerpt or screen capture. -->

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.