### PR TITLE
Docs wording cleanup for meaningful change guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We use the [Octopus Tentacle project in our private Octopus server](https://depl
 Deployments happen automatically - a merge to `main` will trigger a build and a deployment - continuous delivery for the win!
 
 For internal developers, on closing an issue, ReleaseBot will ask you for release notes.
-For external developers, or if ReleaseBot fails for some reason, please add a comment to the issue `Release note: XXXX` to ensure release notes are generated correctly.
+For external developers, or if ReleaseBot fails for some reason, add a comment to the issue `Release note: XXXX` to ensure release notes are generated correctly.
 
 An easy way to find the code associated with a particular version of Tentacle is to check out the [tags](https://github.com/OctopusDeploy/OctopusTentacle/tags). 
 

--- a/docs/meaningful-change.md
+++ b/docs/meaningful-change.md
@@ -9,4 +9,4 @@ To submit a meaningful change, please follow these steps:
 1. If an issue does not already exist, create one to describe the problem your change addresses.
 2. Create a pull request that includes your changes. In the Results section, please include a keyword such as "Resolves #999" along with your issue number. Here are the [appropriate keywords to close issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
 3. Merge the PR once it passes all necessary checks.
-4. By doing this, you will ensure that your changes are recognized as a new version of Tentacle, available on the Downloads page.
+4. By doing this, you ensure that your changes are recognized as a new version of Tentacle and appear on the Downloads page.


### PR DESCRIPTION
This is a docs-only wording cleanup for the meaningful change guide.