### PR TITLE
Tone down the logging when failing to retrieve scriptpodtemplates

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodTemplateService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodTemplateService.cs
@@ -82,15 +82,16 @@ namespace Octopus.Tentacle.Kubernetes
                 catch (Exception ex)
                 {
                     // we are happy to handle all exceptions here and just fallback
-                    Log.WarnFormat(ex, "Failed to retrieve 'scriptpodtemplates' custom resource");
+                    Log.Warn("Could not retrieve 'scriptpodtemplates' custom resource. Continuing without customisation...");
+                    Log.Verbose(ex);
                     return null;
                 }
 
                 return resourceList.Items.OrderBy(r => r.Metadata.CreationTimestamp).FirstOrDefault();
             });
         }
-        
-        public async Task<V1Deployment?> GetOldestScriptPodTemplateDeployment(CancellationToken cancellationToken)
+
+        async Task<V1Deployment?> GetOldestScriptPodTemplateDeployment(CancellationToken cancellationToken)
         {
             return await RetryPolicy.ExecuteAsync(async () =>
             {
@@ -105,7 +106,8 @@ namespace Octopus.Tentacle.Kubernetes
                 catch (Exception ex)
                 {
                     // we are happy to handle all exceptions here and just fallback
-                    Log.WarnFormat(ex, "Failed to retrieve 'scriptpodtemplates' custom resource");
+                    Log.Warn("Could not retrieve 'scriptpodtemplates' custom resource. Continuing without customisation...");
+                    Log.Verbose(ex);
                     return null;
                 }
 


### PR DESCRIPTION
# Background

Customer feedback has indicated they think this is an error state, not just a warning.

# Results

Make the warning message less scary and put the exception as verbose logging (which is off by default)

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.