### PR TITLE
Enable NuGet transitive dependency auditing (NuGetAuditMode=all)

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -16,6 +16,18 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
+	<!-- NuGet security auditing. The .NET 8 SDK default (NuGetAuditMode=direct) only audits
+	     direct PackageReferences; 'all' also audits transitive dependencies, surfacing things
+	     like the transitive System.Security.Cryptography.Xml 8.0.2 CVEs at restore time.
+	     Audit findings (NU1901-NU1904) are kept as warnings so they don't trip the project's
+	     TreatWarningsAsErrors and break the build - this is informational, not a hard gate. -->
+	<PropertyGroup>
+		<NuGetAudit>true</NuGetAudit>
+		<NuGetAuditMode>all</NuGetAuditMode>
+		<NuGetAuditLevel>low</NuGetAuditLevel>
+		<WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+	</PropertyGroup>
+
 	<Choose>
 		<When Condition="'$(TargetFramework)' == 'net48'">
 			<PropertyGroup>


### PR DESCRIPTION
# Background

While remediating the transitive `System.Security.Cryptography.Xml` 8.0.2 CVEs (found by an image scan, fixed in a separate PR), it became clear that **nothing in the build flags vulnerable transitive packages**. The .NET 8 SDK enables NuGet auditing by default, but only in `direct` mode — it audits direct `PackageReference`s and ignores the transitive graph, which is where these CVEs lived.

This PR turns on **`NuGetAuditMode=all`** so `dotnet restore` audits the full dependency graph and emits `NU1901`–`NU1904` warnings for known-vulnerable packages.

# Results

Added to `source/Octopus.Tentacle/Octopus.Tentacle.csproj`:
```xml
<PropertyGroup>
  <NuGetAudit>true</NuGetAudit>
  <NuGetAuditMode>all</NuGetAuditMode>
  <NuGetAuditLevel>low</NuGetAuditLevel>
  <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
</PropertyGroup>
```

A fresh `dotnet restore` (net8.0) now reports — and notably surfaces **5 vulnerable transitive packages**, not just the one we went looking for:

| Package | Severity |
|---|---|
| System.Security.Cryptography.Xml 8.0.2 | high ×2 (the CVEs we're fixing) |
| System.Net.Http 4.1.0 | high |
| System.Private.Uri 4.3.0 | high ×2 + moderate |
| System.Security.Cryptography.X509Certificates 4.1.0 | high |
| System.Text.RegularExpressions 4.3.0 | high |

(The 4.x findings are exactly the packages PR #1205 set out to pin — this is independent confirmation of that work.)

## Important: this does NOT break the build
The project sets `TreatWarningsAsErrors`, so audit findings would otherwise become **errors** and fail CI. `WarningsNotAsErrors` keeps `NU190x` as **warnings** — informational visibility, not a hard gate. Verified: `dotnet restore` exits **0** with the warnings printed.

# How to review this PR

Quality :heavy_check_mark: — single `<PropertyGroup>`. To see it work: `dotnet restore source/Octopus.Tentacle/Octopus.Tentacle.csproj -p:TargetFramework=net8.0 --force` and watch the `NU1903` warnings. If you later want this to be a **gate**, drop the `WarningsNotAsErrors` line (or scope it) so findings fail the build.