### PR TITLE
fix(docker): make Tentacle images OCI-compliant (FD-492)

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -769,9 +769,17 @@ partial class Build
                 };
 
                 // annotation-index.* lands on the image index, annotation.* on each platform manifest.
+                // Guard: annotation values are folded into the comma-separated buildx --output option
+                // list, so a comma in a value would corrupt it (the keys are fixed and comma-free).
                 var output = "type=image,oci-mediatypes=true,push=true";
                 foreach (var (key, value) in annotations)
+                {
+                    if (value.Contains(','))
+                        throw new InvalidOperationException(
+                            $"OCI annotation '{key}' value must not contain a comma; it would break the buildx --output option list: '{value}'");
+
                     output += $",annotation-index.{key}={value},annotation.{key}={value}";
+                }
 
                 settings = settings
                     .SetOutput(output)

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -749,6 +749,8 @@ partial class Build
                 // onto both the image index and each platform manifest. The Dockerfile LABELs
                 // set the same metadata on the image *config*; annotations are the spec-preferred
                 // location that registries and OCI tooling read from the manifest/index.
+                // Keep these values in sync with the org.opencontainers.image.* LABELs in
+                // docker/kubernetes-agent-tentacle/Dockerfile.
                 var annotations = new Dictionary<string, string>
                 {
                     ["org.opencontainers.image.title"] = "Octopus Deploy Kubernetes Agent Tentacle",

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -744,8 +744,30 @@ partial class Build
                 // is used (rather than --provenance=false) so the same switch applies to both
                 // `docker buildx build` here and `docker buildx bake` in the TeamCity Linux
                 // image build (see OctopusDeploy/TeamCity-Configuration).
+                //
+                // We also stamp the OCI image-spec annotations (org.opencontainers.image.*)
+                // onto both the image index and each platform manifest. The Dockerfile LABELs
+                // set the same metadata on the image *config*; annotations are the spec-preferred
+                // location that registries and OCI tooling read from the manifest/index.
+                var annotations = new Dictionary<string, string>
+                {
+                    ["org.opencontainers.image.title"] = "Octopus Deploy Kubernetes Agent Tentacle",
+                    ["org.opencontainers.image.vendor"] = "Octopus Deploy",
+                    ["org.opencontainers.image.url"] = "https://octopus.com",
+                    ["org.opencontainers.image.source"] = "https://github.com/OctopusDeploy/OctopusTentacle",
+                    ["org.opencontainers.image.licenses"] = "Apache-2.0",
+                    ["org.opencontainers.image.description"] = "Octopus Kubernetes Agent Tentacle instance with auto-registration to Octopus Server",
+                    ["org.opencontainers.image.version"] = FullSemVer,
+                    ["org.opencontainers.image.created"] = DateTime.UtcNow.ToString("O"),
+                };
+
+                // annotation-index.* lands on the image index, annotation.* on each platform manifest.
+                var output = "type=image,oci-mediatypes=true,push=true";
+                foreach (var (key, value) in annotations)
+                    output += $",annotation-index.{key}={value},annotation.{key}={value}";
+
                 settings = settings
-                    .SetOutput("type=image,oci-mediatypes=true,push=true")
+                    .SetOutput(output)
                     .AddProcessEnvironmentVariable("BUILDX_NO_DEFAULT_ATTESTATIONS", "1");
             }
             else

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -737,13 +737,16 @@ partial class Build
             if (push)
             {
                 // FD-492: Force a single, consistent OCI media type across the whole image
-                // manifest and disable provenance attestations. Without this, buildx can emit
+                // manifest and disable default attestations. Without this, buildx can emit
                 // a manifest that mixes Docker and OCI layer media types (and an attestation
                 // index), which strict OCI clients such as Podman reject - in particular when
-                // the image is used as a base image (FROM ...).
+                // the image is used as a base image (FROM ...). BUILDX_NO_DEFAULT_ATTESTATIONS
+                // is used (rather than --provenance=false) so the same switch applies to both
+                // `docker buildx build` here and `docker buildx bake` in the TeamCity Linux
+                // image build (see OctopusDeploy/TeamCity-Configuration).
                 settings = settings
                     .SetOutput("type=image,oci-mediatypes=true,push=true")
-                    .AddProcessAdditionalArguments("--provenance=false");
+                    .AddProcessEnvironmentVariable("BUILDX_NO_DEFAULT_ATTESTATIONS", "1");
             }
             else
             {

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -727,8 +727,13 @@ partial class Build
             if (includeDebugger)
                 tag += "-debug";
 
+            // Capture one timestamp and reuse it for both the BUILD_DATE build arg (which feeds
+            // the Dockerfile's org.opencontainers.image.created LABEL) and the created annotation
+            // below, so the image config and the manifest annotation report the same instant.
+            var buildDate = DateTime.UtcNow.ToString("O");
+
             settings = settings
-                .AddBuildArg($"BUILD_NUMBER={FullSemVer}", $"BUILD_DATE={DateTime.UtcNow:O}", $"RuntimeDepsTag={runtimeDepsImageTag}")
+                .AddBuildArg($"BUILD_NUMBER={FullSemVer}", $"BUILD_DATE={buildDate}", $"RuntimeDepsTag={runtimeDepsImageTag}")
                 .SetPlatform(DockerPlatform)
                 .SetTag(tag)
                 .SetFile(dockerfile)
@@ -760,7 +765,7 @@ partial class Build
                     ["org.opencontainers.image.licenses"] = "Apache-2.0",
                     ["org.opencontainers.image.description"] = "Octopus Kubernetes Agent Tentacle instance with auto-registration to Octopus Server",
                     ["org.opencontainers.image.version"] = FullSemVer,
-                    ["org.opencontainers.image.created"] = DateTime.UtcNow.ToString("O"),
+                    ["org.opencontainers.image.created"] = buildDate,
                 };
 
                 // annotation-index.* lands on the image index, annotation.* on each platform manifest.

