### PR TITLE
Default polling workers to CPU-based connection count (Option B: CPU-scaled)

### DIFF
--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -177,10 +177,13 @@ namespace Octopus.Tentacle.Commands
             }
 
             configuration.Value.AddOrUpdateTrustedOctopusServer(server);
+            configuration.Value.SetIsWorker(IsRegisteredAsWorker);
             VoteForRestart();
 
             log.Info("Machine registered successfully");
         }
+
+        protected virtual bool IsRegisteredAsWorker => false;
 
         protected abstract void CheckArgs();
 

--- a/source/Octopus.Tentacle/Commands/RegisterWorkerCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterWorkerCommandBase.cs
@@ -29,6 +29,8 @@ namespace Octopus.Tentacle.Commands
             Options.Add("workerpool=", "The worker pool name, slug or Id to add the machine to - e.g., 'Windows Pool'; specify this argument multiple times to add to multiple pools", s => workerpools.Add(s));
         }
 
+        protected override bool IsRegisteredAsWorker => true;
+
         protected override void CheckArgs()
         {
             if (workerpools.Count == 0 || string.IsNullOrWhiteSpace(workerpools.First()))

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -115,19 +115,19 @@ namespace Octopus.Tentacle.Communications
             }
         }
                 
-        const int MaximumPollingConnectionCount = 8;
-                
+        const uint MinimumPollingConnectionCount = 2;
+        const uint MaximumPollingConnectionCount = 8;
+
         uint GetPollingConnectionCount()
         {
-            //Open multiple polling connections if the env var is set to a non-zero/negative number
-            var connectionCount = 1u;
+            // Default to one connection per CPU core, clamped to [min, max]
+            var connectionCount = (uint)Math.Clamp(Environment.ProcessorCount, MinimumPollingConnectionCount, MaximumPollingConnectionCount);
             if (uint.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentaclePollingConnectionCount), out var count))
             {
                 log.InfoFormat("Requested polling connection count: {0}", count);
                 connectionCount = count;
             }
 
-            //Coerce the requested value as it might be outside our max & min
             switch (connectionCount)
             {
                 case > MaximumPollingConnectionCount:

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -120,8 +120,10 @@ namespace Octopus.Tentacle.Communications
 
         uint GetPollingConnectionCount()
         {
-            // Default to one connection per CPU core, clamped to [min, max]
-            var connectionCount = (uint)Math.Clamp(Environment.ProcessorCount, MinimumPollingConnectionCount, MaximumPollingConnectionCount);
+            // Default to one connection per CPU core (clamped to [min, max]) for workers; deployment targets stay at 1
+            var connectionCount = configuration.IsWorker
+                ? (uint)Math.Clamp(Environment.ProcessorCount, MinimumPollingConnectionCount, MaximumPollingConnectionCount)
+                : 1u;
             if (uint.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentaclePollingConnectionCount), out var count))
             {
                 log.InfoFormat("Requested polling connection count: {0}", count);

--- a/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
@@ -75,6 +75,8 @@ namespace Octopus.Tentacle.Configuration
 
         bool IsRegistered { get; }
 
+        bool IsWorker { get; }
+
         void WriteTo(IWritableKeyValueStore outputStore, IEnumerable<string> excluding);
     }
 
@@ -91,6 +93,8 @@ namespace Octopus.Tentacle.Configuration
         bool SetServicesPortNumber(int port);
 
         bool SetIsRegistered(bool isRegistered = true);
+
+        bool SetIsWorker(bool isWorker = true);
 
         /// <summary>
         /// Sets the IP address to listen on.

--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -19,6 +19,7 @@ namespace Octopus.Tentacle.Configuration
     internal class TentacleConfiguration : ITentacleConfiguration
     {
         internal const string IsRegisteredSettingName = "Tentacle.Services.IsRegistered";
+        internal const string IsWorkerSettingName = "Tentacle.Services.IsWorker";
         internal const string ServicesPortSettingName = "Tentacle.Services.PortNumber";
         internal const string ServicesListenIPSettingName = "Tentacle.Services.ListenIP";
         internal const string ServicesNoListenSettingName = "Tentacle.Services.NoListen";
@@ -69,6 +70,8 @@ namespace Octopus.Tentacle.Configuration
         public int ServicesPortNumber => settings.Get(ServicesPortSettingName, 10933);
 
         public bool IsRegistered => settings.Get(IsRegisteredSettingName, false);
+
+        public bool IsWorker => settings.Get(IsWorkerSettingName, false);
 
         public void WriteTo(IWritableKeyValueStore outputStore, IEnumerable<string> excluding)
         {
@@ -189,6 +192,11 @@ namespace Octopus.Tentacle.Configuration
         public bool SetIsRegistered(bool isRegistered = true)
         {
             return settings.Set(IsRegisteredSettingName, isRegistered);
+        }
+
+        public bool SetIsWorker(bool isWorker = true)
+        {
+            return settings.Set(IsWorkerSettingName, isWorker);
         }
 
         public bool SetListenIpAddress(string? address)


### PR DESCRIPTION
## Summary

- Polling Tentacle workers previously defaulted to **1 TCP connection**, serialising all RPC calls. Under load (e.g. DRB), RPCs queue in Halibut's Pending Request Queue and time out — causing deployment failures.
- This PR implements **Option B** from the [RFC](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/rfc-multiple-polling-connections.md): the default connection count **scales with CPU cores**, clamped to `[2, 8]`.
  - 1-core machine → 2 connections (minimum)
  - 4-core machine → 4 connections
  - 16-core machine → 8 connections (maximum)
- The `TentaclePollingConnectionCount` env var still overrides the default; Halibut's `MaximumActiveTcpConnectionsPerPollingSubscription` cap remains in place as a server-side safeguard.
- See also: [Option A PR](https://github.com/OctopusDeploy/OctopusTentacle/pull/1248) (fixed default of 5) for the simpler alternative.

## Test plan

- [ ] Verify existing tests pass
- [ ] On a 4-core worker: confirm logs show "Starting 4 polling connections"
- [ ] On a 1-core worker: confirm logs show "Starting 2 polling connections" (minimum enforced)
- [ ] Verify `TentaclePollingConnectionCount=1` env var still overrides to 1 connection
- [ ] Verify `TentaclePollingConnectionCount=10` is clamped to 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)