### PR TITLE
Remove Calamari volume mount subpath

### DIFF
--- a/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesScriptPodCreator.cs
@@ -473,8 +473,7 @@ namespace Octopus.Tentacle.Kubernetes
                 container.VolumeMounts.Add(new V1VolumeMount
                 {
                     MountPath = calamariPath,
-                    Name = "calamari",
-                    SubPath = command.CalamariImageConfiguration!.Name
+                    Name = "calamari"
                 });
 
                 //This is used by Octopus Server to adjust where it's looking for the Calamari executable


### PR DESCRIPTION
# Background

The `subPath` is broken on AKS and it's really unnecessary tbh.

# Results

This means the entire calamari image is loaded at the `/calamari` mount path, howwever, there is only a single folder in each docker image, so it just means we end up with paths like `/calamari/Calamari/Calamari` 😂 

Related to MD-2016

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.