### PR TITLE
Bump System.Security.Cryptography.Xml to 8.0.4

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -107,8 +107,8 @@
 	</ItemGroup>
 	<!-- Pin transitive dependencies to fix known CVEs (.NET 8 only; net48 uses the GAC System.Security) -->
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
-		<!-- CVE-2026-26171 (security bypass + DoS) and CVE-2026-33116 (DoS via infinite recursion). Transitive 8.0.2 is vulnerable. -->
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+		<!-- CVE-2026-26171 (security bypass + DoS) and CVE-2026-33116 (DoS via infinite recursion). 8.0.3 is also vulnerable (CVE-2026-50648, CVE-2026-47304); fixed in 8.0.4. -->
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
 		<PackageReference Include="System.Runtime" Version="4.3.0" />


### PR DESCRIPTION
## Summary
- The pinned `System.Security.Cryptography.Xml` 8.0.3 has four newly-flagged advisories that NuGet audit (NU1903, warnings-as-errors) surfaces during restore, failing CI builds.
- Bumps the pin to 8.0.4, which resolves GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h, GHSA-cvvh-rhrc-wg4q, and GHSA-g8r8-53c2-pm3f (confirmed via the advisory pages — all fixed in the 8.0.4 release for the .NET 8.0 line).

## Test plan
- [x] `dotnet restore source/Octopus.Tentacle/Octopus.Tentacle.csproj --force` completes with no NU1903 warnings/errors
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)