### PR TITLE
Make `SilentProcessRunner.Execute` async

### DIFF
--- a/source/Octopus.Manager.Tentacle.Tests/Builders/SetupTentacleWizardModelBuilder.cs
+++ b/source/Octopus.Manager.Tentacle.Tests/Builders/SetupTentacleWizardModelBuilder.cs
@@ -32,6 +32,8 @@ namespace Octopus.Manager.Tentacle.Tests.Builders
             commandLineRunner = Substitute.For<ICommandLineRunner>();
             commandLineRunner.Execute(Arg.Any<CommandLineInvocation>(), Arg.Any<ILog>()).Returns(true);
             commandLineRunner.Execute(Arg.Any<IEnumerable<CommandLineInvocation>>(), Arg.Any<ILog>()).Returns(true);
+            commandLineRunner.ExecuteAsync(Arg.Any<CommandLineInvocation>(), Arg.Any<ILog>()).Returns(true);
+            commandLineRunner.ExecuteAsync(Arg.Any<IEnumerable<CommandLineInvocation>>(), Arg.Any<ILog>()).Returns(true);
         }
 
         public SetupTentacleWizardModelBuilder WithTelemetryService(ITelemetryService telemetryService)

--- a/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
+++ b/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Util;
 
@@ -10,9 +11,18 @@ namespace Octopus.Manager.Tentacle.PreReq
     {
         public string StatusMessage => "Checking that Windows PowerShell 2.0 is installed...";
 
+        // We're at the WPF installer prerequisite boundary. IPrerequisite.Check() must return
+        // synchronously, so this is the sync-over-async bridge: a one-line wrapper over the
+        // private async implementation. Safe because the installer dispatches us on a plain
+        // thread-pool worker. No captured SynchronizationContext, so no deadlock.
+        // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         public PrerequisiteCheckResult Check()
+            => CheckAsync().GetAwaiter().GetResult();
+
+        async Task<PrerequisiteCheckResult> CheckAsync()
         {
-            return CheckPowerShellIsInstalled(out var commandLineOutput)
+            var (installed, commandLineOutput) = await CheckPowerShellIsInstalledAsync();
+            return installed
                 ? PrerequisiteCheckResult.Successful()
                 : PrerequisiteCheckResult.Failed("Windows PowerShell 2.0 or above does not appear to be installed and on the System Path on this machine. Please install Windows PowerShell or add it to the System Path then re-run this setup tool.",
                     helpLink: "http://g.octopushq.com/HowDoIInstallPowerShell",
@@ -20,44 +30,39 @@ namespace Octopus.Manager.Tentacle.PreReq
                     commandLineOutput: commandLineOutput);
         }
 
-        static bool CheckPowerShellIsInstalled(out string commandLineOutput)
+        static async Task<(bool installed, string commandLineOutput)> CheckPowerShellIsInstalledAsync()
         {
             var stdOut = new StringWriter();
             var stdErr = new StringWriter();
 
             const string powerShellExe = "powershell.exe";
             const string arguments = "-NonInteractive -NoProfile -Command \"Write-Output $PSVersionTable.PSVersion\"";
-            commandLineOutput = $"{powerShellExe} {arguments}";
+            var commandLineOutput = $"{powerShellExe} {arguments}";
 
             // Despite our old check conforming to Microsoft's recommendations
             // for PS version checking around the 1.0/2.0 era, and extending
             // to detect 3.0, it failed to detect 4. Going the direct route:
             try
             {
-                // We're in the WPF installer prerequisite check. IPrerequisite.Check() must return
-                // synchronously, so we block on the async call with .GetAwaiter().GetResult().
-                // This is sync-over-async but is safe because the installer dispatches us on a
-                // plain thread-pool worker. No captured SynchronizationContext, so no deadlock.
-                // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
-                SilentProcessRunnerExtended.ExecuteCommandAsync(
+                await SilentProcessRunnerExtended.ExecuteCommandAsync(
                     powerShellExe,
                     arguments,
                     ".",
                     stdOut.WriteLine,
                     s => stdErr.WriteLine($"ERR: {s}"),
-                    cancel: CancellationToken.None).GetAwaiter().GetResult();
+                    cancel: CancellationToken.None);
 
                 var outputText = stdOut.ToString();
                 new SystemLog().Verbose("PowerShell prerequisite check output: " + outputText);
 
                 commandLineOutput = $"{commandLineOutput}{Environment.NewLine}{stdOut}{Environment.NewLine}{stdErr}";
 
-                return outputText.Contains("Major");
+                return (outputText.Contains("Major"), commandLineOutput);
             }
             catch (Exception ex)
             {
                 commandLineOutput = $"{commandLineOutput}{Environment.NewLine}{ex}";
-                return false;
+                return (false, commandLineOutput);
             }
         }
     }

--- a/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
+++ b/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
@@ -11,10 +11,16 @@ namespace Octopus.Manager.Tentacle.PreReq
     {
         public string StatusMessage => "Checking that Windows PowerShell 2.0 is installed...";
 
-        // We're at the WPF installer prerequisite boundary. IPrerequisite.Check() must return
-        // synchronously, so this is the sync-over-async bridge: a one-line wrapper over the
-        // private async implementation. Safe because the installer dispatches us on a plain
-        // thread-pool worker. No captured SynchronizationContext, so no deadlock.
+        // Why this is sync: IPrerequisite.Check() is part of a sync interface used by
+        // the WPF installer's prerequisite plumbing. Making it async would mean
+        // converting the whole IPrerequisite chain, which is a wider refactor than
+        // this PR.
+        //
+        // Why blocking on the async call is safe: PreReqWindow.Start dispatches each
+        // prerequisite via DispatchHelper.Background, which queues us via
+        // ThreadPool.QueueUserWorkItem. That's a plain thread-pool worker with no
+        // SynchronizationContext, so there's nothing for the awaited continuation
+        // to wait on.
         // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         public PrerequisiteCheckResult Check()
             => CheckAsync().GetAwaiter().GetResult();

--- a/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
+++ b/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Util;
 
@@ -33,12 +34,21 @@ namespace Octopus.Manager.Tentacle.PreReq
             // to detect 3.0, it failed to detect 4. Going the direct route:
             try
             {
-                SilentProcessRunnerExtended.ExecuteCommand(
+                // We're in the WPF installer prerequisite check. IPrerequisite.Check() must return
+                // synchronously — there's no async version of the interface — so we block on the async
+                // call with .GetAwaiter().GetResult().
+                // This is safe because we're on a plain thread-pool worker. The risk with blocking on
+                // async is a deadlock: if the async work needs to resume on the same thread that's
+                // blocked waiting for it, neither can make progress. Thread-pool workers don't have
+                // that constraint — when the async work finishes it can pick up on any free thread,
+                // not specifically this one, so the block resolves normally.
+                SilentProcessRunnerExtended.ExecuteCommandAsync(
                     powerShellExe,
                     arguments,
                     ".",
                     stdOut.WriteLine,
-                    s => stdErr.WriteLine($"ERR: {s}"));
+                    s => stdErr.WriteLine($"ERR: {s}"),
+                    cancel: CancellationToken.None).GetAwaiter().GetResult();
 
                 var outputText = stdOut.ToString();
                 new SystemLog().Verbose("PowerShell prerequisite check output: " + outputText);

--- a/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
+++ b/source/Octopus.Manager.Tentacle/PreReq/PowerShellPrerequisite.cs
@@ -35,13 +35,10 @@ namespace Octopus.Manager.Tentacle.PreReq
             try
             {
                 // We're in the WPF installer prerequisite check. IPrerequisite.Check() must return
-                // synchronously — there's no async version of the interface — so we block on the async
-                // call with .GetAwaiter().GetResult().
-                // This is safe because we're on a plain thread-pool worker. The risk with blocking on
-                // async is a deadlock: if the async work needs to resume on the same thread that's
-                // blocked waiting for it, neither can make progress. Thread-pool workers don't have
-                // that constraint — when the async work finishes it can pick up on any free thread,
-                // not specifically this one, so the block resolves normally.
+                // synchronously, so we block on the async call with .GetAwaiter().GetResult().
+                // This is sync-over-async but is safe because the installer dispatches us on a
+                // plain thread-pool worker. No captured SynchronizationContext, so no deadlock.
+                // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
                 SilentProcessRunnerExtended.ExecuteCommandAsync(
                     powerShellExe,
                     arguments,

--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/ReviewAndRunScriptTabViewModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/ReviewAndRunScriptTabViewModel.cs
@@ -46,7 +46,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
             {
                 var script = GenerateScript();
                 ContributeSensitiveValues(logger);
-                success = commandLineRunner.Execute(script, logger);
+                success = await commandLineRunner.ExecuteAsync(script, logger);
             }
             catch (Exception ex)
             {

--- a/source/Octopus.Tentacle.Core/Services/Scripts/RunningScript.cs
+++ b/source/Octopus.Tentacle.Core/Services/Scripts/RunningScript.cs
@@ -96,7 +96,7 @@ namespace Octopus.Tentacle.Core.Services.Scripts
 
                             exitCode = workspace.ShouldMonitorPowerShellStartup()
                                 ? await RunPowershellScriptWithMonitoring(shellPath, writer, runningScriptToken)
-                                : RunScript(shellPath, writer, runningScriptToken);
+                                : await RunScriptAsync(shellPath, writer, runningScriptToken);
                         }
                     }
                     catch (OperationCanceledException)
@@ -147,7 +147,7 @@ namespace Octopus.Tentacle.Core.Services.Scripts
             var monitor = new PowerShellStartupMonitor(workspace.WorkingDirectory, powerShellStartupTimeout, log, taskId);
             
             var monitoringTask = monitor.WaitForStartup(monitoringTaskCts.Token);
-            var scriptTask = Task.Run(() => RunScript(shellPath, writer, scriptTaskCts.Token), scriptTaskCts.Token);
+            var scriptTask = Task.Run(async () => await RunScriptAsync(shellPath, writer, scriptTaskCts.Token), scriptTaskCts.Token);
             
             var completedTask = await Task.WhenAny(monitoringTask, scriptTask);
             
@@ -222,11 +222,11 @@ namespace Octopus.Tentacle.Core.Services.Scripts
             }
         }
 
-        int RunScript(string shellPath, IScriptLogWriter writer, CancellationToken cancellationToken)
+        async Task<int> RunScriptAsync(string shellPath, IScriptLogWriter writer, CancellationToken cancellationToken)
         {
             try
             {
-                var exitCode = SilentProcessRunner.ExecuteCommand(
+                var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
                     shellPath,
                     shell.FormatCommandArguments(workspace.BootstrapScriptFilePath, workspace.ScriptArguments, false),
                     workspace.WorkingDirectory,
@@ -234,7 +234,7 @@ namespace Octopus.Tentacle.Core.Services.Scripts
                     LogScriptOutputTo(writer, ProcessOutputSource.StdOut),
                     LogScriptOutputTo(writer, ProcessOutputSource.StdErr),
                     environmentVariables,
-                    cancellationToken);
+                    cancel: cancellationToken);
 
                 return exitCode;
             }

--- a/source/Octopus.Tentacle.Core/Util/CommandLine/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle.Core/Util/CommandLine/SilentProcessRunner.cs
@@ -27,7 +27,7 @@ namespace Octopus.Tentacle.Util
             return ExecuteCommandAsync(executable, arguments, workingDirectory, debug, info, error, customEnvironmentVariables: null, cancel: cancel);
         }
 
-        public static async Task<int> ExecuteCommandAsync(
+        public static Task<int> ExecuteCommandAsync(
             string executable,
             string arguments,
             string workingDirectory,
@@ -126,7 +126,6 @@ namespace Octopus.Tentacle.Util
                         WriteData(error, errorResetEvent, e);
                     };
 
-                    process.EnableRaisingEvents = true;
                     process.Start();
 
                     var running = true;
@@ -142,11 +141,7 @@ namespace Octopus.Tentacle.Util
                         process.BeginOutputReadLine();
                         process.BeginErrorReadLine();
 
-#if NETFRAMEWORK
-                        await WaitForExitAsyncNetFramework(process, cancel).ConfigureAwait(false);
-#else
-                        await process.WaitForExitAsync(cancel).ConfigureAwait(false);
-#endif
+                        process.WaitForExit();
 
                         SafelyCancelRead(process.CancelErrorRead, debug);
                         SafelyCancelRead(process.CancelOutputRead, debug);
@@ -158,7 +153,7 @@ namespace Octopus.Tentacle.Util
                         debug($"Process {exeFileNameOrFullPath} in {workingDirectory} exited with code {exitCode}");
 
                         running = false;
-                        return exitCode;
+                        return Task.FromResult(exitCode);
                     }
                 }
             }
@@ -208,30 +203,6 @@ namespace Octopus.Tentacle.Util
                 debug($"Swallowing {ex.GetType().Name} calling {action.Method.Name}.");
             }
         }
