### PR TITLE
Docs wording tweak for rollout guide

### DIFF
--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -1,6 +1,6 @@
 # Tentacle Rollout
 
-When you create a change through a PR in Tentacle, a whole lot of processes spring into action. This document tries to outline all the steps that happen.
+When you create a change through a PR in Tentacle, many processes spring into action. This document tries to outline the steps that happen.
 
 ## 1. TeamCity Build
 


### PR DESCRIPTION
This is a minimal documentation wording tweak used to validate the public PR build/artifact path. It does not change runtime code, packaging logic, or workflows.