### PR TITLE
Make a corrupt script log diagnosable

### DIFF
--- a/source/Octopus.Tentacle.Core/Services/Scripts/Logging/ScriptLog.cs
+++ b/source/Octopus.Tentacle.Core/Services/Scripts/Logging/ScriptLog.cs
@@ -25,7 +25,14 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
 
         public IScriptLogWriter CreateWriter()
         {
-            return new Writer(logFile, fileSystem, sync, sensitiveValueMasker);
+            return new Writer(this);
+        }
+
+        string MaskSensitiveValues(string rawMessage)
+        {
+            string? maskedMessage = null;
+            sensitiveValueMasker.SafeSanitize(rawMessage, s => maskedMessage = s);
+            return maskedMessage ?? rawMessage;
         }
 
         public List<ProcessOutput> GetOutput(long afterSequenceNumber, out long nextSequenceNumber)
@@ -113,17 +120,16 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
 
         class Writer : IScriptLogWriter
         {
-            readonly object sync;
-            readonly SensitiveValueMasker sensitiveValueMasker;
+            readonly ScriptLog owner;
             readonly JsonTextWriter json;
             readonly StreamWriter writer;
             readonly Stream writeStream;
+            bool disposed;
 
-            public Writer(string logFile, IOctopusFileSystem fileSystem, object sync, SensitiveValueMasker sensitiveValueMasker)
+            public Writer(ScriptLog owner)
             {
-                this.sync = sync;
-                this.sensitiveValueMasker = sensitiveValueMasker;
-                writeStream = fileSystem.OpenFile(logFile, FileMode.Append, FileAccess.Write);
+                this.owner = owner;
+                writeStream = owner.fileSystem.OpenFile(owner.logFile, FileMode.Append, FileAccess.Write);
                 writer = new StreamWriter(writeStream, Encoding.UTF8);
                 json = new JsonTextWriter(writer);
             }
@@ -133,29 +139,36 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
 
             public void WriteOutput(ProcessOutputSource source, string message, DateTimeOffset occurred)
             {
-                lock (sync)
+                lock (owner.sync)
                 {
+                    // An abandoned script keeps producing output after its runner has disposed this writer.
+                    // Refusing the write is what keeps a half-written entry out of the log.
+                    if (disposed)
+                        throw new ObjectDisposedException(nameof(IScriptLogWriter),
+                            "The script log writer has been disposed. The script it belongs to is no longer being tracked, so its output cannot be recorded.");
+
                     json.WriteStartArray();
                     json.WriteValue(SourceToString(source));
-                    json.WriteValue(MaskSensitiveValues(message));
+                    json.WriteValue(owner.MaskSensitiveValues(message));
                     json.WriteValue(occurred);
                     json.WriteEndArray();
                     json.Flush();
                 }
             }
 
-            string MaskSensitiveValues(string rawMessage)
-            {
-                string? maskedMessage = null;
-                sensitiveValueMasker.SafeSanitize(rawMessage, s => maskedMessage = s);
-                return maskedMessage ?? rawMessage;
-            }
-
             public void Dispose()
             {
-                json.Close();
-                writer.Dispose();
-                writeStream.Dispose();
+                // Closing under the lock keeps disposal from interleaving with an in-flight write, which would
+                // otherwise flush a partial entry and leave an unbalanced token in the log.
+                lock (owner.sync)
+                {
+                    if (disposed) return;
+                    disposed = true;
+
+                    json.Close();
+                    writer.Dispose();
+                    writeStream.Dispose();
+                }
             }
         }
     }

--- a/source/Octopus.Tentacle.Core/Services/Scripts/Logging/ScriptLog.cs
+++ b/source/Octopus.Tentacle.Core/Services/Scripts/Logging/ScriptLog.cs
@@ -16,12 +16,10 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
         readonly SensitiveValueMasker sensitiveValueMasker;
         readonly object sync = new object();
 
-        // Reported by DescribeCorruption, and guarded by sync. Deliberately per-instance: a read that happens
-        // after the script leaves the tracker builds a fresh ScriptLog (ScriptServiceV2.GetResponse,
-        // ScriptService.GetResponse), so on those paths these read as defaults. They do describe reads taken
-        // while the script is still tracked, which is where the failure that prompted this occurred.
-        int openWriters;
-        int peakOpenWriters;
+        // Reported by DescribeCorruption, and guarded by sync. Per-instance, so a read taken after the script
+        // leaves the tracker builds a fresh ScriptLog (ScriptServiceV2.GetResponse, ScriptService.GetResponse)
+        // and sees false. It does cover reads taken while the script is still tracked, which is where the
+        // failure that prompted this occurred.
         bool writeRefusedAfterDisposal;
 
         public ScriptLog(string logFile, IOctopusFileSystem fileSystem, SensitiveValueMasker sensitiveValueMasker)
