### PR TITLE
Add support for setting polling connection count on tentacles. Tentacle Workers default to max(5, core count).

### DIFF
--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -61,6 +61,7 @@ ENV CustomPublicHostName=""
 ENV DISABLE_DIND=N
 ENV ListeningPort=""
 ENV MachinePolicy="Default Machine Policy"
+ENV PollingConnectionCount=""
 ENV PublicHostNameConfiguration="ComputerName"
 ENV ProxyName=""
 ENV ServerApiKey=""

--- a/docker/linux/scripts/configure-tentacle.sh
+++ b/docker/linux/scripts/configure-tentacle.sh
@@ -134,6 +134,11 @@ function configureTentacle() {
     echo "Updating trust ..."
     tentacle configure --instance "$instanceName" --reset-trust
 
+    if [[ ! -z "$PollingConnectionCount" ]]; then
+        echo "Setting polling connection count ..."
+        tentacle configure --instance "$instanceName" --pollingConnectionCount "$PollingConnectionCount"
+    fi
+
     echo "Creating certificate ..."
     tentacle new-certificate --instance "$instanceName" --if-blank
 }

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -61,6 +61,7 @@ It is recommended that you run this using something like docker compose, so that
 - **ServerCommsAddress**: The URL of the Octopus Server that the Tentacle will poll for work. Defaults to `ServerUrl`. Implies a polling Tentacle.
 - **ServerPort**: The port on the Octopus Server that the Tentacle will poll for work. Defaults to 10943. Implies a polling Tentacle.
 - **ListeningPort**: The port that the Octopus Server will connect back to the Tentacle with. Defaults to 10933. Implies a listening Tentacle.
+- **PollingConnectionCount**: The number of polling connections this Tentacle should open to each Octopus Server it polls. Only applies to polling Tentacles. If not set, workers default to at least 5 (scaling with processor count) and deployment targets default to 1.
 - **PublicHostNameConfiguration**: How the url that the Octopus server will use to communicate with the Tentacle is determined. Can be `PublicIp`, `FQDN`, `ComputerName` or `Custom`. Defaults to `PublicIp`.
 - **CustomPublicHostName**: If `PublicHostNameConfiguration` is set to `Custom`, the host name that the Octopus Server should use to communicate with the Tentacle.
 

--- a/docs/polling-connection-count.md
+++ b/docs/polling-connection-count.md
@@ -1,0 +1,30 @@
+# Polling Connection Count
+
+It is possible to control the number of RPCs a Polling Tentacle can execute concurrently.
+ 
+With a value of just `1`, a Polling Tentacle that is sending a large file will be prevented 
+from doing anything else while the file is being transferred. While this works for Polling Tentacle
+Targets which generally do one thing at a time, it doesn't work well for Polling Tentacle Workers since they tend to
+be given multiple requests to execute at the same time. 
+
+## Defaults
+
+Registering with `register-worker` auto-sets the count to `max(5, processor count)` if it hasn't already been set. Deployment targets default to 1. Only applies to polling registrations.
+ 
+## How to set it
+
+- `Tentacle configure --instance MyInstance --pollingConnectionCount 5`
+- `Tentacle set-polling-connection-count --instance MyInstance --pollingConnectionCount 5`
+- Directly in the Tentacle configuration XML:
+
+```xml
+<set key="Tentacle.Communication.PollingConnectionCount">5</set>
+```
+
+## Limits
+
+The value is coerced to `1 <= count <= 512`.
+
+## Docker
+
+Set the `PollingConnectionCount` environment variable on the container. See [docker/readme.md](../docker/readme.md).

