### PR TITLE
Pin K8s agent golang builder to 1.25.11

### DIFF
--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -1,7 +1,7 @@
 ARG RuntimeDepsTag
 
 
-FROM golang:1.25 AS bootstraprunnerbuilder
+FROM golang:1.25.11 AS bootstraprunnerbuilder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docker/kubernetes-agent-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/dev/Dockerfile
@@ -1,7 +1,7 @@
 ARG RuntimeDepsTag
 
 
-FROM golang:1.25 AS bootstraprunnerbuilder
+FROM golang:1.25.11 AS bootstraprunnerbuilder
 
 ARG TARGETARCH
 ARG TARGETOS


### PR DESCRIPTION
# Background

The Kubernetes agent's \`bootstrapRunner\` is compiled with the \`golang:1.25\` builder image, which floats to whatever the latest 1.25 patch is at build time. This pins it explicitly to **\`golang:1.25.11\`** (latest 1.25 patch, released 2026-06-02).

This is a manual stop-gap while the new K8s-agent Renovate config (#1250) can't yet raise PRs — its bot account (\`team-yosemite-bot\`) currently only has **read** access to this repo, so its pushes 403.

# Results

Pins the builder toolchain to a patched release, picking up the security fixes across 1.25.7–1.25.11, notably in **1.25.11**:
- **CVE-2026-42504** (\`mime\`) — CPU exhaustion from malicious MIME headers
- **CVE-2026-27145** (\`crypto/x509\`) — quadratic cert verification cost with large DNS SAN lists
- **CVE-2026-42507** (\`net/textproto\`) — error-message injection

Note: this is the **build-time** toolchain only (the image that compiles \`bootstrapRunner\`), not the shipped \`runtime-deps\` base image. \`go.mod\`'s \`go 1.25\` language-version directive is intentionally left unchanged.

## Before
\`\`\`dockerfile
FROM golang:1.25 AS bootstraprunnerbuilder
\`\`\`
## After
\`\`\`dockerfile
FROM golang:1.25.11 AS bootstraprunnerbuilder
\`\`\`

# How to review this PR

Quality :heavy_check_mark: — two-line change to the builder \`FROM\` tag in both \`Dockerfile\` and \`dev/Dockerfile\`. Green means go.