@@ -33,34 +31,33 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
 
         public IScriptLogWriter CreateWriter()
         {
-            lock (sync)
-            {
-                // Opened under the lock so a reader cannot observe an uncounted writer, and counted only once the
-                // open has succeeded so a failure cannot leave the count overstated.
-                var writer = new Writer(this);
-                openWriters++;
-                if (openWriters > peakOpenWriters) peakOpenWriters = openWriters;
-                return writer;
-            }
+            return new Writer(this);
         }
 
         /// <summary>
-        /// What is known about the log when it fails to parse, to narrow down which writer produced it. Carries no
-        /// log content: a sensitive value spanning two messages is not fully masked on the way in, so everything
-        /// here goes back through the masker before being reported.
+        /// What is known about the log when it fails to parse. Carries no log content: a sensitive value spanning
+        /// two messages is not fully masked on the way in, so everything here goes back through the masker before
+        /// being reported.
         /// </summary>
-        /// <remarks>
-        /// The peak count matters more than the current one. Corruption is only noticed during a read, by which
-        /// point the writer responsible has usually been disposed, so the current count is nearly always zero. A
-        /// peak above one means two writers were appending to this log at the same time.
-        /// </remarks>
         string DescribeCorruption(JsonReaderException ex)
         {
-            var size = fileSystem.FileExists(logFile) ? $"{fileSystem.GetFileSize(logFile)} bytes" : "missing";
-            var refused = writeRefusedAfterDisposal ? ", a write was refused after disposal" : "";
+            var refused = writeRefusedAfterDisposal ? ", and a write was refused after it closed" : "";
             return MaskSensitiveValues(
-                $"Could not parse the script log. It is {size}, with {openWriters} writer(s) open now and a peak " +
-                $"of {peakOpenWriters}{refused}. Parser reported: {ex.Message}");
+                $"Could not parse the script log. It is {DescribeSize()}{refused}. Parser reported: {ex.Message}");
+        }
+
+        string DescribeSize()
+        {
+            // Reported on a best-effort basis. The workspace is deleted once a script completes, so a read racing
+            // that deletion must not lose the parse failure it was in the middle of reporting.
+            try
+            {
+                return $"{fileSystem.GetFileSize(logFile)} bytes";
+            }
+            catch (Exception)
+            {
+                return "of unknown size";
+            }
         }
 
         string MaskSensitiveValues(string rawMessage)
@@ -216,17 +213,9 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
                     if (disposed) return;
                     disposed = true;
 
-                    try
-                    {
-                        json.Close();
-                        writer.Dispose();
-                        writeStream.Dispose();
-                    }
-                    finally
-                    {
-                        // Runs even when closing fails, so a failed close cannot leave the count overstated.
-                        owner.openWriters--;
-                    }
+                    json.Close();
+                    writer.Dispose();
+                    writeStream.Dispose();
                 }
             }
         }

--- a/source/Octopus.Tentacle.Core/Services/Scripts/Logging/ScriptLog.cs
+++ b/source/Octopus.Tentacle.Core/Services/Scripts/Logging/ScriptLog.cs
@@ -16,6 +16,14 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
         readonly SensitiveValueMasker sensitiveValueMasker;
         readonly object sync = new object();
 
