### PR TITLE
Propagate async signature higher into CLI host and Kubernetes paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ scripts/development/
 
 **/.idea/*
 /.nuke/temp
+.worktrees/

--- a/source/Octopus.Manager.Tentacle.Tests/Builders/SetupTentacleWizardModelBuilder.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/Builders/SetupTentacleWizardModelBuilder.cs
@@ -30,8 +30,8 @@ namespace Octopus.Manager.Tentacle.Tests.Builders
             tentacleManagerInstanceIdentifierService.GetIdentifier().Returns(_ => Guid.NewGuid().ToString("N"));
 
             commandLineRunner = Substitute.For<ICommandLineRunner>();
-            commandLineRunner.Execute(Arg.Any<CommandLineInvocation>(), Arg.Any<ILog>()).Returns(true);
-            commandLineRunner.Execute(Arg.Any<IEnumerable<CommandLineInvocation>>(), Arg.Any<ILog>()).Returns(true);
+            commandLineRunner.ExecuteAsync(Arg.Any<CommandLineInvocation>(), Arg.Any<ILog>()).Returns(Task.FromResult(true));
+            commandLineRunner.ExecuteAsync(Arg.Any<IEnumerable<CommandLineInvocation>>(), Arg.Any<ILog>()).Returns(Task.FromResult(true));
         }
 
         public SetupTentacleWizardModelBuilder WithTelemetryService(ITelemetryService telemetryService)

--- a/source/Octopus.Manager.Tentacle/Dialogs/RunProcessDialog.cs
+++ b/source/Octopus.Manager.Tentacle/Dialogs/RunProcessDialog.cs
@@ -51,12 +51,12 @@ namespace Octopus.Manager.Tentacle.Dialogs
 
             if (showOutputLog) ShowOutputLog();
 
-            ThreadPool.QueueUserWorkItem(delegate
+            _ = Task.Run(async () =>
             {
                 var success = false;
                 try
                 {
-                    success = commandLineRunner.Execute(commandLines, logger);
+                    success = await commandLineRunner.ExecuteAsync(commandLines, logger);
                 }
                 catch (Exception ex)
                 {

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/ReviewAndRunScriptTabViewModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/ReviewAndRunScriptTabViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentValidation;
@@ -29,16 +29,16 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
             this.commandLineRunner = commandLineRunner;
             this.onScriptSucceeded = onScriptSucceeded;
             this.onScriptFailed = onScriptFailed;
-            
+
             InstanceName = wizardModel.InstanceName;
             Executable = CommandLine.PathToTentacleExe();
             Validator = CreateValidator();
         }
-        
+
         public string InstanceName { get; }
-        
+
         public string Executable { get; }
-        
+
         public async Task<bool> GenerateAndExecuteScript()
         {
             var success = false;
@@ -46,7 +46,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
             {
                 var script = GenerateScript();
                 ContributeSensitiveValues(logger);
-                success = commandLineRunner.Execute(script, logger);
+                success = await commandLineRunner.ExecuteAsync(script, logger);
             }
             catch (Exception ex)
             {
@@ -57,30 +57,25 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
                 if (success)
                 {
                     if (onScriptSucceeded != null)
-                    {
                         await onScriptSucceeded();
-                    }
                 }
                 else
                 {
-                    Rollback();
+                    await RollbackAsync();
                     if (onScriptFailed != null)
-                    {
                         await onScriptFailed();
-                    }
                 }
             }
 
-            await Task.CompletedTask;
             return success;
         }
-            
-        void Rollback()
+
+        async Task RollbackAsync()
         {
             try
             {
                 var script = GenerateRollbackScript();
-                commandLineRunner.Execute(script, logger);
+                await commandLineRunner.ExecuteAsync(script, logger);
             }
             catch (Exception ex)
             {
@@ -92,7 +87,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
         {
             wizardModel.ContributeSensitiveValues(log);
         }
-        
+
         public IEnumerable<CommandLineInvocation> GenerateScript()
         {
             return wizardModel.GenerateScript();
@@ -102,7 +97,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
         {
             return wizardModel.GenerateRollbackScript();
         }
-        
+
         IValidator CreateValidator()
         {
             var validator = new InlineValidator<ReviewAndRunScriptTabViewModel>();

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesAgentMigrateFromPreinstallationTest.cs
@@ -71,7 +71,7 @@ public class KubernetesAgentMigrateFromPreinstallationTest
         
 
         //Act
-        commandToRun.Start(commandArguments, new NoninteractiveHost(), []);
+        await commandToRun.StartAsync(commandArguments, new NoninteractiveHost(), []);
         
         //Assert
         var configMap = await client.CoreV1.ReadNamespacedConfigMapAsync(DestinationConfigMapName, commandNamespace);
@@ -121,7 +121,7 @@ public class KubernetesAgentMigrateFromPreinstallationTest
 
         
         //Act
-        commandToRun.Start(commandArguments, new NoninteractiveHost(), []);
+        await commandToRun.StartAsync(commandArguments, new NoninteractiveHost(), []);
         
         //Assert
         var configMap = await client.CoreV1.ReadNamespacedConfigMapAsync(DestinationConfigMapName, commandNamespace);

--- a/source/Octopus.Tentacle.Tests/Commands/ServerCommsCommandTest.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/ServerCommsCommandTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -36,7 +37,7 @@ namespace Octopus.Tentacle.Tests.Commands
                 );
         }
 
-        void Execute(string thumbprint, CommunicationStyle style, string? host = null, string? port = null)
+        async Task Execute(string thumbprint, CommunicationStyle style, string? host = null, string? port = null)
         {
             var parameters = new List<string>
             {
@@ -49,7 +50,7 @@ namespace Octopus.Tentacle.Tests.Commands
             if (port != null)
                 parameters.Add($"--port={port}");
 
-            command.Start(
+            await command.StartAsync(
                 parameters.ToArray(),
                 Substitute.For<ICommandRuntime>(),
                 new OptionSet()
@@ -73,18 +74,18 @@ namespace Octopus.Tentacle.Tests.Commands
 
 
         [Test]
-        public void NoTrusts()
+        public async Task NoTrusts()
         {
-            Action action = () => Execute(Thumb1, CommunicationStyle.TentaclePassive);
-            action.Should().Throw<ControlledFailureException>()
+            Func<Task> action = async () => await Execute(Thumb1, CommunicationStyle.TentaclePassive);
+            await action.Should().ThrowAsync<ControlledFailureException>()
                 .WithMessage("Before server communications can be modified, trust must be established with the configure command");
         }
 
         [Test]
-        public void AddPassive()
+        public async Task AddPassive()
         {
             AddTrusts(Thumb1);
-            Execute(Thumb1, CommunicationStyle.TentaclePassive);
+            await Execute(Thumb1, CommunicationStyle.TentaclePassive);
 
             configuration.TrustedOctopusServers.Should().HaveCount(1);
             var server = configuration.TrustedOctopusServers.First();
@@ -92,20 +93,20 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
-        public void AddActiveNoHost()
+        public async Task AddActiveNoHost()
         {
             AddTrusts(Thumb1);
-            Action action = () => Execute(Thumb1, CommunicationStyle.TentacleActive, null, "1234");
-            action.Should().Throw<ControlledFailureException>()
+            Func<Task> action = async () => await Execute(Thumb1, CommunicationStyle.TentacleActive, null, "1234");
+            await action.Should().ThrowAsync<ControlledFailureException>()
                 .WithMessage("Please provide either the server hostname or websocket address, e.g. --host=OCTOPUS");
         }
 
         [Test]
-        public void AddActiveNoPort()
+        public async Task AddActiveNoPort()
         {
             AddTrusts(Thumb1);
 
-            Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", null);
+            await Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", null);
 
             configuration.TrustedOctopusServers.Should().HaveCount(1);
             var server = configuration.TrustedOctopusServers.First();
@@ -113,11 +114,11 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
-        public void AddActive()
+        public async Task AddActive()
         {
             AddTrusts(Thumb1);
 
-            Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
+            await Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
 
             configuration.TrustedOctopusServers.Should().HaveCount(1);
             var server = configuration.TrustedOctopusServers.First();
@@ -125,12 +126,12 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
-        public void AddPassive1ThenActive1()
+        public async Task AddPassive1ThenActive1()
         {
             AddTrusts(Thumb1);
 
-            Execute(Thumb1, CommunicationStyle.TentaclePassive);
-            Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
+            await Execute(Thumb1, CommunicationStyle.TentaclePassive);
+            await Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
 
             var servers = configuration.TrustedOctopusServers.ToArray();
             servers.Should().HaveCount(2);
@@ -139,12 +140,12 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
-        public void AddActive1ThenPassive1()
+        public async Task AddActive1ThenPassive1()
         {
             AddTrusts(Thumb1);
 
-            Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
-            Execute(Thumb1, CommunicationStyle.TentaclePassive);
+            await Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
+            await Execute(Thumb1, CommunicationStyle.TentaclePassive);
 
             var servers = configuration.TrustedOctopusServers.ToArray();
             servers.Should().HaveCount(2);
@@ -153,12 +154,12 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
-        public void AddPassive1ThenActive2()
+        public async Task AddPassive1ThenActive2()
         {
             AddTrusts(Thumb1, Thumb2);
 
-            Execute(Thumb1, CommunicationStyle.TentaclePassive);
-            Execute(Thumb2, CommunicationStyle.TentacleActive, "example.com", "1234");
+            await Execute(Thumb1, CommunicationStyle.TentaclePassive);
+            await Execute(Thumb2, CommunicationStyle.TentacleActive, "example.com", "1234");
 
             var servers = configuration.TrustedOctopusServers.ToArray();
             servers.Should().HaveCount(2);
@@ -167,12 +168,12 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
-        public void AddPassive1ThenPassive2()
+        public async Task AddPassive1ThenPassive2()
         {
             AddTrusts(Thumb1, Thumb2);
 
-            Execute(Thumb1, CommunicationStyle.TentaclePassive);
-            Execute(Thumb2, CommunicationStyle.TentaclePassive);
+            await Execute(Thumb1, CommunicationStyle.TentaclePassive);
+            await Execute(Thumb2, CommunicationStyle.TentaclePassive);
 
             var servers = configuration.TrustedOctopusServers.ToArray();
             servers.Should().HaveCount(2);
@@ -181,12 +182,12 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
-        public void AddActive1ThenActive2()
+        public async Task AddActive1ThenActive2()
         {
             AddTrusts(Thumb1, Thumb2);
 
-            Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
-            Execute(Thumb2, CommunicationStyle.TentacleActive, "foo.com", "1234");
+            await Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
+            await Execute(Thumb2, CommunicationStyle.TentacleActive, "foo.com", "1234");
 
             var servers = configuration.TrustedOctopusServers.ToArray();
             servers.Should().HaveCount(2);
@@ -195,12 +196,12 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
-        public void AddActive1ThenActive1SameAddress()
+        public async Task AddActive1ThenActive1SameAddress()
         {
             AddTrusts(Thumb1);
 
-            Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
-            Execute(Thumb1, CommunicationStyle.TentacleActive, "EXAMPLE.cOm", "1234");
+            await Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
+            await Execute(Thumb1, CommunicationStyle.TentacleActive, "EXAMPLE.cOm", "1234");
 
             configuration.TrustedOctopusServers.Should().HaveCount(1);
             var server = configuration.TrustedOctopusServers.First();
@@ -208,11 +209,11 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
-        public void AddActive1ThenActive1DifferentAddress()
+        public async Task AddActive1ThenActive1DifferentAddress()
         {
             AddTrusts(Thumb1);
 
-            Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
+            await Execute(Thumb1, CommunicationStyle.TentacleActive, "example.com", "1234");
             Execute(Thumb1, CommunicationStyle.TentacleActive, "foo.com", "1234");
 
             var servers = configuration.TrustedOctopusServers.ToArray();

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
@@ -21,7 +21,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         const ulong Megabyte = 1000 * 1000;
         
         [Test]
-        public void DuOutputParses()
+        public async Task DuOutputParses()
         {
             const ulong usedSize = 500 * Megabyte;
             var spr = Substitute.For<ISilentProcessRunner>();
@@ -33,11 +33,11 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 });
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
-            sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
+            (await sut.GetPathUsedBytesAsync("/octopus")).Should().Be(usedSize);
         }
 
         [Test]
-        public void DuOutputParsesWithMultipleLines()
+        public async Task DuOutputParsesWithMultipleLines()
         {
             const ulong usedSize = 500 * Megabyte;
             var spr = Substitute.For<ISilentProcessRunner>();
@@ -51,11 +51,11 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 });
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
-            sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
+            (await sut.GetPathUsedBytesAsync("/octopus")).Should().Be(usedSize);
         }
 
         [Test]
-        public void IfDuFailsWeStillGetData()
+        public async Task IfDuFailsWeStillGetData()
         {
             const ulong usedSize = 500 * Megabyte;
             var spr = Substitute.For<ISilentProcessRunner>();
@@ -68,11 +68,11 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 });
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
-            sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
+            (await sut.GetPathUsedBytesAsync("/octopus")).Should().Be(usedSize);
         }
 
         [Test]
-        public void IfDuFailsWeLogCorrectly()
+        public async Task IfDuFailsWeLogCorrectly()
         {
             const ulong usedSize = 500 * Megabyte;
             var systemLog = new InMemoryLog();
@@ -92,7 +92,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 });
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(systemLog, spr, memoryCache);
-            sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
+            (await sut.GetPathUsedBytesAsync("/octopus")).Should().Be(usedSize);
 
             systemLog.GetLogsForCategory(LogCategory.Warning).Should().Contain("Could not reliably get disk space using du. Getting best approximation...");
             systemLog.GetLogsForCategory(LogCategory.Info).Should().Contain($"Du stdout returned 500\t/octopus, {usedSize}\t/octopus");
@@ -100,18 +100,18 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         }
 
         [Test]
-        public void IfDuFailsCompletelyReturnNull()
+        public async Task IfDuFailsCompletelyReturnNull()
         {
             var spr = Substitute.For<ISilentProcessRunner>();
             spr.ExecuteCommandAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
                 .Returns(Task.FromResult(1));
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
-            sut.GetPathUsedBytes("/octopus").Should().Be(null);
+            (await sut.GetPathUsedBytesAsync("/octopus")).Should().Be(null);
         }
 
         [Test]
-        public void ReturnedValueShouldBeCached()
+        public async Task ReturnedValueShouldBeCached()
         {
             var spr = Substitute.For<ISilentProcessRunner>();
             spr.ExecuteCommandAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
@@ -120,7 +120,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             var clock = new TestClock(baseTime);
             var memoryCache = new MemoryCache(new MemoryCacheOptions(){ Clock = clock});
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
-            sut.GetPathUsedBytes("/octopus").Should().Be(null);
+            (await sut.GetPathUsedBytesAsync("/octopus")).Should().Be(null);
 
             const ulong usedSize = 500 * Megabyte;
             spr.ExecuteCommandAsync("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
@@ -132,11 +132,11 @@ namespace Octopus.Tentacle.Tests.Kubernetes
                 });
             clock.UtcNow = baseTime + TimeSpan.FromSeconds(29);
 
-            sut.GetPathUsedBytes("/octopus").Should().Be(null);
+            (await sut.GetPathUsedBytesAsync("/octopus")).Should().Be(null);
         }
 
         [Test]
-        public void DuCacheExpiresAfter30Seconds()
+        public async Task DuCacheExpiresAfter30Seconds()
         {
             var spr = Substitute.For<ISilentProcessRunner>();
             spr.ExecuteCommandAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
@@ -145,7 +145,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             var clock = new TestClock(baseTime);
             var memoryCache = new MemoryCache(new MemoryCacheOptions(){ Clock = clock});
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
-            sut.GetPathUsedBytes("/octopus").Should().Be(null);
+            (await sut.GetPathUsedBytesAsync("/octopus")).Should().Be(null);
 
             const ulong usedSize = 500 * Megabyte;
             spr.ExecuteCommandAsync("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
@@ -158,7 +158,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
 
             clock.UtcNow = baseTime + TimeSpan.FromSeconds(30);
 
-            sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
+            (await sut.GetPathUsedBytesAsync("/octopus")).Should().Be(usedSize);
         }
 
     }

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPhysicalFileSystemFixture.cs
@@ -25,7 +25,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             
             var directoryInformationProvider = Substitute.For<IKubernetesDirectoryInformationProvider>();
             directoryInformationProvider.GetPathTotalBytes().Returns(totalDiskSpace);
-            directoryInformationProvider.GetPathUsedBytes("/octopus").Returns(diskSpaceUsed);
+            directoryInformationProvider.GetPathUsedBytesAsync("/octopus").Returns(Task.FromResult<ulong?>(diskSpaceUsed));
             
             var homeConfiguration = Substitute.For<IHomeConfiguration>();
             homeConfiguration.HomeDirectory.Returns("/octopus");

--- a/source/Octopus.Tentacle.Tests/Startup/CheckServicesCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Startup/CheckServicesCommandFixture.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -29,25 +29,25 @@ namespace Octopus.Tentacle.Tests.Startup
         }
 
         [Test]
-        public void ThrowsControlledFailureExceptionWhenNoInstancesProvided()
+        public async Task ThrowsControlledFailureExceptionWhenNoInstancesProvided()
         {
-            var ex = Assert.Throws<ControlledFailureException>(() => command.Start(new string[0], Substitute.For<ICommandRuntime>(), new OptionSet()));
+            var ex = await Assert.ThrowsAsync<ControlledFailureException>(async () => await command.StartAsync(new string[0], Substitute.For<ICommandRuntime>(), new OptionSet()));
             ex.Message.Should().Be("Use --instances argument to specify which instances to check. Use --instances=* to check all instances.");
         }
 
         [Test]
         [LinuxTest]
-        public void ThrowsControlledFailureWhenRunOnLinux()
+        public async Task ThrowsControlledFailureWhenRunOnLinux()
         {
-            var ex = Assert.Throws<ControlledFailureException>(() => command.Start(new[] { "--instances", "*" }, Substitute.For<ICommandRuntime>(), new OptionSet()));
+            var ex = await Assert.ThrowsAsync<ControlledFailureException>(async () => await command.StartAsync(new[] { "--instances", "*" }, Substitute.For<ICommandRuntime>(), new OptionSet()));
             ex.Message.Should().Be("This command is only supported on Windows.");
         }
 
         [Test]
         [WindowsTest]
-        public void ChecksThatUserIsElevated()
+        public async Task ChecksThatUserIsElevated()
         {
-            command.Start(new[] { "--instances", "*" }, Substitute.For<ICommandRuntime>(), new OptionSet());
+            await command.StartAsync(new[] { "--instances", "*" }, Substitute.For<ICommandRuntime>(), new OptionSet());
             windowsLocalAdminRightsChecker.Received(1).AssertIsRunningElevated();
         }
     }

--- a/source/Octopus.Tentacle.Tests/Startup/WatchdogCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Startup/WatchdogCommandFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -30,25 +31,25 @@ namespace Octopus.Tentacle.Tests.Startup
 
         [Test]
         [WindowsTest]
-        public void ThrowsControlledFailureExceptionWhenCreateOrDeleteIsNotSpecified()
+        public async Task ThrowsControlledFailureExceptionWhenCreateOrDeleteIsNotSpecified()
         {
-            var ex = Assert.Throws<ControlledFailureException>(() => command.Start(new string[0], Substitute.For<ICommandRuntime>(), new OptionSet()));
+            var ex = await Assert.ThrowsAsync<ControlledFailureException>(async () => await command.StartAsync(new string[0], Substitute.For<ICommandRuntime>(), new OptionSet()));
             ex.Message.Should().Be("Invalid arguments. Please specify either --create or --delete.");
         }
 
         [Test]
         [LinuxTest]
-        public void ThrowsControlledFailureWhenRunOnLinux()
+        public async Task ThrowsControlledFailureWhenRunOnLinux()
         {
-            var ex = Assert.Throws<ControlledFailureException>(() => command.Start(new[] { "--instances", "*" }, Substitute.For<ICommandRuntime>(), new OptionSet()));
+            var ex = await Assert.ThrowsAsync<ControlledFailureException>(async () => await command.StartAsync(new[] { "--instances", "*" }, Substitute.For<ICommandRuntime>(), new OptionSet()));
             ex.Message.Should().Be("This command is only supported on Windows.");
         }
 
         [Test]
         [WindowsTest]
-        public void ChecksThatUserIsElevated()
+        public async Task ChecksThatUserIsElevated()
         {
-            command.Start(new [] { "--create" }, Substitute.For<ICommandRuntime>(), new OptionSet());
+            await command.StartAsync(new[] { "--create" }, Substitute.For<ICommandRuntime>(), new OptionSet());
             windowsLocalAdminRightsChecker.Received(1).AssertIsRunningElevated();
         }
     }

--- a/source/Octopus.Tentacle/Commands/DeregisterMachineCommand.cs
+++ b/source/Octopus.Tentacle/Commands/DeregisterMachineCommand.cs
@@ -47,13 +47,7 @@ namespace Octopus.Tentacle.Commands
             Options.Add("space=", "The space which this machine will be deregistered from, - e.g. 'Finance Department' where Finance Department is the name of an existing space; the default value is the Default space, if one is designated.", s => spaceName = s);
         }
 
-        protected override void Start()
-        {
-            base.Start();
-            StartAsync().GetAwaiter().GetResult();
-        }
-
-        async Task StartAsync()
+        protected override async Task StartAsync()
         {
             //if we are on a polling tentacle with a polling proxy set up, use the api through that proxy
             var proxyOverride = proxyConfig.ParseToWebProxy(configuration.Value.PollingProxyConfiguration);

--- a/source/Octopus.Tentacle/Commands/DeregisterWorkerCommand.cs
+++ b/source/Octopus.Tentacle/Commands/DeregisterWorkerCommand.cs
@@ -47,13 +47,7 @@ namespace Octopus.Tentacle.Commands
             Options.Add("space=", "The space which this worker will be deregistered from, - e.g. 'Finance Department' where Finance Department is the name of an existing space; the default value is the Default space, if one is designated.", s => spaceName = s);
         }
 
-        protected override void Start()
-        {
-            base.Start();
-            StartAsync().GetAwaiter().GetResult();
-        }
-
-        async Task StartAsync()
+        protected override async Task StartAsync()
         {
             //if we are on a polling tentacle with a polling proxy set up, use the api through that proxy
             var proxyOverride = proxyConfig.ParseToWebProxy(configuration.Value.PollingProxyConfiguration);

--- a/source/Octopus.Tentacle/Commands/PollCommand.cs
+++ b/source/Octopus.Tentacle/Commands/PollCommand.cs
@@ -56,13 +56,7 @@ namespace Octopus.Tentacle.Commands
             Options.Add("reuse-server-thumbprint", "Reuse the Server Thumbprint from the first trusted server instance currently configured", _ => reuseThumbprint = true);
         }
 
-        protected override void Start()
-        {
-            base.Start();
-            StartAsync().GetAwaiter().GetResult();
-        }
-
-        async Task StartAsync()
+        protected override async Task StartAsync()
         {
             if (!reuseThumbprint)
             {

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -80,13 +80,7 @@ namespace Octopus.Tentacle.Commands
             Options.Add("tentacle-comms-port=", "When using passive communication, the comms port that the Octopus Server is instructed to call back on to reach this machine; defaults to the configured listening port", s => tentacleCommsPort = int.Parse(s));
         }
 
-        protected override void Start()
-        {
-            base.Start();
-            StartAsync().GetAwaiter().GetResult();
-        }
-
-        async Task StartAsync()
+        protected override async Task StartAsync()
         {
             CheckArgs();
 

--- a/source/Octopus.Tentacle/Commands/ShowConfigurationCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ShowConfigurationCommand.cs
@@ -58,14 +58,8 @@ namespace Octopus.Tentacle.Commands
             apiEndpointOptions = AddOptionSet(new ApiEndpointOptions(Options) { Optional = true });
         }
 
-        protected override void Start()
+        protected override async Task StartAsync()
         {
-            StartAsync().GetAwaiter().GetResult();
-        }
-
-        async Task StartAsync()
-        {
-            base.Start();
 
             DictionaryKeyValueStore outputFile;
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Octopus.Client.Extensions;
 using Microsoft.Extensions.Caching.Memory;
 using Octopus.Tentacle.Core.Diagnostics;
@@ -10,16 +11,16 @@ namespace Octopus.Tentacle.Kubernetes
 {
     public interface IKubernetesDirectoryInformationProvider
     {
-        public ulong? GetPathUsedBytes(string directoryPath);
+        public Task<ulong?> GetPathUsedBytesAsync(string directoryPath);
         public ulong? GetPathTotalBytes();
     }
-    
+
     public class KubernetesDirectoryInformationProvider : IKubernetesDirectoryInformationProvider
     {
         readonly ISystemLog log;
         readonly ISilentProcessRunner silentProcessRunner;
         readonly IMemoryCache directoryInformationCache;
-        
+
         //30s gives us fairly up to date information, but doesn't impact performance too much.
         //For 50 concurrent Cloud deployments:
         //No cache: 30min ea.
@@ -36,12 +37,12 @@ namespace Octopus.Tentacle.Kubernetes
             this.directoryInformationCache = directoryInformationCache;
         }
 
-        public ulong? GetPathUsedBytes(string directoryPath)
+        public Task<ulong?> GetPathUsedBytesAsync(string directoryPath)
         {
-            return directoryInformationCache.GetOrCreate(directoryPath, e =>
+            return directoryInformationCache.GetOrCreateAsync(directoryPath, async e =>
             {
                 e.SetAbsoluteExpiration(CacheExpiry);
-                return GetDriveBytesUsingDu(directoryPath);
+                return await GetDriveBytesUsingDuAsync(directoryPath);
             });
         }
 
@@ -49,15 +50,12 @@ namespace Octopus.Tentacle.Kubernetes
         {
             return KubernetesUtilities.GetResourceBytes(KubernetesConfig.PersistentVolumeSize);
         }
-        
-        
-        ulong? GetDriveBytesUsingDu(string directoryPath)
+
+        async Task<ulong?> GetDriveBytesUsingDuAsync(string directoryPath)
         {
             var stdOut = new List<string>();
             var stdErr = new List<string>();
-            // Sync boundary: called from IMemoryCache.GetOrCreate factory which is synchronous.
-            var exitCode = silentProcessRunner.ExecuteCommandAsync("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add)
-                .GetAwaiter().GetResult();
+            var exitCode = await silentProcessRunner.ExecuteCommandAsync("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add);
 
             if (exitCode != 0)
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Core.Util;
 using Octopus.Tentacle.Util;
@@ -25,7 +26,12 @@ namespace Octopus.Tentacle.Kubernetes
 
         public override void EnsureDiskHasEnoughFreeSpace(string directoryPath, long requiredSpaceInBytes)
         {
-            var spaceInformation = GetStorageInformation();
+            // We're overriding a sync interface method (IOctopusFileSystem) that's called from
+            // contexts we can't make async (config writes, script workspace readiness checks).
+            // We block on the async call with .GetAwaiter().GetResult().
+            // This is safe because all callers run on plain thread-pool workers — no captured
+            // context — so the async work can resume on any free thread when it finishes.
+            var spaceInformation = GetStorageInformationAsync().GetAwaiter().GetResult();
             Log.Verbose($"Directory to be checked is {HomeDir}, script directory is {directoryPath}, required space is {requiredSpaceInBytes} bytes");
 
             // If we can't get the free bytes, we just skip the check
@@ -43,9 +49,9 @@ namespace Octopus.Tentacle.Kubernetes
             }
         }
 
-        public (ulong freeSpaceBytes, ulong totalSpaceBytes)? GetStorageInformation()
+        public async Task<(ulong freeSpaceBytes, ulong totalSpaceBytes)?> GetStorageInformationAsync()
         {
-            var bytesUsed = directoryInformationProvider.GetPathUsedBytes(HomeDir);
+            var bytesUsed = await directoryInformationProvider.GetPathUsedBytesAsync(HomeDir);
             var bytesTotal = directoryInformationProvider.GetPathTotalBytes();
             if (bytesUsed.HasValue && bytesTotal.HasValue)
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -300,7 +300,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         protected async Task<V1Container> CreateScriptContainer(StartKubernetesScriptCommandV1 command, string podName, string scriptName, string homeDir, string workspacePath, string[]? scriptArguments, InMemoryTentacleScriptLog tentacleScriptLog, V1Container? containerSpec)
         {
-            var spaceInformation = kubernetesPhysicalFileSystem.GetStorageInformation();
+            var spaceInformation = await kubernetesPhysicalFileSystem.GetStorageInformationAsync();
             
             var commandString = string.Join(" ", new[]
                 {

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using Autofac;
 using Octopus.Tentacle.Certificates;
 using Octopus.Tentacle.Commands;
@@ -38,9 +39,9 @@ namespace Octopus.Tentacle
 
         protected override ApplicationName ApplicationName => ApplicationName.Tentacle;
 
-        static int Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
-            return new Program(args).Run();
+            return await new Program(args).RunAsync();
         }
 
         public override IContainer BuildContainer(StartUpInstanceRequest startUpInstanceRequest)

--- a/source/Octopus.Tentacle/Startup/AbstractCommand.cs
+++ b/source/Octopus.Tentacle/Startup/AbstractCommand.cs
@@ -71,13 +71,6 @@ namespace Octopus.Tentacle.Startup
             Options.WriteOptionDescriptions(writer);
         }
 
-        public virtual void Start(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
-        {
-            // Sync wrapper for hosts that don't support async dispatch — kept for backwards
-            // compatibility. OctopusProgram calls StartAsync() directly.
-            StartAsync(commandLineArguments, commandRuntime, commonOptions).GetAwaiter().GetResult();
-        }
-
         public virtual async Task StartAsync(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
         {
             runtime = commandRuntime;

--- a/source/Octopus.Tentacle/Startup/AbstractCommand.cs
+++ b/source/Octopus.Tentacle/Startup/AbstractCommand.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Internals.Options;
 
 namespace Octopus.Tentacle.Startup
@@ -46,7 +47,16 @@ namespace Octopus.Tentacle.Startup
                 throw new ControlledFailureException("Unrecognized command line arguments: " + string.Join(" ", arguments));
         }
 
-        protected abstract void Start();
+        // Commands may override either Start() (sync) or StartAsync() (async).
+        // The dispatcher calls StartAsync(); the default implementation calls Start() so
+        // existing sync commands need no changes.
+        protected virtual void Start() { }
+
+        protected virtual Task StartAsync()
+        {
+            Start();
+            return Task.CompletedTask;
+        }
 
         protected virtual void Completed()
         {
@@ -76,7 +86,12 @@ namespace Octopus.Tentacle.Startup
             LogFileOnlyLogger.Info($"==== {GetType().Name} ====");
             LogFileOnlyLogger.Info($"CommandLine: {string.Join(" ", Environment.GetCommandLineArgs())}");
 
-            Start();
+            // We're in the CLI command dispatcher. The CLI host (OctopusProgram) invokes
+            // commands synchronously via ICommandHost.Run, so we block on the async command
+            // here with .GetAwaiter().GetResult(). This is the single sync↔async boundary
+            // for all async commands — callers are on plain thread-pool workers with no
+            // captured context, so the block cannot deadlock.
+            StartAsync().GetAwaiter().GetResult();
             Completed();
         }
 

--- a/source/Octopus.Tentacle/Startup/AbstractCommand.cs
+++ b/source/Octopus.Tentacle/Startup/AbstractCommand.cs
@@ -73,6 +73,13 @@ namespace Octopus.Tentacle.Startup
 
         public virtual void Start(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
         {
+            // Sync wrapper for hosts that don't support async dispatch — kept for backwards
+            // compatibility. OctopusProgram calls StartAsync() directly.
+            StartAsync(commandLineArguments, commandRuntime, commonOptions).GetAwaiter().GetResult();
+        }
+
+        public virtual async Task StartAsync(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
+        {
             runtime = commandRuntime;
 
             var unrecognized = Options.Parse(commandLineArguments);
@@ -86,12 +93,7 @@ namespace Octopus.Tentacle.Startup
             LogFileOnlyLogger.Info($"==== {GetType().Name} ====");
             LogFileOnlyLogger.Info($"CommandLine: {string.Join(" ", Environment.GetCommandLineArgs())}");
 
-            // We're in the CLI command dispatcher. The CLI host (OctopusProgram) invokes
-            // commands synchronously via ICommandHost.Run, so we block on the async command
-            // here with .GetAwaiter().GetResult(). This is the single sync↔async boundary
-            // for all async commands — callers are on plain thread-pool workers with no
-            // captured context, so the block cannot deadlock.
-            StartAsync().GetAwaiter().GetResult();
+            await StartAsync();
             Completed();
         }
 

--- a/source/Octopus.Tentacle/Startup/ConsoleHost.cs
+++ b/source/Octopus.Tentacle/Startup/ConsoleHost.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Internals.Options;
@@ -31,6 +32,14 @@ namespace Octopus.Tentacle.Startup
             Console.ResetColor();
             SafelySetConsoleTitle(displayName);
             start(this);
+            Stop(shutdown);
+        }
+
+        public async Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown)
+        {
+            Console.ResetColor();
+            SafelySetConsoleTitle(displayName);
+            await start(this);
             Stop(shutdown);
         }
 

--- a/source/Octopus.Tentacle/Startup/ConsoleHost.cs
+++ b/source/Octopus.Tentacle/Startup/ConsoleHost.cs
@@ -27,14 +27,6 @@ namespace Octopus.Tentacle.Startup
             this.displayName = displayName;
         }
 
-        public void Run(Action<ICommandRuntime> start, Action shutdown)
-        {
-            Console.ResetColor();
-            SafelySetConsoleTitle(displayName);
-            start(this);
-            Stop(shutdown);
-        }
-
         public async Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown)
         {
             Console.ResetColor();

--- a/source/Octopus.Tentacle/Startup/HelpCommand.cs
+++ b/source/Octopus.Tentacle/Startup/HelpCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Internals.Options;
@@ -29,9 +30,9 @@ namespace Octopus.Tentacle.Startup
 
         public string Format { get; set; } = TextFormat;
 
-        public override void Start(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
+        public override async Task StartAsync(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions)
         {
-            base.Start(commandLineArguments, commandRuntime, commonOptions);
+            await base.StartAsync(commandLineArguments, commandRuntime, commonOptions);
 
             var processPath = Assembly.GetEntryAssembly()?.FullProcessPath() ?? throw new Exception("Could not get path of the current process");
             var executable = PlatformDetection.IsRunningOnWindows
@@ -67,10 +68,6 @@ namespace Octopus.Tentacle.Startup
         protected override void UnrecognizedArguments(IList<string> arguments)
         {
             // Ignore - we're showing help!
-        }
-
-        protected override void Start()
-        {
         }
 
         void PrintCommandHelp(string executable, ICommand command, CommandMetadata metadata, OptionSet commonOptions)

--- a/source/Octopus.Tentacle/Startup/ICommand.cs
+++ b/source/Octopus.Tentacle/Startup/ICommand.cs
@@ -26,7 +26,6 @@ namespace Octopus.Tentacle.Startup
         void WriteHelp(TextWriter writer);
 
         // Common options are provided so that the Help command can inspect them
-        void Start(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions);
         Task StartAsync(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions);
         void Stop();
     }

--- a/source/Octopus.Tentacle/Startup/ICommand.cs
+++ b/source/Octopus.Tentacle/Startup/ICommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Internals.Options;
 
 namespace Octopus.Tentacle.Startup
@@ -26,6 +27,7 @@ namespace Octopus.Tentacle.Startup
 
         // Common options are provided so that the Help command can inspect them
         void Start(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions);
+        Task StartAsync(string[] commandLineArguments, ICommandRuntime commandRuntime, OptionSet commonOptions);
         void Stop();
     }
 }

--- a/source/Octopus.Tentacle/Startup/ICommandHost.cs
+++ b/source/Octopus.Tentacle/Startup/ICommandHost.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Threading.Tasks;
 
 namespace Octopus.Tentacle.Startup
 {
     public interface ICommandHost
     {
         void Run(Action<ICommandRuntime> start, Action shutdown);
+        Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown);
         void Stop(Action shutdown);
         void OnExit(int exitCode);
     }

--- a/source/Octopus.Tentacle/Startup/ICommandHost.cs
+++ b/source/Octopus.Tentacle/Startup/ICommandHost.cs
@@ -5,7 +5,6 @@ namespace Octopus.Tentacle.Startup
 {
     public interface ICommandHost
     {
-        void Run(Action<ICommandRuntime> start, Action shutdown);
         Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown);
         void Stop(Action shutdown);
         void OnExit(int exitCode);

--- a/source/Octopus.Tentacle/Startup/IServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/IServiceConfigurator.cs
@@ -1,16 +1,17 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Octopus.Tentacle.Startup
 {
     public interface IServiceConfigurator
     {
-        void ConfigureServiceByInstanceName(string thisServiceName,
+        Task ConfigureServiceByInstanceNameAsync(string thisServiceName,
             string exePath,
             string instance,
             string serviceDescription,
             ServiceConfigurationState serviceConfigurationState);
-        
-        void ConfigureServiceByConfigPath(string thisServiceName,
+
+        Task ConfigureServiceByConfigPathAsync(string thisServiceName,
             string exePath,
             string configPath,
             string serviceDescription,

--- a/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Util;
 
@@ -19,50 +20,35 @@ namespace Octopus.Tentacle.Startup
             systemCtlHelper = new SystemCtlHelper(log);
         }
 
-        public void ConfigureServiceByInstanceName(string thisServiceName,
+        public Task ConfigureServiceByInstanceNameAsync(string thisServiceName,
             string exePath,
             string instance,
             string serviceDescription,
             ServiceConfigurationState serviceConfigurationState)
-        {
-            ConfigureService(thisServiceName,
-                exePath,
-                instance,
-                null,
-                serviceDescription,
-                serviceConfigurationState);
-        }
+            => ConfigureServiceAsync(thisServiceName, exePath, instance, null, serviceDescription, serviceConfigurationState);
 
-        public void ConfigureServiceByConfigPath(string thisServiceName,
+        public Task ConfigureServiceByConfigPathAsync(string thisServiceName,
             string exePath,
             string configPath,
             string serviceDescription,
             ServiceConfigurationState serviceConfigurationState)
-        {
-            ConfigureService(thisServiceName,
-                exePath,
-                null,
-                configPath,
-                serviceDescription,
-                serviceConfigurationState);
-        }
+            => ConfigureServiceAsync(thisServiceName, exePath, null, configPath, serviceDescription, serviceConfigurationState);
 
-        void ConfigureService(string thisServiceName, string exePath, string? instance, string? configPath, string serviceDescription, ServiceConfigurationState serviceConfigurationState)
+        async Task ConfigureServiceAsync(string thisServiceName, string exePath, string? instance, string? configPath, string serviceDescription, ServiceConfigurationState serviceConfigurationState)
         {
-            //Check if system has bash and systemd
-            CheckSystemPrerequisites();
+            await CheckSystemPrerequisitesAsync();
 
             var cleanedInstanceName = SanitizeString(instance ?? thisServiceName);
             var systemdUnitFilePath = $"/etc/systemd/system/{cleanedInstanceName}.service";
 
             if (serviceConfigurationState.Restart)
-                RestartService(cleanedInstanceName);
+                await RestartServiceAsync(cleanedInstanceName);
 
             if (serviceConfigurationState.Stop)
-                StopService(cleanedInstanceName);
+                await StopServiceAsync(cleanedInstanceName);
 
             if (serviceConfigurationState.Uninstall)
-                UninstallService(cleanedInstanceName, systemdUnitFilePath);
+                await UninstallServiceAsync(cleanedInstanceName, systemdUnitFilePath);
 
             var serviceDependencies = new List<string>();
             serviceDependencies.AddRange(new[] {"network.target"});
@@ -72,62 +58,48 @@ namespace Octopus.Tentacle.Startup
 
             var userName = serviceConfigurationState.Username ?? "root";
             if (serviceConfigurationState.Install)
-                InstallService(cleanedInstanceName,
-                    instance,
-                    configPath,
-                    exePath,
-                    serviceDescription,
-                    systemdUnitFilePath,
-                    userName,
-                    serviceDependencies);
+                await InstallServiceAsync(cleanedInstanceName, instance, configPath, exePath, serviceDescription, systemdUnitFilePath, userName, serviceDependencies);
 
             if (serviceConfigurationState.Reconfigure)
-                ReconfigureService(cleanedInstanceName,
-                    instance,
-                    configPath,
-                    exePath,
-                    serviceDescription,
-                    systemdUnitFilePath,
-                    userName,
-                    serviceDependencies);
+                await ReconfigureServiceAsync(cleanedInstanceName, instance, configPath, exePath, serviceDescription, systemdUnitFilePath, userName, serviceDependencies);
 
             if (serviceConfigurationState.Start)
-                StartService(cleanedInstanceName);
+                await StartServiceAsync(cleanedInstanceName);
         }
 
-        void RestartService(string serviceName)
+        async Task RestartServiceAsync(string serviceName)
         {
             log.Info($"Restarting service: {serviceName}");
-            if (systemCtlHelper.RestartService(serviceName))
+            if (await systemCtlHelper.RestartService(serviceName))
                 log.Info("Service has been restarted");
             else
                 log.Error("The service could not be restarted");
         }
 
-        void StopService(string serviceName)
+        async Task StopServiceAsync(string serviceName)
         {
             log.Info($"Stopping service: {serviceName}");
-            if (systemCtlHelper.StopService(serviceName))
+            if (await systemCtlHelper.StopService(serviceName))
                 log.Info("Service stopped");
             else
                 log.Error("The service could not be stopped");
         }
 
-        void StartService(string serviceName)
+        async Task StartServiceAsync(string serviceName)
         {
-            if (systemCtlHelper.StartService(serviceName, true))
+            if (await systemCtlHelper.StartService(serviceName, true))
                 log.Info($"Service started: {serviceName}");
             else
                 log.Error($"Could not start the systemd service: {serviceName}");
         }
 
-        void UninstallService(string instance, string systemdUnitFilePath)
+        async Task UninstallServiceAsync(string instance, string systemdUnitFilePath)
         {
             log.Info($"Removing systemd service: {instance}");
             try
             {
-                systemCtlHelper.StopService(instance);
-                systemCtlHelper.DisableService(instance);
+                await systemCtlHelper.StopService(instance);
+                await systemCtlHelper.DisableService(instance);
                 File.Delete(systemdUnitFilePath);
                 log.Info("Service uninstalled");
             }
@@ -138,7 +110,7 @@ namespace Octopus.Tentacle.Startup
             }
         }
 
-        void InstallService(string serviceName, 
+        async Task InstallServiceAsync(string serviceName,
             string? instance,
             string? configPath,
             string exePath,
@@ -149,8 +121,8 @@ namespace Octopus.Tentacle.Startup
         {
             try
             {
-                WriteUnitFile(systemdUnitFilePath, GenerateSystemdUnitFile(instance, configPath, serviceDescription, exePath, userName, serviceDependencies));
-                systemCtlHelper.EnableService(serviceName, true);
+                await WriteUnitFileAsync(systemdUnitFilePath, GenerateSystemdUnitFile(instance, configPath, serviceDescription, exePath, userName, serviceDependencies));
+                await systemCtlHelper.EnableService(serviceName, true);
                 log.Info($"Service installed: {serviceName}");
             }
             catch (Exception e)
@@ -160,7 +132,7 @@ namespace Octopus.Tentacle.Startup
             }
         }
 
-        void ReconfigureService(string serviceName,
+        async Task ReconfigureServiceAsync(string serviceName,
             string? instance,
             string? configPath,
             string exePath,
@@ -172,14 +144,12 @@ namespace Octopus.Tentacle.Startup
             try
             {
                 log.Info($"Attempting to remove old service: {serviceName}");
-                //remove service
-                systemCtlHelper.StopService(serviceName);
-                systemCtlHelper.DisableService(serviceName);
+                await systemCtlHelper.StopService(serviceName);
+                await systemCtlHelper.DisableService(serviceName);
                 File.Delete(systemdUnitFilePath);
 
-                //re-add service
-                WriteUnitFile(systemdUnitFilePath, GenerateSystemdUnitFile(instance, configPath, serviceDescription, exePath, userName, serviceDependencies));
-                systemCtlHelper.EnableService(serviceName, true);
+                await WriteUnitFileAsync(systemdUnitFilePath, GenerateSystemdUnitFile(instance, configPath, serviceDescription, exePath, userName, serviceDependencies));
+                await systemCtlHelper.EnableService(serviceName, true);
                 log.Info($"Service installed: {serviceName}");
             }
             catch (Exception e)
@@ -189,60 +159,48 @@ namespace Octopus.Tentacle.Startup
             }
         }
 
-        void WriteUnitFile(string path, string contents)
+        async Task WriteUnitFileAsync(string path, string contents)
         {
             File.WriteAllText(path, contents);
 
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"chmod 644 {path}\"");
-            // Sync boundary: WriteUnitFile is called from IServiceConfigurator.ConfigureService
-            // implementations, which are themselves called from the Tentacle service-management
-            // CLI on a threadpool worker with no sync context. GetAwaiter().GetResult() is
-            // deadlock-safe here.
-            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await commandLineInvocation.ExecuteCommandAsync();
 
             if (result.ExitCode == 0) return;
 
             result.Validate();
         }
 
-        void CheckSystemPrerequisites()
+        async Task CheckSystemPrerequisitesAsync()
         {
             if (!File.Exists("/bin/bash"))
                 throw new ControlledFailureException(
                     "Could not detect bash. bash is required to run tentacle.");
 
-            if (!HaveSudoPrivileges())
+            if (!await HaveSudoPrivilegesAsync())
                 throw new ControlledFailureException(
                     "Requires elevated privileges. Please run command as sudo.");
 
-            if (!IsSystemdInstalled())
+            if (!await IsSystemdInstalledAsync())
                 throw new ControlledFailureException(
                     "Could not detect systemd. systemd is required to run Tentacle as a service");
         }
 
-        bool IsSystemdInstalled()
+        async Task<bool> IsSystemdInstalledAsync()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"command -v systemctl >/dev/null\"");
-            // Sync boundary: IsSystemdInstalled is called from CheckSystemPrerequisites,
-            // which is called from IServiceConfigurator.ConfigureService, which is itself
-            // called from the Tentacle service-management CLI on a threadpool worker with
-            // no sync context. GetAwaiter().GetResult() is deadlock-safe here.
-            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await commandLineInvocation.ExecuteCommandAsync();
             return result.ExitCode == 0;
         }
 
-        bool HaveSudoPrivileges()
+        async Task<bool> HaveSudoPrivilegesAsync()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"sudo -vn 2> /dev/null\"");
-            // Sync boundary: HaveSudoPrivileges is called from CheckSystemPrerequisites,
-            // which is called from IServiceConfigurator.ConfigureService, which is itself
-            // called from the Tentacle service-management CLI on a threadpool worker with
-            // no sync context. GetAwaiter().GetResult() is deadlock-safe here.
-            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await commandLineInvocation.ExecuteCommandAsync();
             return result.ExitCode == 0;
         }
 
-        string GenerateSystemdUnitFile(string? instance, 
+        string GenerateSystemdUnitFile(string? instance,
             string? configPath,
             string serviceDescription, string exePath, string userName, IEnumerable<string> serviceDependencies)
         {
@@ -258,7 +216,7 @@ namespace Octopus.Tentacle.Startup
             if (!string.IsNullOrEmpty(instance))
             {
                 stringBuilder.Append($" --instance={instance}");
-            } 
+            }
             else if (!string.IsNullOrEmpty(configPath))
             {
                 stringBuilder.Append($" --config={configPath}");

--- a/source/Octopus.Tentacle/Startup/MutexHost.cs
+++ b/source/Octopus.Tentacle/Startup/MutexHost.cs
@@ -47,6 +47,24 @@ namespace Octopus.Tentacle.Startup
             start(this);
         }
 
+        public async Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown)
+        {
+            if (Mutex.TryOpenExisting(monitorMutexHost, out var m))
+                task = Task.Run(() =>
+                {
+                    while (!sourceToken.IsCancellationRequested)
+                        if (m!.WaitOne(500))
+                        {
+                            shutdown();
+                            shutdownTrigger.Set();
+                            m.ReleaseMutex();
+                            break;
+                        }
+                });
+
+            await start(this);
+        }
+
         public void Stop(Action shutdown)
         {
             sourceToken.Cancel();

--- a/source/Octopus.Tentacle/Startup/MutexHost.cs
+++ b/source/Octopus.Tentacle/Startup/MutexHost.cs
@@ -29,24 +29,6 @@ namespace Octopus.Tentacle.Startup
             this.log = log;
         }
 
-        public void Run(Action<ICommandRuntime> start, Action shutdown)
-        {
-            if (Mutex.TryOpenExisting(monitorMutexHost, out var m))
-                task = Task.Run(() =>
-                {
-                    while (!sourceToken.IsCancellationRequested)
-                        if (m!.WaitOne(500))
-                        {
-                            shutdown();
-                            shutdownTrigger.Set();
-                            m.ReleaseMutex();
-                            break;
-                        }
-                });
-
-            start(this);
-        }
-
         public async Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown)
         {
             if (Mutex.TryOpenExisting(monitorMutexHost, out var m))

--- a/source/Octopus.Tentacle/Startup/NoninteractiveHost.cs
+++ b/source/Octopus.Tentacle/Startup/NoninteractiveHost.cs
@@ -1,19 +1,11 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octopus.Tentacle.Startup
 {
     class NoninteractiveHost : ICommandHost, ICommandRuntime
     {
-        readonly ManualResetEvent mre = new ManualResetEvent(false);
         readonly TaskCompletionSource<bool> stopTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public void Run(Action<ICommandRuntime> start, Action shutdown)
-        {
-            start(this);
-            mre.WaitOne();
-        }
 
         public async Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown)
         {
@@ -24,7 +16,6 @@ namespace Octopus.Tentacle.Startup
         public void Stop(Action shutdown)
         {
             shutdown();
-            mre.Set();
             stopTcs.TrySetResult(true);
         }
 

--- a/source/Octopus.Tentacle/Startup/NoninteractiveHost.cs
+++ b/source/Octopus.Tentacle/Startup/NoninteractiveHost.cs
@@ -1,11 +1,13 @@
-﻿using System;
+using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Octopus.Tentacle.Startup
 {
     class NoninteractiveHost : ICommandHost, ICommandRuntime
     {
         readonly ManualResetEvent mre = new ManualResetEvent(false);
+        readonly TaskCompletionSource<bool> stopTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public void Run(Action<ICommandRuntime> start, Action shutdown)
         {
@@ -13,10 +15,17 @@ namespace Octopus.Tentacle.Startup
             mre.WaitOne();
         }
 
+        public async Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown)
+        {
+            await start(this);
+            await stopTcs.Task;
+        }
+
         public void Stop(Action shutdown)
         {
             shutdown();
             mre.Set();
+            stopTcs.TrySetResult(true);
         }
 
         public void OnExit(int exitCode)

--- a/source/Octopus.Tentacle/Startup/OctopusProgram.cs
+++ b/source/Octopus.Tentacle/Startup/OctopusProgram.cs
@@ -76,8 +76,6 @@ namespace Octopus.Tentacle.Startup
 
         protected abstract ApplicationName ApplicationName { get; }
 
-        public int Run() => RunAsync().GetAwaiter().GetResult();
-
         public async Task<int> RunAsync()
         {
             var delayedLog = new DelayedLog();

--- a/source/Octopus.Tentacle/Startup/OctopusProgram.cs
+++ b/source/Octopus.Tentacle/Startup/OctopusProgram.cs
@@ -76,7 +76,9 @@ namespace Octopus.Tentacle.Startup
 
         protected abstract ApplicationName ApplicationName { get; }
 
-        public int Run()
+        public int Run() => RunAsync().GetAwaiter().GetResult();
+
+        public async Task<int> RunAsync()
         {
             var delayedLog = new DelayedLog();
             // Need to clean up old files before anything else as they may interfere with initialization
@@ -152,7 +154,7 @@ namespace Octopus.Tentacle.Startup
                     forceNoninteractiveHost,
                     monitorMutexHost);
 
-                RunHost(host);
+                await RunHostAsync(host);
                 // If we make it to here we can set the error code as either an UnknownCommand for which you got some help, or Success!
                 exitCode = (int)(commandFromCommandLine == null ? ExitCode.UnknownCommand : ExitCode.Success);
             }
@@ -186,7 +188,7 @@ namespace Octopus.Tentacle.Startup
             return exitCode;
         }
 
-        void RunHost(ICommandHost host)
+        async Task RunHostAsync(ICommandHost host)
         {
 #if FULL_FRAMEWORK
             /*
@@ -202,7 +204,7 @@ namespace Octopus.Tentacle.Startup
                 return true;
             });
             CtrlSignaling.SetConsoleCtrlHandler(hr, true);
-            host.Run(Start, Shutdown);
+            await host.RunAsync(StartAsync, Shutdown);
             GC.KeepAlive(hr);
 #else
             Console.CancelKeyPress += (s, e) =>
@@ -217,7 +219,7 @@ namespace Octopus.Tentacle.Startup
                 log.Trace("AppDomain process exiting");
                 host.Stop(Shutdown);
             };
-            host.Run(Start, Shutdown);
+            await host.RunAsync(StartAsync, Shutdown);
 
 #endif
         }
@@ -561,6 +563,13 @@ namespace Octopus.Tentacle.Startup
             if (responsibleCommand == null)
                 throw new InvalidOperationException("Responsible command not set");
             responsibleCommand.Start(commandLineArguments, commandRuntime, commonOptions);
+        }
+
+        Task StartAsync(ICommandRuntime commandRuntime)
+        {
+            if (responsibleCommand == null)
+                throw new InvalidOperationException("Responsible command not set");
+            return responsibleCommand.StartAsync(commandLineArguments, commandRuntime, commonOptions);
         }
 
         static string[] TryResolveCommand(

--- a/source/Octopus.Tentacle/Startup/OctopusProgram.cs
+++ b/source/Octopus.Tentacle/Startup/OctopusProgram.cs
@@ -558,13 +558,6 @@ namespace Octopus.Tentacle.Startup
             return commonOptions.Parse(commandLineArguments).ToArray();
         }
 
-        void Start(ICommandRuntime commandRuntime)
-        {
-            if (responsibleCommand == null)
-                throw new InvalidOperationException("Responsible command not set");
-            responsibleCommand.Start(commandLineArguments, commandRuntime, commonOptions);
-        }
-
         Task StartAsync(ICommandRuntime commandRuntime)
         {
             if (responsibleCommand == null)

--- a/source/Octopus.Tentacle/Startup/ServiceCommand.cs
+++ b/source/Octopus.Tentacle/Startup/ServiceCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Configuration.Instances;
 using Octopus.Tentacle.Core.Diagnostics;
@@ -65,7 +66,7 @@ namespace Octopus.Tentacle.Startup
             Options.Add("instance=", "Name of the instance to use, or * to use all instances", v => instanceName = v);
         }
 
-        protected override void Start()
+        protected override async Task StartAsync()
         {
             var exePath = assemblyContainingService.FullProcessPath();
 
@@ -81,7 +82,7 @@ namespace Octopus.Tentacle.Startup
                     try
                     {
                         var thisServiceName = ServiceName.GetWindowsServiceName(applicationName, instance.InstanceName);
-                        serviceConfigurator.ConfigureServiceByInstanceName(thisServiceName,
+                        await serviceConfigurator.ConfigureServiceByInstanceNameAsync(thisServiceName,
                             exePath,
                             instance.InstanceName,
                             serviceDescription,
@@ -104,9 +105,9 @@ namespace Octopus.Tentacle.Startup
                 {
                     if (serviceConfigurationState.Install || serviceConfigurationState.Reconfigure)
                     {
-                        log.Warn("Please note, currently there can only be one un-named instance configured as a service on a machine at a time.");    
+                        log.Warn("Please note, currently there can only be one un-named instance configured as a service on a machine at a time.");
                     }
-                    serviceConfigurator.ConfigureServiceByConfigPath(thisServiceName,
+                    await serviceConfigurator.ConfigureServiceByConfigPathAsync(thisServiceName,
                         exePath,
                         instanceSelector.Current.ConfigurationPath!,
                         serviceDescription,
@@ -114,7 +115,7 @@ namespace Octopus.Tentacle.Startup
                 }
                 else
                 {
-                    serviceConfigurator.ConfigureServiceByInstanceName(thisServiceName,
+                    await serviceConfigurator.ConfigureServiceByInstanceNameAsync(thisServiceName,
                         exePath,
                         currentName,
                         serviceDescription,

--- a/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -7,6 +7,7 @@ using System.Management;
 using System.ServiceProcess;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Util;
 using Polly;
@@ -30,35 +31,21 @@ namespace Octopus.Tentacle.Startup
             this.windowsLocalAdminRightsChecker = windowsLocalAdminRightsChecker;
         }
 
-        public void ConfigureServiceByInstanceName(string thisServiceName,
+        public Task ConfigureServiceByInstanceNameAsync(string thisServiceName,
             string exePath,
             string instance,
             string serviceDescription,
             ServiceConfigurationState serviceConfigurationState)
-        {
-            ConfigureService(thisServiceName,
-                exePath,
-                instance,
-                null,
-                serviceDescription,
-                serviceConfigurationState);
-        }
+            => ConfigureServiceAsync(thisServiceName, exePath, instance, null, serviceDescription, serviceConfigurationState);
 
-        public void ConfigureServiceByConfigPath(string thisServiceName,
+        public Task ConfigureServiceByConfigPathAsync(string thisServiceName,
             string exePath,
             string configPath,
             string serviceDescription,
             ServiceConfigurationState serviceConfigurationState)
-        {
-            ConfigureService(thisServiceName,
-                exePath,
-                null,
-                configPath,
-                serviceDescription,
-                serviceConfigurationState);
-        }
+            => ConfigureServiceAsync(thisServiceName, exePath, null, configPath, serviceDescription, serviceConfigurationState);
 
-        void ConfigureService(string thisServiceName,
+        async Task ConfigureServiceAsync(string thisServiceName,
             string exePath,
             string? instance,
             string? configPath,
@@ -70,19 +57,13 @@ namespace Octopus.Tentacle.Startup
             var controller = services.FirstOrDefault(s => s.ServiceName == thisServiceName);
 
             if (serviceConfigurationState.Restart)
-            {
                 RestartService(thisServiceName, controller);
-            }
 
             if (serviceConfigurationState.Stop)
-            {
                 StopService(thisServiceName, controller);
-            }
 
             if (serviceConfigurationState.Uninstall)
-            {
-                UninstallService(thisServiceName, controller);
-            }
+                await UninstallServiceAsync(thisServiceName, controller);
 
             var serviceDependencies = new List<string>();
             serviceDependencies.AddRange(new[] { "LanmanWorkstation", "TCPIP" });
@@ -95,28 +76,19 @@ namespace Octopus.Tentacle.Startup
             }
 
             if (serviceConfigurationState.Install)
-            {
-                controller = InstallService(thisServiceName, exePath, instance, configPath,
-                    serviceDescription, serviceConfigurationState, controller, serviceDependencies);
-            }
+                controller = await InstallServiceAsync(thisServiceName, exePath, instance, configPath, serviceDescription, serviceConfigurationState, controller, serviceDependencies);
 
             if (serviceConfigurationState.Reconfigure)
-            {
-                ReconfigureService(thisServiceName, exePath, instance, configPath, serviceDescription, serviceDependencies);
-            }
+                await ReconfigureServiceAsync(thisServiceName, exePath, instance, configPath, serviceDescription, serviceDependencies);
 
             if ((serviceConfigurationState.Install || serviceConfigurationState.Reconfigure) && !string.IsNullOrWhiteSpace(serviceConfigurationState.Username))
-            {
-                ConfigureCredentialsForService(thisServiceName, serviceConfigurationState);
-            }
+                await ConfigureCredentialsForServiceAsync(thisServiceName, serviceConfigurationState);
 
             if (serviceConfigurationState.Start)
-            {
                 StartService(thisServiceName, controller);
-            }
         }
 
-        void ConfigureCredentialsForService(string thisServiceName, ServiceConfigurationState serviceConfigurationState)
+        async Task ConfigureCredentialsForServiceAsync(string thisServiceName, ServiceConfigurationState serviceConfigurationState)
         {
             if (!string.IsNullOrWhiteSpace(serviceConfigurationState.Password))
             {
@@ -137,13 +109,13 @@ namespace Octopus.Tentacle.Startup
             }
             else
             {
-                Sc($"config \"{thisServiceName}\" obj= \"{serviceConfigurationState.Username}\"");
+                await ScAsync($"config \"{thisServiceName}\" obj= \"{serviceConfigurationState.Username}\"");
             }
 
             log.Info("Service credentials set");
         }
 
-        void ReconfigureService(string thisServiceName,
+        async Task ReconfigureServiceAsync(string thisServiceName,
             string exePath,
             string? instance,
             string? configPath,
@@ -154,13 +126,13 @@ namespace Octopus.Tentacle.Startup
             var command = exePath.EndsWith(".dll")
                 ? $"config \"{thisServiceName}\" binpath= \"dotnet \\\"{exePath}\\\" run {instanceIdentifier} DisplayName= \"{thisServiceName}\" depend= {string.Join("/", serviceDependencies)} start= auto"
                 : $"config \"{thisServiceName}\" binpath= \"\\\"{exePath}\\\" run {instanceIdentifier} DisplayName= \"{thisServiceName}\" depend= {string.Join("/", serviceDependencies)} start= auto";
-            Sc(command);
-            Sc($"description \"{thisServiceName}\" \"{serviceDescription}\"");
+            await ScAsync(command);
+            await ScAsync($"description \"{thisServiceName}\" \"{serviceDescription}\"");
 
             log.Info("Service reconfigured");
         }
 
-        ServiceController? InstallService(string thisServiceName,
+        async Task<ServiceController?> InstallServiceAsync(string thisServiceName,
             string exePath,
             string? instance,
             string? configPath,
@@ -181,8 +153,8 @@ namespace Octopus.Tentacle.Startup
                     ? $"create \"{thisServiceName}\" binpath= \"dotnet \\\"{exePath}\\\" run {instanceIdentifier} DisplayName= \"{thisServiceName}\" depend= {string.Join("/", serviceDependencies)} start= auto"
                     : $"create \"{thisServiceName}\" binpath= \"\\\"{exePath}\\\" run {instanceIdentifier} DisplayName= \"{thisServiceName}\" depend= {string.Join("/", serviceDependencies)} start= auto";
 
-                Sc(command);
-                Sc($"description \"{thisServiceName}\" \"{serviceDescription}\"");
+                await ScAsync(command);
+                await ScAsync($"description \"{thisServiceName}\" \"{serviceDescription}\"");
             }
 
             log.Info("Service installed");
@@ -195,19 +167,15 @@ namespace Octopus.Tentacle.Startup
         static string InstanceIdentifier(string? instance, string? configPath)
         {
             if (!string.IsNullOrEmpty(instance))
-            {
                 return $"--instance=\\\"{instance}\\\"\"";
-            }
 
             if (!string.IsNullOrEmpty(configPath))
-            {
                 return $"--config=\\\"{configPath}\\\"\"";
-            }
 
             throw new InvalidOperationException("Either the instance name of configuration path must be provided to configure a service");
         }
 
-        void UninstallService(string thisServiceName, ServiceController? controller)
+        async Task UninstallServiceAsync(string thisServiceName, ServiceController? controller)
         {
             if (controller == null)
             {
@@ -215,8 +183,7 @@ namespace Octopus.Tentacle.Startup
             }
             else
             {
-                Sc($"delete \"{thisServiceName}\"");
-
+                await ScAsync($"delete \"{thisServiceName}\"");
                 log.Info("Service uninstalled");
             }
         }
@@ -296,11 +263,7 @@ namespace Octopus.Tentacle.Startup
                     Policy
                         .Handle<Exception>()
                         .WaitAndRetry(5, i => TimeSpan.FromSeconds(Math.Pow(i + 1, 2)), (_, span) => log.Warn($"Failed to start the windows service. Trying again in...{span} "))
-                        .Execute(
-                            () =>
-                            {
-                                controller.Start();
-                            });
+                        .Execute(() => { controller.Start(); });
                 }
 
                 WaitForControllerStatus(controller, ServiceControllerStatus.Running);
@@ -333,7 +296,7 @@ namespace Octopus.Tentacle.Startup
                 150);
         }
 
-        void Sc(string arguments)
+        async Task ScAsync(string arguments)
         {
             var outputBuilder = new StringBuilder();
             var argumentsToLog = string.Join(" ", arguments);
@@ -342,18 +305,14 @@ namespace Octopus.Tentacle.Startup
             var sc = Path.Combine(system32, "sc.exe");
 
             logFileOnlyLogger.Info($"Executing sc.exe {argumentsToLog}");
-            // Sync boundary: Sc() is called from IServiceConfigurator.ConfigureService
-            // implementations, which are themselves called from the Tentacle
-            // service-management CLI on Windows (no sync context, threadpool worker).
-            // GetAwaiter().GetResult() is deadlock-safe here.
-            var exitCode = SilentProcessRunnerExtended.ExecuteCommandAsync(sc,
+            var exitCode = await SilentProcessRunnerExtended.ExecuteCommandAsync(sc,
                 arguments,
                 Environment.CurrentDirectory,
                 output => outputBuilder.AppendLine(output),
                 error => outputBuilder.AppendLine("Error: " + error),
                 cancel: CancellationToken.None,
-                abandon: CancellationToken.None)
-                .GetAwaiter().GetResult();
+                abandon: CancellationToken.None);
+
             if (exitCode == 0)
                 logFileOnlyLogger.Info(outputBuilder.ToString());
             else

--- a/source/Octopus.Tentacle/Startup/WindowsServiceHost.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceHost.cs
@@ -16,23 +16,6 @@ namespace Octopus.Tentacle.Startup
             this.log = log;
         }
 
-        public void Run(Action<ICommandRuntime> start, Action shutdown)
-        {
-            log.Trace("Creating the Windows Service host adapter");
-
-            var startService = new Action(delegate
-            {
-                log.Trace("Starting the Windows Service");
-                start(this);
-                log.Info("The Windows Service has started");
-            });
-
-            var adapter = new WindowsServiceAdapter(startService, () => Stop(shutdown), log);
-
-            log.Trace("Running the service host adapter");
-            ServiceBase.Run(adapter);
-        }
-
         public Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown)
         {
             log.Trace("Creating the Windows Service host adapter");

--- a/source/Octopus.Tentacle/Startup/WindowsServiceHost.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceHost.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.ServiceProcess;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 
 namespace Octopus.Tentacle.Startup
@@ -30,6 +31,27 @@ namespace Octopus.Tentacle.Startup
 
             log.Trace("Running the service host adapter");
             ServiceBase.Run(adapter);
+        }
+
+        public Task RunAsync(Func<ICommandRuntime, Task> start, Action shutdown)
+        {
+            log.Trace("Creating the Windows Service host adapter");
+
+            var startService = new Action(delegate
+            {
+                log.Trace("Starting the Windows Service");
+                // ServiceBase.Run dispatches this on a dedicated background thread (WindowsServiceAdapter.workerThread)
+                // with no SynchronizationContext, so blocking here is deadlock-safe.
+                start(this).GetAwaiter().GetResult();
+                log.Info("The Windows Service has started");
+            });
+
+            var adapter = new WindowsServiceAdapter(startService, () => Stop(shutdown), log);
+
+            log.Trace("Running the service host adapter");
+            // ServiceBase.Run blocks until the Windows service stops — offload to thread pool
+            // so the caller can await it without pinning the main thread.
+            return Task.Run(() => ServiceBase.Run(adapter));
         }
 
         public void Stop(Action shutdown)

--- a/source/Octopus.Tentacle/Util/CommandLineRunner.cs
+++ b/source/Octopus.Tentacle/Util/CommandLineRunner.cs
@@ -1,42 +1,43 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 
 namespace Octopus.Tentacle.Util
 {
     public class CommandLineRunner : ICommandLineRunner
     {
-        public bool Execute(IEnumerable<CommandLineInvocation> commandLineInvocations, ILog log)
+        public Task<bool> ExecuteAsync(IEnumerable<CommandLineInvocation> commandLineInvocations, ILog log)
         {
-            return Execute(commandLineInvocations,
+            return ExecuteAsync(commandLineInvocations,
                 log.Verbose,
                 log.Info,
                 log.Error,
                 log.Error);
         }
 
-        public bool Execute(IEnumerable<CommandLineInvocation> commandLineInvocations,
+        public async Task<bool> ExecuteAsync(IEnumerable<CommandLineInvocation> commandLineInvocations,
                 Action<string> debug,
                 Action<string> info,
                 Action<string> error,
                 Action<Exception, string> exception)
         {
             foreach (var invocation in commandLineInvocations)
-                if (!Execute(invocation, debug, info, error, exception))
+                if (!await ExecuteAsync(invocation, debug, info, error, exception))
                     return false;
 
             return true;
         }
 
-        public bool Execute(CommandLineInvocation invocation, ILog log)
-            => Execute(invocation,
+        public Task<bool> ExecuteAsync(CommandLineInvocation invocation, ILog log)
+            => ExecuteAsync(invocation,
                 log.Info,
                 log.Info,
                 log.Error,
                 log.Error);
 
-        public bool Execute(CommandLineInvocation invocation,
+        public async Task<bool> ExecuteAsync(CommandLineInvocation invocation,
             Action<string> debug,
             Action<string> info,
             Action<string> error,
@@ -44,20 +45,15 @@ namespace Octopus.Tentacle.Util
         {
             try
             {
-                // Sync boundary: ICommandLineRunner is a public interface consumed by
-                // Octopus.Manager.Tentacle (a WPF app) which calls Execute from a
-                // ThreadPool.QueueUserWorkItem — no synchronisation context, so
-                // GetAwaiter().GetResult() here is deadlock-safe.
-                var exitCode = SilentProcessRunner.ExecuteCommandAsync(
-                        invocation.Executable,
-                        (invocation.Arguments ?? "") + " " + (invocation.SystemArguments ?? ""),
-                        Environment.CurrentDirectory,
-                        debug,
-                        info,
-                        error,
-                        cancel: CancellationToken.None,
-                        abandon: CancellationToken.None)
-                    .GetAwaiter().GetResult();
+                var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
+                    invocation.Executable,
+                    (invocation.Arguments ?? "") + " " + (invocation.SystemArguments ?? ""),
+                    Environment.CurrentDirectory,
+                    debug,
+                    info,
+                    error,
+                    cancel: CancellationToken.None,
+                    abandon: CancellationToken.None);
 
                 if (exitCode != 0)
                 {

--- a/source/Octopus.Tentacle/Util/ICommandLineRunner.cs
+++ b/source/Octopus.Tentacle/Util/ICommandLineRunner.cs
@@ -1,22 +1,23 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 
 namespace Octopus.Tentacle.Util
 {
     public interface ICommandLineRunner
     {
-        bool Execute(IEnumerable<CommandLineInvocation> commandLineInvocations, ILog log);
+        Task<bool> ExecuteAsync(IEnumerable<CommandLineInvocation> commandLineInvocations, ILog log);
 
-        bool Execute(IEnumerable<CommandLineInvocation> commandLineInvocations,
+        Task<bool> ExecuteAsync(IEnumerable<CommandLineInvocation> commandLineInvocations,
             Action<string> debug,
             Action<string> info,
             Action<string> error,
             Action<Exception, string> exception);
 
-        bool Execute(CommandLineInvocation commandLineInvocation, ILog log);
+        Task<bool> ExecuteAsync(CommandLineInvocation commandLineInvocation, ILog log);
 
-        bool Execute(CommandLineInvocation invocation,
+        Task<bool> ExecuteAsync(CommandLineInvocation invocation,
             Action<string> debug,
             Action<string> info,
             Action<string> error,

--- a/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
+++ b/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
@@ -14,30 +13,26 @@ namespace Octopus.Tentacle.Util
             this.log = log;
         }
 
-        public bool StartService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("start", serviceName, logFailureAsError);
+        public Task<bool> StartService(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("start", serviceName, logFailureAsError);
 
-        public bool RestartService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("restart", serviceName, logFailureAsError);
+        public Task<bool> RestartService(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("restart", serviceName, logFailureAsError);
 
-        public bool StopService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("stop", serviceName, logFailureAsError);
+        public Task<bool> StopService(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("stop", serviceName, logFailureAsError);
 
-        public bool EnableService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("enable", serviceName, logFailureAsError);
+        public Task<bool> EnableService(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("enable", serviceName, logFailureAsError);
 
-        public bool DisableService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("disable", serviceName, logFailureAsError);
+        public Task<bool> DisableService(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("disable", serviceName, logFailureAsError);
 
-        bool RunServiceCommand(string command, string serviceName, bool logFailureAsError)
+        async Task<bool> RunServiceCommandAsync(string command, string serviceName, bool logFailureAsError)
         {
             // Try without sudo first
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"systemctl {command} {serviceName}\"");
-            // Sync boundary: RunServiceCommand is called from synchronous service-management
-            // helpers (StartService, RestartService, etc.), which are themselves called from
-            // the Tentacle service-management CLI on a threadpool worker with no sync context.
-            // GetAwaiter().GetResult() is deadlock-safe here.
-            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await commandLineInvocation.ExecuteCommandAsync();
             if (result.ExitCode == 0) return true;
 
             // Check if failure is due to authentication/permission issues
@@ -48,18 +43,13 @@ namespace Octopus.Tentacle.Util
                 e.Contains("Permission denied"));
 
             var usedSudo = false;
-            // If authentication issue detected, retry with sudo
             if (needsElevation)
             {
                 log.Info($"Permission denied. Retrying 'systemctl {command} {serviceName}' with sudo...");
                 var sudoInvocation = new CommandLineInvocation("/bin/bash", $"-c \"sudo systemctl {command} {serviceName}\"");
-                // Sync boundary: RunServiceCommand is called from synchronous service-management
-                // helpers (StartService, RestartService, etc.), which are themselves called from
-                // the Tentacle service-management CLI on a threadpool worker with no sync context.
-                // GetAwaiter().GetResult() is deadlock-safe here.
-                result = sudoInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+                result = await sudoInvocation.ExecuteCommandAsync();
                 if (result.ExitCode == 0) return true;
-                
+
                 usedSudo = true;
             }
 


### PR DESCRIPTION
## Summary

Stacks on top of EFT-3295 (the script abandonment PR) to propagate the async signature higher up the call stack — eliminating `.GetAwaiter().GetResult()` calls that were left documented in the abandon PR.

- **Kubernetes disk-space check chain** — `IKubernetesDirectoryInformationProvider.GetPathUsedBytesAsync`, `KubernetesPhysicalFileSystem.GetStorageInformationAsync`, awaited from `KubernetesScriptPodCreator`
- **Service-management CLI command chain** — `IServiceConfigurator.Configure*Async`, `LinuxServiceConfigurator`, `WindowsServiceConfigurator`, `SystemCtlHelper.RunServiceCommandAsync`
- **CLI host async dispatch** — `ICommand.StartAsync`, `ICommandHost.RunAsync`, `Program.Main` becomes `async Task<int>`, sync `Start`/`Run` paths removed
- **`ICommandLineRunner`** — fully async via `ExecuteAsync`; WPF installer's `ReviewAndRunScriptTabViewModel` and `RunProcessDialog` updated

## Test plan
- [ ] Verify Tentacle agent starts via Topshelf (Windows service host)
- [ ] Verify Kubernetes agent starts and runs scripts
- [ ] Verify WPF installer can run the setup wizard
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)