### PR TITLE
Pin System.Security.Cryptography.Xml to 8.0.3 (fix CVE-2026-26171, CVE-2026-33116)

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -105,6 +105,11 @@
 		<PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
 		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
 	</ItemGroup>
+	<!-- Pin transitive dependencies to fix known CVEs (.NET 8 only; net48 uses the GAC System.Security) -->
+	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
+		<!-- CVE-2026-26171 (security bypass + DoS) and CVE-2026-33116 (DoS via infinite recursion). Transitive 8.0.2 is vulnerable. -->
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
 		<PackageReference Include="System.Runtime" Version="4.3.0" />
 		<Reference Include="System.Security" />


### PR DESCRIPTION
Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/1256

# Background

A Trivy CVE scan of the published **`octopusdeploy/kubernetes-agent-tentacle`** image flagged two **HIGH** vulnerabilities in `System.Security.Cryptography.Xml` **8.0.2**, which is pulled in **transitively** (no direct reference exists in the repo):

- **CVE-2026-26171** — .NET XML: security bypass + denial of service
- **CVE-2026-33116** — .NET XML: denial of service via infinite recursion in `XmlDecryptionTransform`

These were the only **fixable** HIGH/CRITICAL findings in the image — the remaining OS-layer CRITICALs (perl, zlib) currently have no Debian fix available.

# How to review this PR

Quality :heavy_check_mark: — single `<ItemGroup>` pin in `Octopus.Tentacle.csproj`. Green means go. Re-running a Trivy scan on a freshly-built image should drop both HIGH findings.