### PR TITLE
Add opt-in assembly trimming for self-contained .NET 8 publishes

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -50,6 +50,21 @@
 	<ItemGroup Condition="('$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net8.0-windows') And '$(EnableTrimming)' == 'true'">
 		<TrimmerRootDescriptor Include="TrimmerRoots.xml" />
 	</ItemGroup>
+	<!-- Full trim mode (-p:TrimMode=full) additionally member-trims app and NuGet assemblies.
+	     These assemblies drive behaviour through reflection (DI, serialization, logging config,
+	     attribute-scanned services), so they are kept whole. EXPERIMENTAL: with these roots the
+	     full-trimmed Tentacle passes command/agent smoke tests but does not yet pass the
+	     integration test suite - use partial mode (the default) for anything real. -->
+	<ItemGroup Condition="('$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net8.0-windows') And '$(EnableTrimming)' == 'true' And '$(TrimMode)' == 'full'">
+		<TrimmerRootAssembly Include="Tentacle" />
+		<TrimmerRootAssembly Include="Octopus.Tentacle.Core" />
+		<TrimmerRootAssembly Include="Octopus.Tentacle.Contracts" />
+		<TrimmerRootAssembly Include="Halibut" />
+		<TrimmerRootAssembly Include="Newtonsoft.Json" />
+		<TrimmerRootAssembly Include="NLog" />
+		<TrimmerRootAssembly Include="Autofac" />
+		<TrimmerRootAssembly Include="KubernetesClient" />
+	</ItemGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
 		<NoWarn>8601</NoWarn>

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -38,6 +38,19 @@
 		<Optimize>True</Optimize>
 	</PropertyGroup>
 
+	<!-- Assembly trimming for self-contained .NET 8 publishes. Partial mode only trims assemblies
+	     that declare themselves trim-compatible (the framework); app and NuGet assemblies are kept
+	     whole, so reflection-based code (Autofac, Newtonsoft.Json, NLog, attribute-scanned Halibut
+	     services) keeps working. Opt in with -p:EnableTrimming=true at publish time. -->
+	<PropertyGroup Condition="('$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net8.0-windows') And '$(EnableTrimming)' == 'true'">
+		<PublishTrimmed>true</PublishTrimmed>
+		<TrimMode Condition="'$(TrimMode)' == ''">partial</TrimMode>
+		<SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
+	</PropertyGroup>
+	<ItemGroup Condition="('$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net8.0-windows') And '$(EnableTrimming)' == 'true'">
+		<TrimmerRootDescriptor Include="TrimmerRoots.xml" />
+	</ItemGroup>
+
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
 		<NoWarn>8601</NoWarn>
 		<DefineConstants>$(DefineConstants);HAS_SYSTEM_IDENTITYMODEL_TOKENS;NLOG_HAS_EVENT_LOG_TARGET;NETFX;FULL_FRAMEWORK</DefineConstants>

--- a/source/Octopus.Tentacle/TrimmerRoots.xml
+++ b/source/Octopus.Tentacle/TrimmerRoots.xml
@@ -1,0 +1,8 @@
+<!-- Types resolved via reflection at runtime that the trimmer cannot see.
+     Autofac materialises Lazy<ICommand, CommandMetadata> registrations by invoking
+     Lazy`2 constructors through reflection, so they must be preserved explicitly. -->
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Lazy`2" />
+  </assembly>
+</linker>


### PR DESCRIPTION
# Background

Self-contained Tentacle publishes carry the full .NET runtime (~102 MB on linux-x64). .NET's assembly trimming can remove the unused parts of the runtime at publish time. This PR adds an **opt-in** trimming mode to measure and validate that saving without changing any default build behaviour.

Trimming is enabled with `-p:EnableTrimming=true` at publish time and uses `TrimMode=partial`, which only trims assemblies that declare themselves trim-compatible (the framework). App and NuGet assemblies (Autofac, Newtonsoft.Json, NLog, KubernetesClient, the attribute-scanned Halibut services) are kept whole, so their reflection-based behaviour is unaffected.

One trimmer root descriptor (`TrimmerRoots.xml`) is required: Autofac materialises `Lazy<ICommand, CommandMetadata>` command registrations by invoking `Lazy` constructors through reflection, which the trimmer cannot see and would otherwise strip.

An experimental full-trim configuration (`-p:TrimMode=full`) with root assemblies for the reflection-driven libraries is also included but is NOT the supported path — see Results.

# Results

Measured on net8.0 Release self-contained publishes (linux-x64):

| Configuration | Size | vs baseline | Status |
|---|---|---|---|
| Baseline | 102 MB (265 files) | — | |
| **Partial trim (this PR's supported mode)** | **59 MB (203 files)** | **-42%** | Integration-tested locally, see below |
| Partial trim + framework feature switches | 57.7 MB | -44% | Measured only |
| Full trim + reflection roots (experimental) | 49 MB | -52% | Passes smoke tests, hangs integration tests |
| Partial trim + compressed single-file | 26 MB (single exe) | -74% | Blocked on `Assembly.Location` usage (IL3000) |

win-x64 shows the same ratio for partial trim (103 MB → 58 MB).

## Before

`dotnet publish -f net8.0 -r linux-x64 -c Release --self-contained` → 102 MB

## After

`dotnet publish -f net8.0 -r linux-x64 -c Release --self-contained -p:EnableTrimming=true` → 59 MB

## Test evidence (partial trim, linux-x64)

Ran `Octopus.Tentacle.Tests.Integration` classes `CapabilitiesServiceV2Test`, `ScriptServiceV2IntegrationTest`, `FileTransferServiceTests`, `TentacleCommandLineTests`, `TentacleStartupAndShutdownTests`, `ScriptServiceTests`, `WorkspaceCleanerTests`, `ScriptsAreGivenRequiredEnvironmentVariables`, `MachineConfigurationHomeDirectoryTests` with the trimmed publish substituted as the Tentacle under test: **105 passed, 12 failed — and an untrimmed control run fails the identical 12 test cases** (old 5.0.4/5.0.12 downloaded tentacle binaries and service-manager tests that cannot run in the sandbox container), i.e. no trimming-attributable failures.

Also smoke-tested: `version`, `help`, `create-instance`, `new-certificate`, `show-thumbprint`, `list-instances --format json`, and an `agent` run with the Halibut listener bound and NLog file logging working.

# How to review this PR

This is an experiment to validate trimming viability — an "in principle" review is the goal. Nothing changes for existing builds: trimming only activates when `-p:EnableTrimming=true` is passed at publish time, and only for the net8.0/net8.0-windows targets. The interesting review questions are whether partial-mode trimming is an acceptable risk profile for reflection-heavy code, and what test coverage should gate turning this on in the release pipeline.

Quality :heavy_check_mark:
Full `Octopus.Tentacle.Tests.Integration` suite on CI against a trimmed publish is the remaining gate before wiring this into the release pipeline; the local subset run above (105 tests, failures identical to untrimmed control) is the evidence so far.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AL61wGJeScoyKmdhtRUPy