### PR TITLE
Merge script pod template ImagePullSecrets

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodTemplateService.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodTemplateService.cs
@@ -65,7 +65,7 @@ namespace Octopus.Tentacle.Kubernetes
             return scriptPodTemplate;
         }
 
-        public async Task<ScriptPodTemplateCustomResource?> GetOldestScriptPodTemplateCustomResource(CancellationToken cancellationToken)
+        async Task<ScriptPodTemplateCustomResource?> GetOldestScriptPodTemplateCustomResource(CancellationToken cancellationToken)
         {
             return await RetryPolicy.ExecuteAsync(async () =>
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -230,7 +230,7 @@ namespace Octopus.Tentacle.Kubernetes
 
             pod.Spec.InitContainers = await CreateInitContainers(command, podName, homeDir, workspacePath, tentacleScriptLog, scriptPodTemplate?.ScriptInitContainerSpec);
             pod.Spec.Containers = await CreateScriptContainers(command, podName, scriptName, homeDir, workspacePath, workspace.ScriptArguments, tentacleScriptLog, scriptPodTemplate);
-            pod.Spec.ImagePullSecrets = imagePullSecretNames;
+            pod.Spec.ImagePullSecrets = Merge(imagePullSecretNames, scriptPodTemplate?.PodSpec?.ImagePullSecrets);
             pod.Spec.ServiceAccountName = serviceAccountName;
             pod.Spec.Volumes = Merge(pod.Spec.Volumes, CreateVolumes(command));
 

--- a/source/Octopus.Tentacle/Kubernetes/ScriptPodTemplate.cs
+++ b/source/Octopus.Tentacle/Kubernetes/ScriptPodTemplate.cs
@@ -21,19 +21,19 @@ namespace Octopus.Tentacle.Kubernetes
         [JsonPropertyName("watchdogContainerSpec")]
         public V1Container? WatchdogContainerSpec { get; set; }
 
-        public static ScriptPodTemplate? GetScriptPodTemplateFromDeployment(V1Deployment deployment)
+        public static ScriptPodTemplate GetScriptPodTemplateFromDeployment(V1Deployment deployment)
         {
             var template = new ScriptPodTemplate
             {
                 PodMetadata = new PodMetadata
                 {
-                    Labels = deployment.Spec.Template.Metadata.Labels.Clone(),
-                    Annotations = deployment.Spec.Template.Metadata.Annotations.Clone(),
+                    Labels = deployment.Spec.Template.Metadata.Labels?.Clone(),
+                    Annotations = deployment.Spec.Template.Metadata.Annotations?.Clone(),
                 },
                 PodSpec = deployment.Spec.Template.Spec.Clone(),
-                ScriptContainerSpec = deployment.Spec.Template.Spec.Containers.First(c => c.Name == ContainerNames.PodTemplateScriptContainerName).Clone(),
-                ScriptInitContainerSpec = deployment.Spec.Template.Spec.Containers.First(c => c.Name == ContainerNames.PodTemplateScriptContainerName).Clone(),
-                WatchdogContainerSpec = deployment.Spec.Template.Spec.Containers.First(c => c.Name == ContainerNames.PodTemplateWatchdogContainerName).Clone()
+                ScriptContainerSpec = deployment.Spec.Template.Spec.Containers.FirstOrDefault(c => c.Name == ContainerNames.PodTemplateScriptContainerName)?.Clone(),
+                ScriptInitContainerSpec = deployment.Spec.Template.Spec.Containers.FirstOrDefault(c => c.Name == ContainerNames.PodTemplateScriptContainerName)?.Clone(),
+                WatchdogContainerSpec = deployment.Spec.Template.Spec.Containers.FirstOrDefault(c => c.Name == ContainerNames.PodTemplateWatchdogContainerName)?.Clone()
             };
             
             // The deployment will have the containers, we should not pull them in here though - we overwrite them and programatically create them later
@@ -43,15 +43,15 @@ namespace Octopus.Tentacle.Kubernetes
             return template;
         }
 
-        public static ScriptPodTemplate? GetScriptPodTemplateFromCustomResource(ScriptPodTemplateCustomResource scriptPodTemplateCustomResource)
+        public static ScriptPodTemplate GetScriptPodTemplateFromCustomResource(ScriptPodTemplateCustomResource scriptPodTemplateCustomResource)
         {
             var template = new ScriptPodTemplate
             {
-                PodMetadata = scriptPodTemplateCustomResource.Spec.PodMetadata.Clone(),
-                PodSpec = scriptPodTemplateCustomResource.Spec.PodSpec.Clone(),
-                ScriptContainerSpec = scriptPodTemplateCustomResource.Spec.ScriptContainerSpec.Clone(),
-                ScriptInitContainerSpec = scriptPodTemplateCustomResource.Spec.ScriptContainerSpec.Clone(),
-                WatchdogContainerSpec = scriptPodTemplateCustomResource.Spec.WatchdogContainerSpec.Clone()
+                PodMetadata = scriptPodTemplateCustomResource.Spec.PodMetadata?.Clone(),
+                PodSpec = scriptPodTemplateCustomResource.Spec.PodSpec?.Clone(),
+                ScriptContainerSpec = scriptPodTemplateCustomResource.Spec.ScriptContainerSpec?.Clone(),
+                ScriptInitContainerSpec = scriptPodTemplateCustomResource.Spec.ScriptContainerSpec?.Clone(),
+                WatchdogContainerSpec = scriptPodTemplateCustomResource.Spec.WatchdogContainerSpec?.Clone()
             };
             return template;
         }


### PR DESCRIPTION
# Background

A customer has reached out that they would like to set the `imagePullSecrets` in the `scriptPodTemplate` resource. Currently, this is overwritten by the values the tentacle logic wants to set.

# Results

We now merge the pod template imagepullsecrets & the tentacle defined ones.

I also fixed some null ref issues when converting the pod template custom resource into our internal object.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.