+        // Reported by DescribeCorruption, and guarded by sync. Deliberately per-instance: a read that happens
+        // after the script leaves the tracker builds a fresh ScriptLog (ScriptServiceV2.GetResponse,
+        // ScriptService.GetResponse), so on those paths these read as defaults. They do describe reads taken
+        // while the script is still tracked, which is where the failure that prompted this occurred.
+        int openWriters;
+        int peakOpenWriters;
+        bool writeRefusedAfterDisposal;
+
         public ScriptLog(string logFile, IOctopusFileSystem fileSystem, SensitiveValueMasker sensitiveValueMasker)
         {
             this.logFile = logFile;
@@ -25,7 +33,34 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
 
         public IScriptLogWriter CreateWriter()
         {
-            return new Writer(this);
+            lock (sync)
+            {
+                // Opened under the lock so a reader cannot observe an uncounted writer, and counted only once the
+                // open has succeeded so a failure cannot leave the count overstated.
+                var writer = new Writer(this);
+                openWriters++;
+                if (openWriters > peakOpenWriters) peakOpenWriters = openWriters;
+                return writer;
+            }
+        }
+
+        /// <summary>
+        /// What is known about the log when it fails to parse, to narrow down which writer produced it. Carries no
+        /// log content: a sensitive value spanning two messages is not fully masked on the way in, so everything
+        /// here goes back through the masker before being reported.
+        /// </summary>
+        /// <remarks>
+        /// The peak count matters more than the current one. Corruption is only noticed during a read, by which
+        /// point the writer responsible has usually been disposed, so the current count is nearly always zero. A
+        /// peak above one means two writers were appending to this log at the same time.
+        /// </remarks>
+        string DescribeCorruption(JsonReaderException ex)
+        {
+            var size = fileSystem.FileExists(logFile) ? $"{fileSystem.GetFileSize(logFile)} bytes" : "missing";
+            var refused = writeRefusedAfterDisposal ? ", a write was refused after disposal" : "";
+            return MaskSensitiveValues(
+                $"Could not parse the script log. It is {size}, with {openWriters} writer(s) open now and a peak " +
+                $"of {peakOpenWriters}{refused}. Parser reported: {ex.Message}");
         }
 
         string MaskSensitiveValues(string rawMessage)
@@ -48,8 +83,20 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
 
                     var sequence = 0L;
                     DateTimeOffset? lastLogLineOccured = null;
-                    while (json.Read())
+                    while (true)
                     {
+                        try
+                        {
+                            if (!json.Read()) break;
+                        }
+                        catch (JsonReaderException ex)
+                        {
+                            // Rethrown rather than handled: the caller failing is existing behaviour, and the same
+                            // type is used so nothing keying on it changes. Only the message improves, from a bare
+                            // parser complaint to something naming the state of the log that produced it.
+                            throw new JsonReaderException(DescribeCorruption(ex), ex);
+                        }
+
                         if (json.TokenType != JsonToken.StartArray)
                             continue;
 
@@ -142,10 +189,14 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
                 lock (owner.sync)
                 {
                     // An abandoned script keeps producing output after its runner has disposed this writer.
-                    // Refusing the write is what keeps a half-written entry out of the log.
+                    // Refusing the write is what keeps a half-written entry out of the log. The refusal is
+                    // recorded because a later parse failure is the only place the two facts can be seen together.
                     if (disposed)
+                    {
+                        owner.writeRefusedAfterDisposal = true;
                         throw new ObjectDisposedException(nameof(IScriptLogWriter),
                             "The script log writer has been disposed. The script it belongs to is no longer being tracked, so its output cannot be recorded.");
+                    }
 
                     json.WriteStartArray();
                     json.WriteValue(SourceToString(source));
@@ -165,9 +216,17 @@ namespace Octopus.Tentacle.Core.Services.Scripts.Logging
                     if (disposed) return;
                     disposed = true;
 
-                    json.Close();
-                    writer.Dispose();
-                    writeStream.Dispose();
+                    try
+                    {
+                        json.Close();
+                        writer.Dispose();
+                        writeStream.Dispose();
+                    }
+                    finally
+                    {
+                        // Runs even when closing fails, so a failed close cannot leave the count overstated.
+                        owner.openWriters--;
+                    }
                 }
             }
         }

--- a/source/Octopus.Tentacle.Core/Services/Scripts/RunningScript.cs
+++ b/source/Octopus.Tentacle.Core/Services/Scripts/RunningScript.cs
@@ -164,6 +164,11 @@ namespace Octopus.Tentacle.Core.Services.Scripts
                     // The script has not started, and the files on disk have been arranged, so it will never meaningfully progress.
                     // We will now abandon the script, as we do we will cancel its cancellation token. Which will result in
                     // the script possibly dying, although from what we have seen, the script will never die.
+
+                    // A task still running here outlives the writer its output goes to, which is the window in which the
+                    // log can be corrupted. The monitor has already reported the timeout, so only add what it cannot know.
+                    log.Warn($"Abandoning the script for task {taskId}; its task was still running: {!scriptTask.IsCompleted}");
+
                     return ScriptExitCodes.PowerShellNeverStartedExitCode;
                 }
             }
