### PR TITLE
chore: Update Renovate configuration for Kubernetes agent dependencies

### DIFF
--- a/.github/workflows/update-k8s-agent-dependencies.yml
+++ b/.github/workflows/update-k8s-agent-dependencies.yml
@@ -16,6 +16,17 @@ on:
         required: false
         default: true
         type: boolean
+      log-level:
+        description: 'Renovate log level'
+        required: false
+        default: 'info'
+        type: choice
+        options:
+          - info
+          - debug
+          - trace
+          - warn
+          - error
 
 jobs:
   renovate-k8s-agent:
@@ -23,12 +34,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v39.0.1
+        uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15
         with:
           configurationFile: docker/kubernetes-agent-tentacle/renovate-config.js
           token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
         env:
-          LOG_LEVEL: debug
+          # On scheduled runs there are no inputs, so fall back to Renovate's
+          # own default log level (info).
+          LOG_LEVEL: ${{ inputs.log-level || 'info' }}
           RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || null }}

--- a/docker/kubernetes-agent-tentacle/renovate-config.js
+++ b/docker/kubernetes-agent-tentacle/renovate-config.js
@@ -15,11 +15,12 @@ module.exports = {
   requireConfig: 'optional',
   onboarding: false,
 
-  // dockerfile  -> golang builder image + any literal FROM tags in the Dockerfiles
-  // gomod       -> bootstrapRunner go.mod language version / module deps
+  // dockerfile   -> golang builder image + any literal FROM tags in the Dockerfiles
+  // gomod        -> bootstrapRunner go.mod language version / module deps
+  // custom.regex -> the runtime-deps base image tag (see customManagers below).
   // The runtime-deps base image tag is not a literal FROM (it is a build-arg
   // sourced from Build.Pack.cs), so it is handled by the custom manager below.
-  enabledManagers: ['dockerfile', 'gomod'],
+  enabledManagers: ['dockerfile', 'gomod', 'custom.regex'],
 
   // Limit Renovate to this feature area. build/Build.Pack.cs is included only
   // so the custom manager can reach the runtime-deps base image tag.
@@ -35,7 +36,7 @@ module.exports = {
   customManagers: [
     {
       customType: 'regex',
-      fileMatch: ['^build/Build\\.Pack\\.cs$'],
+      managerFilePatterns: ['/^build/Build\\.Pack\\.cs$/'],
       matchStrings: [
         'KubernetesTentacleContainerRuntimeDepsTag\\s*=\\s*"(?<currentValue>[^"]+)"',
       ],
@@ -46,7 +47,7 @@ module.exports = {
 
   // Full list of built-in presets: https://docs.renovatebot.com/presets-default/
   extends: [
-    'config:base',
+    'config:recommended',
     'group:monorepos',
     'group:recommended',
     ':rebaseStalePrs',


### PR DESCRIPTION
Add log-level input option to the Renovate workflow for better control over logging verbosity. Update the checkout action version to v6 and modify the log level environment variable to use the input value or default to 'info'. Enhance the Renovate config to include 'custom.regex' in enabled managers and change the extends property to 'config:recommended'.
