### PR TITLE
Correctly look for known tag when matching versions.json tag not found

### DIFF
--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodContainerResolverTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodContainerResolverTests.cs
@@ -69,38 +69,6 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         }
 
         [Test]
-        public async Task GetContainerImageForCluster_VersionMetadataExists_ClusterVersionGreaterThanLatest_ContainerTagIsKnown_ShouldFallbackToKnownContainerTag()
-        {
-            // Arrange
-            var clusterService = Substitute.For<IKubernetesClusterService>();
-            clusterService.GetClusterVersion().Returns(new ClusterVersion(1, 31));
-
-            var podContainerResolver = new KubernetesPodContainerResolver(clusterService, mockToolsImageVersionMetadataProvider);
-
-            // Act
-            var result = await podContainerResolver.GetContainerImageForCluster();
-
-            // Assert
-            result.Should().Be("octopusdeploy/kubernetes-agent-tools-base:1.31");
-        }
-        
-        [Test]
-        public async Task GetContainerImageForCluster_VersionMetadataExists_ClusterVersionGreaterThanLatest_ContainerTagIsUnknown_FallbackToLatest()
-        {
-            // Arrange
-            var clusterService = Substitute.For<IKubernetesClusterService>();
-            clusterService.GetClusterVersion().Returns(new ClusterVersion(1, 50));
-
-            var podContainerResolver = new KubernetesPodContainerResolver(clusterService, mockToolsImageVersionMetadataProvider);
-
-            // Act
-            var result = await podContainerResolver.GetContainerImageForCluster();
-
-            // Assert
-            result.Should().Be("octopusdeploy/kubernetes-agent-tools-base:latest");
-        }
-
-        [Test]
         public async Task GetContainerImageForCluster_VersionMetadataExists_ClusterVersionNotFound_FallbackToLatest()
         {
             // Arrange
@@ -129,7 +97,7 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         [TestCase(27, "1.27")]
         [TestCase(26, "1.26")]
         [TestCase(25, "latest")]
-        public async Task GetContainerImageForCluster_VersionMetadataNotFound_FallBackToKnownTags(int clusterMinorVersion, string expectedImageTag)
+        public async Task GetContainerImageForCluster_VersionMetadataNotFound_FallbackToKnownTags(int clusterMinorVersion, string expectedImageTag)
         {
             // Arrange
             var clusterService = Substitute.For<IKubernetesClusterService>();

--- a/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodContainerResolverTests.cs
+++ b/source/Octopus.Tentacle.Tests/Kubernetes/KubernetesPodContainerResolverTests.cs
@@ -69,11 +69,27 @@ namespace Octopus.Tentacle.Tests.Kubernetes
         }
 
         [Test]
-        public async Task GetContainerImageForCluster_VersionMetadataExists_ClusterVersionGreaterThanLatest_FallbackToLatest()
+        public async Task GetContainerImageForCluster_VersionMetadataExists_ClusterVersionGreaterThanLatest_ContainerTagIsKnown_ShouldFallbackToKnownContainerTag()
         {
             // Arrange
             var clusterService = Substitute.For<IKubernetesClusterService>();
             clusterService.GetClusterVersion().Returns(new ClusterVersion(1, 31));
+
+            var podContainerResolver = new KubernetesPodContainerResolver(clusterService, mockToolsImageVersionMetadataProvider);
+
+            // Act
+            var result = await podContainerResolver.GetContainerImageForCluster();
+
+            // Assert
+            result.Should().Be("octopusdeploy/kubernetes-agent-tools-base:1.31");
+        }
+        
+        [Test]
+        public async Task GetContainerImageForCluster_VersionMetadataExists_ClusterVersionGreaterThanLatest_ContainerTagIsUnknown_FallbackToLatest()
+        {
+            // Arrange
+            var clusterService = Substitute.For<IKubernetesClusterService>();
+            clusterService.GetClusterVersion().Returns(new ClusterVersion(1, 50));
 
             var podContainerResolver = new KubernetesPodContainerResolver(clusterService, mockToolsImageVersionMetadataProvider);
 

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
@@ -23,7 +23,6 @@ namespace Octopus.Tentacle.Kubernetes
         }
 
         const string DefaultKubernetesAgentToolsImage = "octopusdeploy/kubernetes-agent-tools-base";
-        const string FallbackImageTag = "latest";
         
         static readonly List<Version> KnownLatestContainerTags = new()
         {

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
@@ -23,7 +23,8 @@ namespace Octopus.Tentacle.Kubernetes
         }
 
         const string DefaultKubernetesAgentToolsImage = "octopusdeploy/kubernetes-agent-tools-base";
-        
+
+        // we track a list of known image tags just in case the metadata can't be retrieved 
         static readonly List<Version> KnownLatestContainerTags = new()
         {
             new(1, 26),
@@ -41,27 +42,27 @@ namespace Octopus.Tentacle.Kubernetes
 
         public async Task<string> GetContainerImageForCluster()
         {
-            var imageRepository = KubernetesConfig.ScriptPodContainerImage; 
+            var imageRepository = KubernetesConfig.ScriptPodContainerImage;
             if (imageRepository.IsNullOrEmpty())
             {
                 return await GetAgentToolsContainerImage();
             }
 
-            var imageTag = KubernetesConfig.ScriptPodContainerImageTag; 
+            var imageTag = KubernetesConfig.ScriptPodContainerImageTag;
             return $"{imageRepository}:{imageTag}";
         }
 
         async Task<string> GetAgentToolsContainerImage()
         {
             var clusterVersion = await clusterService.GetClusterVersion();
-            
-            var versionMetadata = await imageVersionMetadataProvider.TryGetVersionMetadata();
-            if (TryGetImageTagFromVersionMetadata(versionMetadata, clusterVersion, out var imageTag))
-            {
-                return $"{DefaultKubernetesAgentToolsImage}:{imageTag}";
-            }
 
-            return GetFallbackAgentToolsImage(clusterVersion);
+            var versionMetadata = await imageVersionMetadataProvider.TryGetVersionMetadata();
+
+            var imageTag = TryGetImageTagFromVersionMetadata(versionMetadata, clusterVersion, out var tag)
+                ? tag
+                : GetFallbackAgentToolsTag(clusterVersion); //if we can't get the image tag from the version metadata, do a lookup of known images
+
+            return $"{DefaultKubernetesAgentToolsImage}:{imageTag}";
         }
 
         static bool TryGetImageTagFromVersionMetadata(KubernetesAgentToolsImageVersionMetadata? versionMetadata, ClusterVersion clusterVersion, out string imageTag)
@@ -71,7 +72,7 @@ namespace Octopus.Tentacle.Kubernetes
             {
                 return false;
             }
-            
+
             //if there is a deprecated image, use that
             var versionDeprecation = versionMetadata.Deprecations.FirstOrDefault(kvp => ClusterVersion.FromVersion(kvp.Key).Equals(clusterVersion));
             if (versionDeprecation.Key is not null)
@@ -80,12 +81,6 @@ namespace Octopus.Tentacle.Kubernetes
                 return true;
             }
 
-            //if the latest version is less than the cluster version, bauk
-            if (ClusterVersion.FromVersion(versionMetadata.Latest).CompareTo(clusterVersion) < 0)
-            {
-                return false;
-            }
-            
             var imageExists = versionMetadata.ToolVersions.Kubectl.Any(v => ClusterVersion.FromVersion(v).Equals(clusterVersion));
             if (imageExists)
             {
@@ -96,13 +91,11 @@ namespace Octopus.Tentacle.Kubernetes
             return false;
         }
 
-        static string GetFallbackAgentToolsImage(ClusterVersion clusterVersion)
+        static string GetFallbackAgentToolsTag(ClusterVersion clusterVersion)
         {
             var tagVersion = KnownLatestContainerTags.FirstOrDefault(tag => tag.Major == clusterVersion.Major && tag.Minor == clusterVersion.Minor);
 
-            var tag = tagVersion?.ToString(2) ?? "latest";
-
-            return $"{DefaultKubernetesAgentToolsImage}:{tag}";
+            return tagVersion?.ToString(2) ?? "latest";
         }
     }
 }