@@ -240,8 +245,10 @@ namespace Octopus.Tentacle.Core.Services.Scripts
             }
             catch (Exception ex)
             {
-                writer.WriteOutput(ProcessOutputSource.StdErr, "An exception was thrown when invoking " + shellPath + ": " + ex.Message);
-                writer.WriteOutput(ProcessOutputSource.StdErr, ex.ToString());
+                // An abandoned script reaches here after its log was closed, so these writes are best-effort.
+                // Left unguarded they escape into an un-awaited task, where the runtime discards them unseen.
+                TryWriteOutput(writer, "An exception was thrown when invoking " + shellPath + ": " + ex.Message);
+                TryWriteOutput(writer, ex.ToString());
 
                 return ScriptExitCodes.PowershellInvocationErrorExitCode;
             }
@@ -249,14 +256,41 @@ namespace Octopus.Tentacle.Core.Services.Scripts
 
         Action<string> LogScriptOutputTo(IScriptLogWriter logOutput, ProcessOutputSource level)
         {
+            return output =>
+            {
+                try
+                {
+                    logOutput.WriteOutput(level, output);
+                }
+                catch (ObjectDisposedException e)
+                {
+                    // Reached when this script was abandoned and its log closed while the process kept producing
+                    // output. Only this failure is handled: anything else, a full disk say, must keep propagating
+                    // to the process runner exactly as it did before.
+                    WarnOnceThatScriptOutputCannotBeRecorded(e);
+                }
+            };
+        }
+
+        int scriptOutputLossWarned;
+
+        void WarnOnceThatScriptOutputCannotBeRecorded(Exception e)
+        {
+            if (Interlocked.Exchange(ref scriptOutputLossWarned, 1) != 0) return;
+
+            log.Warn(e, $"Could not write script output to log, for task {taskId}. This script's log is closed, " +
+                "so any further output it produces will be discarded.");
+        }
+
+        void TryWriteOutput(IScriptLogWriter logOutput, string message)
+        {
             try
             {
-                return output => logOutput.WriteOutput(level, output);
+                logOutput.WriteOutput(ProcessOutputSource.StdErr, message);
             }
-            catch (Exception e)
+            catch (ObjectDisposedException e)
             {
-                log.Warn(e, $"Could not write script output to log, for task {taskId}");
-                throw;
+                WarnOnceThatScriptOutputCannotBeRecorded(e);
             }
         }
     }

--- a/source/Octopus.Tentacle.Core/Services/Scripts/RunningScript.cs
+++ b/source/Octopus.Tentacle.Core/Services/Scripts/RunningScript.cs
@@ -167,8 +167,10 @@ namespace Octopus.Tentacle.Core.Services.Scripts
 
                     // A task still running here outlives the writer its output goes to, which is the window in which the
                     // log can be corrupted. The monitor has already reported the timeout, so only add what it cannot
-                    // know. Status rather than IsCompleted, so a task that faulted is not reported as simply finished.
-                    log.Warn($"Abandoning the script for task {taskId}; its task was {scriptTask.Status}");
+                    // know. Both, because the status alone reads as never-started when it is really in flight, and
+                    // IsCompleted alone reports a faulted task as simply finished.
+                    log.Warn($"Abandoning the script for task {taskId}; its task had" +
+                        $"{(scriptTask.IsCompleted ? "" : " not")} finished, status {scriptTask.Status}");
 
                     return ScriptExitCodes.PowerShellNeverStartedExitCode;
                 }

--- a/source/Octopus.Tentacle.Core/Services/Scripts/RunningScript.cs
+++ b/source/Octopus.Tentacle.Core/Services/Scripts/RunningScript.cs
@@ -166,8 +166,9 @@ namespace Octopus.Tentacle.Core.Services.Scripts
                     // the script possibly dying, although from what we have seen, the script will never die.
 
                     // A task still running here outlives the writer its output goes to, which is the window in which the
-                    // log can be corrupted. The monitor has already reported the timeout, so only add what it cannot know.
-                    log.Warn($"Abandoning the script for task {taskId}; its task was still running: {!scriptTask.IsCompleted}");
+                    // log can be corrupted. The monitor has already reported the timeout, so only add what it cannot
+                    // know. Status rather than IsCompleted, so a task that faulted is not reported as simply finished.
+                    log.Warn($"Abandoning the script for task {taskId}; its task was {scriptTask.Status}");
 
                     return ScriptExitCodes.PowerShellNeverStartedExitCode;
                 }

