### PR TITLE
Pin System.Security.Cryptography.Xml to 8.0.3

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -105,6 +105,11 @@
 		<PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
 		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
 	</ItemGroup>
+	<!-- Pin transitive dependencies to fix known CVEs (.NET 8 only; net48 uses the GAC System.Security) -->
+	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
+		<!-- CVE-2026-26171 (security bypass + DoS) and CVE-2026-33116 (DoS via infinite recursion). Transitive 8.0.2 is vulnerable. -->
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
 		<PackageReference Include="System.Runtime" Version="4.3.0" />
 		<Reference Include="System.Security" />


### PR DESCRIPTION
Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/1256

System.Security.Cryptography.Xml to 8.0.2 has:
 - CVE-2026-26171 (.NET XML: security bypass + DoS)
 - CVE-2026-33116 (.NET XML: DoS via infinite recursion in XmlDecryptionTransform)

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.