### PR TITLE
Fix k8s tentacle multi-arch Docker build crash under QEMU

### DIFF
--- a/docker/kubernetes-agent-tentacle/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/Dockerfile
@@ -1,7 +1,7 @@
 ARG RuntimeDepsTag
 
 
-FROM golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS bootstraprunnerbuilder
+FROM --platform=$BUILDPLATFORM golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS bootstraprunnerbuilder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/docker/kubernetes-agent-tentacle/dev/Dockerfile
+++ b/docker/kubernetes-agent-tentacle/dev/Dockerfile
@@ -1,7 +1,7 @@
 ARG RuntimeDepsTag
 
 
-FROM golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS bootstraprunnerbuilder
+FROM --platform=$BUILDPLATFORM golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS bootstraprunnerbuilder
 
 ARG TARGETARCH
 ARG TARGETOS


### PR DESCRIPTION
## Summary
- The nightly `Kubernetes Tentacle Multi-Arch Docker image` build (9.2.4233-main-nightly) was failing with Go compiler panics (`fatal error: found pointer to free object`, `panic: runtime error: growslice: len out of range`) while building the `bootstraprunnerbuilder` stage.
- Root cause: `docker buildx build --platform linux/arm64,linux/amd64 ...` runs the `golang:1.26` builder stage under QEMU emulation for the non-native target platform (arm64 on the amd64 build agent). The stage only needs `GOOS`/`GOARCH` cross-compilation, never execution of foreign-arch code, but without a platform pin buildx still runs the compiler itself under QEMU — a known source of Go runtime memory-corruption crashes.
- Fix: pin the builder stage to `--platform=$BUILDPLATFORM` (Docker's standard pattern for Go cross-compile stages) so `go build` always runs natively on the build host and cross-compiles via `GOARCH`, in both `docker/kubernetes-agent-tentacle/Dockerfile` and the equivalent `dev/Dockerfile`.

## Test plan
- [x] Rebuilt the `bootstraprunnerbuilder` stage locally via `docker buildx build --target bootstraprunnerbuilder` for a foreign target platform, confirming it builds successfully and produces all `bootstrapRunner-linux-{amd64,arm64,386,arm}` binaries.
- [ ] Re-run the nightly `Kubernetes Tentacle Multi-Arch Docker image` build on TeamCity to confirm the arm64-on-amd64 crash is resolved (couldn't reproduce the exact amd64-host/arm64-QEMU crash locally since my dev machine is arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)