--- a/source/Octopus.Tentacle.Tests.Integration/PowerShellStartupDetectionTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/PowerShellStartupDetectionTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 using Octopus.Tentacle.CommonTestUtils;
 using Octopus.Tentacle.CommonTestUtils.Builders;
 using Octopus.Tentacle.CommonTestUtils.Diagnostics;
@@ -63,8 +64,103 @@ namespace Octopus.Tentacle.Tests.Integration
                     powerShellStartupTimeout ?? PowerShellStartupDetection.PowerShellStartupTimeout);
             }
 
-            public void Dispose() => _tempDir.Dispose();
+            public void Dispose()
+            {
+                PreserveScriptLogs();
+                _tempDir.Dispose();
+            }
+
+            /// <summary>
+            /// Copies the JSON script logs somewhere that outlives the workspace, unconditionally. Deciding
+            /// whether to keep them belongs in teardown, not here: this runs from the test method body, where an
+            /// unhandled exception has not yet been recorded, so the test still looks Inconclusive. Assertion
+            /// failures are recorded eagerly and would be visible, but the corruption this exists to diagnose
+            /// surfaces as an unhandled exception — exactly the case that would be missed.
+            /// </summary>
+            void PreserveScriptLogs()
+            {
+                try
+                {
+                    var scriptLogs = Directory.GetFiles(_tempDir.DirectoryPath, ScriptLogFileName, SearchOption.AllDirectories);
+                    if (scriptLogs.Length == 0) return;
+
+                    Directory.CreateDirectory(PreservedScriptLogDirectory);
+
+                    foreach (var scriptLog in scriptLogs)
+                    {
+                        var workspace = Path.GetFileName(Path.GetDirectoryName(scriptLog));
+                        File.Copy(scriptLog, Path.Combine(PreservedScriptLogDirectory, $"{workspace}.log"), overwrite: true);
+                    }
+                }
+                catch (Exception e)
+                {
+                    TestContext.Write($"Failed to preserve script logs: {e}{Environment.NewLine}");
+                }
+            }
         }
+
+        const string ScriptLogFileName = "Output.log";
+        const int MaxInlineScriptLogCharacters = 256 * 1024;
+
+        static string PreservedScriptLogDirectory
+            => Path.Combine(TestContext.CurrentContext.WorkDirectory, "script-logs", TestContext.CurrentContext.Test.ID);
+
+        /// <summary>
+        /// Reports the preserved script logs when the test failed, and discards them otherwise. Runs in teardown
+        /// because that is the first point where the outcome is final for an unhandled exception.
+        /// </summary>
+        [TearDown]
+        public void ReportPreservedScriptLogs()
+        {
+            var directory = PreservedScriptLogDirectory;
+            if (!Directory.Exists(directory)) return;
+
+            try
+            {
+                if (TestContext.CurrentContext.Result.Outcome.Status != TestStatus.Failed)
+                {
+                    Directory.Delete(directory, recursive: true);
+                    return;
+                }
+
+                foreach (var preserved in Directory.GetFiles(directory))
+                {
+                    // Inline as well as preserved: the bytes are what identify the corruption. Bounded, and read
+                    // bounded, so a chatty script cannot pull a huge file into memory just to truncate it.
+                    var size = new FileInfo(preserved).Length;
+                    var truncated = size > MaxInlineScriptLogCharacters;
+
+                    TestContext.Write($"### SCRIPT LOG {preserved} ({size} bytes)" +
+                        $"{(truncated ? $", first {MaxInlineScriptLogCharacters} chars only" : "")} ###{Environment.NewLine}");
+                    TestContext.Write(ReadBounded(preserved) + Environment.NewLine);
+                    TestContext.Write($"### END SCRIPT LOG ###{Environment.NewLine}");
+
+                    if (TeamCityDetection.IsRunningInTeamCity())
+                        Console.WriteLine($"##teamcity[publishArtifacts '{EscapeServiceMessageValue(preserved)}']");
+                }
+            }
+            catch (Exception e)
+            {
+                TestContext.Write($"Failed to report preserved script logs: {e}{Environment.NewLine}");
+            }
+        }
+
+        static string ReadBounded(string path)
+        {
+            using var reader = new StreamReader(path);
+            var buffer = new char[MaxInlineScriptLogCharacters];
+            var read = reader.ReadBlock(buffer, 0, buffer.Length);
+            return new string(buffer, 0, read);
+        }
+
+        // https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values
+        static string EscapeServiceMessageValue(string value)
+            => value.Replace("|", "||")
+                .Replace("'", "|'")
+                .Replace("\n", "|n")
+                .Replace("\r", "|r")
+                .Replace("[", "|[")
+                .Replace("]", "|]");
 
         [Test]
         public async Task WhenPowerShellScriptHasDetectionComment_AndRunsSuccessfully_ScriptSucceeds()

