### PR TITLE
Fetch tenant-scoped tagsets only in the setup wizard

### DIFF
--- a/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
+++ b/source/Octopus.Manager.Tentacle/TentacleConfiguration/SetupWizard/SetupTentacleWizardModel.cs
@@ -1041,7 +1041,7 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
             var workerPools = areWorkersSupported ? await LoadWorkerPools() : new List<WorkerPoolResource>();
 
             var areTenantsSupported = await repository.HasLink("Tenants");
-            var tenantTagSets = areTenantsSupported ? await LoadTagSets() : new List<TagSetResource>();
+            var tenantTagSets = areTenantsSupported ? await LoadTenantTagSets() : new List<TagSetResource>();
             var tenants = areTenantsSupported ? await LoadTenants() : new List<TenantResource>();
 
             var (machinePoliciesAreSupported, machinePolicies) = await GetMachinePolicies();
@@ -1054,10 +1054,10 @@ namespace Octopus.Manager.Tentacle.TentacleConfiguration.SetupWizard
                 return await repository.WorkerPools.GetAll(CancellationToken.None);
             }
 
-            async Task<List<TagSetResource>> LoadTagSets()
+            async Task<List<TagSetResource>> LoadTenantTagSets()
             {
                 onProgress("Getting available tenant tags...");
-                return await repository.TagSets.GetAll(CancellationToken.None);
+                return await repository.TagSets.FindAll(null, new { scopes = new[] { "Tenant" } }, CancellationToken.None);
             }
 
             async Task<List<TenantResource>> LoadTenants()


### PR DESCRIPTION
# Background
This PR ensures only tenant tags are shown on the tenant tags dropdown 🐛  in our tentacle installation wizard on recent versions (2026.1+) of Octopus.

With the extended tag sets feature, `TagSet` repository can no longer be assumed to return tenant tags. In order to only fetch the tenant tags, a scopes query parameter is necessary now.

Our API ignores unknown query params, so older versions of Octopus should not see any issues.

# Results

Fixes HPY-1408
Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/1238

See [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) (including [this flowchart](https://whimsical.com/r-d-incoming-work-workflow-aug-21-NsDnGQXcwBLwU66a88Zhue) 

## Before
### Machine roles
<img width="631" height="274" alt="image" src="https://github.com/user-attachments/assets/867c808c-f758-4163-8fb1-1eeadd950b1d" />

### Tenant tags
(This was before having a tenant tag  so it only displays the machine roles, but this will display all tag sets from all scopes)
<img width="649" height="367" alt="image" src="https://github.com/user-attachments/assets/ee1dc94f-af67-4533-898a-3a27fe185b4b" />



## After
### Machine roles
<img width="631" height="274" alt="image" src="https://github.com/user-attachments/assets/93dd2f5c-94cf-4f58-ab6e-61e8157c57ff" />

### Tenant tags
<img width="772" height="376" alt="image" src="https://github.com/user-attachments/assets/b2d0e477-91f0-4ec6-99b3-631c7b5b6060" />



# How to review this PR

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.