-
-#if NETFRAMEWORK
-        static Task WaitForExitAsyncNetFramework(Process process, CancellationToken cancellationToken)
-        {
-            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-            CancellationTokenRegistration registration = default;
-            void OnExited(object? sender, EventArgs e)
-            {
-                registration.Dispose();
-                tcs.TrySetResult(null);
-            }
-            process.Exited += OnExited;
-            if (process.HasExited) tcs.TrySetResult(null);
-            if (cancellationToken.CanBeCanceled)
-            {
-                registration = cancellationToken.Register(() =>
-                {
-                    process.Exited -= OnExited;
-                    tcs.TrySetCanceled(cancellationToken);
-                });
-            }
-            return tcs.Task;
-        }
-#endif
 
         static void DoOurBestToCleanUp(Process process, Action<string> error)
         {

--- a/source/Octopus.Tentacle.Core/Util/CommandLine/SilentProcessRunner.cs
+++ b/source/Octopus.Tentacle.Core/Util/CommandLine/SilentProcessRunner.cs
@@ -8,13 +8,14 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 
 namespace Octopus.Tentacle.Util
 {
     public static class SilentProcessRunner
     {
-        public static int ExecuteCommand(
+        public static Task<int> ExecuteCommandAsync(
             string executable,
             string arguments,
             string workingDirectory,
@@ -23,10 +24,10 @@ namespace Octopus.Tentacle.Util
             Action<string> error,
             CancellationToken cancel)
         {
-            return ExecuteCommand(executable, arguments, workingDirectory, debug, info, error, customEnvironmentVariables: null, cancel: cancel);
+            return ExecuteCommandAsync(executable, arguments, workingDirectory, debug, info, error, customEnvironmentVariables: null, cancel: cancel);
         }
 
-        public static int ExecuteCommand(
+        public static async Task<int> ExecuteCommandAsync(
             string executable,
             string arguments,
             string workingDirectory,
@@ -125,6 +126,7 @@ namespace Octopus.Tentacle.Util
                         WriteData(error, errorResetEvent, e);
                     };
 
+                    process.EnableRaisingEvents = true;
                     process.Start();
 
                     var running = true;
@@ -140,7 +142,11 @@ namespace Octopus.Tentacle.Util
                         process.BeginOutputReadLine();
                         process.BeginErrorReadLine();
 
-                        process.WaitForExit();
+#if NETFRAMEWORK
+                        await WaitForExitAsyncNetFramework(process, cancel).ConfigureAwait(false);
+#else
+                        await process.WaitForExitAsync(cancel).ConfigureAwait(false);
+#endif
 
                         SafelyCancelRead(process.CancelErrorRead, debug);
                         SafelyCancelRead(process.CancelOutputRead, debug);
@@ -202,6 +208,30 @@ namespace Octopus.Tentacle.Util
                 debug($"Swallowing {ex.GetType().Name} calling {action.Method.Name}.");
             }
         }
+
+#if NETFRAMEWORK
+        static Task WaitForExitAsyncNetFramework(Process process, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            CancellationTokenRegistration registration = default;
+            void OnExited(object? sender, EventArgs e)
+            {
+                registration.Dispose();
+                tcs.TrySetResult(null);
+            }
+            process.Exited += OnExited;
+            if (process.HasExited) tcs.TrySetResult(null);
+            if (cancellationToken.CanBeCanceled)
+            {
+                registration = cancellationToken.Register(() =>
+                {
+                    process.Exited -= OnExited;
+                    tcs.TrySetCanceled(cancellationToken);
+                });
+            }
+            return tcs.Task;
+        }
+#endif
 
         static void DoOurBestToCleanUp(Process process, Action<string> error)
         {

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesClusterOneTimeSetUp.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesAgent/KubernetesClusterOneTimeSetUp.cs
@@ -17,7 +17,7 @@ public class KubernetesClusterOneTimeSetUp
         installer = new KubernetesClusterInstaller(KubernetesTestsGlobalContext.Instance.TemporaryDirectory, kindExePath, helmExePath, kubeCtlPath, KubernetesTestsGlobalContext.Instance.Logger);
         await installer.InstallLatestSupported();
 
-        KubernetesTestsGlobalContext.Instance.TentacleImageAndTag = SetupHelpers.GetTentacleImageAndTag(kindExePath, installer);
+        KubernetesTestsGlobalContext.Instance.TentacleImageAndTag = await SetupHelpers.GetTentacleImageAndTag(kindExePath, installer);
         KubernetesTestsGlobalContext.Instance.SetToolExePaths(helmExePath, kubeCtlPath);
         KubernetesTestsGlobalContext.Instance.KubeConfigPath = installer.KubeConfigPath;
     }

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesClientCompatibilityTests.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/KubernetesClientCompatibilityTests.cs
@@ -165,7 +165,7 @@ public class KubernetesClientCompatibilityTests
         clusterInstaller = new KubernetesClusterInstaller(testContext.TemporaryDirectory, kindExePath, helmExePath, kubeCtlPath, testContext.Logger);
         await clusterInstaller.Install(clusterVersion);
 
-        testContext.TentacleImageAndTag = SetupHelpers.GetTentacleImageAndTag(kindExePath, clusterInstaller);
+        testContext.TentacleImageAndTag = await SetupHelpers.GetTentacleImageAndTag(kindExePath, clusterInstaller);
         testContext.SetToolExePaths(helmExePath, kubeCtlPath);
         testContext.KubeConfigPath = clusterInstaller.KubeConfigPath;
     }

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/DockerImageLoader.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/DockerImageLoader.cs
@@ -18,16 +18,16 @@ public class DockerImageLoader
         this.kindExePath = kindExePath;
     }
 
-    public string? LoadMostRecentImageIntoKind(string clusterName)
+    public async Task<string?> LoadMostRecentImageIntoKind(string clusterName)
     {
-        var mostRecentTag = FindMostRecentTag();
+        var mostRecentTag = await FindMostRecentTag();
 
         return !string.IsNullOrWhiteSpace(mostRecentTag)
-            ? LoadImageIntoKind(mostRecentTag, clusterName)
+            ? await LoadImageIntoKind(mostRecentTag, clusterName)
             : null;
     }
 
-    string? FindMostRecentTag()
+    async Task<string?> FindMostRecentTag()
     {
         var sb = new StringBuilder();
         var tags = new List<string>();
@@ -36,7 +36,7 @@ public class DockerImageLoader
             .WriteTo.StringBuilder(sb)
             .CreateLogger();
 
-        var exitCode = SilentProcessRunner.ExecuteCommand(
+        var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
             "docker",
             "images octopusdeploy/kubernetes-agent-tentacle --format \"{{.Tag}}\"",
             temporaryDirectory.DirectoryPath,
@@ -47,7 +47,7 @@ public class DockerImageLoader
                 tags.Add(line);
             },
             sprLogger.Error,
-            CancellationToken.None
+            cancel: CancellationToken.None
         );
 
         if (exitCode != 0)
@@ -55,11 +55,11 @@ public class DockerImageLoader
             logger.Error("Failed to get latest image tag from docker");
             throw new InvalidOperationException($"Failed to get latest image tag from docker. Logs: {sb}");
         }
-        
+
         return tags.FirstOrDefault();
     }
 
-    string LoadImageIntoKind(string mostRecentTag, string clusterName)
+    async Task<string> LoadImageIntoKind(string mostRecentTag, string clusterName)
     {
         var image = $"octopusdeploy/kubernetes-agent-tentacle:{mostRecentTag}";
 
@@ -69,14 +69,14 @@ public class DockerImageLoader
             .WriteTo.StringBuilder(sb)
             .CreateLogger();
 
-        var exitCode = SilentProcessRunner.ExecuteCommand(
+        var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
             kindExePath,
             $"load docker-image {image} --name={clusterName}",
             temporaryDirectory.DirectoryPath,
             sprLogger.Debug,
             sprLogger.Information,
             sprLogger.Error,
-            CancellationToken.None
+            cancel: CancellationToken.None
         );
 
         if (exitCode != 0)

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
@@ -219,10 +219,13 @@ public class KubernetesAgentInstaller
                 NamespaceFlag,
                 AgentName);
 
-            // We're in IDisposable.Dispose(). Dispose() must return synchronously, so we
-            // block on the async call with .GetAwaiter().GetResult(). This is sync-over-async
-            // but is safe because the NUnit test runner dispatches us on a worker thread
-            // without a captured SynchronizationContext, so no deadlock.
+            // Why this is sync: IDisposable.Dispose() must return sync.
+            //
+            // Why blocking on the async call is safe: this only runs under NUnit,
+            // which dispatches us on a worker thread with no SynchronizationContext.
+            //
+            // Why low risk: this is test code. The worst case for a wrong call here
+            // is a hung test, not a production incident.
             // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var exitCode = SilentProcessRunner.ExecuteCommandAsync(
                 helmExePath,

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
@@ -56,14 +56,14 @@ public class KubernetesAgentInstaller
             .MinimumLevel.Debug()
             .CreateLogger();
 
-        var exitCode = SilentProcessRunner.ExecuteCommand(
+        var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
             helmExePath,
             arguments,
             temporaryDirectory.DirectoryPath,
             sprLogger.Debug,
             sprLogger.Information,
             sprLogger.Error,
-            CancellationToken.None);
+            cancel: CancellationToken.None);
 
         sw.Stop();
 
@@ -169,7 +169,7 @@ public class KubernetesAgentInstaller
                 .MinimumLevel.Debug()
                 .CreateLogger();
             
-            var exitCode = SilentProcessRunner.ExecuteCommand(
+            var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
                 kubeCtlExePath,
                 //get the generated thumbprint from the config map
                 $"get cm tentacle-config --namespace {Namespace} --kubeconfig=\"{kubeConfigPath}\" -o \"jsonpath={{.data['Tentacle\\.CertificateThumbprint']}}\"",
@@ -181,7 +181,7 @@ public class KubernetesAgentInstaller
                     thumbprint = x;
                 },
                 sprLogger.Error,
-                CancellationToken.None);
+                cancel: CancellationToken.None);
 
             if (exitCode != 0)
             {
@@ -219,14 +219,16 @@ public class KubernetesAgentInstaller
                 NamespaceFlag,
                 AgentName);
 
-            var exitCode = SilentProcessRunner.ExecuteCommand(
+            // Dispose() cannot be made async; .GetAwaiter().GetResult() is safe here
+            // because this runs in test teardown (not inside an async context with a sync-blocking SynchronizationContext).
+            var exitCode = SilentProcessRunner.ExecuteCommandAsync(
                 helmExePath,
                 uninstallArgs,
                 temporaryDirectory.DirectoryPath,
                 logger.Debug,
                 logger.Information,
                 logger.Error,
-                CancellationToken.None);
+                cancel: CancellationToken.None).GetAwaiter().GetResult();
 
             if (exitCode != 0)
             {

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesAgentInstaller.cs
@@ -219,8 +219,11 @@ public class KubernetesAgentInstaller
                 NamespaceFlag,
                 AgentName);
 
-            // Dispose() cannot be made async; .GetAwaiter().GetResult() is safe here
-            // because this runs in test teardown (not inside an async context with a sync-blocking SynchronizationContext).
+            // We're in IDisposable.Dispose(). Dispose() must return synchronously, so we
+            // block on the async call with .GetAwaiter().GetResult(). This is sync-over-async
+            // but is safe because the NUnit test runner dispatches us on a worker thread
+            // without a captured SynchronizationContext, so no deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var exitCode = SilentProcessRunner.ExecuteCommandAsync(
                 helmExePath,
                 uninstallArgs,

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesClusterInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesClusterInstaller.cs
@@ -53,7 +53,7 @@ public class KubernetesClusterInstaller
 
         var sw = new Stopwatch();
         sw.Restart();
-        var exitCode = SilentProcessRunner.ExecuteCommand(
+        var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
             kindExePath,
             //we give the cluster a unique name
             $"create cluster --name={clusterName} --config=\"{configFilePath}\" --kubeconfig=\"{kubeConfigName}\"",
@@ -61,7 +61,7 @@ public class KubernetesClusterInstaller
             logger.Debug,
             logger.Information,
             logger.Error,
-            CancellationToken.None);
+            cancel: CancellationToken.None);
 
         sw.Stop();
 
@@ -92,7 +92,7 @@ public class KubernetesClusterInstaller
             .WriteTo.StringBuilder(sb)
             .CreateLogger();
 
