### PR TITLE
Remove max polling connection count limiter

### DIFF
--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -115,8 +115,6 @@ namespace Octopus.Tentacle.Communications
             }
         }
                 
-        const int MaximumPollingConnectionCount = 8;
-                
         uint GetPollingConnectionCount()
         {
             //Open multiple polling connections if the env var is set to a non-zero/negative number
@@ -127,17 +125,11 @@ namespace Octopus.Tentacle.Communications
                 connectionCount = count;
             }
 
-            //Coerce the requested value as it might be outside our max & min
-            switch (connectionCount)
+            // Ensure we have at least 1 connection
+            if (connectionCount == 0)
             {
-                case > MaximumPollingConnectionCount:
-                    log.InfoFormat("The requested polling connection count exceeds the maximum of {0}, limiting to {0}", MaximumPollingConnectionCount);
-                    connectionCount = MaximumPollingConnectionCount;
-                    break;
-                case 0:
-                    log.InfoFormat("The requested polling connection count must be greater than 0, setting to 1");
-                    connectionCount = 1;
-                    break;
+                log.InfoFormat("The requested polling connection count must be greater than 0, setting to 1");
+                connectionCount = 1;
             }
 
             log.InfoFormat("Starting {0} polling connections", connectionCount);

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -115,7 +115,8 @@ namespace Octopus.Tentacle.Communications
             }
         }
                 
-        const int MaximumPollingConnectionCount = 8;
+        // We don't expect anyone to hit this, but the theoretical cap is the number of allocatable outbound ports
+        const int MaximumPollingConnectionCount = 65535;
                 
         uint GetPollingConnectionCount()
         {

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -115,6 +115,8 @@ namespace Octopus.Tentacle.Communications
             }
         }
                 
+        const int MaximumPollingConnectionCount = 8;
+                
         uint GetPollingConnectionCount()
         {
             //Open multiple polling connections if the env var is set to a non-zero/negative number
@@ -125,11 +127,17 @@ namespace Octopus.Tentacle.Communications
                 connectionCount = count;
             }
 
-            // Ensure we have at least 1 connection
-            if (connectionCount == 0)
+            //Coerce the requested value as it might be outside our max & min
+            switch (connectionCount)
             {
-                log.InfoFormat("The requested polling connection count must be greater than 0, setting to 1");
-                connectionCount = 1;
+                case > MaximumPollingConnectionCount:
+                    log.InfoFormat("The requested polling connection count exceeds the maximum of {0}, limiting to {0}", MaximumPollingConnectionCount);
+                    connectionCount = MaximumPollingConnectionCount;
+                    break;
+                case 0:
+                    log.InfoFormat("The requested polling connection count must be greater than 0, setting to 1");
+                    connectionCount = 1;
+                    break;
             }
 
             log.InfoFormat("Starting {0} polling connections", connectionCount);

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -116,7 +116,7 @@ namespace Octopus.Tentacle.Communications
         }
                 
         // We don't expect anyone to hit this, but the theoretical cap is the number of allocatable outbound ports
-        const int MaximumPollingConnectionCount = 65535;
+        const int MaximumPollingConnectionCount = 10000;
                 
         uint GetPollingConnectionCount()
         {


### PR DESCRIPTION
To support self-hosted customers with large, multi-space agents, the maximum polling connection count was a hindrance rather than a good safety net. This PR removes it.