--- a/source/Octopus.Tentacle.Tests.Integration/TentacleCommandLineTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/TentacleCommandLineTests.cs
@@ -594,6 +594,7 @@ Or one of the common options:
   ""Tentacle"": {{
     ""CertificateThumbprint"": ""{clientAndTentacle.RunningTentacle.Thumbprint}"",
     ""Communication"": {{
+      ""PollingConnectionCount"": null,
       ""TrustedOctopusServers"": [
         {{
           ""Thumbprint"": ""{clientAndTentacle.Server.Thumbprint}"",
@@ -630,6 +631,7 @@ Or one of the common options:
   ""Tentacle"": {{
     ""CertificateThumbprint"": ""{clientAndTentacle.RunningTentacle.Thumbprint}"",
     ""Communication"": {{
+      ""PollingConnectionCount"": null,
       ""TrustedOctopusServers"": [
         {{
           ""Thumbprint"": ""{clientAndTentacle.Server.Thumbprint}"",

--- a/source/Octopus.Tentacle.Tests/Commands/ConfigureCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/ConfigureCommandFixture.cs
@@ -41,6 +41,21 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
+        public void ShouldSetPollingConnectionCount()
+        {
+            Start("--pollingConnectionCount=7");
+            tentacleConfiguration.PollingConnectionCount.Should().Be(7);
+        }
+
+        [Test]
+        public void ShouldRejectAPollingConnectionCountLessThanOne()
+        {
+            Action start = () => Start("--pollingConnectionCount=0");
+            start.Should().Throw<ControlledFailureException>();
+            tentacleConfiguration.PollingConnectionCount.Should().BeNull();
+        }
+
+        [Test]
         public void ShouldSetApplicationDirectory()
         {
             fileSystem.GetFullPath(Arg.Any<string>()).Returns("C:\\Apps");

--- a/source/Octopus.Tentacle.Tests/Commands/ConfigureCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/ConfigureCommandFixture.cs
@@ -56,6 +56,14 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
+        public void ShouldRejectAPollingConnectionCountThatIsNotANumber()
+        {
+            Action start = () => Start("--pollingConnectionCount=notanumber");
+            start.Should().Throw<ControlledFailureException>().WithMessage("*not a valid whole number*");
+            tentacleConfiguration.PollingConnectionCount.Should().BeNull();
+        }
+
+        [Test]
         public void ShouldSetApplicationDirectory()
         {
             fileSystem.GetFullPath(Arg.Any<string>()).Returns("C:\\Apps");

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
@@ -156,6 +156,27 @@ namespace Octopus.Tentacle.Tests.Commands
                 "--server-comms-address=https://polling.localhost/");
         }
 
+        [Test]
+        public void ShouldDefaultPollingConnectionCountToOneWhenRegisteringAPollingTentacle()
+        {
+            AssertPollingTentacleRegistered("https://localhost:10943/");
+            configuration.Received().SetPollingConnectionCount(1);
+        }
+
+        [Test]
+        public void ShouldNotSetPollingConnectionCountWhenRegisteringAListeningTentacle()
+        {
+            Start("--env=Development",
+                "--server=http://localhost",
+                "--name=MyMachine",
+                "--publicHostName=mymachine.test",
+                "--apiKey=ABC123",
+                "--force",
+                "--role=app-server");
+
+            configuration.DidNotReceive().SetPollingConnectionCount(Arg.Any<int>());
+        }
+
         void AssertPollingTentacleRegistered(string expectedServerAddress, params string[] additionalArgs)
         {
             var args = new []

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
@@ -153,6 +153,36 @@ namespace Octopus.Tentacle.Tests.Commands
         // no need for tests like ShouldReuseSubscriptionIdForPollingTentacleIfReRegistering
         // because it runs the same code for Workers and Deployment targets
 
+        [Test]
+        public void ShouldDefaultPollingConnectionCountToFiveWhenRegisteringAPollingWorker()
+        {
+            AssertPollingWorkerRegistered("https://localhost:10943/");
+            configuration.Received().SetPollingConnectionCount(5);
+        }
+
+        [Test]
+        public void ShouldNotSetPollingConnectionCountWhenRegisteringAListeningWorker()
+        {
+            Start("--workerpool=SomePool",
+                "--server=http://localhost",
+                "--name=MyMachine",
+                "--publicHostName=mymachine.test",
+                "--apiKey=ABC123",
+                "--force");
+
+            configuration.DidNotReceive().SetPollingConnectionCount(Arg.Any<int>());
+        }
+
+        [Test]
+        public void ShouldNotOverridePollingConnectionCountWhenAlreadyConfigured()
+        {
+            configuration.PollingConnectionCount.Returns(3);
+
+            AssertPollingWorkerRegistered("https://localhost:10943/");
+
+            configuration.DidNotReceive().SetPollingConnectionCount(Arg.Any<int>());
+        }
+
         void AssertPollingWorkerRegistered(string expectedServerAddress, params string[] additionalArgs)
         {
             var args = new []

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
@@ -154,10 +154,14 @@ namespace Octopus.Tentacle.Tests.Commands
         // because it runs the same code for Workers and Deployment targets
 
         [Test]
-        public void ShouldDefaultPollingConnectionCountToFiveWhenRegisteringAPollingWorker()
+        public void ShouldDefaultPollingConnectionCountWhenRegisteringAPollingWorker()
         {
+            // Workers default to at least five connections, scaling up with the processor count. Compute the
+            // expected value the same way the production code does so the test is correct on any machine/CI agent.
+            var expectedConnectionCount = Math.Max(5, Environment.ProcessorCount);
+
             AssertPollingWorkerRegistered("https://localhost:10943/");
-            configuration.Received().SetPollingConnectionCount(5);
+            configuration.Received().SetPollingConnectionCount(expectedConnectionCount);
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests/Commands/SetPollingConnectionCountCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/SetPollingConnectionCountCommandFixture.cs
@@ -1,0 +1,57 @@
+using System;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Tentacle.Commands;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Core.Diagnostics;
+using Octopus.Tentacle.Startup;
+
+namespace Octopus.Tentacle.Tests.Commands
+{
+    [TestFixture]
+    public class SetPollingConnectionCountCommandFixture : CommandFixture<SetPollingConnectionCountCommand>
+    {
+        StubTentacleConfiguration tentacleConfiguration;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            tentacleConfiguration = new StubTentacleConfiguration();
+            var log = Substitute.For<ISystemLog>();
+            var selector = Substitute.For<IApplicationInstanceSelector>();
+            selector.Current.Returns(info => new ApplicationInstanceConfiguration(null, null!, null!, null!));
+            Command = new SetPollingConnectionCountCommand(
+                new Lazy<IWritableTentacleConfiguration>(() => tentacleConfiguration),
+                selector,
+                log,
+                Substitute.For<ILogFileOnlyLogger>());
+        }
+
+        [Test]
+        public void ShouldSetThePollingConnectionCount()
+        {
+            Start("--count=5");
+            tentacleConfiguration.PollingConnectionCount.Should().Be(5);
+        }
+
+        [Test]
+        public void ShouldFailWhenNoCountProvided()
+        {
+            Action start = () => Start();
+            start.Should().Throw<ControlledFailureException>();
+            tentacleConfiguration.PollingConnectionCount.Should().BeNull();
+        }
+
+        [Test]
+        public void ShouldFailWhenCountIsLessThanOne()
+        {
+            Action start = () => Start("--count=0");
+            start.Should().Throw<ControlledFailureException>();
+            tentacleConfiguration.PollingConnectionCount.Should().BeNull();
+        }
+    }
+}

--- a/source/Octopus.Tentacle.Tests/Commands/SetPollingConnectionCountCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/SetPollingConnectionCountCommandFixture.cs
@@ -34,7 +34,7 @@ namespace Octopus.Tentacle.Tests.Commands
         [Test]
         public void ShouldSetThePollingConnectionCount()
         {
-            Start("--count=5");
+            Start("--pollingConnectionCount=5");
             tentacleConfiguration.PollingConnectionCount.Should().Be(5);
         }
 
@@ -49,8 +49,16 @@ namespace Octopus.Tentacle.Tests.Commands
         [Test]
         public void ShouldFailWhenCountIsLessThanOne()
         {
-            Action start = () => Start("--count=0");
+            Action start = () => Start("--pollingConnectionCount=0");
             start.Should().Throw<ControlledFailureException>();
+            tentacleConfiguration.PollingConnectionCount.Should().BeNull();
+        }
+
+        [Test]
+        public void ShouldFailWithAFriendlyErrorWhenCountIsNotANumber()
+        {
+            Action start = () => Start("--pollingConnectionCount=notanumber");
+            start.Should().Throw<ControlledFailureException>().WithMessage("*not a valid whole number*");
             tentacleConfiguration.PollingConnectionCount.Should().BeNull();
         }
     }

--- a/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/StubTentacleConfiguration.cs
@@ -37,6 +37,7 @@ namespace Octopus.Tentacle.Tests.Commands
         public IProxyConfiguration ProxyConfiguration { get; set; } = null!;
         public IPollingProxyConfiguration PollingProxyConfiguration { get; set; } = null!;
         public bool IsRegistered { get; set; } = false;
+        public int? PollingConnectionCount { get; set; }
         public void WriteTo(IWritableKeyValueStore outputStore, IEnumerable<string> excluding)
         {
             throw new NotImplementedException();
@@ -57,6 +58,12 @@ namespace Octopus.Tentacle.Tests.Commands
         public bool SetIsRegistered(bool isRegistered = true)
         {
             IsRegistered = isRegistered;
+            return true;
+        }
+
+        public bool SetPollingConnectionCount(int count)
+        {
+            PollingConnectionCount = count;
             return true;
         }
 

--- a/source/Octopus.Tentacle.Tests/Communications/HalibutInitializerFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Communications/HalibutInitializerFixture.cs
@@ -43,9 +43,8 @@ namespace Octopus.Tentacle.Tests.Communications
             HalibutInitializer.DeterminePollingConnectionCount(null, 0, Substitute.For<ISystemLog>()).Should().Be(1);
         }
 
-        // The maximum is computed the same way the production code computes it, so the test stays correct on any
-        // machine regardless of Environment.ProcessorCount (the cap scales with core count but is never below 32).
-        static readonly uint ExpectedMaximumPollingConnectionCount = (uint)Math.Max(32, Environment.ProcessorCount * 4);
+        // Mirrors the fixed cap in HalibutInitializer.MaximumPollingConnectionCount.
+        const uint ExpectedMaximumPollingConnectionCount = 512;
 
         [Test]
         public void PollingConnectionCountCoercesValuesAboveTheMaximum()

--- a/source/Octopus.Tentacle.Tests/Communications/HalibutInitializerFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Communications/HalibutInitializerFixture.cs
@@ -43,10 +43,24 @@ namespace Octopus.Tentacle.Tests.Communications
             HalibutInitializer.DeterminePollingConnectionCount(null, 0, Substitute.For<ISystemLog>()).Should().Be(1);
         }
 
+        // The maximum is computed the same way the production code computes it, so the test stays correct on any
+        // machine regardless of Environment.ProcessorCount (the cap scales with core count but is never below 32).
+        static readonly uint ExpectedMaximumPollingConnectionCount = (uint)Math.Max(32, Environment.ProcessorCount * 4);
+
         [Test]
         public void PollingConnectionCountCoercesValuesAboveTheMaximum()
         {
-            HalibutInitializer.DeterminePollingConnectionCount("100000", null, Substitute.For<ISystemLog>()).Should().Be(10000);
+            // 1,000,000 is comfortably above the maximum on any conceivable machine, so it must be coerced to the cap.
+            HalibutInitializer.DeterminePollingConnectionCount("1000000", null, Substitute.For<ISystemLog>())
+                .Should().Be(ExpectedMaximumPollingConnectionCount);
+        }
+
+        [Test]
+        public void PollingConnectionCountAllowsTheConfiguredValueUpToTheMaximum()
+        {
+            // A request exactly at the cap should be honoured, not coerced.
+            HalibutInitializer.DeterminePollingConnectionCount(ExpectedMaximumPollingConnectionCount.ToString(), null, Substitute.For<ISystemLog>())
+                .Should().Be(ExpectedMaximumPollingConnectionCount);
         }
 
         string defaultProxyHost = "127.0.0.1";

--- a/source/Octopus.Tentacle.Tests/Communications/HalibutInitializerFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Communications/HalibutInitializerFixture.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Halibut;
 using NSubstitute;
 using NUnit.Framework;
+using Octopus.Tentacle.Communications;
 using Octopus.Tentacle.Configuration;
 using Octopus.Tentacle.Core.Diagnostics;
 
@@ -12,6 +13,42 @@ namespace Octopus.Tentacle.Tests.Communications
     [TestFixture]
     public class HalibutInitializerFixture
     {
+        [Test]
+        public void PollingConnectionCountDefaultsToOneWhenNeitherEnvVarNorConfigIsSet()
+        {
+            HalibutInitializer.DeterminePollingConnectionCount(null, null, Substitute.For<ISystemLog>()).Should().Be(1);
+        }
+
+        [Test]
+        public void PollingConnectionCountUsesTheConfiguredValueWhenEnvVarIsNotSet()
+        {
+            HalibutInitializer.DeterminePollingConnectionCount(null, 5, Substitute.For<ISystemLog>()).Should().Be(5);
+        }
+
+        [Test]
+        public void PollingConnectionCountEnvVarWinsOverTheConfiguredValue()
+        {
+            HalibutInitializer.DeterminePollingConnectionCount("8", 5, Substitute.For<ISystemLog>()).Should().Be(8);
+        }
+
+        [Test]
+        public void PollingConnectionCountIgnoresAnUnparseableEnvVarAndFallsBackToConfig()
+        {
+            HalibutInitializer.DeterminePollingConnectionCount("not-a-number", 5, Substitute.For<ISystemLog>()).Should().Be(5);
+        }
+
+        [Test]
+        public void PollingConnectionCountCoercesZeroConfiguredValueToOne()
+        {
+            HalibutInitializer.DeterminePollingConnectionCount(null, 0, Substitute.For<ISystemLog>()).Should().Be(1);
+        }
+
+        [Test]
+        public void PollingConnectionCountCoercesValuesAboveTheMaximum()
+        {
+            HalibutInitializer.DeterminePollingConnectionCount("100000", null, Substitute.For<ISystemLog>()).Should().Be(10000);
+        }
+
         string defaultProxyHost = "127.0.0.1";
         int defaultProxyPort = 1111;
         string defaultProxyUsername = "username";

--- a/source/Octopus.Tentacle/Commands/ConfigureCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ConfigureCommand.cs
@@ -80,11 +80,9 @@ namespace Octopus.Tentacle.Commands
                 }
                 VoteForRestart();
             }));
-            Options.Add("pollingConnectionCount=", "The number of polling connections this Tentacle should open to each Octopus Server it polls. Only applies to polling Tentacles.", v => QueueOperation(delegate
+            Options.Add(PollingConnectionCountOption.Prototype, PollingConnectionCountOption.Description, v => QueueOperation(delegate
             {
-                var pollingConnectionCount = int.Parse(v);
-                if (pollingConnectionCount < 1)
-                    throw new ControlledFailureException("The polling connection count must be greater than 0.");
+                var pollingConnectionCount = PollingConnectionCountOption.Parse(v);
                 tentacleConfiguration.Value.SetPollingConnectionCount(pollingConnectionCount);
                 log.Info("Polling connection count set to: " + pollingConnectionCount);
                 VoteForRestart();

--- a/source/Octopus.Tentacle/Commands/ConfigureCommand.cs
+++ b/source/Octopus.Tentacle/Commands/ConfigureCommand.cs
@@ -80,6 +80,15 @@ namespace Octopus.Tentacle.Commands
                 }
                 VoteForRestart();
             }));
+            Options.Add("pollingConnectionCount=", "The number of polling connections this Tentacle should open to each Octopus Server it polls. Only applies to polling Tentacles.", v => QueueOperation(delegate
+            {
+                var pollingConnectionCount = int.Parse(v);
+                if (pollingConnectionCount < 1)
+                    throw new ControlledFailureException("The polling connection count must be greater than 0.");
+                tentacleConfiguration.Value.SetPollingConnectionCount(pollingConnectionCount);
+                log.Info("Polling connection count set to: " + pollingConnectionCount);
+                VoteForRestart();
+            }));
             Options.Add("trust=", "The thumbprint of the Octopus Server to trust", v => octopusToAdd.Add(v));
             Options.Add("remove-trust=", "The thumbprint of the Octopus Server to remove from the trusted list", v => octopusToRemove.Add(v));
             Options.Add("reset-trust", "Removes all trusted Octopus Servers", v => resetTrust = true);

--- a/source/Octopus.Tentacle/Commands/PollingConnectionCountOption.cs
+++ b/source/Octopus.Tentacle/Commands/PollingConnectionCountOption.cs
@@ -1,0 +1,37 @@
+using System;
+using Octopus.Tentacle.Startup;
+
+namespace Octopus.Tentacle.Commands
+{
+    /// <summary>
+    /// Shared definition of the "polling connection count" command-line option so that the <c>configure</c> and
+    /// <c>set-polling-connection-count</c> commands expose the same option name and apply identical parsing and
+    /// validation.
+    /// </summary>
+    internal static class PollingConnectionCountOption
+    {
+        public const string Name = "pollingConnectionCount";
+
+        public const string Description = "The number of polling connections this Tentacle should open to each Octopus Server it polls. Only applies to polling Tentacles.";
+
+        /// <summary>
+        /// The option as it should be passed to <c>OptionSet.Add</c> (i.e. expecting a value).
+        /// </summary>
+        public const string Prototype = Name + "=";
+
+        /// <summary>
+        /// Parses and validates a user-supplied polling connection count, throwing a friendly
+        /// <see cref="ControlledFailureException"/> if the value cannot be parsed or is out of range.
+        /// </summary>
+        public static int Parse(string value)
+        {
+            if (!int.TryParse(value, out var count))
+                throw new ControlledFailureException($"The polling connection count '{value}' is not a valid whole number. Specify a positive integer, e.g. --{Name}=5");
+
+            if (count < 1)
+                throw new ControlledFailureException($"The polling connection count must be greater than 0, but was {count}.");
+
+            return count;
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -154,6 +154,15 @@ namespace Octopus.Tentacle.Commands
                 var subscriptionId = GetServerSubscriptionId(existingServer);
                 registerMachineOperation.SubscriptionId = subscriptionId;
                 server.SubscriptionId = subscriptionId.ToString();
+
+                // Polling Tentacles benefit from multiple connections to the server. Seed a sensible default
+                // based on whether this is a worker or a deployment target, but never override a value the
+                // operator has already configured explicitly.
+                if (configuration.Value.PollingConnectionCount is null)
+                {
+                    log.Info($"Setting the polling connection count to {DefaultPollingConnectionCount}");
+                    configuration.Value.SetPollingConnectionCount(DefaultPollingConnectionCount);
+                }
             }
 
             registerMachineOperation.MachinePolicy = policy;
@@ -181,6 +190,12 @@ namespace Octopus.Tentacle.Commands
 
             log.Info("Machine registered successfully");
         }
+
+        /// <summary>
+        /// The number of polling connections to configure when registering a polling Tentacle and no value has been
+        /// explicitly configured. Deployment targets default to 1; workers override this to open more connections.
+        /// </summary>
+        protected virtual int DefaultPollingConnectionCount => 1;
 
         protected abstract void CheckArgs();
 

--- a/source/Octopus.Tentacle/Commands/RegisterWorkerCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterWorkerCommandBase.cs
@@ -29,6 +29,11 @@ namespace Octopus.Tentacle.Commands
             Options.Add("workerpool=", "The worker pool name, slug or Id to add the machine to - e.g., 'Windows Pool'; specify this argument multiple times to add to multiple pools", s => workerpools.Add(s));
         }
 
+        // No less than five connections ensures a few file uploads won't completely block the worker.
+        // We also look to take ProcessorCount for larger workers so that Polling Tentacles somewhat
+        // scale with the number of Processors.
+        protected override int DefaultPollingConnectionCount => Math.Max(5, Environment.ProcessorCount);
+
         protected override void CheckArgs()
         {
             if (workerpools.Count == 0 || string.IsNullOrWhiteSpace(workerpools.First()))

--- a/source/Octopus.Tentacle/Commands/SetPollingConnectionCountCommand.cs
+++ b/source/Octopus.Tentacle/Commands/SetPollingConnectionCountCommand.cs
@@ -1,0 +1,43 @@
+using System;
+using Octopus.Tentacle.Configuration;
+using Octopus.Tentacle.Configuration.Instances;
+using Octopus.Tentacle.Core.Diagnostics;
+using Octopus.Tentacle.Startup;
+
+namespace Octopus.Tentacle.Commands
+{
+    public class SetPollingConnectionCountCommand : AbstractStandardCommand
+    {
+        readonly Lazy<IWritableTentacleConfiguration> configuration;
+        readonly ISystemLog log;
+        int? count;
+
+        public SetPollingConnectionCountCommand(
+            Lazy<IWritableTentacleConfiguration> configuration,
+            IApplicationInstanceSelector instanceSelector,
+            ISystemLog log,
+            ILogFileOnlyLogger logFileOnlyLogger)
+            : base(instanceSelector, log, logFileOnlyLogger)
+        {
+            this.configuration = configuration;
+            this.log = log;
+
+            Options.Add("count=", "The number of polling connections this Tentacle should open to each Octopus Server it polls. Only applies to polling Tentacles.", s => count = int.Parse(s));
+        }
+
+        protected override void Start()
+        {
+            base.Start();
+
+            if (count is null)
+                throw new ControlledFailureException("Please specify the number of polling connections, e.g. --count=5");
+
+            if (count < 1)
+                throw new ControlledFailureException("The polling connection count must be greater than 0.");
+
+            configuration.Value.SetPollingConnectionCount(count.Value);
+            log.Info($"Polling connection count set to: {count.Value}");
+            VoteForRestart();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Commands/SetPollingConnectionCountCommand.cs
+++ b/source/Octopus.Tentacle/Commands/SetPollingConnectionCountCommand.cs
@@ -10,7 +10,7 @@ namespace Octopus.Tentacle.Commands
     {
         readonly Lazy<IWritableTentacleConfiguration> configuration;
         readonly ISystemLog log;
-        int? count;
+        string? countValue;
 
         public SetPollingConnectionCountCommand(
             Lazy<IWritableTentacleConfiguration> configuration,
@@ -22,21 +22,20 @@ namespace Octopus.Tentacle.Commands
             this.configuration = configuration;
             this.log = log;
 
-            Options.Add("count=", "The number of polling connections this Tentacle should open to each Octopus Server it polls. Only applies to polling Tentacles.", s => count = int.Parse(s));
+            Options.Add(PollingConnectionCountOption.Prototype, PollingConnectionCountOption.Description, v => countValue = v);
         }
 
         protected override void Start()
         {
             base.Start();
 
-            if (count is null)
-                throw new ControlledFailureException("Please specify the number of polling connections, e.g. --count=5");
+            if (countValue is null)
+                throw new ControlledFailureException($"Please specify the number of polling connections, e.g. --{PollingConnectionCountOption.Name}=5");
 
-            if (count < 1)
-                throw new ControlledFailureException("The polling connection count must be greater than 0.");
+            var count = PollingConnectionCountOption.Parse(countValue);
 
-            configuration.Value.SetPollingConnectionCount(count.Value);
-            log.Info($"Polling connection count set to: {count.Value}");
+            configuration.Value.SetPollingConnectionCount(count);
+            log.Info($"Polling connection count set to: {count}");
             VoteForRestart();
         }
     }

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -106,6 +106,7 @@ namespace Octopus.Tentacle.Communications
                 var serviceEndPoint = new ServiceEndPoint(pollingEndPoint.Address, pollingEndPoint.Thumbprint, halibutProxy, halibutTimeoutsAndLimits);
 
                 var connectionCount = GetPollingConnectionCount();
+                log.InfoFormat("Starting {0} polling connections", connectionCount);
 
                 for (var i = 0; i < connectionCount; i++)
                 {
@@ -115,8 +116,7 @@ namespace Octopus.Tentacle.Communications
         }
                 
         // Limit Polling connections to something within the realm of reasonable.
-        // We allow polling connection count to scale with core count, if someone has a 32-core machine, 128 connections might not be unreasonable. 
-        static readonly int MaximumPollingConnectionCount = Math.Max(32, Environment.ProcessorCount * 4);
+        static readonly int MaximumPollingConnectionCount = 512;
                 
         uint GetPollingConnectionCount()
         {
@@ -152,8 +152,7 @@ namespace Octopus.Tentacle.Communications
                     log.InfoFormat("The requested polling connection count must be greater than 0, setting to 1");
                     connectionCount = 1;
             }
-
-            log.InfoFormat("Starting {0} polling connections", connectionCount);
+            
             return connectionCount;
         }
 

--- a/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
+++ b/source/Octopus.Tentacle/Communications/HalibutInitializer.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using Halibut;
-using Halibut.Diagnostics;
 using Octopus.Client.Model;
 using Octopus.Client.Model.Endpoints;
 using Octopus.Tentacle.Configuration;
@@ -115,30 +114,43 @@ namespace Octopus.Tentacle.Communications
             }
         }
                 
-        // We don't expect anyone to hit this, but the theoretical cap is the number of allocatable outbound ports
-        const int MaximumPollingConnectionCount = 10000;
+        // Limit Polling connections to something within the realm of reasonable.
+        // We allow polling connection count to scale with core count, if someone has a 32-core machine, 128 connections might not be unreasonable. 
+        static readonly int MaximumPollingConnectionCount = Math.Max(32, Environment.ProcessorCount * 4);
                 
         uint GetPollingConnectionCount()
         {
-            //Open multiple polling connections if the env var is set to a non-zero/negative number
+            var envVarValue = Environment.GetEnvironmentVariable(EnvironmentVariables.TentaclePollingConnectionCount);
+            return DeterminePollingConnectionCount(envVarValue, configuration.PollingConnectionCount, log);
+        }
+
+        // The TentaclePollingConnectionCount environment variable wins if set. Otherwise, the value persisted in the
+        // Tentacle configuration is used. If neither is set, we default to a single polling connection.
+        internal static uint DeterminePollingConnectionCount(string? envVarValue, int? configuredCount, ISystemLog log)
+        {
             var connectionCount = 1u;
-            if (uint.TryParse(Environment.GetEnvironmentVariable(EnvironmentVariables.TentaclePollingConnectionCount), out var count))
+            if (uint.TryParse(envVarValue, out var countFromEnvVar))
             {
-                log.InfoFormat("Requested polling connection count: {0}", count);
-                connectionCount = count;
+                log.InfoFormat("Requested polling connection count (from {0} environment variable): {1}", EnvironmentVariables.TentaclePollingConnectionCount, countFromEnvVar);
+                connectionCount = countFromEnvVar;
+            }
+            else if (configuredCount is { } countFromConfig && countFromConfig > 0)
+            {
+                log.InfoFormat("Requested polling connection count (from Tentacle configuration): {0}", countFromConfig);
+                connectionCount = (uint)countFromConfig;
             }
 
             //Coerce the requested value as it might be outside our max & min
-            switch (connectionCount)
+            
+            if (connectionCount > MaximumPollingConnectionCount)
             {
-                case > MaximumPollingConnectionCount:
-                    log.InfoFormat("The requested polling connection count exceeds the maximum of {0}, limiting to {0}", MaximumPollingConnectionCount);
-                    connectionCount = MaximumPollingConnectionCount;
-                    break;
-                case 0:
+                log.InfoFormat("The requested polling connection count exceeds the maximum of {0}, limiting to {0}", MaximumPollingConnectionCount);
+                connectionCount = (uint)MaximumPollingConnectionCount;
+            }
+            
+            if(connectionCount <= 0) {
                     log.InfoFormat("The requested polling connection count must be greater than 0, setting to 1");
                     connectionCount = 1;
-                    break;
             }
 
             log.InfoFormat("Starting {0} polling connections", connectionCount);

--- a/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/ITentacleConfiguration.cs
@@ -64,6 +64,13 @@ namespace Octopus.Tentacle.Configuration
         OctopusServerConfiguration? LastReceivedHandshake { get; }
 
         /// <summary>
+        /// The number of polling connections this Tentacle should open to each Octopus Server it polls.
+        /// Returns null when no value has been explicitly configured. Only applies to polling (active) Tentacles.
+        /// The <c>TentaclePollingConnectionCount</c> environment variable, when set, takes precedence over this value.
+        /// </summary>
+        int? PollingConnectionCount { get; }
+
+        /// <summary>
         /// Gets the proxy used for communications.
         /// </summary>
         IProxyConfiguration ProxyConfiguration { get; }
@@ -91,6 +98,11 @@ namespace Octopus.Tentacle.Configuration
         bool SetServicesPortNumber(int port);
 
         bool SetIsRegistered(bool isRegistered = true);
+
+        /// <summary>
+        /// Sets the number of polling connections this Tentacle should open to each Octopus Server it polls.
+        /// </summary>
+        bool SetPollingConnectionCount(int count);
 
         /// <summary>
         /// Sets the IP address to listen on.

--- a/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
+++ b/source/Octopus.Tentacle/Configuration/TentacleConfiguration.cs
@@ -27,6 +27,7 @@ namespace Octopus.Tentacle.Configuration
         internal const string CertificateSettingName = "Tentacle.Certificate";
         internal const string CertificateThumbprintSettingName = "Tentacle.CertificateThumbprint";
         internal const string LastReceivedHandshakeSettingName = "Tentacle.Communication.LastReceivedHandshake";
+        internal const string PollingConnectionCountSettingName = "Tentacle.Communication.PollingConnectionCount";
 
         readonly IKeyValueStore settings;
         readonly IHomeConfiguration home;
@@ -70,6 +71,8 @@ namespace Octopus.Tentacle.Configuration
 
         public bool IsRegistered => settings.Get(IsRegisteredSettingName, false);
 
+        public int? PollingConnectionCount => settings.Get<int?>(PollingConnectionCountSettingName, null);
+
         public void WriteTo(IWritableKeyValueStore outputStore, IEnumerable<string> excluding)
         {
             excluding = new HashSet<string>(excluding);
@@ -82,6 +85,7 @@ namespace Octopus.Tentacle.Configuration
             SetIfNotExcluded(CertificateSettingName, TentacleCertificate);
             SetIfNotExcluded(CertificateThumbprintSettingName, TentacleCertificate?.Thumbprint ?? string.Empty);
             SetIfNotExcluded(LastReceivedHandshakeSettingName, LastReceivedHandshake);
+            SetIfNotExcluded(PollingConnectionCountSettingName, PollingConnectionCount);
 
             void SetIfNotExcluded<T>(string settingName, T value)
             {
@@ -189,6 +193,11 @@ namespace Octopus.Tentacle.Configuration
         public bool SetIsRegistered(bool isRegistered = true)
         {
             return settings.Set(IsRegisteredSettingName, isRegistered);
+        }
+
+        public bool SetPollingConnectionCount(int count)
+        {
+            return settings.Set(PollingConnectionCountSettingName, count);
         }
 
         public bool SetListenIpAddress(string? address)

--- a/source/Octopus.Tentacle/Program.cs
+++ b/source/Octopus.Tentacle/Program.cs
@@ -10,7 +10,6 @@ using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Kubernetes;
 using Octopus.Tentacle.Maintenance;
 using Octopus.Tentacle.Properties;
-using Octopus.Tentacle.Scripts;
 using Octopus.Tentacle.Services;
 using Octopus.Tentacle.Startup;
 using Octopus.Tentacle.Time;
@@ -72,6 +71,7 @@ namespace Octopus.Tentacle
                 .WithParameter("applicationName", ApplicationName);
             builder.RegisterCommand<RunAgentCommand>("agent", "Starts the Tentacle Agent in debug mode", "", "run");
             builder.RegisterCommand<ConfigureCommand>("configure", "Sets Tentacle settings such as the port number and thumbprints");
+            builder.RegisterCommand<SetPollingConnectionCountCommand>("set-polling-connection-count", "Sets the number of polling connections this Tentacle opens to each Octopus Server it polls");
             builder.RegisterCommand<UpdateTrustCommand>("update-trust", "Replaces the trusted Octopus Server thumbprint of any matching polling or listening registrations with a new thumbprint to trust");
             builder.RegisterCommand<RegisterMachineCommand>("register-with", "Registers this machine as a deployment target with an Octopus Server");
             builder.RegisterCommand<RegisterWorkerCommand>("register-worker", "Registers this machine as a worker with an Octopus Server");


### PR DESCRIPTION


# Background

Halibut can do one RPC per TCP connection, this is problem for Polling Tentacles since:
* A single long running RPC can cause other RPCs to be starved and fail.
* It does not scale with the Tentacle e.g. a 4 core tentacle can still only do one RPC at a time.

With this change going forward newly configured tentacle workers will have the number of Polling connections set to either 5 or the number of processors at configuration time (whatever is larger). Tentacle targets will remain with a connection count of 1, but this can be configured.

## PollingConnectionCount Setting
Additionally this adds a new configuration setting:
```
<set key="Tentacle.Communication.PollingConnectionCount">16</set>
```
To the Tentacle configuration xml to set (and persist) the number of polling connections.

Note that:
* The environment variable `TentaclePollingConnectionCount` overrides the value in config.
* The actual number of connections is set to be within `0 < NumberOfPollingConnections <= 512`.

## New pollingConnectionCount option added to the configure command.

Add an option to the `configure` command: `--pollingConnectionCount=N` sets and persists the polling connection count. Values less than 1 are rejected with a controlled failure.

## New set-polling-connection-count command.

The number of polling connections to use can be set by:
`Tentacle set-polling-connection-count --instance=MyInstance --pollingConnectionCount=N`

## Updated limits for Max Polling Connection Count

Updates the value from 10K to a fixed cap of `512`, which is a more sensible ceiling on the number of polling connections a single Tentacle should open.

# Results

This lets polling Tentacles open more than a single TCP connection to the Octopus Server, so that long-running RPCs no longer starve other RPCs and throughput scales with the Tentacle's core count. Workers default to a higher connection count (at least 5, or the processor count) while deployment targets default to 1, and operators can override the count via the `configure` command, the new `set-polling-connection-count` command, or the `TentaclePollingConnectionCount` environment variable.

Verified end-to-end against a local Octopus: a registered worker opened the expected number of live polling connections, and the `TentaclePollingConnectionCount` environment variable correctly overrode the persisted config value.


Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/1267

Fixes EFT-3416

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.



