### PR TITLE
Bump the version of `Octopus.Client` package

### DIFF
--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -53,7 +53,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-		<PackageReference Include="Octopus.Client" Version="22.2.2842" />
+		<PackageReference Include="Octopus.Client" Version="22.3.2857" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="4.6.2" />

--- a/source/Octopus.Tentacle/Octopus.Tentacle.csproj
+++ b/source/Octopus.Tentacle/Octopus.Tentacle.csproj
@@ -53,7 +53,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-		<PackageReference Include="Octopus.Client" Version="17.15.2394" />
+		<PackageReference Include="Octopus.Client" Version="22.2.2842" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Autofac" Version="4.6.2" />


### PR DESCRIPTION
# Background

Currently the OctopusTentacle version is using `Octopus.Client` package with [v17](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/source/Octopus.Tentacle/Octopus.Tentacle.csproj#L56), while the latest version of `Octopus.Client` is [v22](https://github.com/OctopusDeploy/OctopusClients/tags). It would be nice to update to the latest version, so that new operations in `Octopus.Client` can be used.

Fixes OctopusDeploy/OctopusTentacle#1282
# Results

This PR bumps the version of `Octopus.Client` package used in this repo from v17 to v22.

Although the bump is across 5 major release, I have double checked the commits associated to a major release in [OctopusClient repo](https://github.com/OctopusDeploy/OctopusClients), none of the breaking changes impact this repo considering this repo only use a small set of `Octopus.Client`.

`Octopus.Client` does not come with changelog, besides manually checking Git history, I have also used Claude to list all the breaking changes, which is more detailed. None of the breaking change is related to this repo as reported.
<details>
<summary>Click here to show details from Claude about breaking changes in Octopus.Client</summary>

Changes: 17.15.2394 → 22.2.2842

- Span: ~10 months (Oct 2025 → Aug 2026)
- Volume: 154 commits, 885 files, 5 major version bumps (18 → 19 → 20 → 21 → 22)
- Source of truth below is the public API surface-area approval test, so removals/renames are exact.

---
⚠️ Breaking changes

Removed types

- ReportDeploymentCountOverTimeResource, NumericReportData, NumericReportSeries — deleted with the deprecated reporting/deployments-counted-by-week endpoint.

Removed properties

- EventNotificationSubscription.SlackChannelId / SlackChannelName → use SlackChannelIds / SlackChannelNames.
- ProjectTemplateDetailsResource.CurrentVersion → removed (new IsShared added). Constructor also changed.
- FeaturesConfigurationResource lost: IsActionContainersEnabled, IsConfigurationAsCodeEnabled, IsKubernetesEnabled, IsServiceNowIntegrationEnabled, IsStepUiFrameworkEnabled, IsBulkDeploymentCreationEnabled.
- OctopusIDConfigurationResource.AllowM2MDynamicRegistration → removed.

Renames

- ProjectResource.ExecuteDeploymentsOnResilientPipeline → ExecuteDeploymentsOnEventBasedPipeline.
- ObservabilityRepository.GetResource → GetLiveKubernetesResource (+ request type rename).
- ObservabilityRepository.GetResourceManifest → GetLiveKubernetesResourceManifest (+ request type rename).

Type / signature changes

- WebhookHeaderValue: String → PropertyValueResource (now supports sensitive values).
- RunbookRetentionPeriod class → RunbookRetentionPolicy. Unit is now get-only; construct via static Count() / Default() / Forever().
- RecurringSchedule (deployment freezes): concrete class → abstract base, with new Daily/Weekly/Monthly/Annually subclasses. Old direct usage breaks.
- GitDependencyResource constructor: 7 → 8 args (added a git connection param).
- HasPendingInterruptions on TaskResource and DashboardItemResource: setter removed (get; set; → get;). New PendingInterruptionTypes replaces it as the writable field.
- ActionTemplateSearchResource.Website — type corrected (fix).

Behavior changes (no signature change, but watch out)

- UserResource.IsActive now defaults to true when unspecified (was defaulting off).
- Rate-limiting policy request rate config changed from per-hour → per-minute — same field, different unit.
- Removed Detected automation environment log line.
</details>

<details>
<summary>Click here to show details from Claude about analysis for upgrading Octopus.Client in Tentacle</summary>
Why the breaking changes don't hit this repo
Tentacle uses a tiny slice of the client — registration/deregistration only.

Types actually used:

Client: IOctopusAsyncClient, IOctopusAsyncRepository, IOctopusSpaceAsyncRepository, IOctopusSystemAsyncRepository, OctopusAsyncRepository, OctopusClientOptions, OctopusServerEndpoint
Operations: RegisterMachineOperation, RegisterWorkerOperation, RegisterKubernetes{Cluster,DeploymentTarget,Worker}Operation
Resources: Machine, Worker, MachinePolicy, Environment, TagSet, Tenant, WorkerPool, Space, Root, CertificateConfiguration, ListeningTentacleEndpoint
Exceptions: OctopusResourceNotFound, OctopusSecurity, OctopusValidation
I diffed the public-API approval file (PublicSurfaceAreaFixture...approved.txt) in OctopusClients across the full range. Of ~1500 changed lines, not one removal touches any type above. The only additions on them are OctopusServerEndpoint.CreateWithOidcTokenExchange and IHaveSpaceResource markers — both purely additive.

Every listed breaking change is in areas Tentacle never touches: reporting, subscriptions, features config, projects, runbooks, freezes, observability, webhooks, git deps, dashboards.

Other risk checks, all clear:

Octopus.Client.csproj still targets netstandard2.0;net462;net48 — Tentacle's net48 target survives.
.nuspec is byte-identical → still ILMerged, still zero transitive deps. No dependency-graph churn.
No hand-rolled implementations of client interfaces — only NSubstitute mocks, which absorb interface additions.
No test asserts on the removed Detected automation environment log line.
The .NET 10 toolchain move in OctopusClients is build-side only; shipped assemblies unchanged.
</details>

## Before

N/A

## After

I have manually tested by
- build the Tentacle project locally on MacOS with `dotnet build source/Octopus.Tentacle/Octopus.Tentacle.csproj -f net8.0`
- being able to register the tentacle with `dotnet Tentacle.dll register-with --instance=t2   --server=http://localhost:8065 --apiKey=API-xxx   --environment=Development --role=test-polling   --comms-style=TentacleActive --server-comms-port=10943`
- running Tentacle as following screenshot and seeing it live on local Octopus Server

<img width="1008" height="270" alt="Screenshot 2026-08-14 at 9 34 30 AM" src="https://github.com/user-attachments/assets/016f3972-fbdd-49d8-9382-dc24daa0222e" />

<img width="1920" height="662" alt="Screenshot 2026-08-14 at 9 34 49 AM" src="https://github.com/user-attachments/assets/446af3e2-2c59-4f7a-8d44-98edc37bdf1c" />

# How to review this PR

Do you see any risk for bumping the version of `Octopus.Client` package, I will also send this PR to the related team for reviewing.

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.