### PR TITLE
feat: add liveness probe support for polling Tentacles

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/LivezCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/LivezCommandFixture.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Tentacle.Commands;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Core.Diagnostics;
+using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Startup;
+using Octopus.Tentacle.Util;
+using Octopus.Time;
+
+namespace Octopus.Tentacle.Tests.Commands
+{
+    [TestFixture]
+    public class LivezCommandFixture : CommandFixture<LivezCommand>
+    {
+        string homeDirectory = null!;
+        string heartbeatPath = null!;
+        IHomeConfiguration homeConfiguration = null!;
+        IClock clock = null!;
+        IApplicationInstanceSelector instanceSelector = null!;
+        OctopusPhysicalFileSystem fileSystem = null!;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            fileSystem = new OctopusPhysicalFileSystem(Substitute.For<ISystemLog>());
+            homeDirectory = fileSystem.CreateTemporaryDirectory();
+            heartbeatPath = Path.Combine(homeDirectory, LivenessHeartbeatTask.HeartbeatFileName);
+
+            homeConfiguration = Substitute.For<IHomeConfiguration>();
+            homeConfiguration.HomeDirectory.Returns(homeDirectory);
+
+            clock = Substitute.For<IClock>();
+
+            instanceSelector = Substitute.For<IApplicationInstanceSelector>();
+            instanceSelector.Current.Returns(_ => new ApplicationInstanceConfiguration(null, null!, null!, null!));
+
+            Command = new LivezCommand(
+                new Lazy<IHomeConfiguration>(() => homeConfiguration),
+                clock,
+                instanceSelector,
+                Substitute.For<ISystemLog>(),
+                Substitute.For<ILogFileOnlyLogger>());
+        }
+
+        [TearDown]
+        public void TearDownAfterEachTest()
+        {
+            try
+            {
+                if (Directory.Exists(homeDirectory))
+                    Directory.Delete(homeDirectory, recursive: true);
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+
+        [Test]
+        public void Succeeds_When_Heartbeat_Is_Fresh()
+        {
+            var now = new DateTime(2026, 5, 26, 12, 0, 0, DateTimeKind.Utc);
+            WriteHeartbeatWithMtime(now);
+            clock.GetUtcTime().Returns(new DateTimeOffset(now.AddSeconds(5), TimeSpan.Zero));
+
+            Action act = () => Start();
+
+            act.Should().NotThrow();
+        }
+
+        [Test]
+        public void Fails_When_Heartbeat_Is_Stale()
+        {
+            var now = new DateTime(2026, 5, 26, 12, 0, 0, DateTimeKind.Utc);
+            WriteHeartbeatWithMtime(now);
+            clock.GetUtcTime().Returns(new DateTimeOffset(now.AddMinutes(5), TimeSpan.Zero));
+
+            Action act = () => Start();
+
+            act.Should().Throw<ControlledFailureException>()
+                .WithMessage("*stale*");
+        }
+
+        [Test]
+        public void Fails_When_Heartbeat_File_Is_Missing()
+        {
+            clock.GetUtcTime().Returns(DateTimeOffset.UtcNow);
+
+            Action act = () => Start();
+
+            act.Should().Throw<ControlledFailureException>()
+                .WithMessage("*not found*");
+        }
+
+        [Test]
+        public void Custom_MaxAge_Allows_Older_Heartbeat()
+        {
+            var now = new DateTime(2026, 5, 26, 12, 0, 0, DateTimeKind.Utc);
+            WriteHeartbeatWithMtime(now);
+            clock.GetUtcTime().Returns(new DateTimeOffset(now.AddSeconds(90), TimeSpan.Zero));
+
+            Action act = () => Start("--max-age=120");
+
+            act.Should().NotThrow();
+        }
+
+        [Test]
+        public void Custom_MaxAge_Tighter_Than_Default_Fails_Sooner()
+        {
+            var now = new DateTime(2026, 5, 26, 12, 0, 0, DateTimeKind.Utc);
+            WriteHeartbeatWithMtime(now);
+            clock.GetUtcTime().Returns(new DateTimeOffset(now.AddSeconds(30), TimeSpan.Zero));
+
+            Action act = () => Start("--max-age=10");
+
+            act.Should().Throw<ControlledFailureException>()
+                .WithMessage("*stale*");
+        }
+
+        [Test]
+        public void Fails_When_MaxAge_Is_Not_Positive()
+        {
+            var now = new DateTime(2026, 5, 26, 12, 0, 0, DateTimeKind.Utc);
+            WriteHeartbeatWithMtime(now);
+            clock.GetUtcTime().Returns(new DateTimeOffset(now, TimeSpan.Zero));
+
+            Action act = () => Start("--max-age=0");
+
+            act.Should().Throw<ControlledFailureException>()
+                .WithMessage("*positive*");
+        }
+
+        void WriteHeartbeatWithMtime(DateTime mtimeUtc)
+        {
+            File.WriteAllBytes(heartbeatPath, Array.Empty<byte>());
+            File.SetLastWriteTimeUtc(heartbeatPath, mtimeUtc);
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Diagnostics/LivenessHeartbeatTaskFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Diagnostics/LivenessHeartbeatTaskFixture.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Threading;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Core.Diagnostics;
+using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Util;
+
+namespace Octopus.Tentacle.Tests.Diagnostics
+{
+    [TestFixture]
+    public class LivenessHeartbeatTaskFixture
+    {
+        string homeDirectory = null!;
+        string heartbeatPath = null!;
+        OctopusPhysicalFileSystem fileSystem = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            fileSystem = new OctopusPhysicalFileSystem(Substitute.For<ISystemLog>());
+            homeDirectory = fileSystem.CreateTemporaryDirectory();
+            heartbeatPath = Path.Combine(homeDirectory, LivenessHeartbeatTask.HeartbeatFileName);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                if (Directory.Exists(homeDirectory))
+                    Directory.Delete(homeDirectory, recursive: true);
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+
+        [Test]
+        public void Touches_Heartbeat_File_On_First_Tick()
+        {
+            var task = CreateTask(TimeSpan.FromMilliseconds(50));
+
+            task.Start();
+            try
+            {
+                WaitUntil(() => File.Exists(heartbeatPath), timeout: TimeSpan.FromSeconds(2))
+                    .Should().BeTrue("the heartbeat file should be created on the first tick");
+            }
+            finally
+            {
+                task.Stop();
+            }
+        }
+
+        [Test]
+        public void Refreshes_Heartbeat_File_Mtime_On_Subsequent_Ticks()
+        {
+            var task = CreateTask(TimeSpan.FromMilliseconds(50));
+
+            task.Start();
+            try
+            {
+                WaitUntil(() => File.Exists(heartbeatPath), TimeSpan.FromSeconds(2))
+                    .Should().BeTrue();
+                var firstMtime = File.GetLastWriteTimeUtc(heartbeatPath);
+
+                WaitUntil(() => File.GetLastWriteTimeUtc(heartbeatPath) > firstMtime, TimeSpan.FromSeconds(2))
+                    .Should().BeTrue("a subsequent tick should refresh the mtime");
+            }
+            finally
+            {
+                task.Stop();
+            }
+        }
+
+        [Test]
+        public void Survives_Io_Errors_And_Logs_A_Warning()
+        {
+            var log = Substitute.For<ISystemLog>();
+            var unwritableHome = Path.Combine(homeDirectory, "does", "not", "exist");
+            var homeConfig = Substitute.For<IHomeConfiguration>();
+            homeConfig.HomeDirectory.Returns(unwritableHome);
+
+            var task = new LivenessHeartbeatTask(homeConfig, log, TimeSpan.FromMilliseconds(50));
+
+            task.Start();
+            try
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(200));
+                log.ReceivedWithAnyArgs().Warn(Arg.Any<Exception>(), Arg.Any<string>());
+            }
+            finally
+            {
+                task.Stop();
+            }
+
+            File.Exists(Path.Combine(unwritableHome, LivenessHeartbeatTask.HeartbeatFileName))
+                .Should().BeFalse();
+        }
+
+        [Test]
+        public void Exits_Cleanly_When_Home_Directory_Is_Not_Configured()
+        {
+            var log = Substitute.For<ISystemLog>();
+            var homeConfig = Substitute.For<IHomeConfiguration>();
+            homeConfig.HomeDirectory.Returns((string?)null);
+
+            var task = new LivenessHeartbeatTask(homeConfig, log, TimeSpan.FromMilliseconds(50));
+
+            task.Start();
+            try
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(200));
+                log.ReceivedWithAnyArgs().Warn(Arg.Any<string>());
+            }
+            finally
+            {
+                task.Stop();
+            }
+        }
+
+        LivenessHeartbeatTask CreateTask(TimeSpan tickInterval)
+        {
+            var homeConfig = Substitute.For<IHomeConfiguration>();
+            homeConfig.HomeDirectory.Returns(homeDirectory);
+            return new LivenessHeartbeatTask(homeConfig, Substitute.For<ISystemLog>(), tickInterval);
+        }
+
+        static bool WaitUntil(Func<bool> condition, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (condition()) return true;
+                Thread.Sleep(20);
+            }
+            return condition();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Commands/LivezCommand.cs
+++ b/source/Octopus.Tentacle/Commands/LivezCommand.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Core.Diagnostics;
+using Octopus.Tentacle.Diagnostics;
+using Octopus.Tentacle.Startup;
+using Octopus.Time;
+
+namespace Octopus.Tentacle.Commands
+{
+    public class LivezCommand : AbstractStandardCommand
+    {
+        const int DefaultMaxAgeSeconds = 60;
+
+        readonly Lazy<IHomeConfiguration> homeConfiguration;
+        readonly IClock clock;
+
+        int maxAgeSeconds = DefaultMaxAgeSeconds;
+
+        public LivezCommand(
+            Lazy<IHomeConfiguration> homeConfiguration,
+            IClock clock,
+            IApplicationInstanceSelector instanceSelector,
+            ISystemLog log,
+            ILogFileOnlyLogger logFileOnlyLogger)
+            : base(instanceSelector, log, logFileOnlyLogger)
+        {
+            this.homeConfiguration = homeConfiguration;
+            this.clock = clock;
+
+            Options.Add(
+                "max-age=",
+                $"Maximum allowed age of the liveness heartbeat in seconds (default {DefaultMaxAgeSeconds}).",
+                v => maxAgeSeconds = int.Parse(v));
+        }
+
+        protected override void Start()
+        {
+            base.Start();
+
+            if (maxAgeSeconds <= 0)
+                throw new ControlledFailureException("--max-age must be a positive number of seconds.");
+
+            var home = homeConfiguration.Value.HomeDirectory;
+            if (string.IsNullOrWhiteSpace(home))
+                throw new ControlledFailureException("Could not determine the Tentacle home directory for the selected instance.");
+
+            var heartbeatPath = Path.Combine(home!, LivenessHeartbeatTask.HeartbeatFileName);
+
+            if (!File.Exists(heartbeatPath))
+                throw new ControlledFailureException($"Liveness heartbeat file not found at {heartbeatPath}; the Tentacle agent may not be running.");
+
+            var lastWriteUtc = File.GetLastWriteTimeUtc(heartbeatPath);
+            var age = clock.GetUtcTime().DateTime - lastWriteUtc;
+
+            if (age > TimeSpan.FromSeconds(maxAgeSeconds))
+                throw new ControlledFailureException($"Liveness heartbeat at {heartbeatPath} is stale: last written {(int)age.TotalSeconds}s ago (threshold {maxAgeSeconds}s).");
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Diagnostics/LivenessHeartbeatTask.cs
+++ b/source/Octopus.Tentacle/Diagnostics/LivenessHeartbeatTask.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Octopus.Tentacle.Background;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Core.Diagnostics;
+
+namespace Octopus.Tentacle.Diagnostics
+{
+    public interface ILivenessHeartbeatTask : IBackgroundTask
+    {
+    }
+
+    class LivenessHeartbeatTask : BackgroundTask, ILivenessHeartbeatTask
+    {
+        public const string HeartbeatFileName = "livez.heartbeat";
+        static readonly TimeSpan DefaultTickInterval = TimeSpan.FromSeconds(10);
+
+        readonly IHomeConfiguration homeConfiguration;
+        readonly TimeSpan tickInterval;
+
+        public LivenessHeartbeatTask(IHomeConfiguration homeConfiguration, ISystemLog log)
+            : this(homeConfiguration, log, DefaultTickInterval)
+        {
+        }
+
+        internal LivenessHeartbeatTask(IHomeConfiguration homeConfiguration, ISystemLog log, TimeSpan tickInterval)
+            : base(log, TimeSpan.FromSeconds(2))
+        {
+            this.homeConfiguration = homeConfiguration;
+            this.tickInterval = tickInterval;
+        }
+
+        protected override async Task RunTask(CancellationToken cancellationToken)
+        {
+            var heartbeatPath = ResolveHeartbeatPath();
+            if (heartbeatPath is null)
+            {
+                Log.Warn("Liveness heartbeat task could not resolve a home directory; heartbeat file will not be written.");
+                return;
+            }
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                TouchHeartbeat(heartbeatPath);
+
+                try
+                {
+                    await Task.Delay(tickInterval, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }
+        }
+
+        string? ResolveHeartbeatPath()
+        {
+            var home = homeConfiguration.HomeDirectory;
+            return string.IsNullOrWhiteSpace(home) ? null : Path.Combine(home, HeartbeatFileName);
+        }
+
+        void TouchHeartbeat(string path)
+        {
+            try
+            {
+                using (File.Create(path))
+                {
+                }
+            }
+            catch (IOException e)
+            {
+                Log.Warn(e, $"Failed to update liveness heartbeat file at {path}.");
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                Log.Warn(e, $"Failed to update liveness heartbeat file at {path}.");
+            }
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Maintenance/MaintenanceModule.cs
+++ b/source/Octopus.Tentacle/Maintenance/MaintenanceModule.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Octopus.Tentacle.Background;
+using Octopus.Tentacle.Diagnostics;
 
 namespace Octopus.Tentacle.Maintenance
 {
@@ -12,6 +13,7 @@ namespace Octopus.Tentacle.Maintenance
             builder.RegisterType<WorkspaceCleanerConfiguration>().SingleInstance();
             builder.RegisterType<WorkspaceCleaner>().SingleInstance();
             builder.RegisterType<WorkspaceCleanerTask>().As<IWorkspaceCleanerTask>().As<IBackgroundTask>().SingleInstance();
+            builder.RegisterType<LivenessHeartbeatTask>().As<ILivenessHeartbeatTask>().As<IBackgroundTask>().SingleInstance();
         }
     }
 }

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -98,6 +98,7 @@ namespace Octopus.Tentacle
             builder.RegisterCommand<ClearTrustedServersCommand>("clear-trusted-servers", "Clears trusted servers in the Tentacle Configuration");
             builder.RegisterCommand<ListInstancesCommand>("list-instances", "Lists all installed Tentacle instances");
             builder.RegisterCommand<VersionCommand>("version", "Show the Tentacle version information");
+            builder.RegisterCommand<LivezCommand>("livez", "Checks that the Tentacle agent process is alive (suitable for a Kubernetes liveness probe).");
             builder.RegisterCommand<ShowConfigurationCommand>("show-configuration", "Outputs the Tentacle configuration");
 
             return builder.Build();


### PR DESCRIPTION
# Background

Polling Kubernetes Tentacles need a liveness probe so Kubernetes can detect and recover from cases where a pod remains `Running` but the Tentacle process is stuck (deadlocked, frozen by EDR contention, etc.). Readiness is already covered by an exec-based command, so this PR closes the remaining gap.

Polling Tentacles run with `NoListen=true` and therefore do not expose an HTTP endpoint, so a Helm-chart-only change isn't viable — the signal has to come from the Tentacle process itself.

# Results

Adds a `tentacle livez` exec command suitable for use as a Kubernetes `livenessProbe`.

Two pieces work together:

- **`LivenessHeartbeatTask`** — a `BackgroundTask` registered in `MaintenanceModule` that touches `<HomeDirectory>/livez.heartbeat` every 10 seconds while the agent is running. Failure to write is logged but does not crash the task — the heartbeat going stale is the signal.
- **`LivezCommand`** — `tentacle livez [--max-age=<seconds>]` (default 60s). Resolves the heartbeat path from the selected instance's `IHomeConfiguration`, then fails with a `ControlledFailureException` (non-zero exit) if the file is missing or its `LastWriteTimeUtc` is older than the threshold. Time comes from `IClock` so the behaviour is testable.

This pairs with the matching change in [OctopusDeploy/helm-charts#608](https://github.com/OctopusDeploy/helm-charts/pull/608), which wires the new command into the polling-Tentacle pod spec as a `livenessProbe`.

## Before

Polling Tentacles had no liveness signal. A stuck agent in a `Running` pod would stay stuck until something external (operator, manual `kubectl delete pod`) restarted it.

## After

```
$ tentacle livez --instance=Tentacle
# exit 0 while the heartbeat is fresh

$ tentacle livez --instance=Tentacle --max-age=30
Liveness heartbeat at /etc/octopus/.../livez.heartbeat is stale: last written 47s ago (threshold 30s).
# exit non-zero — kubelet restarts the pod
```

# How to review this PR

Quality :heavy_check_mark:

Two areas worth a careful look:

1. **Threshold choice.** Heartbeat ticks every 10s, default `--max-age` is 60s — a 6× margin against transient I/O blips. Open to feedback on whether that's the right ratio for the Helm chart's `periodSeconds` / `failureThreshold` defaults.
2. **Failure modes of the heartbeat task itself.** `IOException` and `UnauthorizedAccessException` on the touch are logged and swallowed so a brief filesystem hiccup doesn't take down the task entirely. Anything else bubbles up and ends the task — which is intentional, because a permanently broken heartbeat *should* trip the probe.

Test coverage in `LivezCommandFixture` and `LivenessHeartbeatTaskFixture` (fresh / stale / missing / invalid `--max-age` / heartbeat file gets written and refreshed).

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