--- a/source/Octopus.Tentacle.Tests.Integration/PowerShellStartupDetectionTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/PowerShellStartupDetectionTests.cs
@@ -100,7 +100,7 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         const string ScriptLogFileName = "Output.log";
-        const int MaxInlineScriptLogCharacters = 256 * 1024;
+        const int MaxInlineScriptLogBytes = 256 * 1024;
 
         static string PreservedScriptLogDirectory
             => Path.Combine(TestContext.CurrentContext.WorkDirectory, "script-logs", TestContext.CurrentContext.Test.ID);
@@ -125,14 +125,17 @@ namespace Octopus.Tentacle.Tests.Integration
 
                 foreach (var preserved in Directory.GetFiles(directory))
                 {
-                    // Inline as well as preserved: the bytes are what identify the corruption. Bounded, and read
-                    // bounded, so a chatty script cannot pull a huge file into memory just to truncate it.
+                    // The bytes are what identify the corruption, so they go inline. Checked before reading rather
+                    // than truncated after, so a chatty script cannot pull a large file into memory at all.
                     var size = new FileInfo(preserved).Length;
-                    var truncated = size > MaxInlineScriptLogCharacters;
+                    if (size > MaxInlineScriptLogBytes)
+                    {
+                        TestContext.Write($"### SCRIPT LOG {preserved} ({size} bytes), too large to inline ###{Environment.NewLine}");
+                        continue;
+                    }
 
-                    TestContext.Write($"### SCRIPT LOG {preserved} ({size} bytes)" +
-                        $"{(truncated ? $", first {MaxInlineScriptLogCharacters} chars only" : "")} ###{Environment.NewLine}");
-                    TestContext.Write(ReadBounded(preserved) + Environment.NewLine);
+                    TestContext.Write($"### SCRIPT LOG {preserved} ({size} bytes) ###{Environment.NewLine}");
+                    TestContext.Write(File.ReadAllText(preserved) + Environment.NewLine);
                     TestContext.Write($"### END SCRIPT LOG ###{Environment.NewLine}");
                 }
             }
@@ -141,15 +144,6 @@ namespace Octopus.Tentacle.Tests.Integration
                 TestContext.Write($"Failed to report preserved script logs: {e}{Environment.NewLine}");
             }
         }
-
-        static string ReadBounded(string path)
-        {
-            using var reader = new StreamReader(path);
-            var buffer = new char[MaxInlineScriptLogCharacters];
-            var read = reader.ReadBlock(buffer, 0, buffer.Length);
-            return new string(buffer, 0, read);
-        }
-
 
         [Test]
         public async Task WhenPowerShellScriptHasDetectionComment_AndRunsSuccessfully_ScriptSucceeds()

--- a/source/Octopus.Tentacle.Tests.Integration/PowerShellStartupDetectionTests.cs
+++ b/source/Octopus.Tentacle.Tests.Integration/PowerShellStartupDetectionTests.cs
@@ -134,9 +134,6 @@ namespace Octopus.Tentacle.Tests.Integration
                         $"{(truncated ? $", first {MaxInlineScriptLogCharacters} chars only" : "")} ###{Environment.NewLine}");
                     TestContext.Write(ReadBounded(preserved) + Environment.NewLine);
                     TestContext.Write($"### END SCRIPT LOG ###{Environment.NewLine}");
-
-                    if (TeamCityDetection.IsRunningInTeamCity())
-                        Console.WriteLine($"##teamcity[publishArtifacts '{EscapeServiceMessageValue(preserved)}']");
                 }
             }
             catch (Exception e)
@@ -153,14 +150,6 @@ namespace Octopus.Tentacle.Tests.Integration
             return new string(buffer, 0, read);
         }
 
