### PR TITLE
Don't clean up work directory when auto pod cleanup is disabled

### DIFF
--- a/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
+++ b/source/Octopus.Tentacle/Services/Scripts/Kubernetes/KubernetesScriptServiceV1.cs
@@ -123,15 +123,21 @@ namespace Octopus.Tentacle.Services.Scripts.Kubernetes
 
         public async Task CompleteScriptAsync(CompleteKubernetesScriptCommandV1 command, CancellationToken cancellationToken)
         {
-            var workspace = workspaceFactory.GetWorkspace(command.ScriptTicket, WorkspaceReadinessCheck.Skip);
-            await workspace.Delete(cancellationToken);
+            // Don't delete the workspace if automatic pod cleanup is enabled. This allows for debugging of the bootstrap script
+            if (!KubernetesConfig.DisableAutomaticPodCleanup)
+            {
+                var workspace = workspaceFactory.GetWorkspace(command.ScriptTicket, WorkspaceReadinessCheck.Skip);
+                await workspace.Delete(cancellationToken);
+            }
 
             scriptLogProvider.Delete(command.ScriptTicket);
             scriptPodSinceTimeStore.Delete(command.ScriptTicket);
             scriptPodLogEncryptionKeyProvider.Delete(command.ScriptTicket);
 
             if (!KubernetesConfig.DisableAutomaticPodCleanup)
+            {
                 await podService.DeleteIfExists(command.ScriptTicket, cancellationToken);
+            }
         }
 
         async Task<KubernetesScriptStatusResponseV1> GetResponse(ITrackedScriptPod trackedPod, long lastLogSequence, CancellationToken cancellationToken)


### PR DESCRIPTION
# Background

When debugging pod issues, we sometimes disable automatic pod clean up. A problem with this is that the workspace files are cleaned up, even though the pod remains. This makes diagnosing issues with bootstrap scripts hard.

# Results

Doesn't delete the workspace directory if the automatic pod clean up is disabled.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.