### PR TITLE
Fix an issue where cancelled scripts would wait for the STDOUT/STDERR pipes to be closed.

### DIFF
--- a/source/Octopus.Tentacle.Core/Util/CommandLine/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle.Core/Util/CommandLine/SilentProcessRunner.cs
@@ -221,6 +221,21 @@ namespace Octopus.Tentacle.Util
                     error($"Failed to kill the launched process: {killProcessException}");
                 }
             }
+            finally
+            {
+                try
+                {
+                    // When cancelling, close the file handles.
+                    // If the child finishes, but the grandchild holds stdout/stderr and never completes,
+                    // THEN we won't issue a kill to the grandchild but will wait for the grandchild to
+                    // close the handles.
+                    process.Close();
+                }
+                catch (Exception ex)
+                {
+                    error($"Failed to close process resources: {ex.Message}");
+                }
+            }
         }
 
         [DllImport("kernel32.dll", SetLastError = true)]

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
@@ -1,11 +1,16 @@
 ﻿using System;
+using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
+using Octopus.Tentacle.CommonTestUtils;
 using Octopus.Tentacle.Tests.Integration.Support;
 using Octopus.Tentacle.Tests.Integration.Support.TestAttributes;
 using Octopus.Tentacle.Util;
+using PlatformDetection = Octopus.Tentacle.Util.PlatformDetection;
 
 namespace Octopus.Tentacle.Tests.Integration.Util
 {
@@ -49,11 +54,11 @@ namespace Octopus.Tentacle.Tests.Integration.Util
                     cts.Token);
 
                 exitCode.Should().Be(99, "our custom exit code should be reflected");
-                
+
                 // It seems the encoding can change during the lifetime of the OS so don't expect it wont change in tests.
                 debugMessages.ToString().Should().ContainEquivalentOf($"Starting {command} in working directory '' using '");
                 debugMessages.ToString().Should().ContainEquivalentOf($"' encoding running as '{TestEnvironmentHelper.CurrentUserName}'");
-                
+
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
                 infoMessages.ToString().Should().BeEmpty("no messages should be written to stdout");
             }
@@ -116,6 +121,189 @@ namespace Octopus.Tentacle.Tests.Integration.Util
 
                 errorMessages.ToString().Should().BeEmpty("no messages should be written to stderr");
             }
