### PR TITLE
Create Octopus.Tentacle.CrossPlatformBundle.Development nuget package

### DIFF
--- a/build/Build.Pack.cs
+++ b/build/Build.Pack.cs
@@ -563,7 +563,7 @@ partial class Build
             const string title = "Octopus Tentacle cross platform bundle";
             const string description = "The deployment agent that is installed on each machine you plan to deploy to using Octopus.";
 
-            CreateNugetPackage(workingDirectory, id, description, author, title);
+            CreateNugetPackage(workingDirectory, id, author, title, description);
         });
 
     [PublicAPI]
@@ -621,6 +621,38 @@ partial class Build
             CreateNugetPackage(workingDirectory, id, author, title, description);
         });
 
+    [PublicAPI]
+    Target PackCrossPlatformBundleForDevelopment => _ => _
+        .Description("Packs a slim cross-platform Tentacle bundle (Windows x64, macOS ARM64, Linux x64 archives) for local dev environments and integration/E2E test setup.")
+        .Executes(() =>
+        {
+            (ArtifactsDirectory / "nuget").CreateDirectory();
+
+            var workingDirectory = BuildDirectory / "Octopus.Tentacle.CrossPlatformBundle.Development";
+            workingDirectory.CreateDirectory();
+
+            // Get the archives (binaries) for all required runtimes
+            foreach (var runtimeId in CrossPlatformBundleForDevelopmentRequiredRuntimes)
+            {
+                var fileExtension = runtimeId.StartsWith("win") ? "zip" : "tar.gz";
+                var path = ArtifactsDirectory / "zip" / $"tentacle-{FullSemVer}-{NetCore}-{runtimeId}.{fileExtension}";
+                path.Copy(workingDirectory / $"tentacle-{NetCore}-{runtimeId}.{fileExtension}");
+            }
+
+            // Assert all the expected files have been successfully copied
+            Assert.True((workingDirectory / $"tentacle-{NetCore}-win-x64.zip").FileExists(), $"Missing tentacle-{NetCore}-win-x64.zip");
+            Assert.True((workingDirectory / $"tentacle-{NetCore}-osx-arm64.tar.gz").FileExists(), $"Missing tentacle-{NetCore}-osx-arm64.tar.gz");
+            Assert.True((workingDirectory / $"tentacle-{NetCore}-linux-x64.tar.gz").FileExists(), $"Missing tentacle-{NetCore}-linux-x64.tar.gz");
+
+            const string id = "Octopus.Tentacle.CrossPlatformBundle.Development";
+
+            const string author = "Octopus Deploy";
+            const string title = "Octopus Tentacle cross platform bundle (for local development and testing)";
+            const string description = "The deployment agent that is installed on each machine you plan to deploy to using Octopus.";
+
+            CreateNugetPackage(workingDirectory, id, author, title, description);
+        });
+
     void CreateNugetPackage(
         AbsolutePath workingDirectory,
         string id,
@@ -643,6 +675,7 @@ partial class Build
         .Description("Pack all the artifacts. Notional task - running this on a single host is possible but cumbersome.")
         .DependsOn(PackCrossPlatformBundle)
         .DependsOn(PackCrossPlatformBundleForServer)
+        .DependsOn(PackCrossPlatformBundleForDevelopment)
         .DependsOn(PackContracts)
         .DependsOn(PackCore)
         .DependsOn(PackClient);

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -79,6 +79,8 @@ partial class Build : NukeBuild
 
     IEnumerable<string> CrossPlatformBundleForServerRequiredRuntimes => ["win", "win-x86", "win-x64", "linux-x64", "linux-arm64", "linux-arm"];
 
+    IEnumerable<string> CrossPlatformBundleForDevelopmentRequiredRuntimes => ["win-x64", "osx-arm64", "linux-x64"];
+
     static readonly string Timestamp = DateTime.Now.ToString("yyyyMMddHHmmss");
 
     string FullSemVer =>


### PR DESCRIPTION
# Background

Following [#1164](https://github.com/OctopusDeploy/OctopusTentacle/pull/1164) (which introduced the slim `Octopus.Tentacle.CrossPlatformBundle.Server` bundle for Octopus Server), this PR adds a third, even slimmer bundle variant — `Octopus.Tentacle.CrossPlatformBundle.Development`.

It is intended for the **secondary** bundle usages: **local dev environment setup** and **integration/E2E test setup**. It contains only the extractable Tentacle binary archives for the three platforms those scenarios actually run on.

# What changed

- New NUKE target `PackCrossPlatformBundleForDevelopment` in `build/Build.Pack.cs`.
- Required-runtimes list `["win-x64", "osx-arm64", "linux-x64"]` in `build/Build.cs`.
- Registered the new target on the notional `Pack` target.
- Fixed a pre-existing argument-order bug in the full bundle's `CreateNugetPackage` call (`id, description, author, title` → `id, author, title, description`) that scrambled the full `CrossPlatformBundle`'s NuGet metadata.

# Bundle contents

- `tentacle-net8.0-win-x64.zip`
- `tentacle-net8.0-osx-arm64.tar.gz`
- `tentacle-net8.0-linux-x64.tar.gz`

# Notes / out of scope

- The in-repo integration-test consumer (`NugetTentacleFetcher`) is intentionally **unchanged**. It only downloads hard-coded historical Tentacle versions (the current build uses the locally-built exe), and those releases predate this bundle, so it cannot consume it. Rationale captured in the spec.
- The external TeamCity build chain and feedz.io deployment wiring are handled separately (other repos), mirroring what was done for the `.Server` bundle.

# How to review this PR

- The change mirrors the `.Server` bundle pattern from #1164.
- Verified locally: `build/_build.csproj` compiles, and `PackCrossPlatformBundleForDevelopment` is listed by NUKE and wired into `Pack`.

# Test Plan

- [x] `dotnet build build/_build.csproj` compiles with no errors/warnings
- [x] `PackCrossPlatformBundleForDevelopment` appears in the NUKE target list and is a dependency of `Pack`
- [x] CI: confirm the produced `.nupkg` contains exactly the three archives above

🤖 Generated with [Claude Code](https://claude.com/claude-code)