-        // https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values
-        static string EscapeServiceMessageValue(string value)
-            => value.Replace("|", "||")
-                .Replace("'", "|'")
-                .Replace("\n", "|n")
-                .Replace("\r", "|r")
-                .Replace("[", "|[")
-                .Replace("]", "|]");
 
         [Test]
         public async Task WhenPowerShellScriptHasDetectionComment_AndRunsSuccessfully_ScriptSucceeds()

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using FluentAssertions;
 using NSubstitute;
@@ -87,6 +88,22 @@ namespace Octopus.Tentacle.Tests.Integration
             logs.Count.Should().Be(2);
 
             logs[1].Text.Should().Be("Corrupt Tentacle log at line 2, no more logs will be read");
+        }
+
+        [Test]
+        public void ShouldRefuseWritesAfterDisposalRatherThanCorruptTheLog()
+        {
+            var appender = sut.CreateWriter();
+            appender.WriteOutput(ProcessOutputSource.StdOut, "Before disposal");
+            appender.Dispose();
+
+            Action writeAfterDisposal = () => appender.WriteOutput(ProcessOutputSource.StdOut, "After disposal");
+
+            writeAfterDisposal.Should().Throw<ObjectDisposedException>();
+
+            var logs = sut.GetOutput(long.MinValue, out _);
+            logs.Count.Should().Be(1);
+            logs[0].Text.Should().Be("Before disposal");
         }
 
         [Test]

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
@@ -125,23 +125,6 @@ namespace Octopus.Tentacle.Tests.Integration
         }
 
         [Test]
-        public void ShouldReportPeakWriterCountWhenTheLogCannotBeParsed()
-        {
-            var first = sut.CreateWriter();
-            var second = sut.CreateWriter();
-            first.WriteOutput(ProcessOutputSource.StdOut, "Hello");
-            second.Dispose();
-            first.Dispose();
-
-            File.AppendAllText(logFile, "]");
-
-            Action read = () => sut.GetOutput(long.MinValue, out _);
-
-            read.Should().Throw<JsonReaderException>()
-                .WithMessage("*peak of 2*", "two writers open at once is how the log gets clobbered, and by read time both are gone");
-        }
-
-        [Test]
         public void ShouldReportThatAWriteWasRefusedAfterDisposal()
         {
             var appender = sut.CreateWriter();
@@ -162,7 +145,7 @@ namespace Octopus.Tentacle.Tests.Integration
             Action read = () => sut.GetOutput(long.MinValue, out _);
 
             read.Should().Throw<JsonReaderException>()
-                .WithMessage("*a write was refused after disposal*",
+                .WithMessage("*a write was refused after it closed*",
                     "this ties an orphaned writer to the corruption without correlating two log sources");
         }
 

--- a/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Integration/ScriptLogFixture.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using Newtonsoft.Json;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Tentacle.Contracts;
@@ -104,6 +105,65 @@ namespace Octopus.Tentacle.Tests.Integration
             var logs = sut.GetOutput(long.MinValue, out _);
             logs.Count.Should().Be(1);
             logs[0].Text.Should().Be("Before disposal");
+        }
+
+        [Test]
+        public void ShouldReportTheStateOfTheLogWhenItCannotBeParsed()
+        {
+            using (var appender = sut.CreateWriter())
+            {
+                appender.WriteOutput(ProcessOutputSource.StdOut, "Hello");
+            }
+
+            File.AppendAllText(logFile, "]");
+
+            Action read = () => sut.GetOutput(long.MinValue, out _);
+
+            read.Should().Throw<JsonReaderException>()
+                .WithMessage("Could not parse the script log*bytes*")
+                .WithInnerException<JsonReaderException>("the parser's own detail is preserved");
+        }
+
+        [Test]
+        public void ShouldReportPeakWriterCountWhenTheLogCannotBeParsed()
+        {
+            var first = sut.CreateWriter();
+            var second = sut.CreateWriter();
+            first.WriteOutput(ProcessOutputSource.StdOut, "Hello");
+            second.Dispose();
+            first.Dispose();
+
+            File.AppendAllText(logFile, "]");
+
+            Action read = () => sut.GetOutput(long.MinValue, out _);
+
+            read.Should().Throw<JsonReaderException>()
+                .WithMessage("*peak of 2*", "two writers open at once is how the log gets clobbered, and by read time both are gone");
+        }
+
+        [Test]
+        public void ShouldReportThatAWriteWasRefusedAfterDisposal()
+        {
+            var appender = sut.CreateWriter();
+            appender.WriteOutput(ProcessOutputSource.StdOut, "Hello");
+            appender.Dispose();
+
+            try
+            {
+                appender.WriteOutput(ProcessOutputSource.StdOut, "Arrived after the log closed");
+            }
+            catch (ObjectDisposedException)
+            {
+                // The refusal is the point; handling it is covered by ShouldRefuseWritesAfterDisposal...
+            }
+
+            File.AppendAllText(logFile, "]");
+
+            Action read = () => sut.GetOutput(long.MinValue, out _);
+
+            read.Should().Throw<JsonReaderException>()
+                .WithMessage("*a write was refused after disposal*",
+                    "this ties an orphaned writer to the corruption without correlating two log sources");
         }
 
         [Test]


