### PR TITLE
Clear sensitive env variables before spawning tentacle process

### DIFF
--- a/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
+++ b/docker/kubernetes-agent-tentacle/scripts/configure-and-run.sh
@@ -444,6 +444,13 @@ else
   echo "Configuration successful"
 fi
 
+echo "==============================================="
+echo "Sanitising Tentacle Environment"
+echo "==============================================="
+
+# Clear sensitive env variables that should not be inherited by the tentacle process or any forked child processes
+unset ServerApiKey BearerToken ServerUsername ServerPassword
+
 markAsInitialised
 
 echo "==============================================="

--- a/docker/linux/scripts/configure-and-run.sh
+++ b/docker/linux/scripts/configure-and-run.sh
@@ -3,4 +3,7 @@ set -eu
 
 /scripts/configure-tentacle.sh
 
+# Clear sensitive env variables that should not be inherited by the tentacle process or any forked child processes
+ unset ServerApiKey BearerToken ServerUsername ServerPassword
+
 exec /scripts/run-tentacle.sh

--- a/docker/windows/Scripts/configure-and-run-tentacle-wrapper.ps1
+++ b/docker/windows/Scripts/configure-and-run-tentacle-wrapper.ps1
@@ -1,2 +1,9 @@
 ﻿& ./configure-tentacle.ps1 -Verbose
+
+# Clear sensitive env variables that should not be inherited by the tentacle process or any forked child processes
+Remove-Item Env:\ServerApiKey -ErrorAction SilentlyContinue
+Remove-Item Env:\BearerToken -ErrorAction SilentlyContinue
+Remove-Item Env:\ServerUsername -ErrorAction SilentlyContinue
+Remove-Item Env:\ServerPassword -ErrorAction SilentlyContinue
+
 & ./run-tentacle.ps1 -Verbose


### PR DESCRIPTION
Fixes FD-620.

# Background

The `octopusdeploy/tentacle` Docker image accepts registration credentials (`ServerApiKey`, `BearerToken`, `ServerUsername`, `ServerPassword`) via environment variables which are used once by `configure-tentacle.sh` to register the machine with Octopus Server. As these variables are not unset before the entrypoint `exec`s into the long-running Tentacle process, they currently persist in that process's environment (and `/proc/1/environ`) for the container's entire lifetime.

This has non-trivial security implications: any deployment or runbook script that runs on that target/worker inherits these variables as a child process of Tentacle, effectively exposing a full Octopus Server credential to anyone who can get a script executed on the machine, regardless of how narrowly their actual deployment permissions are scoped (e.g. a deploy-only user restricted to a single project can end up with a credential that reaches every space on the instance).

This is not just a theoretical vulnerability: during testing I was able to exploit this to succesfully perform a privilege escalation attack by using a script step to echo out the sensitive variables from `/proc/1/environ`.

# Results

Each entrypoint now clears the credential variables after registration is complete and before handing off to the long-running Tentacle process:
- **Linux**: `unset ServerApiKey BearerToken ServerUsername ServerPassword` inserted between `configure-tentacle.sh` and `exec run-tentacle.sh`.
- **Kubernetes Agent**: same `unset`, inserted after the registration `if/else` block (covers both the "already registered" and "fresh registration" paths) and before the final `exec tentacle agent`.
- **Windows**: `Remove-Item Env:\...` for all four variables, inserted between `configure-tentacle.ps1` and `run-tentacle.ps1` .

Manually tested by rebuilding the Tentacle image and unsuccessfully attempting to replicate the same privilege escalation attack as described previously. 

NOTE: sensitive variables remain exposed to anyone with access to the Tentacle container via `docker inspect` / `docker exec` / `kubectl describe pod`. Whether this is an issue, and how we plan to fix it, is deliberately left as out-of-scope here.

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.