-        var exitCode = SilentProcessRunner.ExecuteCommand(
+        var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
             kubeCtlPath,
             //we give the cluster a unique name
             $"apply -n default -f \"{manifestFilePath}\" --kubeconfig=\"{KubeConfigPath}\"",
@@ -100,7 +100,7 @@ public class KubernetesClusterInstaller
             sprLogger.Debug,
             sprLogger.Information,
             sprLogger.Error,
-            CancellationToken.None);
+            cancel: CancellationToken.None);
 
         if (exitCode != 0)
         {
@@ -143,14 +143,14 @@ public class KubernetesClusterInstaller
             .WriteTo.StringBuilder(sb)
             .CreateLogger();
         
-        var exitCode = SilentProcessRunner.ExecuteCommand(
+        var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
             helmExePath,
             installArgs,
             tempDir.DirectoryPath,
             sprLogger.Debug,
             sprLogger.Information,
             sprLogger.Error,
-            CancellationToken.None);
+            cancel: CancellationToken.None);
 
         if (exitCode != 0)
         {
@@ -174,7 +174,9 @@ public class KubernetesClusterInstaller
 
     public void Dispose()
     {
-        var exitCode = SilentProcessRunner.ExecuteCommand(
+        // Dispose() cannot be made async; .GetAwaiter().GetResult() is safe here
+        // because this runs in test teardown (not inside an async context with a sync-blocking SynchronizationContext).
+        var exitCode = SilentProcessRunner.ExecuteCommandAsync(
             kindExePath,
             //delete the cluster for this test run
             $"delete cluster --name={clusterName}",
@@ -182,7 +184,7 @@ public class KubernetesClusterInstaller
             logger.Debug,
             logger.Information,
             logger.Error,
-            CancellationToken.None);
+            cancel: CancellationToken.None).GetAwaiter().GetResult();
 
         if (exitCode != 0)
         {

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesClusterInstaller.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/KubernetesClusterInstaller.cs
@@ -174,8 +174,11 @@ public class KubernetesClusterInstaller
 
     public void Dispose()
     {
-        // Dispose() cannot be made async; .GetAwaiter().GetResult() is safe here
-        // because this runs in test teardown (not inside an async context with a sync-blocking SynchronizationContext).
+        // We're in IDisposable.Dispose(). Dispose() must return synchronously, so we
+        // block on the async call with .GetAwaiter().GetResult(). This is sync-over-async
+        // but is safe because the NUnit test runner dispatches us on a worker thread
+        // without a captured SynchronizationContext, so no deadlock.
+        // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         var exitCode = SilentProcessRunner.ExecuteCommandAsync(
             kindExePath,
             //delete the cluster for this test run

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/SetupHelpers.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/SetupHelpers.cs
@@ -46,7 +46,7 @@ static class SetupHelpers
             builder.Build());
     }
     
-    public static string? GetTentacleImageAndTag(string kindExePath, KubernetesClusterInstaller clusterInstaller)
+    public static async Task<string?> GetTentacleImageAndTag(string kindExePath, KubernetesClusterInstaller clusterInstaller)
     {
         if (clusterInstaller == null)
         {
@@ -68,9 +68,9 @@ static class SetupHelpers
         {
             //if we should use the latest locally build image, load the tag from docker and load it into kind
             var imageLoader = new DockerImageLoader(KubernetesTestsGlobalContext.Instance.TemporaryDirectory, KubernetesTestsGlobalContext.Instance.Logger, kindExePath);
-            imageAndTag = imageLoader.LoadMostRecentImageIntoKind(clusterInstaller.ClusterName);
+            imageAndTag = await imageLoader.LoadMostRecentImageIntoKind(clusterInstaller.ClusterName);
         }
-        
+
         if(imageAndTag is not null)
             KubernetesTestsGlobalContext.Instance.Logger.Information("Using tentacle image: {ImageAndTag}", imageAndTag);
 

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/HelmDownloader.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/HelmDownloader.cs
@@ -27,7 +27,7 @@ public class HelmDownloader : ToolDownloader
 
     static string GetArchitectureLabel(Architecture processArchitecture) => processArchitecture == Architecture.Arm64 ? "arm64" : "amd64";
 
-    protected override string PostDownload(string targetDirectory, string downloadFilePath, Architecture processArchitecture, OperatingSystem operatingSystem)
+    protected override async Task<string> PostDownload(string targetDirectory, string downloadFilePath, Architecture processArchitecture, OperatingSystem operatingSystem)
     {
         var architecture = GetArchitectureLabel(processArchitecture);
         var osName = GetOsName(operatingSystem);
@@ -43,7 +43,7 @@ public class HelmDownloader : ToolDownloader
         else
         {
             //everything else is tar.gz
-            ExtractTarGzip(downloadFilePath, extractionDir);
+            await ExtractTarGzip(downloadFilePath, extractionDir);
         }
 
         //move the extracted helm executable to the root target directory
@@ -66,7 +66,7 @@ public class HelmDownloader : ToolDownloader
             _ => throw new ArgumentOutOfRangeException(nameof(operatingSystem), operatingSystem, null)
         };
 
-    void ExtractTarGzip(string gzArchiveName, string destFolder)
+    async Task ExtractTarGzip(string gzArchiveName, string destFolder)
     {
         if (!Directory.Exists(destFolder))
         {
@@ -79,14 +79,14 @@ public class HelmDownloader : ToolDownloader
         // Falling back to good old fashioned `tar` does the job nicely :)
         using var tmp = new TemporaryDirectory();
 
-        var exitCode = SilentProcessRunner.ExecuteCommand(
+        var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
             "tar",
             $"xzvf \"{gzArchiveName}\" -C \"{destFolder}\"",
             tmp.DirectoryPath,
             Logger.Debug,
             Logger.Information,
             Logger.Error,
-            CancellationToken.None);
+            cancel: CancellationToken.None);
 
         if (exitCode != 0)
         {

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/ToolDownloader.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Setup/Tooling/ToolDownloader.cs
@@ -37,19 +37,19 @@ public abstract class ToolDownloader : IToolDownloader
         Logger.Information("Downloading {DownloadUrl} to {DownloadFilePath}", downloadUrl, downloadFilePath);
         await OctopusPackageDownloader.DownloadPackage(downloadUrl, downloadFilePath, Logger, cancellationToken);
 
-        downloadFilePath = PostDownload(targetDirectory, downloadFilePath, RuntimeInformation.ProcessArchitecture, os);
+        downloadFilePath = await PostDownload(targetDirectory, downloadFilePath, RuntimeInformation.ProcessArchitecture, os);
 
         //if this is not running on windows, chmod the tool to be executable
         if (os is not OperatingSystem.Windows)
         {
-            var exitCode = SilentProcessRunner.ExecuteCommand(
+            var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
                 "chmod",
                 $"+x \"{downloadFilePath}\"",
                 targetDirectory,
                 Logger.Debug,
                 Logger.Information,
                 Logger.Error,
-                CancellationToken.None);
+                cancel: CancellationToken.None);
 
             if (exitCode != 0)
             {
@@ -62,12 +62,12 @@ public abstract class ToolDownloader : IToolDownloader
 
     protected abstract string BuildDownloadUrl(Architecture processArchitecture, OperatingSystem operatingSystem);
 
-    protected virtual string PostDownload(string downloadDirectory, string downloadFilePath, Architecture processArchitecture, OperatingSystem operatingSystem)
+    protected virtual Task<string> PostDownload(string downloadDirectory, string downloadFilePath, Architecture processArchitecture, OperatingSystem operatingSystem)
     {
         var targetFilename = Path.Combine(downloadDirectory, ExecutableName);
         File.Move(downloadFilePath, targetFilename);
 
-        return targetFilename;
+        return Task.FromResult(targetFilename);
     }
 
     static OperatingSystem GetOperationSystem()

--- a/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Tooling/KubeCtlTool.cs
+++ b/source/Octopus.Tentacle.Kubernetes.Tests.Integration/Tooling/KubeCtlTool.cs
@@ -25,10 +25,10 @@ public class KubeCtlTool
 
     public Task<KubeCtlCommandResult> ExecuteNamespacedCommand(string command, CancellationToken cancellationToken = default)
     {
-        return Task.Run(() => ExecuteCommand($"{command} --namespace {ns}", cancellationToken), cancellationToken);
+        return ExecuteCommand($"{command} --namespace {ns}", cancellationToken);
     }
 
-    KubeCtlCommandResult ExecuteCommand(string command, CancellationToken cancellationToken = default)
+    async Task<KubeCtlCommandResult> ExecuteCommand(string command, CancellationToken cancellationToken = default)
     {
         var sb = new StringBuilder();
         var sprLogger = new LoggerConfiguration()
@@ -40,7 +40,7 @@ public class KubeCtlTool
         var stdOut = new List<string>();
         var stdErr = new List<string>();
 
-        var exitCode = SilentProcessRunner.ExecuteCommand(
+        var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
             kubeCtlExePath,
             $"{command} --kubeconfig=\"{kubeConfigPath}\"",
             temporaryDirectory.DirectoryPath,
@@ -55,7 +55,7 @@ public class KubeCtlTool
                 sprLogger.Error(y);
                 stdErr.Add(y);
             },
-            cancellationToken);
+            cancel: cancellationToken);
 
         return new (exitCode, stdOut, stdErr);
     }

--- a/source/Octopus.Tentacle.Tests.Integration/PowerShellStartupDetectionTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/PowerShellStartupDetectionTests.cs
@@ -271,14 +271,14 @@ write-output 'This should never be printed'
             var args = shell.FormatCommandArguments(workspace.BootstrapScriptFilePath, null, allowInteractive: false);
 
             var directOutput = new List<string>();
-            var directExitCode = SilentProcessRunner.ExecuteCommand(
+            var directExitCode = await SilentProcessRunner.ExecuteCommandAsync(
                 shell.GetFullPath(),
                 args,
                 workspace.WorkingDirectory,
                 _ => { },
                 line => directOutput.Add(line),
                 line => directOutput.Add(line),
-                CancellationToken.None);
+                cancel: CancellationToken.None);
 
             var directOutputText = string.Join("\n", directOutput);
             Logger.Information("Direct invocation output:\n{Output}", directOutputText);
@@ -338,14 +338,14 @@ write-output 'This should never be printed'
             var args = shell.FormatCommandArguments(bootstrapScriptFilePath, null, allowInteractive: false);
 
             var directOutput = new List<string>();
-            var directExitCode = SilentProcessRunner.ExecuteCommand(
+            var directExitCode = await SilentProcessRunner.ExecuteCommandAsync(
                 shell.GetFullPath(),
                 args,
                 workspace.WorkingDirectory,
                 _ => { },
                 line => directOutput.Add(line),
                 line => directOutput.Add(line),
-                CancellationToken.None);
+                cancel: CancellationToken.None);
 
             var directOutputText = string.Join("\n", directOutput);
             Logger.Information("Direct invocation output:\n{Output}", directOutputText);
@@ -370,15 +370,17 @@ write-output 'This should never be printed'
             // First check if pwsh is available
             try
             {
-                var result = SilentProcessRunner.ExecuteCommand(
+                var result = SilentProcessRunner.ExecuteCommandAsync(
                     "which",
                     "pwsh",
                     Environment.CurrentDirectory,
                     _ => { },
                     _ => { },
                     _ => { },
-                    new Dictionary<string, string>(),
-                    CancellationToken.None);
+                    customEnvironmentVariables: new Dictionary<string, string>(),
+                    cancel: CancellationToken.None)
+                    // Safe: static helper, no synchronisation context.
+                    .GetAwaiter().GetResult();
 
                 if (result == 0)
                 {

--- a/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using Octopus.Tentacle.CommonTestUtils.Diagnostics;
@@ -21,22 +22,22 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
     {
         [Test]
         [RequiresSudoOnLinux]
-        public void CanInstallServiceAsRoot()
+        public async Task CanInstallServiceAsRoot()
         {
-            CanInstallService(null, null);
+            await CanInstallService(null, null);
         }
 
         [Test]
         [RequiresSudoOnLinux]
-        public void CanInstallServiceAsUser()
+        public async Task CanInstallServiceAsUser()
         {
             var user = new LinuxTestUserPrincipal("octo-shared-svc-test");
-            CanInstallService(user.UserName, user.Password);
+            await CanInstallService(user.UserName, user.Password);
         }
 
         [Test]
         [RequiresSudoOnLinux]
-        public void CannotWriteToServiceFileAsUser()
+        public async Task CannotWriteToServiceFileAsUser()
         {
             const string serviceName = "OctopusShared.ServiceHelperTest";
             const string instance = "TestCannotWriteToServiceFileInstance";
@@ -47,8 +48,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
             WriteUnixFile(scriptPath);
 
             var chmodCmd = new CommandLineInvocation("/bin/bash", $"-c \"chmod 777 {scriptPath}\"");
-            // Safe: sync test helper, no synchronisation context.
-            chmodCmd.ExecuteCommandAsync().GetAwaiter().GetResult();
+            await chmodCmd.ExecuteCommandAsync();
 
             var configureServiceHelper = new LinuxServiceConfigurator(log);
 
@@ -67,12 +67,11 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
                 serviceConfigurationState);
 
             var statCmd = new CommandLineInvocation("/bin/bash", $"-c \"stat -c '%A' /etc/systemd/system/{instance}.service\"");
-            // Safe: sync test helper, no synchronisation context.
-            var result = statCmd.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await statCmd.ExecuteCommandAsync();
             result.Infos.Single().Should().Be("-rw-r--r--"); // Service file should only be writeable for the root user
         }
 
-        void CanInstallService(string username, string password)
+        async Task CanInstallService(string username, string password)
         {
             const string serviceName = "OctopusShared.ServiceHelperTest";
             const string instance = "TestInstance";
@@ -83,8 +82,7 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
             WriteUnixFile(scriptPath);
 
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"chmod 777 {scriptPath}\"");
-            // Safe: sync test helper, no synchronisation context.
-            commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            await commandLineInvocation.ExecuteCommandAsync();
 
             var configureServiceHelper = new LinuxServiceConfigurator(log);
 
@@ -103,19 +101,19 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
                 serviceConfigurationState);
 
             //Check that the systemd unit service file has been written
-            Assert.IsTrue(DoesServiceUnitFileExist(instance), "The service unit file has not been created");
+            Assert.IsTrue(await DoesServiceUnitFileExist(instance), "The service unit file has not been created");
 
-            var status = GetServiceStatus(instance);
+            var status = await GetServiceStatus(instance);
             status["ActiveState"].Should().Be("active");
             status["SubState"].Should().Be("running");
             status["LoadState"].Should().Be("loaded");
             status["User"].Should().Be(username ?? "root");
 
             //Check that the Service is running
-            Assert.IsTrue(IsServiceRunning(instance), "The service is not running");
+            Assert.IsTrue(await IsServiceRunning(instance), "The service is not running");
 
             //Check that the service is enabled to run on startup
-            Assert.IsTrue(IsServiceEnabled(instance), "The service has not been enabled to run on startup");
+            Assert.IsTrue(await IsServiceEnabled(instance), "The service has not been enabled to run on startup");
 
             var stopServiceConfigurationState = new ServiceConfigurationState
             {
@@ -130,13 +128,13 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
                 stopServiceConfigurationState);
 
             //Check that the Service has stopped
-            Assert.IsFalse(IsServiceRunning(instance), "The service has not been stopped");
+            Assert.IsFalse(await IsServiceRunning(instance), "The service has not been stopped");
 
             //Check that the service is disabled
-            Assert.IsFalse(IsServiceEnabled(instance), "The service has not been disabled");
+            Assert.IsFalse(await IsServiceEnabled(instance), "The service has not been disabled");
 
             //Check that the service is disabled
-            Assert.IsFalse(DoesServiceUnitFileExist(instance), "The service unit file still exists");
+            Assert.IsFalse(await DoesServiceUnitFileExist(instance), "The service unit file still exists");
         }
 
         void WriteUnixFile(string path)
@@ -151,11 +149,10 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
             }
         }
 
-        Dictionary<string, string> GetServiceStatus(string serviceName)
+        async Task<Dictionary<string, string>> GetServiceStatus(string serviceName)
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"systemctl show {serviceName}\"");
-            // Safe: sync test helper, no synchronisation context.
-            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await commandLineInvocation.ExecuteCommandAsync();
             Console.WriteLine($"Status of service {serviceName}");
             foreach (var info in result.Infos)
                 Console.WriteLine(info);
@@ -164,29 +161,28 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
                 .ToDictionary(x => x[0], x => x[1]);
         }
 
-        bool IsServiceRunning(string serviceName)
+        async Task<bool> IsServiceRunning(string serviceName)
         {
-            var result = RunBashCommand($"systemctl is-active --quiet {serviceName}");
+            var result = await RunBashCommand($"systemctl is-active --quiet {serviceName}");
             return result.ExitCode == 0;
         }
 
-        bool IsServiceEnabled(string serviceName)
+        async Task<bool> IsServiceEnabled(string serviceName)
         {
-            var result = RunBashCommand($"systemctl is-enabled --quiet {serviceName}");
+            var result = await RunBashCommand($"systemctl is-enabled --quiet {serviceName}");
             return result.ExitCode == 0;
         }
 
-        bool DoesServiceUnitFileExist(string serviceName)
+        async Task<bool> DoesServiceUnitFileExist(string serviceName)
         {
-            var result = RunBashCommand($"ls /etc/systemd/system | grep {serviceName}.service");
+            var result = await RunBashCommand($"ls /etc/systemd/system | grep {serviceName}.service");
             return result.ExitCode == 0;
         }
 
-        CmdResult RunBashCommand(string command)
+        async Task<CmdResult> RunBashCommand(string command)
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"{command}\"");
-            // Safe: sync test helper, no synchronisation context.
-            return commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            return await commandLineInvocation.ExecuteCommandAsync();
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Startup/LinuxConfigureServiceHelperFixture.cs
@@ -47,7 +47,8 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
             WriteUnixFile(scriptPath);
 
             var chmodCmd = new CommandLineInvocation("/bin/bash", $"-c \"chmod 777 {scriptPath}\"");
-            chmodCmd.ExecuteCommand();
+            // Safe: sync test helper, no synchronisation context.
+            chmodCmd.ExecuteCommandAsync().GetAwaiter().GetResult();
 
             var configureServiceHelper = new LinuxServiceConfigurator(log);
 
@@ -66,7 +67,8 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
                 serviceConfigurationState);
 
             var statCmd = new CommandLineInvocation("/bin/bash", $"-c \"stat -c '%A' /etc/systemd/system/{instance}.service\"");
-            var result = statCmd.ExecuteCommand();
+            // Safe: sync test helper, no synchronisation context.
+            var result = statCmd.ExecuteCommandAsync().GetAwaiter().GetResult();
             result.Infos.Single().Should().Be("-rw-r--r--"); // Service file should only be writeable for the root user
         }
 
@@ -81,7 +83,8 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
             WriteUnixFile(scriptPath);
 
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"chmod 777 {scriptPath}\"");
-            commandLineInvocation.ExecuteCommand();
+            // Safe: sync test helper, no synchronisation context.
+            commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
 
             var configureServiceHelper = new LinuxServiceConfigurator(log);
 
@@ -151,7 +154,8 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
         Dictionary<string, string> GetServiceStatus(string serviceName)
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"systemctl show {serviceName}\"");
-            var result = commandLineInvocation.ExecuteCommand();
+            // Safe: sync test helper, no synchronisation context.
+            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
             Console.WriteLine($"Status of service {serviceName}");
             foreach (var info in result.Infos)
                 Console.WriteLine(info);
@@ -181,7 +185,8 @@ namespace Octopus.Tentacle.Tests.Integration.Startup
         CmdResult RunBashCommand(string command)
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"{command}\"");
-            return commandLineInvocation.ExecuteCommand();
+            // Safe: sync test helper, no synchronisation context.
+            return commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
@@ -62,6 +62,12 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             using var tmp = new TemporaryDirectory();
 
             Action<string> log = s => logger.Information(s);
+            // We're in a synchronous public static helper (ExtractTarGzip). The method
+            // must return synchronously, so we block on the async call with
+            // .GetAwaiter().GetResult(). This is sync-over-async but is safe because
+            // the NUnit test runner dispatches us on a worker thread without a captured
+            // SynchronizationContext, so no deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var exitCode = SilentProcessRunner.ExecuteCommandAsync(
                 "tar",
                 $"xzvf \"{gzArchiveName}\" -C \"{destFolder}\"",
@@ -69,9 +75,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
                 log,
                 log,
                 log,
-                cancel: CancellationToken.None)
-                // Safe: static void helper, no synchronisation context.
-                .GetAwaiter().GetResult();
+                cancel: CancellationToken.None).GetAwaiter().GetResult();
 
             if (exitCode != 0)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
@@ -44,11 +44,11 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
 
             var extractionDirectory = new DirectoryInfo(Path.Combine(directoryPath, "extracted"));
 
-            ExtractTarGzip(downloadFilePath, extractionDirectory.FullName, logger);
+            await ExtractTarGzipAsync(downloadFilePath, extractionDirectory.FullName, logger);
             return Path.Combine(extractionDirectory.FullName, "tentacle", "Tentacle");
         }
 