### PR DESCRIPTION
# Background

The Tentacle nightly failed with an unhandled `JsonReaderException` out of `ScriptLog.GetOutput`. The real failure was one test in [Integration Test: net8.0 on Windows 2012 R2 #9.2.4244-main-nightly](https://build.octopushq.com/buildConfiguration/TeamFireAndMotion_OctopusTentacle_TentacleVLatest_net80_IntegrationTestNet80onWindows2012r2/23575913); the chain build just relayed it. That test has passed 39 of its last 40 runs, so this is a flake, not a regression.

I could not work out why the log was corrupt. The test deletes its workspace at the end of the method and nothing prints that file anywhere, so there was nothing left by the time I looked.

So this PR adds the diagnostics we were missing. Next time it happens there should be enough to go on.

# Results

- When the log cannot be parsed, the error now says how big it was and whether a write arrived after it closed. Before it just quoted the JSON token that tripped the parser, which told you nothing about how the log got that way. This is the only change a user sees.
- A failing integration test prints the script log into the build output. Nothing printed it before, and the workspace was gone by teardown.
- Closing the log takes the same lock as every write. It could previously close midway through a write and leave half an entry on disk.
- Writes arriving after the log closed are refused rather than attempted, so they cannot leave a partial entry either.
- Failed writes get logged. The try/catch was around the wrong code, so this had been failing silently.
- Abandoning a script logs whether its task finished and what state it was in, which tells us if a live writer was left on the log.

A corrupt log still fails the step, exactly as it does today. The behaviour is unchanged.

## Before

The parse error, with nothing to explain it:

```
Newtonsoft.Json.JsonReaderException : JsonToken EndArray is not valid for closing JsonType None. Path '', line 1, position 1450.
   at Newtonsoft.Json.JsonReader.ValidateEnd(JsonToken endToken)
   at Octopus.Tentacle.Core.Services.Scripts.Logging.ScriptLog.GetOutput(Int64 afterSequenceNumber, Int64& nextSequenceNumber)
```

## After

Same failure, now saying what state the log was in:

```
Could not parse the script log. It is 56 bytes, and a write was refused after it closed. Parser reported: JsonToken EndArray is not valid for closing JsonType None. Path '', line 1, position 53.
```

And from a real build, forced to fail on a Linux agent to check this reaches the build output:

```
Abandoning the script for task 1312161c...; its task had not finished, status WaitingForActivation
Could not write script output to log, for task 1312161c.... This script's log is closed, so any
further output it produces will be discarded.
System.ObjectDisposedException: The script log writer has been disposed...
### SCRIPT LOG .../script-logs/0-1419/l8MFdaAcskqTMUz3sjNxaw.log (832 bytes) ###
["stdout","##octopus[stdout-verbose]","2026-08-04T08:28:09.2980966+00:00"]["stdout","Acquiring isolation mutex RunningScript with FullIsolation in 1312161c...","2026-08-04T08:28:09.2987699+00:00"]...
### END SCRIPT LOG ###
```

That middle warning is the interesting one. It fired on a real agent, so the abandoned script really does try to write after its log has closed. That was silent before this.

# How to review this PR

The claim worth checking is that behaviour does not change. `ShouldHandleIncompleteLine` is the guard for it. I did not touch the existing corrupt-log handling, so that test still asserts the same message it always did.

Two production changes to think about: `Writer.Dispose` now takes the lock, and writes after the log closes are refused. The rest is log lines and test code.

`ScriptLog` is shared by net48 and net8.0. I could only run net8.0 locally, so the net48 side rests on the build.

# Follow ups

Right now the log is only text in the build output. Copying it into `artifacts/trace-logs` would publish it as a proper artifact, since these configs already have a rule for that path. Needs a build to prove it works, so not in this PR.