+        }
+
+        [Test]
+        [WindowsTest]
+        public async Task CancellationToken_WhenGrandchildHoldsRedirectedPipes_ShouldNotHang()
+        {
+            using var tempDir = new TemporaryDirectory();
+            var grandchildPidFile = Path.Combine(tempDir.DirectoryPath, "grandchild.pid");
+
+            // This test reproduces the cancel-time hang.
+            // The issue was SilentProcessRunner will wait for stdout/stderr pipes to be closed.
+            // The pipes can be inherited by grandchildren, and remain open even after the
+            // child process has died.
+            //
+            // Normally Process.Kill(entireProcessTree:true) would kill the entire process tree.
+            // However if the child process dies THEN we issue the kill command, we do NOT see any
+            // process under the child and so the Kill() command completes. This leaves the grandchild
+            // running, holding our pipes we are waiting on.
+            //
+            // The test stacks three processes: PowerShell (the child) launches cmd.exe (a
+            // throwaway middle layer) which does `start /b ping` to background ping (the
+            // grandchild) and then exits. cmd exiting before we cancel is what breaks the
+            // PPID chain — without that, ping would still be a direct child of PowerShell
+            // and Kill(true) would find it.
+            //
+            // Two non-obvious bits below, both load-bearing:
+            //   * $psi.RedirectStandardInput = $true — we don't use stdin, but redirecting
+            //     any stream is what flips bInheritHandles=true in .NET's Process.Start. That
+            //     is what makes cmd (and by extension ping) inherit our pipe write-ends.
+            //     Without this the grandchild doesn't hold our pipes and there is no bug to
+            //     reproduce.
+            //   * The WMI lookup — we need the grandchild's PID so the test can clean it up.
+            var psScript = @"
+$pidFile = 'PIDFILE_PLACEHOLDER'
+$pingPath = Join-Path $env:WINDIR 'System32\PING.EXE'
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = Join-Path $env:WINDIR 'System32\cmd.exe'
+# -n 60000 just makes ping long-running enough to outlive the test.
+$psi.Arguments = '/c start /b """" ""' + $pingPath + '"" -n 60000 127.0.0.1'
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow  = $true
+# Redirecting any stream flips bInheritHandles=true in .NET's Process.Start,
+# so non-redirected streams pass through via GetStdHandle to the child.
+$psi.RedirectStandardInput = $true
+$cmd = [System.Diagnostics.Process]::Start($psi)
+$cmd.StandardInput.Close()
+$cmdPid = $cmd.Id
+# Wait for cmd to exit -- breaks the PPID chain and makes Kill(true) miss ping.
+$cmd.WaitForExit()
+# Poll until ping appears in WMI — there's a lag between cmd exiting and the
+# orphaned ping becoming visible.
+$deadline = (Get-Date).AddSeconds(10)
+while ((Get-Date) -lt $deadline) {
+    $p = Get-CimInstance Win32_Process -Filter ""ParentProcessId=$cmdPid AND Name='PING.EXE'"" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($p) { Set-Content -Path $pidFile -Value $p.ProcessId; break }
+    Start-Sleep -Milliseconds 100
+}
+";
+            psScript = psScript.Replace("PIDFILE_PLACEHOLDER", grandchildPidFile);
+            var encoded = Convert.ToBase64String(Encoding.Unicode.GetBytes(psScript));
+
+            try
+            {
+                using (var cts = new CancellationTokenSource())
+                {
+                    var task = Task.Run(() => Execute(
+                        "powershell.exe",
+                        $"-NoProfile -NonInteractive -EncodedCommand {encoded}",
+                        "",
+                        out _,
+                        out _,
+                        out _,
+                        cts.Token));
+
+                    // Wait for the grandchild to actually be spawned before cancelling
+                    await WaitForGrandchildSpawnAsync(grandchildPidFile, TimeSpan.FromSeconds(60));
+
+                    var sw = Stopwatch.StartNew();
+                    cts.Cancel();
+
+                    var completed = task.Wait(TimeSpan.FromSeconds(30));
+                    sw.Stop();
+
+                    completed.Should().BeTrue(
+                        $"ExecuteCommand should return shortly after cancellation even when a grandchild " +
+                        $"holds the redirected pipes. Without proactively closing the redirected streams " +
+                        $"after Kill, Process.WaitForExit() blocks indefinitely. Elapsed since cancel: {sw.Elapsed.TotalSeconds:F1}s");
+                }
+            }
+            finally
+            {
+                TryKillGrandchild(grandchildPidFile);
+            }
+        }
+
+        [Test]
+        public async Task CancellationToken_WhenUnixGrandchildHoldsRedirectedPipes_ShouldNotHang()
+        {
+            if (PlatformDetection.IsRunningOnWindows)
+                Assert.Ignore("Unix-only repro (Mac/Linux). The Windows equivalent is covered by the [WindowsTest] above.");
+
+            // This test reproduces the cancel-time hang.
+            // The issue is SilentProcessRunner will wait for stdout/stderr pipes to be closed.
+            // The pipes can be inherited by grandchildren, and remain open even after the
+            // child process has died.
+            //
+            // Normally Process.Kill(entireProcessTree:true) would kill the entire process tree.
+            // However if the child process dies THEN we issue the kill command, we do NOT see any
+            // process under the child and so the Kill() command completes. This leaves the grandchild
+            // running, holding our pipes we are waiting on.
+            //
+            // The test is simple we run "sh", the child process, and tell it to yeet
+            // sleep, the grandchild, into the background. The grandchild now keeps
+            // running holding on to our pipes we will wait for an EOF on.
+
+            using var tempDir = new TemporaryDirectory();
+            var grandchildPidFile = Path.Combine(tempDir.DirectoryPath, "grandchild.pid");
+            var grandchild = $"sleep 600 & echo $! > '{grandchildPidFile}'; exit 0";
+
+            try
+            {
+                using (var cts = new CancellationTokenSource())
+                {
+                    var task = Task.Run(() => Execute(
+                        "/bin/sh",
+                        $"-c \"{grandchild}\"", // We run this in background and `sh` does not wait for it.
+                        "",
+                        out _,
+                        out _,
+                        out _,
+                        cts.Token));
+
+                    await WaitForGrandchildSpawnAsync(grandchildPidFile, TimeSpan.FromSeconds(30));
+
+                    var sw = Stopwatch.StartNew();
+                    cts.Cancel();
+
+                    // Cancel should be super quick, if it takes a long time, then we have an issue where we are waiting for the grandchild.
+                    var completed = task.Wait(TimeSpan.FromSeconds(30));
+                    sw.Stop();
+
+                    completed.Should().BeTrue(
+                        $"ExecuteCommand should return shortly after cancellation even when a Unix " +
+                        $"grandchild (reparented to init/launchd) holds the redirected pipes. " +
+                        $"Without proactively closing the redirected streams after Kill, " +
+                        $"Process.WaitForExit() blocks indefinitely. Elapsed since cancel: {sw.Elapsed.TotalSeconds:F1}s");
+                }
+            }
+            finally
+            {
+                TryKillGrandchild(grandchildPidFile);
+            }
+        }
+
+        static async Task WaitForGrandchildSpawnAsync(string pidFile, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (File.Exists(pidFile) && int.TryParse(SafelyReadAllText(pidFile).Trim(), out var pid) && pid > 0)
+                    return;
+                await Task.Delay(50);
+            }
+            throw new TimeoutException(
+                $"Test setup failed: the grandchild PID was never written to '{pidFile}'. " +
+                $"The grandchild-pipe scenario is not being exercised.");
+        }
+
+        static string SafelyReadAllText(string path)
+        {
+            try { return File.ReadAllText(path); } catch { return string.Empty; }
+        }
+
+        static void TryKillGrandchild(string pidFile)
+        {
+            try
+            {
+                if (File.Exists(pidFile) && int.TryParse(SafelyReadAllText(pidFile).Trim(), out var pid))
+                {
+                    try { Process.GetProcessById(pid).Kill(); } catch { /* already gone */ }
+                }
+            }
+            catch { /* ignore */ }
         }
 
         [Test]


### PR DESCRIPTION
Fixes: EFT-3354
Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/1225

# Background

Fixes an issue where cancellation would hang forever waiting for a grandchild process that is holding open STDOUT/STDERR, but will never be killed since its parent was already completed.

The problem occurs when:
1. Tentacle starts a child which starts a grandchild that inherits the STDOUT/STDERR pipes.
2. The child process completes (the child does not wait for the grandchild), and the grandchild continues on.
3. Cancellation occurs, since the parent is already completed we don't find the grandchild and so never Kill it.
4. Tentacle waits forever for the STDOUT/STDERR pipes to be closed. This will only happen when the grandchild dies.


The Fix is: When cancellation occurs after we attempt to kill, we close the pipes.

# Results

## Before

Tests added fail.

## After

Tests added pass.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.