-        public static void ExtractTarGzip(string gzArchiveName, string destFolder, ILogger logger)
+        public static async Task ExtractTarGzipAsync(string gzArchiveName, string destFolder, ILogger logger)
         {
             if (!Directory.Exists(destFolder))
             {
@@ -62,20 +62,14 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             using var tmp = new TemporaryDirectory();
 
             Action<string> log = s => logger.Information(s);
-            // We're in a synchronous public static helper (ExtractTarGzip). The method
-            // must return synchronously, so we block on the async call with
-            // .GetAwaiter().GetResult(). This is sync-over-async but is safe because
-            // the NUnit test runner dispatches us on a worker thread without a captured
-            // SynchronizationContext, so no deadlock.
-            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
-            var exitCode = SilentProcessRunner.ExecuteCommandAsync(
+            var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
                 "tar",
                 $"xzvf \"{gzArchiveName}\" -C \"{destFolder}\"",
                 tmp.DirectoryPath,
                 log,
                 log,
                 log,
-                cancel: CancellationToken.None).GetAwaiter().GetResult();
+                cancel: CancellationToken.None);
 
             if (exitCode != 0)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/LinuxTentacleFetcher.cs
@@ -62,14 +62,16 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             using var tmp = new TemporaryDirectory();
 
             Action<string> log = s => logger.Information(s);
-            var exitCode = SilentProcessRunner.ExecuteCommand(
+            var exitCode = SilentProcessRunner.ExecuteCommandAsync(
                 "tar",
                 $"xzvf \"{gzArchiveName}\" -C \"{destFolder}\"",
                 tmp.DirectoryPath,
                 log,
                 log,
                 log,
-                CancellationToken.None);
+                cancel: CancellationToken.None)
+                // Safe: static void helper, no synchronisation context.
+                .GetAwaiter().GetResult();
 
             if (exitCode != 0)
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/NugetTentacleFetcher.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Support/TentacleFetchers/NugetTentacleFetcher.cs
@@ -61,7 +61,7 @@ namespace Octopus.Tentacle.Tests.Integration.Support.TentacleFetchers
             var tentacleFolder = Path.Combine(directoryPath, "tentacle");
             if (tentacleArtifact.EndsWith(".tar.gz"))
             {
-                LinuxTentacleFetcher.ExtractTarGzip(tentacleArtifact, tentacleFolder, logger);
+                await LinuxTentacleFetcher.ExtractTarGzipAsync(tentacleArtifact, tentacleFolder, logger);
             }
             else
             {

--- a/source/Octopus.Tentacle.Tests.Integration/Util/LinuxTestUserPrincipal.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/LinuxTestUserPrincipal.cs
@@ -22,7 +22,12 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         static void RunCommand(string arguments, bool failOnNonZeroExitCode = true)
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", arguments);
-            // Safe: constructor-time helper, no synchronisation context.
+            // We're in a synchronous test helper called from the LinuxTestUserPrincipal
+            // constructor. Constructors must return synchronously, so we block on the
+            // async call with .GetAwaiter().GetResult(). This is sync-over-async but is
+            // safe because the NUnit test runner dispatches us on a worker thread without
+            // a captured SynchronizationContext, so no deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
 
             foreach (var line in result.Errors)

--- a/source/Octopus.Tentacle.Tests.Integration/Util/LinuxTestUserPrincipal.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/LinuxTestUserPrincipal.cs
@@ -22,7 +22,8 @@ namespace Octopus.Tentacle.Tests.Integration.Util
         static void RunCommand(string arguments, bool failOnNonZeroExitCode = true)
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", arguments);
-            var result = commandLineInvocation.ExecuteCommand();
+            // Safe: constructor-time helper, no synchronisation context.
+            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
 
             foreach (var line in result.Errors)
                 Console.WriteLine(line);

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
@@ -406,8 +406,6 @@ while ((Get-Date) -lt $deadline) {
             return $"${varName}";
         }
 
-        // Sync-over-async is safe here: NUnit runs tests on a plain ThreadPool thread with no
-        // synchronisation context, so there is no risk of deadlock.
         static int Execute(
             string command,
             string arguments,
@@ -421,6 +419,13 @@ while ((Get-Date) -lt $deadline) {
             var info = new StringBuilder();
             var error = new StringBuilder();
 
+            // We're in a synchronous test helper (Execute) that exposes a sync int
+            // return and out parameters. The method must return synchronously, so we
+            // block on the async call with .GetAwaiter().GetResult(). This is
+            // sync-over-async but is safe because the NUnit test runner dispatches us
+            // on a worker thread without a captured SynchronizationContext, so no
+            // deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var exitCode = SilentProcessRunner.ExecuteCommandAsync(
                 command,
                 arguments,

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
@@ -419,12 +419,15 @@ while ((Get-Date) -lt $deadline) {
             var info = new StringBuilder();
             var error = new StringBuilder();
 
-            // We're in a synchronous test helper (Execute) that exposes a sync int
-            // return and out parameters. The method must return synchronously, so we
-            // block on the async call with .GetAwaiter().GetResult(). This is
-            // sync-over-async but is safe because the NUnit test runner dispatches us
-            // on a worker thread without a captured SynchronizationContext, so no
-            // deadlock.
+            // Why this is sync: Execute is a test helper that returns int and uses
+            // out parameters — both force the signature to be sync. It's invoked
+            // directly from sync NUnit test methods.
+            //
+            // Why blocking on the async call is safe: NUnit dispatches us on a
+            // worker thread with no SynchronizationContext.
+            //
+            // Why low risk: this is test code. The worst case for a wrong call here
+            // is a hung test, not a production incident.
             // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var exitCode = SilentProcessRunner.ExecuteCommandAsync(
                 command,

--- a/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/Util/SilentProcessRunnerFixture.cs
@@ -406,6 +406,8 @@ while ((Get-Date) -lt $deadline) {
             return $"${varName}";
         }
 
+        // Sync-over-async is safe here: NUnit runs tests on a plain ThreadPool thread with no
+        // synchronisation context, so there is no risk of deadlock.
         static int Execute(
             string command,
             string arguments,
@@ -418,7 +420,8 @@ while ((Get-Date) -lt $deadline) {
             var debug = new StringBuilder();
             var info = new StringBuilder();
             var error = new StringBuilder();
-            var exitCode = SilentProcessRunner.ExecuteCommand(
+
+            var exitCode = SilentProcessRunner.ExecuteCommandAsync(
                 command,
                 arguments,
                 workingDirectory,
@@ -437,7 +440,7 @@ while ((Get-Date) -lt $deadline) {
                     Console.WriteLine($"{DateTime.UtcNow} ERR: {x}");
                     error.Append(x);
                 },
-                cancel);
+                cancel: cancel).GetAwaiter().GetResult();
 
             debugMessages = debug;
             infoMessages = info;

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesDirectoryInformationProviderFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Internal;
@@ -24,27 +25,29 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         {
             const ulong usedSize = 500 * Megabyte;
             var spr = Substitute.For<ISilentProcessRunner>();
-            spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
-                .Do(x =>
+            spr.ExecuteCommandAsync("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+                .Returns(callInfo =>
                 {
-                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    return Task.FromResult(0);
                 });
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
         }
-        
+
         [Test]
         public void DuOutputParsesWithMultipleLines()
         {
             const ulong usedSize = 500 * Megabyte;
             var spr = Substitute.For<ISilentProcessRunner>();
-            spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
-                .Do(x =>
+            spr.ExecuteCommandAsync("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+                .Returns(callInfo =>
                 {
-                    x.ArgAt<Action<string>>(3).Invoke($"500\t/octopus/extradir");
-                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
-                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize+1000}\tTotal");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"500\t/octopus/extradir");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"{usedSize+1000}\tTotal");
+                    return Task.FromResult(0);
                 });
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
@@ -56,18 +59,18 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         {
             const ulong usedSize = 500 * Megabyte;
             var spr = Substitute.For<ISilentProcessRunner>();
-            spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
-                .Do(x =>
+            spr.ExecuteCommandAsync("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+                .Returns(callInfo =>
                 {
-                    x.ArgAt<Action<string>>(3).Invoke($"500\t/octopus");
-                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"500\t/octopus");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    return Task.FromResult(1);
                 });
-            spr.ReturnsForAll(1);
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
         }
-        
+
         [Test]
         public void IfDuFailsWeLogCorrectly()
         {
@@ -75,22 +78,22 @@ namespace Octopus.Tentacle.Tests.Kubernetes
             var systemLog = new InMemoryLog();
             var spr = Substitute.For<ISilentProcessRunner>();
 
-            spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
-                .Do(x =>
+            spr.ExecuteCommandAsync("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+                .Returns(callInfo =>
                 {
                     // stdout
-                    x.ArgAt<Action<string>>(3).Invoke("500\t/octopus");
-                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
-                    
+                    callInfo.ArgAt<Action<string>>(3).Invoke("500\t/octopus");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+
                     // stderr
-                    x.ArgAt<Action<string>>(4).Invoke("no permission for foo");
-                    x.ArgAt<Action<string>>(4).Invoke("also no permission for bar");
+                    callInfo.ArgAt<Action<string>>(4).Invoke("no permission for foo");
+                    callInfo.ArgAt<Action<string>>(4).Invoke("also no permission for bar");
+                    return Task.FromResult(1);
                 });
-            spr.ReturnsForAll(1);
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(systemLog, spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
-            
+
             systemLog.GetLogsForCategory(LogCategory.Warning).Should().Contain("Could not reliably get disk space using du. Getting best approximation...");
             systemLog.GetLogsForCategory(LogCategory.Info).Should().Contain($"Du stdout returned 500\t/octopus, {usedSize}\t/octopus");
             systemLog.GetLogsForCategory(LogCategory.Info).Should().Contain("Du stderr returned no permission for foo, also no permission for bar");
@@ -100,56 +103,61 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         public void IfDuFailsCompletelyReturnNull()
         {
             var spr = Substitute.For<ISilentProcessRunner>();
-            spr.ReturnsForAll(1);
+            spr.ExecuteCommandAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+                .Returns(Task.FromResult(1));
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(null);
         }
-        
+
         [Test]
         public void ReturnedValueShouldBeCached()
         {
             var spr = Substitute.For<ISilentProcessRunner>();
-            spr.ReturnsForAll(1);
+            spr.ExecuteCommandAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+                .Returns(Task.FromResult(1));
             var baseTime = DateTimeOffset.UtcNow;
             var clock = new TestClock(baseTime);
             var memoryCache = new MemoryCache(new MemoryCacheOptions(){ Clock = clock});
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(null);
-            
+
             const ulong usedSize = 500 * Megabyte;
-            spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
-                .Do(x =>
+            spr.ExecuteCommandAsync("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+                .Returns(callInfo =>
                 {
-                    x.ArgAt<Action<string>>(3).Invoke($"123\t/octopus");
-                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"123\t/octopus");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    return Task.FromResult(0);
                 });
             clock.UtcNow = baseTime + TimeSpan.FromSeconds(29);
 
             sut.GetPathUsedBytes("/octopus").Should().Be(null);
         }
-        
+
         [Test]
         public void DuCacheExpiresAfter30Seconds()
         {
             var spr = Substitute.For<ISilentProcessRunner>();
-            spr.ReturnsForAll(1);
+            spr.ExecuteCommandAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+                .Returns(Task.FromResult(1));
             var baseTime = DateTimeOffset.UtcNow;
             var clock = new TestClock(baseTime);
             var memoryCache = new MemoryCache(new MemoryCacheOptions(){ Clock = clock});
             var sut = new KubernetesDirectoryInformationProvider(Substitute.For<ISystemLog>(), spr, memoryCache);
             sut.GetPathUsedBytes("/octopus").Should().Be(null);
-            
+
             const ulong usedSize = 500 * Megabyte;
-            spr.When(x => x.ExecuteCommand("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>()))
-                .Do(x =>
+            spr.ExecuteCommandAsync("du", "-s -B 1 /octopus", "/", Arg.Any<Action<string>>(), Arg.Any<Action<string>>())
+                .Returns(callInfo =>
                 {
-                    x.ArgAt<Action<string>>(3).Invoke($"123\t/octopus");
-                    x.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"123\t/octopus");
+                    callInfo.ArgAt<Action<string>>(3).Invoke($"{usedSize}\t/octopus");
+                    return Task.FromResult(0);
                 });
 
             clock.UtcNow = baseTime + TimeSpan.FromSeconds(30);
-            
+
             sut.GetPathUsedBytes("/octopus").Should().Be(usedSize);
         }
 

--- a/source/Octopus.Tentacle.Tests/Util/LinuxTestUserPrincipal.cs
+++ b/source/Octopus.Tentacle.Tests/Util/LinuxTestUserPrincipal.cs
@@ -19,6 +19,15 @@ namespace Octopus.Tentacle.Tests.Util
 
         public string UserName { get;  }
 
+        // Why this is sync: RunCommand is called from the constructor, which can't
+        // be async.
+        //
+        // Why blocking on the async call is safe: this only runs under NUnit, which
+        // dispatches us on a worker thread with no SynchronizationContext.
+        //
+        // Why low risk: this is test code. The worst case for a wrong call here is
+        // a hung test, not a production incident.
+        // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         static void RunCommand(string arguments, bool failOnNonZeroExitCode = true)
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", arguments);

--- a/source/Octopus.Tentacle.Tests/Util/LinuxTestUserPrincipal.cs
+++ b/source/Octopus.Tentacle.Tests/Util/LinuxTestUserPrincipal.cs
@@ -22,7 +22,7 @@ namespace Octopus.Tentacle.Tests.Util
         static void RunCommand(string arguments, bool failOnNonZeroExitCode = true)
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", arguments);
-            var result = commandLineInvocation.ExecuteCommand();
+            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
 
             foreach (var line in result.Errors)
                 Console.WriteLine(line);

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
@@ -55,13 +55,12 @@ namespace Octopus.Tentacle.Kubernetes
         {
             var stdOut = new List<string>();
             var stdErr = new List<string>();
-            // Sync boundary: called from IMemoryCache.GetOrCreate factory which is synchronous.
-            // We block on the async ExecuteCommandAsync with .GetAwaiter().GetResult().
-            // This is safe because we're on a plain thread-pool worker. The risk with blocking on
-            // async is a deadlock: if the async work needs to resume on the same thread that's
-            // blocked waiting for it, neither can make progress. Thread-pool workers don't have
-            // that constraint — when the async work finishes it can pick up on any free thread,
-            // not specifically this one, so the block resolves normally.
+            // We're in the IMemoryCache.GetOrCreate factory that populates the disk-space cache entry.
+            // The cache factory delegate is synchronous (Func<ICacheEntry, T>), so we block on the
+            // async call with .GetAwaiter().GetResult().
+            // This is sync-over-async but is safe because the cache factory runs on a plain
+            // thread-pool worker. No captured SynchronizationContext, so no deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var exitCode = silentProcessRunner.ExecuteCommandAsync("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add)
                 .GetAwaiter().GetResult();
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
@@ -12,6 +12,7 @@ namespace Octopus.Tentacle.Kubernetes
     public interface IKubernetesDirectoryInformationProvider
     {
         public ulong? GetPathUsedBytes(string directoryPath);
+        public Task<ulong?> GetPathUsedBytesAsync(string directoryPath);
         public ulong? GetPathTotalBytes();
     }
 
@@ -37,16 +38,17 @@ namespace Octopus.Tentacle.Kubernetes
             this.directoryInformationCache = directoryInformationCache;
         }
 
-        // We're at the IKubernetesDirectoryInformationProvider boundary. Callers (capacity
-        // reporting) are sync, so this is the sync-over-async bridge: a one-line wrapper over
-        // the private async implementation. Safe because the consumer is a background sweeper
-        // running on a plain thread-pool worker. No captured SynchronizationContext, so no
-        // deadlock.
+        // Sync-over-async bridge for the one remaining sync caller: KubernetesPhysicalFileSystem
+        // overrides IOctopusFileSystem.EnsureDiskHasEnoughFreeSpace (sync), which calls
+        // GetStorageInformation (sync), which calls this. Async callers should use
+        // GetPathUsedBytesAsync directly. Safe because the Kubernetes agent is a console process
+        // (no SynchronizationContext) and the file-system call paths run on plain thread-pool
+        // workers, so no deadlock.
         // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         public ulong? GetPathUsedBytes(string directoryPath)
             => GetPathUsedBytesAsync(directoryPath).GetAwaiter().GetResult();
 
-        async Task<ulong?> GetPathUsedBytesAsync(string directoryPath)
+        public async Task<ulong?> GetPathUsedBytesAsync(string directoryPath)
         {
             return await directoryInformationCache.GetOrCreateAsync(directoryPath, async e =>
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
@@ -38,12 +38,15 @@ namespace Octopus.Tentacle.Kubernetes
             this.directoryInformationCache = directoryInformationCache;
         }
 
-        // Sync-over-async bridge for the one remaining sync caller: KubernetesPhysicalFileSystem
-        // overrides IOctopusFileSystem.EnsureDiskHasEnoughFreeSpace (sync), which calls
-        // GetStorageInformation (sync), which calls this. Async callers should use
-        // GetPathUsedBytesAsync directly. Safe because the Kubernetes agent is a console process
-        // (no SynchronizationContext) and the file-system call paths run on plain thread-pool
-        // workers, so no deadlock.
+        // Why this is sync: the only caller is EnsureDiskHasEnoughFreeSpace, which
+        // overrides a sync method on the IOctopusFileSystem chain. Making that
+        // whole chain async is a wider refactor than this PR. New code should
+        // call GetPathUsedBytesAsync directly instead of going through here.
+        //
+        // Why blocking on the async call is safe: .GetAwaiter().GetResult() can
+        // deadlock when the calling thread has a SynchronizationContext. The
+        // Kubernetes agent is a console app and doesn't set one up, so there's
+        // nothing for the awaited continuation to wait on.
         // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         public ulong? GetPathUsedBytes(string directoryPath)
             => GetPathUsedBytesAsync(directoryPath).GetAwaiter().GetResult();

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Octopus.Client.Extensions;
 using Microsoft.Extensions.Caching.Memory;
 using Octopus.Tentacle.Core.Diagnostics;
@@ -13,13 +14,13 @@ namespace Octopus.Tentacle.Kubernetes
         public ulong? GetPathUsedBytes(string directoryPath);
         public ulong? GetPathTotalBytes();
     }
-    
+
     public class KubernetesDirectoryInformationProvider : IKubernetesDirectoryInformationProvider
     {
         readonly ISystemLog log;
         readonly ISilentProcessRunner silentProcessRunner;
         readonly IMemoryCache directoryInformationCache;
-        
+
         //30s gives us fairly up to date information, but doesn't impact performance too much.
         //For 50 concurrent Cloud deployments:
         //No cache: 30min ea.
@@ -36,12 +37,21 @@ namespace Octopus.Tentacle.Kubernetes
             this.directoryInformationCache = directoryInformationCache;
         }
 
+        // We're at the IKubernetesDirectoryInformationProvider boundary. Callers (capacity
+        // reporting) are sync, so this is the sync-over-async bridge: a one-line wrapper over
+        // the private async implementation. Safe because the consumer is a background sweeper
+        // running on a plain thread-pool worker. No captured SynchronizationContext, so no
+        // deadlock.
+        // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         public ulong? GetPathUsedBytes(string directoryPath)
+            => GetPathUsedBytesAsync(directoryPath).GetAwaiter().GetResult();
+
+        async Task<ulong?> GetPathUsedBytesAsync(string directoryPath)
         {
-            return directoryInformationCache.GetOrCreate(directoryPath, e =>
+            return await directoryInformationCache.GetOrCreateAsync(directoryPath, async e =>
             {
                 e.SetAbsoluteExpiration(CacheExpiry);
-                return GetDriveBytesUsingDu(directoryPath);
+                return await GetDriveBytesUsingDuAsync(directoryPath);
             });
         }
 
@@ -49,20 +59,13 @@ namespace Octopus.Tentacle.Kubernetes
         {
             return KubernetesUtilities.GetResourceBytes(KubernetesConfig.PersistentVolumeSize);
         }
-        
-        
-        ulong? GetDriveBytesUsingDu(string directoryPath)
+
+
+        async Task<ulong?> GetDriveBytesUsingDuAsync(string directoryPath)
         {
             var stdOut = new List<string>();
             var stdErr = new List<string>();
-            // We're in the IMemoryCache.GetOrCreate factory that populates the disk-space cache entry.
-            // The cache factory delegate is synchronous (Func<ICacheEntry, T>), so we block on the
-            // async call with .GetAwaiter().GetResult().
-            // This is sync-over-async but is safe because the cache factory runs on a plain
-            // thread-pool worker. No captured SynchronizationContext, so no deadlock.
-            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
-            var exitCode = silentProcessRunner.ExecuteCommandAsync("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add)
-                .GetAwaiter().GetResult();
+            var exitCode = await silentProcessRunner.ExecuteCommandAsync("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add);
 
             if (exitCode != 0)
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesDirectoryInformationProvider.cs
@@ -55,7 +55,15 @@ namespace Octopus.Tentacle.Kubernetes
         {
             var stdOut = new List<string>();
             var stdErr = new List<string>();
-            var exitCode = silentProcessRunner.ExecuteCommand("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add);
+            // Sync boundary: called from IMemoryCache.GetOrCreate factory which is synchronous.
+            // We block on the async ExecuteCommandAsync with .GetAwaiter().GetResult().
+            // This is safe because we're on a plain thread-pool worker. The risk with blocking on
+            // async is a deadlock: if the async work needs to resume on the same thread that's
+            // blocked waiting for it, neither can make progress. Thread-pool workers don't have
+            // that constraint — when the async work finishes it can pick up on any free thread,
+            // not specifically this one, so the block resolves normally.
+            var exitCode = silentProcessRunner.ExecuteCommandAsync("du", $"-s -B 1 {directoryPath}", "/", stdOut.Add, stdErr.Add)
+                .GetAwaiter().GetResult();
 
             if (exitCode != 0)
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
@@ -47,18 +47,21 @@ namespace Octopus.Tentacle.Kubernetes
         public (ulong freeSpaceBytes, ulong totalSpaceBytes)? GetStorageInformation()
         {
             var bytesUsed = directoryInformationProvider.GetPathUsedBytes(HomeDir);
-            var bytesTotal = directoryInformationProvider.GetPathTotalBytes();
-            if (bytesUsed.HasValue && bytesTotal.HasValue)
-            {
-                return (bytesTotal.Value - bytesUsed.Value, bytesTotal.Value);
-            }
-
-            return null;
+            return BuildStorageInformation(bytesUsed);
         }
 
         public async Task<(ulong freeSpaceBytes, ulong totalSpaceBytes)?> GetStorageInformationAsync()
         {
             var bytesUsed = await directoryInformationProvider.GetPathUsedBytesAsync(HomeDir);
+            return BuildStorageInformation(bytesUsed);
+        }
+
+        // Shared sync assembler used by both GetStorageInformation (sync, for the
+        // IOctopusFileSystem override path) and GetStorageInformationAsync (for
+        // CreateScriptContainer). Pulled out to keep the post-fetch logic DRY
+        // across the sync/async pair we need.
+        (ulong freeSpaceBytes, ulong totalSpaceBytes)? BuildStorageInformation(ulong? bytesUsed)
+        {
             var bytesTotal = directoryInformationProvider.GetPathTotalBytes();
             if (bytesUsed.HasValue && bytesTotal.HasValue)
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPhysicalFileSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Core.Util;
 using Octopus.Tentacle.Util;
@@ -46,6 +47,18 @@ namespace Octopus.Tentacle.Kubernetes
         public (ulong freeSpaceBytes, ulong totalSpaceBytes)? GetStorageInformation()
         {
             var bytesUsed = directoryInformationProvider.GetPathUsedBytes(HomeDir);
+            var bytesTotal = directoryInformationProvider.GetPathTotalBytes();
+            if (bytesUsed.HasValue && bytesTotal.HasValue)
+            {
+                return (bytesTotal.Value - bytesUsed.Value, bytesTotal.Value);
+            }
+
+            return null;
+        }
+
+        public async Task<(ulong freeSpaceBytes, ulong totalSpaceBytes)?> GetStorageInformationAsync()
+        {
+            var bytesUsed = await directoryInformationProvider.GetPathUsedBytesAsync(HomeDir);
             var bytesTotal = directoryInformationProvider.GetPathTotalBytes();
             if (bytesUsed.HasValue && bytesTotal.HasValue)
             {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -300,7 +300,7 @@ namespace Octopus.Tentacle.Kubernetes
 
         protected async Task<V1Container> CreateScriptContainer(StartKubernetesScriptCommandV1 command, string podName, string scriptName, string homeDir, string workspacePath, string[]? scriptArguments, InMemoryTentacleScriptLog tentacleScriptLog, V1Container? containerSpec)
         {
-            var spaceInformation = kubernetesPhysicalFileSystem.GetStorageInformation();
+            var spaceInformation = await kubernetesPhysicalFileSystem.GetStorageInformationAsync();
             
             var commandString = string.Join(" ", new[]
                 {

--- a/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
@@ -48,15 +48,18 @@ namespace Octopus.Tentacle.Startup
                 serviceConfigurationState);
         }
 
-        // We're at the IServiceConfigurator boundary. IServiceConfigurator is consumed by
-        // ServiceCommand (an AbstractCommand), and AbstractCommand.Start() is sync because
-        // ICommand.Start() is sync (Topshelf's runtime callback API is sync). So
-        // ConfigureService must return synchronously. This is the single sync-over-async
-        // bridge for the Linux service-configuration code path: a one-line wrapper over the
-        // private async implementation. Safe because no SynchronizationContext is captured on
-        // this call stack: the console-app main thread has none by default, and Topshelf's
-        // OnStart callback runs on a `new Thread(...)` worker that also has none. Either way,
-        // no captured context means no deadlock.
+        // Used by ServiceCommand (an AbstractCommand) to install/configure the
+        // Tentacle as a Linux systemd service.
+        //
+        // Why this is sync: AbstractCommand.Start() is sync because ICommand.Start()
+        // is sync. When Tentacle runs as a Windows service we host AbstractCommands
+        // via Topshelf, whose runtime callback API is also sync — so the call path
+        // has to return sync end-to-end.
+        //
+        // Why blocking on the async call is safe: the console-app main thread has
+        // no SynchronizationContext. Topshelf's OnStart callback runs on a fresh
+        // `new Thread(...)` worker that also has none. Either way, nothing for the
+        // awaited continuation to wait on.
         // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         void ConfigureService(string thisServiceName, string exePath, string? instance, string? configPath, string serviceDescription, ServiceConfigurationState serviceConfigurationState)
             => ConfigureServiceAsync(thisServiceName, exePath, instance, configPath, serviceDescription, serviceConfigurationState).GetAwaiter().GetResult();

--- a/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
@@ -194,7 +194,11 @@ namespace Octopus.Tentacle.Startup
             File.WriteAllText(path, contents);
 
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"chmod 644 {path}\"");
-            var result = commandLineInvocation.ExecuteCommand();
+            // Sync boundary: WriteUnitFile is called from IServiceConfigurator.ConfigureService
+            // implementations, which are themselves called from the Tentacle service-management
+            // CLI on a threadpool worker with no sync context. GetAwaiter().GetResult() is
+            // deadlock-safe here.
+            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
 
             if (result.ExitCode == 0) return;
 
@@ -219,14 +223,22 @@ namespace Octopus.Tentacle.Startup
         bool IsSystemdInstalled()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"command -v systemctl >/dev/null\"");
-            var result = commandLineInvocation.ExecuteCommand();
+            // Sync boundary: IsSystemdInstalled is called from CheckSystemPrerequisites,
+            // which is called from IServiceConfigurator.ConfigureService, which is itself
+            // called from the Tentacle service-management CLI on a threadpool worker with
+            // no sync context. GetAwaiter().GetResult() is deadlock-safe here.
+            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
             return result.ExitCode == 0;
         }
 
         bool HaveSudoPrivileges()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"sudo -vn 2> /dev/null\"");
-            var result = commandLineInvocation.ExecuteCommand();
+            // Sync boundary: HaveSudoPrivileges is called from CheckSystemPrerequisites,
+            // which is called from IServiceConfigurator.ConfigureService, which is itself
+            // called from the Tentacle service-management CLI on a threadpool worker with
+            // no sync context. GetAwaiter().GetResult() is deadlock-safe here.
+            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
             return result.ExitCode == 0;
         }
 

--- a/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
@@ -194,11 +194,20 @@ namespace Octopus.Tentacle.Startup
             File.WriteAllText(path, contents);
 
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"chmod 644 {path}\"");
-            // We're in WriteUnitFile, called from IServiceConfigurator.ConfigureService implementations
-            // which are sync (called from the Tentacle service-management CLI), so we block on the
-            // async call with .GetAwaiter().GetResult().
-            // This is sync-over-async but is safe because the CLI dispatches us on a plain
-            // thread-pool worker. No captured SynchronizationContext, so no deadlock.
+            // We're in LinuxServiceConfigurator, which implements IServiceConfigurator.
+            // IServiceConfigurator is consumed by ServiceCommand (an AbstractCommand).
+            // AbstractCommand.Start() is sync because it implements ICommand.Start(),
+            // which is sync because Topshelf's runtime callback API is sync. So
+            // ConfigureService must return synchronously, and we block on the async
+            // call with .GetAwaiter().GetResult(). This is sync-over-async but is safe
+            // because no SynchronizationContext is ever captured on this call stack.
+            // When the user runs `tentacle service ...` from a shell, we enter through
+            // the process entry point (Main), and the main thread of a .NET console app
+            // has no SynchronizationContext installed by default. When running as an
+            // installed systemd service, Topshelf's OnStart callback runs on a
+            // dedicated worker (a `new Thread(...)`) that also has no
+            // SynchronizationContext. Either way, no captured context means no
+            // deadlock.
             // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
 
@@ -225,8 +234,21 @@ namespace Octopus.Tentacle.Startup
         bool IsSystemdInstalled()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"command -v systemctl >/dev/null\"");
-            // Same sync-over-async boundary as WriteUnitFile: CheckSystemPrerequisites is called
-            // from the sync ConfigureService path, on a plain thread-pool worker.
+            // We're in LinuxServiceConfigurator, which implements IServiceConfigurator.
+            // IServiceConfigurator is consumed by ServiceCommand (an AbstractCommand).
+            // AbstractCommand.Start() is sync because it implements ICommand.Start(),
+            // which is sync because Topshelf's runtime callback API is sync. So
+            // ConfigureService must return synchronously, and we block on the async
+            // call with .GetAwaiter().GetResult(). This is sync-over-async but is safe
+            // because no SynchronizationContext is ever captured on this call stack.
+            // When the user runs `tentacle service ...` from a shell, we enter through
+            // the process entry point (Main), and the main thread of a .NET console app
+            // has no SynchronizationContext installed by default. When running as an
+            // installed systemd service, Topshelf's OnStart callback runs on a
+            // dedicated worker (a `new Thread(...)`) that also has no
+            // SynchronizationContext. Either way, no captured context means no
+            // deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
             return result.ExitCode == 0;
         }
@@ -234,7 +256,21 @@ namespace Octopus.Tentacle.Startup
         bool HaveSudoPrivileges()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"sudo -vn 2> /dev/null\"");
-            // Same sync-over-async boundary as IsSystemdInstalled.
+            // We're in LinuxServiceConfigurator, which implements IServiceConfigurator.
+            // IServiceConfigurator is consumed by ServiceCommand (an AbstractCommand).
+            // AbstractCommand.Start() is sync because it implements ICommand.Start(),
+            // which is sync because Topshelf's runtime callback API is sync. So
+            // ConfigureService must return synchronously, and we block on the async
+            // call with .GetAwaiter().GetResult(). This is sync-over-async but is safe
+            // because no SynchronizationContext is ever captured on this call stack.
+            // When the user runs `tentacle service ...` from a shell, we enter through
+            // the process entry point (Main), and the main thread of a .NET console app
+            // has no SynchronizationContext installed by default. When running as an
+            // installed systemd service, Topshelf's OnStart callback runs on a
+            // dedicated worker (a `new Thread(...)`) that also has no
+            // SynchronizationContext. Either way, no captured context means no
+            // deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
             return result.ExitCode == 0;
         }

--- a/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Util;
 
@@ -47,22 +48,35 @@ namespace Octopus.Tentacle.Startup
                 serviceConfigurationState);
         }
 
+        // We're at the IServiceConfigurator boundary. IServiceConfigurator is consumed by
+        // ServiceCommand (an AbstractCommand), and AbstractCommand.Start() is sync because
+        // ICommand.Start() is sync (Topshelf's runtime callback API is sync). So
+        // ConfigureService must return synchronously. This is the single sync-over-async
+        // bridge for the Linux service-configuration code path: a one-line wrapper over the
+        // private async implementation. Safe because no SynchronizationContext is captured on
+        // this call stack: the console-app main thread has none by default, and Topshelf's
+        // OnStart callback runs on a `new Thread(...)` worker that also has none. Either way,
+        // no captured context means no deadlock.
+        // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         void ConfigureService(string thisServiceName, string exePath, string? instance, string? configPath, string serviceDescription, ServiceConfigurationState serviceConfigurationState)
+            => ConfigureServiceAsync(thisServiceName, exePath, instance, configPath, serviceDescription, serviceConfigurationState).GetAwaiter().GetResult();
+
+        async Task ConfigureServiceAsync(string thisServiceName, string exePath, string? instance, string? configPath, string serviceDescription, ServiceConfigurationState serviceConfigurationState)
         {
             //Check if system has bash and systemd
-            CheckSystemPrerequisites();
+            await CheckSystemPrerequisitesAsync();
 
             var cleanedInstanceName = SanitizeString(instance ?? thisServiceName);
             var systemdUnitFilePath = $"/etc/systemd/system/{cleanedInstanceName}.service";
 
             if (serviceConfigurationState.Restart)
-                RestartService(cleanedInstanceName);
+                await RestartServiceAsync(cleanedInstanceName);
 
             if (serviceConfigurationState.Stop)
-                StopService(cleanedInstanceName);
+                await StopServiceAsync(cleanedInstanceName);
 
             if (serviceConfigurationState.Uninstall)
-                UninstallService(cleanedInstanceName, systemdUnitFilePath);
+                await UninstallServiceAsync(cleanedInstanceName, systemdUnitFilePath);
 
             var serviceDependencies = new List<string>();
             serviceDependencies.AddRange(new[] {"network.target"});
@@ -72,7 +86,7 @@ namespace Octopus.Tentacle.Startup
 
             var userName = serviceConfigurationState.Username ?? "root";
             if (serviceConfigurationState.Install)
-                InstallService(cleanedInstanceName,
+                await InstallServiceAsync(cleanedInstanceName,
                     instance,
                     configPath,
                     exePath,
@@ -82,7 +96,7 @@ namespace Octopus.Tentacle.Startup
                     serviceDependencies);
 
             if (serviceConfigurationState.Reconfigure)
-                ReconfigureService(cleanedInstanceName,
+                await ReconfigureServiceAsync(cleanedInstanceName,
                     instance,
                     configPath,
                     exePath,
@@ -92,42 +106,42 @@ namespace Octopus.Tentacle.Startup
                     serviceDependencies);
 
             if (serviceConfigurationState.Start)
-                StartService(cleanedInstanceName);
+                await StartServiceAsync(cleanedInstanceName);
         }
 
-        void RestartService(string serviceName)
+        async Task RestartServiceAsync(string serviceName)
         {
             log.Info($"Restarting service: {serviceName}");
-            if (systemCtlHelper.RestartService(serviceName))
+            if (await systemCtlHelper.RestartServiceAsync(serviceName))
                 log.Info("Service has been restarted");
             else
                 log.Error("The service could not be restarted");
         }
 
-        void StopService(string serviceName)
+        async Task StopServiceAsync(string serviceName)
         {
             log.Info($"Stopping service: {serviceName}");
-            if (systemCtlHelper.StopService(serviceName))
+            if (await systemCtlHelper.StopServiceAsync(serviceName))
                 log.Info("Service stopped");
             else
                 log.Error("The service could not be stopped");
         }
 
-        void StartService(string serviceName)
+        async Task StartServiceAsync(string serviceName)
         {
-            if (systemCtlHelper.StartService(serviceName, true))
+            if (await systemCtlHelper.StartServiceAsync(serviceName, true))
                 log.Info($"Service started: {serviceName}");
             else
                 log.Error($"Could not start the systemd service: {serviceName}");
         }
 
-        void UninstallService(string instance, string systemdUnitFilePath)
+        async Task UninstallServiceAsync(string instance, string systemdUnitFilePath)
         {
             log.Info($"Removing systemd service: {instance}");
             try
             {
-                systemCtlHelper.StopService(instance);
-                systemCtlHelper.DisableService(instance);
+                await systemCtlHelper.StopServiceAsync(instance);
+                await systemCtlHelper.DisableServiceAsync(instance);
                 File.Delete(systemdUnitFilePath);
                 log.Info("Service uninstalled");
             }
@@ -138,7 +152,7 @@ namespace Octopus.Tentacle.Startup
             }
         }
 
-        void InstallService(string serviceName, 
+        async Task InstallServiceAsync(string serviceName,
             string? instance,
             string? configPath,
             string exePath,
@@ -149,8 +163,8 @@ namespace Octopus.Tentacle.Startup
         {
             try
             {
-                WriteUnitFile(systemdUnitFilePath, GenerateSystemdUnitFile(instance, configPath, serviceDescription, exePath, userName, serviceDependencies));
-                systemCtlHelper.EnableService(serviceName, true);
+                await WriteUnitFileAsync(systemdUnitFilePath, GenerateSystemdUnitFile(instance, configPath, serviceDescription, exePath, userName, serviceDependencies));
+                await systemCtlHelper.EnableServiceAsync(serviceName, true);
                 log.Info($"Service installed: {serviceName}");
             }
             catch (Exception e)
@@ -160,7 +174,7 @@ namespace Octopus.Tentacle.Startup
             }
         }
 
-        void ReconfigureService(string serviceName,
+        async Task ReconfigureServiceAsync(string serviceName,
             string? instance,
             string? configPath,
             string exePath,
@@ -173,13 +187,13 @@ namespace Octopus.Tentacle.Startup
             {
                 log.Info($"Attempting to remove old service: {serviceName}");
                 //remove service
-                systemCtlHelper.StopService(serviceName);
-                systemCtlHelper.DisableService(serviceName);
+                await systemCtlHelper.StopServiceAsync(serviceName);
+                await systemCtlHelper.DisableServiceAsync(serviceName);
                 File.Delete(systemdUnitFilePath);
 
                 //re-add service
-                WriteUnitFile(systemdUnitFilePath, GenerateSystemdUnitFile(instance, configPath, serviceDescription, exePath, userName, serviceDependencies));
-                systemCtlHelper.EnableService(serviceName, true);
+                await WriteUnitFileAsync(systemdUnitFilePath, GenerateSystemdUnitFile(instance, configPath, serviceDescription, exePath, userName, serviceDependencies));
+                await systemCtlHelper.EnableServiceAsync(serviceName, true);
                 log.Info($"Service installed: {serviceName}");
             }
             catch (Exception e)
@@ -189,93 +203,48 @@ namespace Octopus.Tentacle.Startup
             }
         }
 
-        void WriteUnitFile(string path, string contents)
+        async Task WriteUnitFileAsync(string path, string contents)
         {
             File.WriteAllText(path, contents);
 
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"chmod 644 {path}\"");
-            // We're in LinuxServiceConfigurator, which implements IServiceConfigurator.
-            // IServiceConfigurator is consumed by ServiceCommand (an AbstractCommand).
-            // AbstractCommand.Start() is sync because it implements ICommand.Start(),
-            // which is sync because Topshelf's runtime callback API is sync. So
-            // ConfigureService must return synchronously, and we block on the async
-            // call with .GetAwaiter().GetResult(). This is sync-over-async but is safe
-            // because no SynchronizationContext is ever captured on this call stack.
-            // When the user runs `tentacle service ...` from a shell, we enter through
-            // the process entry point (Main), and the main thread of a .NET console app
-            // has no SynchronizationContext installed by default. When running as an
-            // installed systemd service, Topshelf's OnStart callback runs on a
-            // dedicated worker (a `new Thread(...)`) that also has no
-            // SynchronizationContext. Either way, no captured context means no
-            // deadlock.
-            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
-            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await commandLineInvocation.ExecuteCommandAsync();
 
             if (result.ExitCode == 0) return;
 
             result.Validate();
         }
 
-        void CheckSystemPrerequisites()
+        async Task CheckSystemPrerequisitesAsync()
         {
             if (!File.Exists("/bin/bash"))
                 throw new ControlledFailureException(
                     "Could not detect bash. bash is required to run tentacle.");
 
-            if (!HaveSudoPrivileges())
+            if (!await HaveSudoPrivilegesAsync())
                 throw new ControlledFailureException(
                     "Requires elevated privileges. Please run command as sudo.");
 
-            if (!IsSystemdInstalled())
+            if (!await IsSystemdInstalledAsync())
                 throw new ControlledFailureException(
                     "Could not detect systemd. systemd is required to run Tentacle as a service");
         }
 
-        bool IsSystemdInstalled()
+        async Task<bool> IsSystemdInstalledAsync()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"command -v systemctl >/dev/null\"");
-            // We're in LinuxServiceConfigurator, which implements IServiceConfigurator.
-            // IServiceConfigurator is consumed by ServiceCommand (an AbstractCommand).
-            // AbstractCommand.Start() is sync because it implements ICommand.Start(),
-            // which is sync because Topshelf's runtime callback API is sync. So
-            // ConfigureService must return synchronously, and we block on the async
-            // call with .GetAwaiter().GetResult(). This is sync-over-async but is safe
-            // because no SynchronizationContext is ever captured on this call stack.
-            // When the user runs `tentacle service ...` from a shell, we enter through
-            // the process entry point (Main), and the main thread of a .NET console app
-            // has no SynchronizationContext installed by default. When running as an
-            // installed systemd service, Topshelf's OnStart callback runs on a
-            // dedicated worker (a `new Thread(...)`) that also has no
-            // SynchronizationContext. Either way, no captured context means no
-            // deadlock.
-            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
-            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await commandLineInvocation.ExecuteCommandAsync();
             return result.ExitCode == 0;
         }
 
-        bool HaveSudoPrivileges()
+        async Task<bool> HaveSudoPrivilegesAsync()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"sudo -vn 2> /dev/null\"");
-            // We're in LinuxServiceConfigurator, which implements IServiceConfigurator.
-            // IServiceConfigurator is consumed by ServiceCommand (an AbstractCommand).
-            // AbstractCommand.Start() is sync because it implements ICommand.Start(),
-            // which is sync because Topshelf's runtime callback API is sync. So
-            // ConfigureService must return synchronously, and we block on the async
-            // call with .GetAwaiter().GetResult(). This is sync-over-async but is safe
-            // because no SynchronizationContext is ever captured on this call stack.
-            // When the user runs `tentacle service ...` from a shell, we enter through
-            // the process entry point (Main), and the main thread of a .NET console app
-            // has no SynchronizationContext installed by default. When running as an
-            // installed systemd service, Topshelf's OnStart callback runs on a
-            // dedicated worker (a `new Thread(...)`) that also has no
-            // SynchronizationContext. Either way, no captured context means no
-            // deadlock.
-            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
-            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await commandLineInvocation.ExecuteCommandAsync();
             return result.ExitCode == 0;
         }
 
-        string GenerateSystemdUnitFile(string? instance, 
+        string GenerateSystemdUnitFile(string? instance,
             string? configPath,
             string serviceDescription, string exePath, string userName, IEnumerable<string> serviceDependencies)
         {
@@ -291,7 +260,7 @@ namespace Octopus.Tentacle.Startup
             if (!string.IsNullOrEmpty(instance))
             {
                 stringBuilder.Append($" --instance={instance}");
-            } 
+            }
             else if (!string.IsNullOrEmpty(configPath))
             {
                 stringBuilder.Append($" --config={configPath}");

--- a/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/LinuxServiceConfigurator.cs
@@ -194,10 +194,12 @@ namespace Octopus.Tentacle.Startup
             File.WriteAllText(path, contents);
 
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"chmod 644 {path}\"");
-            // Sync boundary: WriteUnitFile is called from IServiceConfigurator.ConfigureService
-            // implementations, which are themselves called from the Tentacle service-management
-            // CLI on a threadpool worker with no sync context. GetAwaiter().GetResult() is
-            // deadlock-safe here.
+            // We're in WriteUnitFile, called from IServiceConfigurator.ConfigureService implementations
+            // which are sync (called from the Tentacle service-management CLI), so we block on the
+            // async call with .GetAwaiter().GetResult().
+            // This is sync-over-async but is safe because the CLI dispatches us on a plain
+            // thread-pool worker. No captured SynchronizationContext, so no deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
 
             if (result.ExitCode == 0) return;
@@ -223,10 +225,8 @@ namespace Octopus.Tentacle.Startup
         bool IsSystemdInstalled()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"command -v systemctl >/dev/null\"");
-            // Sync boundary: IsSystemdInstalled is called from CheckSystemPrerequisites,
-            // which is called from IServiceConfigurator.ConfigureService, which is itself
-            // called from the Tentacle service-management CLI on a threadpool worker with
-            // no sync context. GetAwaiter().GetResult() is deadlock-safe here.
+            // Same sync-over-async boundary as WriteUnitFile: CheckSystemPrerequisites is called
+            // from the sync ConfigureService path, on a plain thread-pool worker.
             var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
             return result.ExitCode == 0;
         }
@@ -234,10 +234,7 @@ namespace Octopus.Tentacle.Startup
         bool HaveSudoPrivileges()
         {
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", "-c \"sudo -vn 2> /dev/null\"");
-            // Sync boundary: HaveSudoPrivileges is called from CheckSystemPrerequisites,
-            // which is called from IServiceConfigurator.ConfigureService, which is itself
-            // called from the Tentacle service-management CLI on a threadpool worker with
-            // no sync context. GetAwaiter().GetResult() is deadlock-safe here.
+            // Same sync-over-async boundary as IsSystemdInstalled.
             var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
             return result.ExitCode == 0;
         }

--- a/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
@@ -342,10 +342,12 @@ namespace Octopus.Tentacle.Startup
             var sc = Path.Combine(system32, "sc.exe");
 
             logFileOnlyLogger.Info($"Executing sc.exe {argumentsToLog}");
-            // Sync boundary: Sc() is called from IServiceConfigurator.ConfigureService
-            // implementations, which are themselves called from the Tentacle
-            // service-management CLI on Windows (no sync context, threadpool worker).
-            // GetAwaiter().GetResult() is deadlock-safe here.
+            // We're in Sc() running sc.exe, called from IServiceConfigurator.ConfigureService
+            // implementations which are sync (called from the Tentacle service-management CLI on
+            // Windows), so we block on the async call with .GetAwaiter().GetResult().
+            // This is sync-over-async but is safe because the CLI dispatches us on a plain
+            // thread-pool worker. No captured SynchronizationContext, so no deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var exitCode = SilentProcessRunnerExtended.ExecuteCommandAsync(sc,
                 arguments,
                 Environment.CurrentDirectory,

--- a/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -7,6 +7,7 @@ using System.Management;
 using System.ServiceProcess;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Util;
 using Polly;
@@ -58,7 +59,25 @@ namespace Octopus.Tentacle.Startup
                 serviceConfigurationState);
         }
 
+        // We're at the IServiceConfigurator boundary. IServiceConfigurator is consumed by
+        // ServiceCommand (an AbstractCommand), and AbstractCommand.Start() is sync because
+        // ICommand.Start() is sync (Topshelf's runtime callback API is sync). So
+        // ConfigureService must return synchronously. This is the single sync-over-async
+        // bridge for the Windows service-configuration code path: a one-line wrapper over the
+        // private async implementation. Safe because no SynchronizationContext is captured on
+        // this call stack: the console-app main thread has none by default, and Topshelf's
+        // OnStart callback runs on a `new Thread(...)` worker that also has none. Either way,
+        // no captured context means no deadlock.
+        // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         void ConfigureService(string thisServiceName,
+            string exePath,
+            string? instance,
+            string? configPath,
+            string serviceDescription,
+            ServiceConfigurationState serviceConfigurationState)
+            => ConfigureServiceAsync(thisServiceName, exePath, instance, configPath, serviceDescription, serviceConfigurationState).GetAwaiter().GetResult();
+
+        async Task ConfigureServiceAsync(string thisServiceName,
             string exePath,
             string? instance,
             string? configPath,
@@ -81,7 +100,7 @@ namespace Octopus.Tentacle.Startup
 
             if (serviceConfigurationState.Uninstall)
             {
-                UninstallService(thisServiceName, controller);
+                await UninstallServiceAsync(thisServiceName, controller);
             }
 
             var serviceDependencies = new List<string>();
@@ -96,18 +115,18 @@ namespace Octopus.Tentacle.Startup
 
             if (serviceConfigurationState.Install)
             {
-                controller = InstallService(thisServiceName, exePath, instance, configPath,
+                controller = await InstallServiceAsync(thisServiceName, exePath, instance, configPath,
                     serviceDescription, serviceConfigurationState, controller, serviceDependencies);
             }
 
             if (serviceConfigurationState.Reconfigure)
             {
-                ReconfigureService(thisServiceName, exePath, instance, configPath, serviceDescription, serviceDependencies);
+                await ReconfigureServiceAsync(thisServiceName, exePath, instance, configPath, serviceDescription, serviceDependencies);
             }
 
             if ((serviceConfigurationState.Install || serviceConfigurationState.Reconfigure) && !string.IsNullOrWhiteSpace(serviceConfigurationState.Username))
             {
-                ConfigureCredentialsForService(thisServiceName, serviceConfigurationState);
+                await ConfigureCredentialsForServiceAsync(thisServiceName, serviceConfigurationState);
             }
 
             if (serviceConfigurationState.Start)
@@ -116,7 +135,7 @@ namespace Octopus.Tentacle.Startup
             }
         }
 
-        void ConfigureCredentialsForService(string thisServiceName, ServiceConfigurationState serviceConfigurationState)
+        async Task ConfigureCredentialsForServiceAsync(string thisServiceName, ServiceConfigurationState serviceConfigurationState)
         {
             if (!string.IsNullOrWhiteSpace(serviceConfigurationState.Password))
             {
@@ -137,13 +156,13 @@ namespace Octopus.Tentacle.Startup
             }
             else
             {
-                Sc($"config \"{thisServiceName}\" obj= \"{serviceConfigurationState.Username}\"");
+                await ScAsync($"config \"{thisServiceName}\" obj= \"{serviceConfigurationState.Username}\"");
             }
 
             log.Info("Service credentials set");
         }
 
-        void ReconfigureService(string thisServiceName,
+        async Task ReconfigureServiceAsync(string thisServiceName,
             string exePath,
             string? instance,
             string? configPath,
@@ -154,13 +173,13 @@ namespace Octopus.Tentacle.Startup
             var command = exePath.EndsWith(".dll")
                 ? $"config \"{thisServiceName}\" binpath= \"dotnet \\\"{exePath}\\\" run {instanceIdentifier} DisplayName= \"{thisServiceName}\" depend= {string.Join("/", serviceDependencies)} start= auto"
                 : $"config \"{thisServiceName}\" binpath= \"\\\"{exePath}\\\" run {instanceIdentifier} DisplayName= \"{thisServiceName}\" depend= {string.Join("/", serviceDependencies)} start= auto";
-            Sc(command);
-            Sc($"description \"{thisServiceName}\" \"{serviceDescription}\"");
+            await ScAsync(command);
+            await ScAsync($"description \"{thisServiceName}\" \"{serviceDescription}\"");
 
             log.Info("Service reconfigured");
         }
 
-        ServiceController? InstallService(string thisServiceName,
+        async Task<ServiceController?> InstallServiceAsync(string thisServiceName,
             string exePath,
             string? instance,
             string? configPath,
@@ -181,8 +200,8 @@ namespace Octopus.Tentacle.Startup
                     ? $"create \"{thisServiceName}\" binpath= \"dotnet \\\"{exePath}\\\" run {instanceIdentifier} DisplayName= \"{thisServiceName}\" depend= {string.Join("/", serviceDependencies)} start= auto"
                     : $"create \"{thisServiceName}\" binpath= \"\\\"{exePath}\\\" run {instanceIdentifier} DisplayName= \"{thisServiceName}\" depend= {string.Join("/", serviceDependencies)} start= auto";
 
-                Sc(command);
-                Sc($"description \"{thisServiceName}\" \"{serviceDescription}\"");
+                await ScAsync(command);
+                await ScAsync($"description \"{thisServiceName}\" \"{serviceDescription}\"");
             }
 
             log.Info("Service installed");
@@ -207,7 +226,7 @@ namespace Octopus.Tentacle.Startup
             throw new InvalidOperationException("Either the instance name of configuration path must be provided to configure a service");
         }
 
-        void UninstallService(string thisServiceName, ServiceController? controller)
+        async Task UninstallServiceAsync(string thisServiceName, ServiceController? controller)
         {
             if (controller == null)
             {
@@ -215,7 +234,7 @@ namespace Octopus.Tentacle.Startup
             }
             else
             {
-                Sc($"delete \"{thisServiceName}\"");
+                await ScAsync($"delete \"{thisServiceName}\"");
 
                 log.Info("Service uninstalled");
             }
@@ -333,7 +352,7 @@ namespace Octopus.Tentacle.Startup
                 150);
         }
 
-        void Sc(string arguments)
+        async Task ScAsync(string arguments)
         {
             var outputBuilder = new StringBuilder();
             var argumentsToLog = string.Join(" ", arguments);
@@ -342,19 +361,12 @@ namespace Octopus.Tentacle.Startup
             var sc = Path.Combine(system32, "sc.exe");
 
             logFileOnlyLogger.Info($"Executing sc.exe {argumentsToLog}");
-            // We're in Sc() running sc.exe, called from IServiceConfigurator.ConfigureService
-            // implementations which are sync (called from the Tentacle service-management CLI on
-            // Windows), so we block on the async call with .GetAwaiter().GetResult().
-            // This is sync-over-async but is safe because the CLI dispatches us on a plain
-            // thread-pool worker. No captured SynchronizationContext, so no deadlock.
-            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
-            var exitCode = SilentProcessRunnerExtended.ExecuteCommandAsync(sc,
+            var exitCode = await SilentProcessRunnerExtended.ExecuteCommandAsync(sc,
                 arguments,
                 Environment.CurrentDirectory,
                 output => outputBuilder.AppendLine(output),
                 error => outputBuilder.AppendLine("Error: " + error),
-                cancel: CancellationToken.None)
-                .GetAwaiter().GetResult();
+                cancel: CancellationToken.None);
             if (exitCode == 0)
                 logFileOnlyLogger.Info(outputBuilder.ToString());
             else

--- a/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
@@ -59,15 +59,18 @@ namespace Octopus.Tentacle.Startup
                 serviceConfigurationState);
         }
 
-        // We're at the IServiceConfigurator boundary. IServiceConfigurator is consumed by
-        // ServiceCommand (an AbstractCommand), and AbstractCommand.Start() is sync because
-        // ICommand.Start() is sync (Topshelf's runtime callback API is sync). So
-        // ConfigureService must return synchronously. This is the single sync-over-async
-        // bridge for the Windows service-configuration code path: a one-line wrapper over the
-        // private async implementation. Safe because no SynchronizationContext is captured on
-        // this call stack: the console-app main thread has none by default, and Topshelf's
-        // OnStart callback runs on a `new Thread(...)` worker that also has none. Either way,
-        // no captured context means no deadlock.
+        // Used by ServiceCommand (an AbstractCommand) to install/configure the
+        // Tentacle as a Windows Service.
+        //
+        // Why this is sync: AbstractCommand.Start() is sync because ICommand.Start()
+        // is sync. When Tentacle runs as a Windows service we host AbstractCommands
+        // via Topshelf, whose runtime callback API is also sync — so the call path
+        // has to return sync end-to-end.
+        //
+        // Why blocking on the async call is safe: the console-app main thread has
+        // no SynchronizationContext. Topshelf's OnStart callback runs on a fresh
+        // `new Thread(...)` worker that also has none. Either way, nothing for the
+        // awaited continuation to wait on.
         // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         void ConfigureService(string thisServiceName,
             string exePath,

--- a/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
+++ b/source/Octopus.Tentacle/Startup/WindowsServiceConfigurator.cs
@@ -342,11 +342,17 @@ namespace Octopus.Tentacle.Startup
             var sc = Path.Combine(system32, "sc.exe");
 
             logFileOnlyLogger.Info($"Executing sc.exe {argumentsToLog}");
-            var exitCode = SilentProcessRunnerExtended.ExecuteCommand(sc,
+            // Sync boundary: Sc() is called from IServiceConfigurator.ConfigureService
+            // implementations, which are themselves called from the Tentacle
+            // service-management CLI on Windows (no sync context, threadpool worker).
+            // GetAwaiter().GetResult() is deadlock-safe here.
+            var exitCode = SilentProcessRunnerExtended.ExecuteCommandAsync(sc,
                 arguments,
                 Environment.CurrentDirectory,
                 output => outputBuilder.AppendLine(output),
-                error => outputBuilder.AppendLine("Error: " + error));
+                error => outputBuilder.AppendLine("Error: " + error),
+                cancel: CancellationToken.None)
+                .GetAwaiter().GetResult();
             if (exitCode == 0)
                 logFileOnlyLogger.Info(outputBuilder.ToString());
             else

--- a/source/Octopus.Tentacle/Util/CommandLineRunner.cs
+++ b/source/Octopus.Tentacle/Util/CommandLineRunner.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using Octopus.Tentacle.Core.Diagnostics;
 
 namespace Octopus.Tentacle.Util
@@ -43,12 +44,19 @@ namespace Octopus.Tentacle.Util
         {
             try
             {
-                var exitCode = SilentProcessRunner.ExecuteCommand(invocation.Executable,
-                    (invocation.Arguments ?? "") + " " + (invocation.SystemArguments ?? ""),
-                    Environment.CurrentDirectory,
-                    debug,
-                    info,
-                    error);
+                // Sync boundary: ICommandLineRunner is a public interface consumed by
+                // Octopus.Manager.Tentacle (a WPF app) which calls Execute from a
+                // ThreadPool.QueueUserWorkItem — no synchronisation context, so
+                // GetAwaiter().GetResult() here is deadlock-safe.
+                var exitCode = SilentProcessRunner.ExecuteCommandAsync(
+                        invocation.Executable,
+                        (invocation.Arguments ?? "") + " " + (invocation.SystemArguments ?? ""),
+                        Environment.CurrentDirectory,
+                        debug,
+                        info,
+                        error,
+                        cancel: CancellationToken.None)
+                    .GetAwaiter().GetResult();
 
                 if (exitCode != 0)
                 {

--- a/source/Octopus.Tentacle/Util/CommandLineRunner.cs
+++ b/source/Octopus.Tentacle/Util/CommandLineRunner.cs
@@ -44,10 +44,12 @@ namespace Octopus.Tentacle.Util
         {
             try
             {
-                // Sync boundary: ICommandLineRunner is a public interface consumed by
-                // Octopus.Manager.Tentacle (a WPF app) which calls Execute from a
-                // ThreadPool.QueueUserWorkItem — no synchronisation context, so
-                // GetAwaiter().GetResult() here is deadlock-safe.
+                // We're in CommandLineRunner.Execute, consumed by Octopus.Manager.Tentacle (WPF).
+                // The WPF installer calls Execute from ThreadPool.QueueUserWorkItem (a sync
+                // delegate), so we block on the async call with .GetAwaiter().GetResult().
+                // This is sync-over-async but is safe because the installer dispatches us on a
+                // plain thread-pool worker. No captured SynchronizationContext, so no deadlock.
+                // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
                 var exitCode = SilentProcessRunner.ExecuteCommandAsync(
                         invocation.Executable,
                         (invocation.Arguments ?? "") + " " + (invocation.SystemArguments ?? ""),

--- a/source/Octopus.Tentacle/Util/CommandLineRunner.cs
+++ b/source/Octopus.Tentacle/Util/CommandLineRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 
 namespace Octopus.Tentacle.Util
@@ -8,13 +9,11 @@ namespace Octopus.Tentacle.Util
     public class CommandLineRunner : ICommandLineRunner
     {
         public bool Execute(IEnumerable<CommandLineInvocation> commandLineInvocations, ILog log)
-        {
-            return Execute(commandLineInvocations,
+            => Execute(commandLineInvocations,
                 log.Verbose,
                 log.Info,
                 log.Error,
                 log.Error);
-        }
 
         public bool Execute(IEnumerable<CommandLineInvocation> commandLineInvocations,
                 Action<string> debug,
@@ -36,7 +35,48 @@ namespace Octopus.Tentacle.Util
                 log.Error,
                 log.Error);
 
+        // We're at the ICommandLineRunner sync entry point, consumed by Octopus.Manager.Tentacle
+        // (WPF). The WPF installer calls Execute from ThreadPool.QueueUserWorkItem (a sync
+        // delegate), so this is the sync-over-async bridge: a one-line wrapper over the public
+        // async implementation. Safe because the installer dispatches us on a plain thread-pool
+        // worker. No captured SynchronizationContext, so no deadlock. Async callers should call
+        // ExecuteAsync directly.
+        // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
         public bool Execute(CommandLineInvocation invocation,
+            Action<string> debug,
+            Action<string> info,
+            Action<string> error,
+            Action<Exception, string> exception)
+            => ExecuteAsync(invocation, debug, info, error, exception).GetAwaiter().GetResult();
+
+        public Task<bool> ExecuteAsync(IEnumerable<CommandLineInvocation> commandLineInvocations, ILog log)
+            => ExecuteAsync(commandLineInvocations,
+                log.Verbose,
+                log.Info,
+                log.Error,
+                log.Error);
+
+        public async Task<bool> ExecuteAsync(IEnumerable<CommandLineInvocation> commandLineInvocations,
+            Action<string> debug,
+            Action<string> info,
+            Action<string> error,
+            Action<Exception, string> exception)
+        {
+            foreach (var invocation in commandLineInvocations)
+                if (!await ExecuteAsync(invocation, debug, info, error, exception))
+                    return false;
+
+            return true;
+        }
+
+        public Task<bool> ExecuteAsync(CommandLineInvocation invocation, ILog log)
+            => ExecuteAsync(invocation,
+                log.Info,
+                log.Info,
+                log.Error,
+                log.Error);
+
+        public async Task<bool> ExecuteAsync(CommandLineInvocation invocation,
             Action<string> debug,
             Action<string> info,
             Action<string> error,
@@ -44,21 +84,14 @@ namespace Octopus.Tentacle.Util
         {
             try
             {
-                // We're in CommandLineRunner.Execute, consumed by Octopus.Manager.Tentacle (WPF).
-                // The WPF installer calls Execute from ThreadPool.QueueUserWorkItem (a sync
-                // delegate), so we block on the async call with .GetAwaiter().GetResult().
-                // This is sync-over-async but is safe because the installer dispatches us on a
-                // plain thread-pool worker. No captured SynchronizationContext, so no deadlock.
-                // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
-                var exitCode = SilentProcessRunner.ExecuteCommandAsync(
-                        invocation.Executable,
-                        (invocation.Arguments ?? "") + " " + (invocation.SystemArguments ?? ""),
-                        Environment.CurrentDirectory,
-                        debug,
-                        info,
-                        error,
-                        cancel: CancellationToken.None)
-                    .GetAwaiter().GetResult();
+                var exitCode = await SilentProcessRunner.ExecuteCommandAsync(
+                    invocation.Executable,
+                    (invocation.Arguments ?? "") + " " + (invocation.SystemArguments ?? ""),
+                    Environment.CurrentDirectory,
+                    debug,
+                    info,
+                    error,
+                    cancel: CancellationToken.None);
 
                 if (exitCode != 0)
                 {

--- a/source/Octopus.Tentacle/Util/ICommandLineRunner.cs
+++ b/source/Octopus.Tentacle/Util/ICommandLineRunner.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 
 namespace Octopus.Tentacle.Util
@@ -17,6 +18,22 @@ namespace Octopus.Tentacle.Util
         bool Execute(CommandLineInvocation commandLineInvocation, ILog log);
 
         bool Execute(CommandLineInvocation invocation,
+            Action<string> debug,
+            Action<string> info,
+            Action<string> error,
+            Action<Exception, string> exception);
+
+        Task<bool> ExecuteAsync(IEnumerable<CommandLineInvocation> commandLineInvocations, ILog log);
+
+        Task<bool> ExecuteAsync(IEnumerable<CommandLineInvocation> commandLineInvocations,
+            Action<string> debug,
+            Action<string> info,
+            Action<string> error,
+            Action<Exception, string> exception);
+
+        Task<bool> ExecuteAsync(CommandLineInvocation commandLineInvocation, ILog log);
+
+        Task<bool> ExecuteAsync(CommandLineInvocation invocation,
             Action<string> debug,
             Action<string> info,
             Action<string> error,

--- a/source/Octopus.Tentacle/Util/ISilentProcessRunner.cs
+++ b/source/Octopus.Tentacle/Util/ISilentProcessRunner.cs
@@ -1,13 +1,14 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Startup;
 
 namespace Octopus.Tentacle.Util
 {
     public interface ISilentProcessRunner
     {
-        public int ExecuteCommand(
+        Task<int> ExecuteCommandAsync(
             string executable,
             string arguments,
             string workingDirectory,
@@ -15,7 +16,7 @@ namespace Octopus.Tentacle.Util
             Action<string> error,
             CancellationToken cancel = default);
 
-        public int ExecuteCommand(
+        Task<int> ExecuteCommandAsync(
             string executable,
             string arguments,
             string workingDirectory,
@@ -27,23 +28,23 @@ namespace Octopus.Tentacle.Util
 
     public class SilentProcessRunnerWrapper : ISilentProcessRunner
     {
-        public int ExecuteCommand(string executable, string arguments, string workingDirectory, Action<string> info, Action<string> error, CancellationToken cancel = default)
+        public Task<int> ExecuteCommandAsync(string executable, string arguments, string workingDirectory, Action<string> info, Action<string> error, CancellationToken cancel = default)
         {
-            return SilentProcessRunnerExtended.ExecuteCommand(executable, arguments, workingDirectory, info, error, cancel);
+            return SilentProcessRunnerExtended.ExecuteCommandAsync(executable, arguments, workingDirectory, info, error, cancel);
         }
 
-        public int ExecuteCommand(string executable, string arguments, string workingDirectory, Action<string> debug, Action<string> info, Action<string> error, CancellationToken cancel = default)
+        public Task<int> ExecuteCommandAsync(string executable, string arguments, string workingDirectory, Action<string> debug, Action<string> info, Action<string> error, CancellationToken cancel = default)
         {
-            return SilentProcessRunner.ExecuteCommand(executable, arguments, workingDirectory, debug, info, error, cancel: cancel);
+            return SilentProcessRunner.ExecuteCommandAsync(executable, arguments, workingDirectory, debug, info, error, cancel: cancel);
         }
     }
 
     public static class SilentProcessRunnerExtended
     {
-        public static CmdResult ExecuteCommand(this CommandLineInvocation invocation)
-            => ExecuteCommand(invocation, Environment.CurrentDirectory);
+        public static async Task<CmdResult> ExecuteCommandAsync(this CommandLineInvocation invocation)
+            => await ExecuteCommandAsync(invocation, Environment.CurrentDirectory);
 
-        public static CmdResult ExecuteCommand(this CommandLineInvocation invocation, string workingDirectory)
+        public static async Task<CmdResult> ExecuteCommandAsync(this CommandLineInvocation invocation, string workingDirectory)
         {
             if (workingDirectory == null)
                 throw new ArgumentNullException(nameof(workingDirectory));
@@ -52,7 +53,7 @@ namespace Octopus.Tentacle.Util
             var infos = new List<string>();
             var errors = new List<string>();
 
-            var exitCode = ExecuteCommand(
+            var exitCode = await ExecuteCommandAsync(
                 invocation.Executable,
                 arguments,
                 workingDirectory,
@@ -63,14 +64,14 @@ namespace Octopus.Tentacle.Util
             return new CmdResult(exitCode, infos, errors);
         }
 
-        public static int ExecuteCommand(
+        public static Task<int> ExecuteCommandAsync(
             string executable,
             string arguments,
             string workingDirectory,
             Action<string> info,
             Action<string> error,
             CancellationToken cancel = default)
-            => SilentProcessRunner.ExecuteCommand(executable,
+            => SilentProcessRunner.ExecuteCommandAsync(executable,
                 arguments,
                 workingDirectory,
                 LogFileOnlyLogger.Current.Info,

--- a/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
+++ b/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
@@ -32,10 +32,12 @@ namespace Octopus.Tentacle.Util
         {
             // Try without sudo first
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"systemctl {command} {serviceName}\"");
-            // Sync boundary: RunServiceCommand is called from synchronous service-management
-            // helpers (StartService, RestartService, etc.), which are themselves called from
-            // the Tentacle service-management CLI on a threadpool worker with no sync context.
-            // GetAwaiter().GetResult() is deadlock-safe here.
+            // We're in SystemCtlHelper running a systemctl command. All callers (StartService,
+            // RestartService, etc.) are sync, called from the Tentacle service-management CLI
+            // which has no async path, so we block on the async call with .GetAwaiter().GetResult().
+            // This is sync-over-async but is safe because the CLI dispatches us on a plain
+            // thread-pool worker. No captured SynchronizationContext, so no deadlock.
+            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
             var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
             if (result.ExitCode == 0) return true;
 
@@ -52,10 +54,7 @@ namespace Octopus.Tentacle.Util
             {
                 log.Info($"Permission denied. Retrying 'systemctl {command} {serviceName}' with sudo...");
                 var sudoInvocation = new CommandLineInvocation("/bin/bash", $"-c \"sudo systemctl {command} {serviceName}\"");
-                // Sync boundary: RunServiceCommand is called from synchronous service-management
-                // helpers (StartService, RestartService, etc.), which are themselves called from
-                // the Tentacle service-management CLI on a threadpool worker with no sync context.
-                // GetAwaiter().GetResult() is deadlock-safe here.
+                // Same sync-over-async boundary as above: sudo retry on the same thread-pool worker.
                 result = sudoInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
                 if (result.ExitCode == 0) return true;
                 

--- a/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
+++ b/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Octopus.Tentacle.Core.Diagnostics;
 
 namespace Octopus.Tentacle.Util
@@ -13,32 +14,26 @@ namespace Octopus.Tentacle.Util
             this.log = log;
         }
 
-        public bool StartService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("start", serviceName, logFailureAsError);
+        public Task<bool> StartServiceAsync(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("start", serviceName, logFailureAsError);
 
-        public bool RestartService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("restart", serviceName, logFailureAsError);
+        public Task<bool> RestartServiceAsync(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("restart", serviceName, logFailureAsError);
 
-        public bool StopService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("stop", serviceName, logFailureAsError);
+        public Task<bool> StopServiceAsync(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("stop", serviceName, logFailureAsError);
 
-        public bool EnableService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("enable", serviceName, logFailureAsError);
+        public Task<bool> EnableServiceAsync(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("enable", serviceName, logFailureAsError);
 
-        public bool DisableService(string serviceName, bool logFailureAsError = false)
-            => RunServiceCommand("disable", serviceName, logFailureAsError);
+        public Task<bool> DisableServiceAsync(string serviceName, bool logFailureAsError = false)
+            => RunServiceCommandAsync("disable", serviceName, logFailureAsError);
 
-        bool RunServiceCommand(string command, string serviceName, bool logFailureAsError)
+        async Task<bool> RunServiceCommandAsync(string command, string serviceName, bool logFailureAsError)
         {
             // Try without sudo first
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"systemctl {command} {serviceName}\"");
-            // We're in SystemCtlHelper running a systemctl command. All callers (StartService,
-            // RestartService, etc.) are sync, called from the Tentacle service-management CLI
-            // which has no async path, so we block on the async call with .GetAwaiter().GetResult().
-            // This is sync-over-async but is safe because the CLI dispatches us on a plain
-            // thread-pool worker. No captured SynchronizationContext, so no deadlock.
-            // See https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
-            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+            var result = await commandLineInvocation.ExecuteCommandAsync();
             if (result.ExitCode == 0) return true;
 
             // Check if failure is due to authentication/permission issues
@@ -54,10 +49,9 @@ namespace Octopus.Tentacle.Util
             {
                 log.Info($"Permission denied. Retrying 'systemctl {command} {serviceName}' with sudo...");
                 var sudoInvocation = new CommandLineInvocation("/bin/bash", $"-c \"sudo systemctl {command} {serviceName}\"");
-                // Same sync-over-async boundary as above: sudo retry on the same thread-pool worker.
-                result = sudoInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
+                result = await sudoInvocation.ExecuteCommandAsync();
                 if (result.ExitCode == 0) return true;
-                
+
                 usedSudo = true;
             }
 

--- a/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
+++ b/source/Octopus.Tentacle/Util/SystemCtlHelper.cs
@@ -32,7 +32,11 @@ namespace Octopus.Tentacle.Util
         {
             // Try without sudo first
             var commandLineInvocation = new CommandLineInvocation("/bin/bash", $"-c \"systemctl {command} {serviceName}\"");
-            var result = commandLineInvocation.ExecuteCommand();
+            // Sync boundary: RunServiceCommand is called from synchronous service-management
+            // helpers (StartService, RestartService, etc.), which are themselves called from
+            // the Tentacle service-management CLI on a threadpool worker with no sync context.
+            // GetAwaiter().GetResult() is deadlock-safe here.
+            var result = commandLineInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
             if (result.ExitCode == 0) return true;
 
             // Check if failure is due to authentication/permission issues
@@ -48,7 +52,11 @@ namespace Octopus.Tentacle.Util
             {
                 log.Info($"Permission denied. Retrying 'systemctl {command} {serviceName}' with sudo...");
                 var sudoInvocation = new CommandLineInvocation("/bin/bash", $"-c \"sudo systemctl {command} {serviceName}\"");
-                result = sudoInvocation.ExecuteCommand();
+                // Sync boundary: RunServiceCommand is called from synchronous service-management
+                // helpers (StartService, RestartService, etc.), which are themselves called from
+                // the Tentacle service-management CLI on a threadpool worker with no sync context.
+                // GetAwaiter().GetResult() is deadlock-safe here.
+                result = sudoInvocation.ExecuteCommandAsync().GetAwaiter().GetResult();
                 if (result.ExitCode == 0) return true;
                 
                 usedSudo = true;


### PR DESCRIPTION
## Why

Tentacle needs to release the script-isolation mutex even when a script can't be cancelled. Philips is running into situations where CrowdStrike and Rapid7 contention freezes the script running on the Tentacle and our cancel signal can't shake it loose. The only recovery today is restart tentacle.

To make this so in a follow up PR `SilentProcessRunner.ExecuteCommand` becomes async. Which makes everything that calls it async too.

This PR just adds the changes to method signatures that need to become async, to make the next riskier PR easier to review.

## What changed

Replaces `SilentProcessRunner.ExecuteCommand` with `ExecuteCommandAsync`, plus the matching interfaces (`ISilentProcessRunner`, `ICommandLineRunner`) and their wrappers. All ~20 callers in production, integration tests, and test scaffolding.

There are 5 places we synchronously call these new async call paths, each documented well in code:

- `KubernetesDirectoryInformationProvider.GetPathUsedBytes` (only called via an `IOctopusFileSystem` sync override)
- `PowerShellPrerequisite.Check` (`IPrerequisite` is sync, used by the WPF installer)
- `CommandLineRunner.Execute` (sync wrapper for the WPF installer flow)
- `LinuxServiceConfigurator` and `WindowsServiceConfigurator` (Topshelf's `ServiceCommand → AbstractCommand → ICommand.Start` chain is sync top to bottom)

## Risks & mitigations

The classic sync-over-async deadlock is the obvious worry here. `.GetAwaiter().GetResult()` hangs when the calling thread has captured a `SynchronizationContext`. See each call site for why it is safe.

Mock vs. production drift in tests was a surprising issue I ran intodue to places we mock `Execute` we needed to switch this to  `ExecuteAsync`. We hit this on `WhenSettingUpPollingTentacle_TelemetryEventShouldBeSent` and the wizard model builder now stubs both.

## For Kubernetes agent owners

This PR touches your ownership area but should cause no behaviour changes.

- `KubernetesDirectoryInformationProvider`: exposes sync (existing) and async (new) ways to read path usage. Same `du` invocation, same 30-second cache; we need both because one downstream is sync and another is async.
- `KubernetesPhysicalFileSystem`: same shape. Sync `GetStorageInformation` stays, new async `GetStorageInformationAsync` added. Both go through one private helper so the two never drift.
- `KubernetesScriptPodCreator.CreateScriptContainer`: previously blocked on async work indirectly. Now `await`s the new async sibling directly. No behaviour change, just one fewer sync-over-async hop on your script-pod creation path.
- `KubernetesAgentInstaller.Dispose` (integration test scaffolding only): still blocks on async because `Dispose` is sync.

What we'd love your eyes on: there's one remaining sync-over-async hop in the K8s agent at `EnsureDiskHasEnoughFreeSpace`, because it implements a sync filesystem interface. It blocks on the async `du` path. This is safe in a normal .NET console app because there's no `SynchronizationContext` for the awaited continuation to come back to. If you know of anything in the K8s agent's host startup (pod watchers, bootstrap, a custom task scheduler) that would install a `SynchronizationContext` and break that assumption, the disk-space check is where the deadlock would surface. Worth a quick sanity check against your mental model of how the agent boots up.

## How to review

- Is this change safe?
- Is there anything I you would do to de-risk it further beyond a green build?