--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -732,9 +732,23 @@ partial class Build
                 .SetPlatform(DockerPlatform)
                 .SetTag(tag)
                 .SetFile(dockerfile)
-                .SetPath(RootDirectory)
-                .SetPush(push)
-                .SetLoad(load);
+                .SetPath(RootDirectory);
+
+            if (push)
+            {
+                // FD-492: Force a single, consistent OCI media type across the whole image
+                // manifest and disable provenance attestations. Without this, buildx can emit
+                // a manifest that mixes Docker and OCI layer media types (and an attestation
+                // index), which strict OCI clients such as Podman reject - in particular when
+                // the image is used as a base image (FROM ...).
+                settings = settings
+                    .SetOutput("type=image,oci-mediatypes=true,push=true")
+                    .AddProcessAdditionalArguments("--provenance=false");
+            }
+            else
+            {
+                settings = settings.SetLoad(load);
+            }
 
             if (includeDebugger)
             {

--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -115,6 +115,8 @@ ENV TentaclePollingProxyPassword=""
 
 ENTRYPOINT ["/scripts/configure-and-run.sh"]
 
+# org.opencontainers.image.* metadata for the kubernetes-agent-tentacle image.
+# Keep in sync with the OCI annotations set in build/Build.Pack.cs.
 LABEL \
     org.opencontainers.image.title="Octopus Deploy Kubernetes Agent Tentacle" \
     org.opencontainers.image.vendor="Octopus Deploy" \

--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -116,12 +116,11 @@ ENV TentaclePollingProxyPassword=""
 ENTRYPOINT ["/scripts/configure-and-run.sh"]
 
 LABEL \
-    org.label-schema.schema-version="1.0" \
-    org.label-schema.name="Octopus Deploy Kubernetes Agent Tentacle" \
-    org.label-schema.vendor="Octopus Deploy" \
-    org.label-schema.url="https://octopus.com" \
-    org.label-schema.vcs-url="https://github.com/OctopusDeploy/OctopusTentacle" \
-    org.label-schema.license="Apache"  \
-    org.label-schema.description="Octopus Kubernetes Agent Tentacle instance with auto-registration to Octopus Server" \
-    org.label-schema.version=${BUILD_NUMBER} \
-    org.label-schema.build-date=${BUILD_DATE}
+    org.opencontainers.image.title="Octopus Deploy Kubernetes Agent Tentacle" \
+    org.opencontainers.image.vendor="Octopus Deploy" \
+    org.opencontainers.image.url="https://octopus.com" \
+    org.opencontainers.image.source="https://github.com/OctopusDeploy/OctopusTentacle" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.description="Octopus Kubernetes Agent Tentacle instance with auto-registration to Octopus Server" \
+    org.opencontainers.image.version=${BUILD_NUMBER} \
+    org.opencontainers.image.created=${BUILD_DATE}

--- a/docker/kubernetes-agent-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/dev/Dockerfile
@@ -100,15 +100,14 @@ ENV TentaclePollingProxyPassword=""
 ENTRYPOINT [ "/dev-scripts/bootstrap.sh" ] 
 
 LABEL \
-    org.label-schema.schema-version="1.0" \
-    org.label-schema.name="Octopus Deploy Kubernetes Tentacle" \
-    org.label-schema.vendor="Octopus Deploy" \
-    org.label-schema.url="https://octopus.com" \
-    org.label-schema.vcs-url="https://github.com/OctopusDeploy/OctopusTentacle" \
-    org.label-schema.license="Apache"  \
-    org.label-schema.description="Octopus Kubernetes Tentacle instance with auto-registration to Octopus Server" \
-    org.label-schema.version=${BUILD_NUMBER} \
-    org.label-schema.build-date=${BUILD_DATE}
+    org.opencontainers.image.title="Octopus Deploy Kubernetes Tentacle" \
+    org.opencontainers.image.vendor="Octopus Deploy" \
+    org.opencontainers.image.url="https://octopus.com" \
+    org.opencontainers.image.source="https://github.com/OctopusDeploy/OctopusTentacle" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.description="Octopus Kubernetes Tentacle instance with auto-registration to Octopus Server" \
+    org.opencontainers.image.version=${BUILD_NUMBER} \
+    org.opencontainers.image.created=${BUILD_DATE}
 
 # This installs the required tools, but there are versioning issues and it isn't working as expected
 

--- a/docker/kubernetes-agent-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/dev/Dockerfile
@@ -99,6 +99,8 @@ ENV TentaclePollingProxyPassword=""
 
 ENTRYPOINT [ "/dev-scripts/bootstrap.sh" ] 
 
+# org.opencontainers.image.* metadata for the dev/debug kubernetes tentacle image.
+# Keep in sync with docker/kubernetes-agent-tentacle/Dockerfile.
 LABEL \
     org.opencontainers.image.title="Octopus Deploy Kubernetes Tentacle" \
     org.opencontainers.image.vendor="Octopus Deploy" \

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -82,6 +82,9 @@ VOLUME /var/lib/docker
 
 ENTRYPOINT [ "/scripts/configure-and-run.sh" ]
 
+# org.opencontainers.image.* metadata for the published octopusdeploy/tentacle image.
+# Keep in sync with docker/windows/Dockerfile and the index annotations in the TeamCity
+# "Build: Docker manifest" step (OctopusDeploy/TeamCity-Configuration).
 LABEL \
     org.opencontainers.image.title="Octopus Deploy Tentacle" \
     org.opencontainers.image.vendor="Octopus Deploy" \

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -83,12 +83,11 @@ VOLUME /var/lib/docker
 ENTRYPOINT [ "/scripts/configure-and-run.sh" ]
 
 LABEL \
-    org.label-schema.schema-version="1.0" \
-    org.label-schema.name="Octopus Deploy Tentacle" \
-    org.label-schema.vendor="Octopus Deploy" \
-    org.label-schema.url="https://octopus.com" \
-    org.label-schema.vcs-url="https://github.com/OctopusDeploy/OctopusTentacle" \
-    org.label-schema.license="Apache"  \
-    org.label-schema.description="Octopus Tentacle instance with auto-registration to Octopus Server" \
-    org.label-schema.version=${BUILD_NUMBER} \
-    org.label-schema.build-date=${BUILD_DATE}
+    org.opencontainers.image.title="Octopus Deploy Tentacle" \
+    org.opencontainers.image.vendor="Octopus Deploy" \
+    org.opencontainers.image.url="https://octopus.com" \
+    org.opencontainers.image.source="https://github.com/OctopusDeploy/OctopusTentacle" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.description="Octopus Tentacle instance with auto-registration to Octopus Server" \
+    org.opencontainers.image.version=${BUILD_NUMBER} \
+    org.opencontainers.image.created=${BUILD_DATE}

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -8,15 +8,14 @@ ENV TentacleVersion ${BUILD_NUMBER}
 ENV OCTOPUS_RUNNING_IN_CONTAINER Y
 
 LABEL \
-    org.label-schema.schema-version="1.0" \
-    org.label-schema.name="Octopus Deploy Tentacle" \
-    org.label-schema.vendor="Octopus Deploy" \
-    org.label-schema.url="https://octopus.com" \
-    org.label-schema.vcs-url="https://github.com/OctopusDeploy/OctopusTentacle" \
-    org.label-schema.license="Apache"  \
-    org.label-schema.description="Octopus Tentacle instance with auto-registration to Octopus Server" \
-    org.label-schema.version=${BUILD_NUMBER} \
-    org.label-schema.build-date=${BUILD_DATE}
+    org.opencontainers.image.title="Octopus Deploy Tentacle" \
+    org.opencontainers.image.vendor="Octopus Deploy" \
+    org.opencontainers.image.url="https://octopus.com" \
+    org.opencontainers.image.source="https://github.com/OctopusDeploy/OctopusTentacle" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.description="Octopus Tentacle instance with auto-registration to Octopus Server" \
+    org.opencontainers.image.version=${BUILD_NUMBER} \
+    org.opencontainers.image.created=${BUILD_DATE}
 
 EXPOSE 10933
 

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -7,6 +7,9 @@ ARG INSTALLATION_FOLDER="C:/Program Files/Octopus Deploy/Tentacle"
 ENV TentacleVersion ${BUILD_NUMBER}
 ENV OCTOPUS_RUNNING_IN_CONTAINER Y
 
+# org.opencontainers.image.* metadata for the published octopusdeploy/tentacle image.
+# Keep in sync with docker/linux/Dockerfile and the index annotations in the TeamCity
+# "Build: Docker manifest" step (OctopusDeploy/TeamCity-Configuration).
 LABEL \
     org.opencontainers.image.title="Octopus Deploy Tentacle" \
     org.opencontainers.image.vendor="Octopus Deploy" \


### PR DESCRIPTION
**Linear:** [FD-492 — Image octopusdeploy/tentacle not OCI Compliant](https://linear.app/octopus/issue/FD-492/image-octopusdeploytentacle-not-oci-compliant)

## Background

Customer FD-492 (Zendesk 209584, ARUP Laboratories) reported that the `octopusdeploy/tentacle` Docker image is **not OCI compliant**: Podman rejects it when it is used as a base image (`FROM octopusdeploy/tentacle …`).

The root cause is **not** Dockerfile content and **not** the Debian 11→12 base-image upgrade (#1218 / EFT-3311) — that PR does not touch the manifest format, and building the old vs new image locally shows no difference. The actual problem is **inconsistent/mixed manifest media types** produced by the build/push pipeline. Docker tolerates this; strict OCI clients like Podman do not.

### What Octopus Server actually does (verified in the OctopusDeploy repo)

The triage note claimed Server "fixed the same issue in Jan 2026." I checked the Server repo history directly and that framing is **not accurate**. There is **no `oci-mediatypes`/`--provenance` flag combination anywhere in Server's history** (`git log -S` finds zero hits). Instead, Server builds its Linux image **single-architecture (`linux/amd64`) with the classic Docker builder** (`DockerTasks.DockerBuild` + `DockerTasks.DockerPush`, `nuke-build/Build.DockerImages.cs`), producing one self-consistent Docker schema2 manifest with no manifest list and no attestation index. Server avoids the problem by **never producing a multi-arch/attestation manifest**, rather than by fixing one with flags.

### Why this PR uses buildx flags instead of copying Server

The Tentacle **Kubernetes agent** image is genuinely **multi-arch** (`linux/arm64,linux/amd64`) and therefore *must* be built with buildx and a manifest list — it can't adopt Server's single-arch classic-build approach without dropping arm64. For a multi-arch buildx image, the correct equivalent remedy is to force a single OCI media type and drop the attestation index.

## Manifest evidence (verified against the published registry)

**`octopusdeploy/tentacle:latest` (the customer's image) — confirmed two distinct OCI violations:**

1. The OCI index mixes manifest formats:

   | Platform | Manifest mediaType |
   |---|---|
   | linux/amd64 | `application/vnd.oci.image.manifest.v1+json` (OCI — buildx) |
   | windows/amd64 | `application/vnd.docker.distribution.manifest.v2+json` (Docker schema2 — classic `docker build`/`push`) |

   A strict OCI consumer rejects an OCI index that references a Docker-schema2 manifest.

2. Even the linux/amd64 manifest mixes **layer** media types — `application/vnd.docker.image.rootfs.diff.tar.gzip` ×4 (inherited `debian` base layers) + `application/vnd.oci.image.layer.v1.tar+gzip` ×8 (new layers). This is the literal "mixes two layer format standards", normalized by `oci-mediatypes=true`.

**`kubernetes-agent-tentacle:latest` (this repo's image) — current published index contains 4 manifests:** arm64, amd64, **plus two `unknown/unknown` `attestation-manifest` entries** (buildx provenance). Its per-platform layers are already uniformly OCI, so here the defect is purely the attestation index — removed by disabling default attestations (`BUILDX_NO_DEFAULT_ATTESTATIONS=1`). (Per-platform layer types verified all-OCI.)

## Changes

1. **Build the Kubernetes agent image with consistent OCI media types** (`build/Build.Pack.cs`)
   - On push, use `--output type=image,oci-mediatypes=true,push=true` and `BUILDX_NO_DEFAULT_ATTESTATIONS=1` so the whole manifest uses a single OCI media type with no attestation index.
   - The local `--load` path (used by tests/dev) is unchanged.

2. **Modernize image labels** across all four Dockerfiles
   - Replace the deprecated `org.label-schema.*` namespace (retired 2016) with the standard `org.opencontainers.image.*` annotation keys.
   - Use the SPDX identifier `Apache-2.0` for the license.

## ⚠️ Follow-up required (out of scope for this repo)

The customer-reported image, **`octopusdeploy/tentacle`** (`docker/linux/Dockerfile`), is **amd64-only on Linux** but published in a multi-platform tag alongside the Windows image, and is built in the **TeamCity pipeline**, not in this repo's NUKE build. Closing FD-492 for that image requires, in TeamCity: (a) build/push the Linux image with `oci-mediatypes=true` so its layers are uniformly OCI, and (b) assemble the multi-platform tag so the Windows manifest is also OCI (otherwise the OCI index keeps referencing a Docker-schema2 manifest). This PR fixes the Kubernetes agent image (built here) and the shared label metadata.

## Testing notes

- `dotnet build build/_build.csproj` succeeds.
- Verify the pushed manifest with `docker buildx imagetools inspect --raw <tag>`: the index should contain only the two platform manifests (no `unknown/unknown` attestation manifests), and every layer `mediaType` should be `application/vnd.oci.image.layer.v1.tar+gzip`. Plus a `podman pull` / `FROM` smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note (review follow-up):** the attestation switch is standardised on `BUILDX_NO_DEFAULT_ATTESTATIONS=1` to match the `docker buildx bake` step in OctopusDeploy/TeamCity-Configuration#112 (identical across buildx `build` and `bake`, covers all default attestations, and avoids a post-PATH CLI flag).

---
**OCI annotations (review follow-up):** in addition to the Dockerfile `LABEL`s (which set `org.opencontainers.image.*` on the image *config*), the k8s agent build now also stamps those annotations onto the image **index** and each **platform manifest** via the buildx exporter `annotation-index.*` / `annotation.*` options — the spec-preferred location registries/OCI tooling read. Verified locally on a multi-arch build. The linux `octopusdeploy/tentacle` `:latest` index is assembled by a separate `docker manifest create` step (TeamCity-Configuration), so its index annotations are deferred to the manifest-step follow-up (switching to `docker buildx imagetools create --annotation`).