--- a/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
+++ b/source/Octopus.Tentacle/Kubernetes/KubernetesPodContainerResolver.cs
@@ -73,6 +73,7 @@ namespace Octopus.Tentacle.Kubernetes
                 return false;
             }
             
+            //if there is a deprecated image, use that
             var versionDeprecation = versionMetadata.Deprecations.FirstOrDefault(kvp => ClusterVersion.FromVersion(kvp.Key).Equals(clusterVersion));
             if (versionDeprecation.Key is not null)
             {
@@ -80,10 +81,10 @@ namespace Octopus.Tentacle.Kubernetes
                 return true;
             }
 
+            //if the latest version is less than the cluster version, bauk
             if (ClusterVersion.FromVersion(versionMetadata.Latest).CompareTo(clusterVersion) < 0)
             {
-                imageTag = FallbackImageTag;
-                return true;
+                return false;
             }
             
             var imageExists = versionMetadata.ToolVersions.Kubectl.Any(v => ClusterVersion.FromVersion(v).Equals(clusterVersion));
@@ -92,9 +93,8 @@ namespace Octopus.Tentacle.Kubernetes
                 imageTag = $"{clusterVersion}-{versionMetadata.RevisionHash}";
                 return true;
             }
-            
-            imageTag = FallbackImageTag;
-            return true;
+
+            return false;
         }
 
         static string GetFallbackAgentToolsImage(ClusterVersion clusterVersion)


### PR DESCRIPTION
# Background

I noticed in my k3s cluster, which is running `1.36.x` of K8s, that the agent was using the `latest` tag of the agent tools. We are publishing a `1.36` of the agent tools image, so what's going on?

# Results

There was a bug/issue where if the cluster version was newer than the `latest` value in the versions metadata, it would just fallback to the `latest` tag.

Now if we can't get the version metadata or specifically use a deprecated image tag or a known tag matching the cluster version, we just fallback to the list of known tags or `latest` if nothing matches

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered appropriate testing for my change.