### PR TITLE
LEV-1803: Move the Linux Tentacle image from Debian 11 to Ubuntu 22.04 +semver: major

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ git commit --allow-empty -m "+semver: major"
 
 For further details refer to [Tentacle Rollout](docs/rollout.md).
 
+#### Testing the Linux Docker image locally
+
+The Linux Tentacle container image (`docker/linux/Dockerfile`) is built in TeamCity rather than by NUKE, and there is no `Test: Linux Docker Image` configuration to match the Windows one - `Build: Linux Docker image` feeds straight into `Build: Docker manifest` without ever starting a container. Build-time regressions go red in CI; runtime ones do not.
+
+[`testing/docker-linux/build-and-test-linux-docker-image.sh`](testing/docker-linux/build-and-test-linux-docker-image.sh) reproduces that chain locally - it builds the `.deb`, builds the image with the same `docker-compose.build.yml` command TeamCity runs, smoke-tests the result, and optionally registers a listening and a polling Tentacle against a real Octopus Server. Run it before changing anything under `docker/linux/`:
+
+```
+./testing/docker-linux/build-and-test-linux-docker-image.sh --help
+```
+
 ### Bundling Tentacle with Octopus Server
 
 We bundle Tentacle inside Octopus Server to make it super duper easy to keep Tentacle updated across entire fleets of customer installations. Choosing the version of Tentacle to bundle inside Octopus Server is currently a manual process.
@@ -133,3 +143,4 @@ NOTE: This script has only been tested on MacOS so far and requires Docker Deskt
 ## Additional Resources
 
 - Scripts to help with manual testing can be found in [./testing](./testing/README.md).
+- To build and verify the Linux Tentacle container image locally, see [./testing/docker-linux](./testing/docker-linux/build-and-test-linux-docker-image.sh).

--- a/build-and-test-linux-docker-image.sh
+++ b/build-and-test-linux-docker-image.sh
@@ -1,0 +1,819 @@
+#!/usr/bin/env bash
+#
+# build-and-test-linux-docker-image.sh
+#
+# Builds and verifies the Linux Tentacle container image (docker/linux/Dockerfile)
+# end to end, the same way TeamCity does:
+#
+#   TeamFireAndMotion_OctopusTentacle_TentacleVLatest_net80
+#     -> Build: Tentacle (Linux)      (produces _artifacts/deb/tentacle_<ver>_amd64.deb)
+#     -> Build: Linux Docker image    (docker-compose -f docker-compose.build.yml build ...)
+#
+# Stages:
+#   1. deb    - build the linux-x64 .deb via NUKE (--target PackDebianPackage)
+#   2. image  - build docker/linux/Dockerfile via docker-compose.build.yml
+#   3. smoke  - assert the image's contents and behaviour
+#   4. e2e    - stand up a real Octopus Server and point a listening and a
+#               polling Tentacle, built from the fresh image, at it
+#
+# Environment:
+#   OCTOPUS_SERVER_BASE64_LICENSE
+#       A base64-encoded Octopus Server licence. An unlicensed server enforces
+#       a limit of 0 targets, so without one no Tentacle can register.
+#       If this is unset AND stdin is a TTY, the script reads a development
+#       licence from 1Password:
+#           op://software licencing/octopus deploy ultimate license key base64
+#       the same item the Octopus Server repo's ./environment.sh setup uses.
+#       `op` may prompt you to authenticate; the value is never printed. It is
+#       never invoked non-interactively (CI, background shells, agents), since
+#       `op` cannot prompt there and would hang.
+#       With a licence, stage 4 asserts full registration, comms style and
+#       health status. Without one it falls back to asserting configuration
+#       and server connectivity up to the licence refusal.
+#
+# Note: stage 1 runs the real NUKE build, which stamps the calculated version
+# into installer/Octopus.Tentacle.Installer/Product.wxs and regenerates
+# .nuke/build.schema.json. Both are tracked, so `git checkout --` them
+# afterwards if you do not want that noise in your working tree.
+#
+# Usage: ./build-and-test-linux-docker-image.sh [options]
+#   --skip-deb     Reuse the newest existing _artifacts/deb/tentacle_*_amd64.deb
+#   --skip-image   Reuse the already-built image for the resolved BUILD_NUMBER
+#   --skip-smoke   Skip the image smoke tests
+#   --skip-e2e     Skip the Octopus Server registration test
+#   --keep         Leave the e2e containers running afterwards (for debugging)
+#   --no-1password Never invoke `op`; use OCTOPUS_SERVER_BASE64_LICENSE only.
+#                  Needed anywhere `op` must not run (CI, sandboxes).
+#   -h, --help     Show this help
+#
+set -euo pipefail
+
+REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$REPO_DIR"
+
+SKIP_DEB=0
+SKIP_IMAGE=0
+SKIP_SMOKE=0
+SKIP_E2E=0
+KEEP=0
+NO_1PASSWORD=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-deb) SKIP_DEB=1 ;;
+        --skip-image) SKIP_IMAGE=1 ;;
+        --skip-smoke) SKIP_SMOKE=1 ;;
+        --skip-e2e) SKIP_E2E=1 ;;
+        --keep) KEEP=1 ;;
+        --no-1password) NO_1PASSWORD=1 ;;
+        # Print the header comment block, minus the shebang, as the help text.
+        -h|--help)
+            awk 'NR>1 { if (/^#/) { sub(/^# ?/, ""); print } else { exit } }' "${BASH_SOURCE[0]}"
+            exit 0 ;;
+        *) echo "Unknown option: $1 (try --help)" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+###############################################################################
+# Output helpers
+###############################################################################
+
+if [[ -t 1 ]]; then
+    C_RESET=$'\033[0m'; C_RED=$'\033[31m'; C_GREEN=$'\033[32m'
+    C_YELLOW=$'\033[33m'; C_BOLD=$'\033[1m'
+else
+    C_RESET=""; C_RED=""; C_GREEN=""; C_YELLOW=""; C_BOLD=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+step()  { echo; echo "${C_BOLD}==> $*${C_RESET}"; }
+info()  { echo "    $*"; }
+warn()  { echo "${C_YELLOW}    WARN: $*${C_RESET}"; }
+die()   { echo "${C_RED}ERROR: $*${C_RESET}" >&2; exit 1; }
+
+pass()  { TESTS_RUN=$((TESTS_RUN + 1)); echo "    ${C_GREEN}PASS${C_RESET}  $1"; }
+fail()  {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILED_NAMES+=("$1")
+    echo "    ${C_RED}FAIL${C_RESET}  $1"
+    [[ -n "${2:-}" ]] && echo "          $2"
+    return 0
+}
+
+# assert_contains <name> <haystack> <needle>
+assert_contains() {
+    if [[ "$2" == *"$3"* ]]; then
+        pass "$1"
+    else
+        fail "$1" "expected to find '$3' in: $(echo "$2" | head -3 | tr '\n' ' ')"
+    fi
+}
+
+# assert_equals <name> <actual> <expected>
+assert_equals() {
+    if [[ "$2" == "$3" ]]; then
+        pass "$1"
+    else
+        fail "$1" "expected '$3', got '$2'"
+    fi
+}
+
+###############################################################################
+# Host platform
+###############################################################################
+
+# The .deb we build (and therefore the image) is amd64. On an arm64 host
+# (Apple Silicon) Docker would otherwise default to arm64 and the `apt install`
+# of the .deb would fail, so pin the platform for every build and run.
+PLATFORM="linux/amd64"
+export DOCKER_DEFAULT_PLATFORM="$PLATFORM"
+# Suppress Docker Scout hints, which are written to stderr and look like errors.
+export DOCKER_CLI_HINTS=false
+
+if [[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]]; then
+    info "Host is $(uname -m); building and running everything as $PLATFORM under emulation."
+fi
+
+command -v docker >/dev/null || die "docker is not on PATH"
+docker info >/dev/null 2>&1 || die "the Docker daemon is not running"
+
+###############################################################################
+# 1. Build the .deb
+###############################################################################
+
+find_deb() {
+    # Newest tentacle_*_amd64.deb, or empty if there are none.
+    ls -t _artifacts/deb/tentacle_*_amd64.deb 2>/dev/null | head -1
+}
+
+if [[ $SKIP_DEB -eq 1 ]]; then
+    step "Stage 1/4: .deb (skipped, reusing existing)"
+    DEB_PATH=$(find_deb)
+    [[ -n "$DEB_PATH" ]] || die "--skip-deb was given but no _artifacts/deb/tentacle_*_amd64.deb exists"
+else
+    step "Stage 1/4: building the linux-x64 .deb via NUKE"
+    info "This runs 'PackDebianPackage', which cross-compiles Tentacle for linux-x64"
+    info "and packages it inside the tool-linux-packages container. Takes a few minutes."
+
+    # NUKE resolves every [ParameterFromPasswordStore] at start-up, which shells out
+    # to the 1Password CLI. Those secrets are only used by the SBOM target, and the
+    # 'op' call hangs when it cannot prompt interactively, so opt out.
+    export OCTOPUS__Tests__SecretManagerEnabled=False
+
+    # Only linux-x64 is needed for docker/linux/Dockerfile; building every runtime
+    # ID would take far longer for no benefit.
+    ./build.sh --target PackDebianPackage --runtime-ids linux-x64
+
+    DEB_PATH=$(find_deb)
+    [[ -n "$DEB_PATH" ]] || die "PackDebianPackage finished but no .deb landed in _artifacts/deb/"
+fi
+
+DEB_FILE=$(basename "$DEB_PATH")
+# tentacle_<BUILD_NUMBER>_amd64.deb
+BUILD_NUMBER="${DEB_FILE#tentacle_}"
+BUILD_NUMBER="${BUILD_NUMBER%_amd64.deb}"
+[[ -n "$BUILD_NUMBER" ]] || die "could not derive BUILD_NUMBER from $DEB_FILE"
+
+info "Package:      $DEB_PATH"
+info "BUILD_NUMBER: $BUILD_NUMBER"
+
+###############################################################################
+# 2. Build the image
+###############################################################################
+
+IMAGE="docker.packages.octopushq.com/octopusdeploy/tentacle:${BUILD_NUMBER}-linux"
+
+# TeamCity uses `date --iso-8601=seconds`, which is GNU-only; this is equivalent
+# and works on both macOS and Linux.
+BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z)
+
+export BUILD_NUMBER BUILD_DATE
+export BUILD_ARCH=amd64
+
+if [[ $SKIP_IMAGE -eq 1 ]]; then
+    step "Stage 2/4: image (skipped, reusing existing)"
+    docker image inspect "$IMAGE" >/dev/null 2>&1 \
+        || die "--skip-image was given but $IMAGE has not been built"
+else
+    step "Stage 2/4: building the image from docker/linux/Dockerfile"
+    info "Image: $IMAGE"
+    docker compose -f docker-compose.build.yml build --pull octopusdeploy-tentacle-linux
+fi
+
+###############################################################################
+# 3. Smoke tests
+###############################################################################
+
+# run_in_image <command...> - run a shell snippet in the image, bypassing the
+# entrypoint (which would otherwise try to register a Tentacle).
+run_in_image() {
+    docker run --rm --platform "$PLATFORM" --entrypoint bash "$IMAGE" -c "$1" 2>&1
+}
+
+if [[ $SKIP_SMOKE -eq 0 ]]; then
+    step "Stage 3/4: smoke-testing the image"
+
+    # --- base image -------------------------------------------------------
+    OS_ID=$(run_in_image '. /etc/os-release && echo "$ID"')
+    OS_VER=$(run_in_image '. /etc/os-release && echo "$VERSION_ID"')
+    assert_equals "base image is Ubuntu"        "$OS_ID"  "ubuntu"
+    assert_equals "base image is 22.04 (jammy)" "$OS_VER" "22.04"
+
+    # --- .NET runtime dependencies ---------------------------------------
+    # These are the Ubuntu 22.04 equivalents of the Debian 11 names the
+    # Dockerfile used to install; getting them wrong fails the image build,
+    # but a silently-missing one would fail Tentacle at runtime instead.
+    for pkg in ca-certificates libc6 libgcc-s1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g; do
+        # Captured rather than piped into grep -q: see the note on wait_for_log.
+        PKG_STATUS=$(run_in_image "dpkg-query -W -f='\${Status}' $pkg")
+        if [[ "$PKG_STATUS" == *"install ok installed"* ]]; then
+            pass "runtime dependency installed: $pkg"
+        else
+            fail "runtime dependency installed: $pkg"
+        fi
+    done
+
+    # --- tools the Dockerfile installs explicitly ------------------------
+    for tool in curl dos2unix jq sudo xxd; do
+        if run_in_image "command -v $tool >/dev/null" >/dev/null 2>&1; then
+            pass "tool on PATH: $tool"
+        else
+            fail "tool on PATH: $tool"
+        fi
+    done
+
+    # --- Tentacle --------------------------------------------------------
+    # A local NUKE build appends '-<yyyyMMddHHmmss>' to FullSemVer for the package
+    # filename (Build.cs), but the binary itself only carries the plain FullSemVer,
+    # followed by '+Branch...Sha...'. Normalise both ends before comparing. On
+    # TeamCity there is no timestamp suffix and this is a straight comparison.
+    EXPECTED_VERSION=$(echo "$BUILD_NUMBER" | sed -E 's/-[0-9]{14}$//')
+    TENTACLE_VERSION=$(run_in_image 'tentacle version')
+    assert_equals "'tentacle version' reports the built version" \
+        "${TENTACLE_VERSION%%+*}" "$EXPECTED_VERSION"
+
+    SYMLINK=$(run_in_image 'readlink -f /usr/bin/tentacle')
+    assert_equals "/usr/bin/tentacle symlinks to the install" "$SYMLINK" "/opt/octopus/tentacle/Tentacle"
+
+    # OpenSSL 3 is what libssl3 provides; Tentacle's .deb accepts 1.0/1.1/3.
+    OPENSSL_VER=$(run_in_image 'openssl version')
+    assert_contains "OpenSSL is 3.x" "$OPENSSL_VER" "OpenSSL 3."
+
+    # --- Docker-in-Docker ------------------------------------------------
+    # install-docker.sh adds Docker's apt repo. That repo is distro-specific,
+    # so it has to point at .../linux/ubuntu now, not .../linux/debian.
+    DOCKER_LIST=$(run_in_image 'cat /etc/apt/sources.list.d/docker.list')
+    assert_contains "Docker apt source targets the Ubuntu repo" "$DOCKER_LIST" "download.docker.com/linux/ubuntu"
+    assert_contains "Docker apt source targets jammy"           "$DOCKER_LIST" "jammy"
+
+    for bin in docker dockerd containerd; do
+        if run_in_image "command -v $bin >/dev/null" >/dev/null 2>&1; then
+            pass "docker-in-docker binary present: $bin"
+        else
+            fail "docker-in-docker binary present: $bin"
+        fi
+    done
+
+    for f in /usr/local/bin/dind /usr/local/bin/dockerd-entrypoint.sh; do
+        if run_in_image "test -x $f" >/dev/null 2>&1; then
+            pass "executable: $f"
+        else
+            fail "executable: $f"
+        fi
+    done
+
+    # install-docker.sh switches the iptables alternatives; if that step were
+    # skipped, dockerd would fail to create its NAT chain at runtime.
+    # Read the link one level only: -f would resolve on through to the shared
+    # xtables-*-multi binary, which does not say which mode was selected.
+    IPTABLES_ALT=$(run_in_image 'readlink /etc/alternatives/iptables')
+    if [[ "$IPTABLES_ALT" == *"iptables-legacy" || "$IPTABLES_ALT" == *"iptables-nft" ]]; then
+        pass "iptables alternative selected ($(basename "$IPTABLES_ALT"))"
+    else
+        fail "iptables alternative selected" "got '$IPTABLES_ALT'"
+    fi
+
+    if run_in_image 'getent passwd dockremap >/dev/null && grep -q "^dockremap:" /etc/subuid /etc/subgid' >/dev/null 2>&1; then
+        pass "dockremap user and subuid/subgid ranges configured"
+    else
+        fail "dockremap user and subuid/subgid ranges configured"
+    fi
+
+    # --- entrypoint scripts ----------------------------------------------
+    for s in configure-and-run.sh configure-tentacle.sh run-tentacle.sh dockerd-entrypoint.sh; do
+        if run_in_image "test -x /scripts/$s" >/dev/null 2>&1; then
+            pass "executable: /scripts/$s"
+        else
+            fail "executable: /scripts/$s"
+        fi
+    done
+
+    # --- image metadata ---------------------------------------------------
+    INSPECT=$(docker image inspect "$IMAGE")
+    assert_contains "ENTRYPOINT is configure-and-run.sh" "$INSPECT" "/scripts/configure-and-run.sh"
+    assert_contains "port 10933 is exposed"              "$INSPECT" "10933/tcp"
+    assert_contains "/var/lib/docker is a volume"        "$INSPECT" "/var/lib/docker"
+    assert_contains "version label matches the build"    "$INSPECT" "$BUILD_NUMBER"
+
+    # --- entrypoint behaviour --------------------------------------------
+    # The EULA gate and the argument validation are the two ways a user most
+    # often gets a container that will not start, so assert they still bite.
+    EULA_OUT=$(docker run --rm --platform "$PLATFORM" "$IMAGE" 2>&1 || true)
+    assert_contains "container refuses to start without ACCEPT_EULA=Y" "$EULA_OUT" "You must accept the EULA"
+
+    NOSERVER_OUT=$(docker run --rm --platform "$PLATFORM" -e ACCEPT_EULA=Y -e ServerApiKey=API-FAKE "$IMAGE" 2>&1 || true)
+    assert_contains "container refuses to start without ServerUrl" "$NOSERVER_OUT" "Please specify an Octopus Server"
+fi
+
+###############################################################################
+# 4. End-to-end registration test
+###############################################################################
+
+E2E_NET="tentacle-e2e-net"
+E2E_SQL="tentacle-e2e-sql"
+E2E_SERVER="tentacle-e2e-octopus"
+E2E_LISTENING="tentacle-e2e-listening"
+E2E_POLLING="tentacle-e2e-polling"
+E2E_CONTAINERS=("$E2E_LISTENING" "$E2E_POLLING" "$E2E_SERVER" "$E2E_SQL")
+
+# random_password - 20 characters of upper case, lower case and digits.
+#
+# Alphanumeric only, deliberately: the value is interpolated into a SQL Server
+# connection string, a `sqlcmd -P` argument and a JSON request body, and
+# punctuation would need escaping differently in each of the three.
+#
+# At least one character of each class is guaranteed rather than left to
+# chance. SQL Server's SA password policy demands characters from three of its
+# four categories, and with punctuation off the table that means upper, lower
+# and digit are all mandatory - a purely random draw could legally come up
+# without one and fail the container at start-up.
+#
+# /dev/urandom is read in fixed-size chunks so `head` finishes before `tr`
+# does. Piping from an unbounded read would SIGPIPE the producer and trip
+# `set -o pipefail`.
+random_password() {
+    local length=20 pw
+    while :; do
+        pw=""
+        while (( ${#pw} < length )); do
+            pw+=$(head -c 256 /dev/urandom | LC_ALL=C tr -cd 'A-Za-z0-9')
+        done
+        pw=${pw:0:length}
+        if [[ "$pw" == *[[:upper:]]* && "$pw" == *[[:lower:]]* && "$pw" == *[[:digit:]]* ]]; then
+            printf '%s' "$pw"
+            return 0
+        fi
+    done
+}
+
+# Fresh for every run, and never written anywhere but the containers they are
+# created for, which are torn down at the end.
+SA_PASSWORD=$(random_password)
+OCTOPUS_USER="admin"
+OCTOPUS_PASSWORD=$(random_password)
+
+# An Octopus Server with no licence enforces a limit of 0 targets, so no
+# Tentacle can register against it. Supply a base64-encoded licence in
+# OCTOPUS_SERVER_BASE64_LICENSE to run the full registration and health-check
+# assertions; without one the stage falls back to verifying configuration and
+# connectivity up to the licence check.
+OCTOPUS_LICENSE="${OCTOPUS_SERVER_BASE64_LICENSE:-}"
+
+# Failing that, try 1Password, which is where the Octopus Server repo's own
+# `./environment.sh setup` gets a local development licence from (see
+# setup-octopus/OctopusInstanceManager.cs). Note the vault is "software
+# licencing", not the "Octopus Server Secrets for Tests" vault the secrets
+# docs walk you through, so you need access to both. The value is never
+# echoed, and it is handed to the container through an env file rather than
+# `-e`, so it stays out of `ps` output.
+#
+# Only attempted when stdin is a TTY. `op` has to prompt to authenticate, so
+# with nothing to prompt it hangs or fails - the same trap that stalls NUKE's
+# own 1Password lookup in stage 1. Gating on a TTY keeps it out of CI runners,
+# background shells and agents without anyone having to remember a flag.
+OCTOPUS_LICENSE_OP_REF="op://software licencing/octopus deploy ultimate license key base64/value"
+
+if [[ -z "$OCTOPUS_LICENSE" && $SKIP_E2E -eq 0 && $NO_1PASSWORD -eq 0 ]] \
+        && [[ -t 0 ]] && command -v op >/dev/null 2>&1; then
+    info "Looking up a development licence in 1Password (you may be prompted)..."
+    if OCTOPUS_LICENSE=$(op read "$OCTOPUS_LICENSE_OP_REF" 2>/dev/null) && [[ -n "$OCTOPUS_LICENSE" ]]; then
+        info "Licence retrieved from 1Password (${#OCTOPUS_LICENSE} chars)."
+    else
+        OCTOPUS_LICENSE=""
+        warn "Could not read a licence from 1Password. Sign in with 'op signin'"
+        warn "and check you have access to the 'software licencing' vault, or set"
+        warn "OCTOPUS_SERVER_BASE64_LICENSE yourself."
+    fi
+fi
+
+# Note: this also runs *before* the stack is started, to clear out anything a
+# previous run left behind, so it must not touch $E2E_HELPER - that is cleaned
+# up by the EXIT trap instead.
+e2e_teardown() {
+    if [[ $KEEP -eq 1 ]]; then
+        warn "--keep was given; leaving the e2e containers running."
+        warn "Tear down with: docker rm -f ${E2E_CONTAINERS[*]}; docker network rm $E2E_NET"
+        return
+    fi
+    docker rm -f "${E2E_CONTAINERS[@]}" >/dev/null 2>&1 || true
+    docker network rm "$E2E_NET" >/dev/null 2>&1 || true
+}
+
+# dump_logs <container> - print the tail of a container's logs, for diagnosis.
+dump_logs() {
+    echo "    --- last 30 log lines from $1 ---"
+    # The Octopus Server image logs its own `license --licenseBase64 <value>`
+    # invocation, so scrub the licence before anything reaches the terminal or
+    # a CI log. Base64 never contains '|', so it is safe as the sed delimiter.
+    docker logs --tail 30 "$1" 2>&1 \
+        | { if [[ -n "${OCTOPUS_LICENSE:-}" ]]; then
+                sed "s|${OCTOPUS_LICENSE}|<redacted licence>|g"
+            else
+                cat
+            fi; } \
+        | sed 's/^/    | /' || true
+    echo "    --- end ---"
+}
+
+# wait_for <description> <timeout-seconds> <shell test> - poll until the test
+# passes, or give up. Returns non-zero on timeout.
+wait_for() {
+    local what="$1" timeout="$2" test_cmd="$3"
+    local waited=0
+    while (( waited < timeout )); do
+        if eval "$test_cmd" >/dev/null 2>&1; then
+            info "$what ready after ${waited}s"
+            return 0
+        fi
+        sleep 5
+        waited=$((waited + 5))
+        if (( waited % 60 == 0 )); then
+            info "still waiting for $what (${waited}s/${timeout}s)"
+        fi
+    done
+    return 1
+}
+
+# Octopus authenticates API calls with either an API key or a session cookie.
+# Minting an API key itself needs an authenticated POST, so signing in and
+# reusing the session is simpler. This runs inside a curl container on the e2e
+# network; it is written to a file and mounted rather than passed with `sh -c`
+# so the quoting stays readable.
+#
+# /tmp is one of Docker Desktop's default shared paths, so the mount works on
+# macOS as well as Linux.
+# e2e_rm_temp - remove the helper script and every env file holding a secret.
+# Referenced by both EXIT traps, so it must tolerate any of them being unset.
+e2e_rm_temp() {
+    rm -f "${E2E_HELPER:-}" \
+          "${E2E_ENV_SQL:-}" "${E2E_ENV_SERVER:-}" \
+          "${E2E_ENV_AGENT:-}" "${E2E_ENV_API:-}" 2>/dev/null || true
+}
+
+# BSD (macOS) mktemp only substitutes Xs at the very end of the template.
+E2E_HELPER=$(mktemp /tmp/octopus-api.XXXXXX)
+trap 'e2e_rm_temp' EXIT
+cat > "$E2E_HELPER" <<'HELPER_SH'
+#!/bin/sh
+# usage: octopus-api.sh <server-url> <GET|POST> <path> [body]
+# Credentials come from OCTO_USER / OCTO_PASS in the environment, supplied by
+# --env-file, so they never appear in the container's argv.
+set -e
+SERVER="$1"; METHOD="$2"; API_PATH="$3"; BODY="${4:-}"
+: "${OCTO_USER:?OCTO_USER not set}" "${OCTO_PASS:?OCTO_PASS not set}"
+
+HEADERS=$(curl -sf -D - -o /dev/null -H 'Content-Type: application/json' \
+    -d "{\"Username\":\"${OCTO_USER}\",\"Password\":\"${OCTO_PASS}\"}" \
+    "${SERVER}/api/users/login")
+
+# curl will not replay cookies from its jar for a single-label host such as a
+# Docker container name, so build the Cookie header from the login response
+# instead of relying on -c/-b.
+COOKIE=$(printf '%s' "$HEADERS" \
+    | grep -i '^set-cookie:' \
+    | sed 's/^[Ss]et-[Cc]ookie: //' \
+    | cut -d';' -f1 | tr -d '\r' | tr '\n' ';')
+
+if [ "$METHOD" = "GET" ]; then
+    curl -sf -H "Cookie: ${COOKIE}" "${SERVER}${API_PATH}"
+else
+    # The anti-forgery header has to carry the token exactly as the Set-Cookie
+    # delivered it, i.e. still URL-encoded. URL-decoding it earns a 403.
+    CSRF=$(printf '%s' "$HEADERS" \
+        | grep -io 'Octopus-Csrf-Token_[^;]*' | head -1 | cut -d= -f2- | tr -d '\r')
+    curl -sf -X POST \
+        -H "Cookie: ${COOKIE}" \
+        -H 'Content-Type: application/json' \
+        -H "X-Octopus-Csrf-Token: ${CSRF}" \
+        -d "$BODY" "${SERVER}${API_PATH}"
+fi
+HELPER_SH
+
+# Every secret reaches a container through --env-file rather than `-e`, so
+# none of them appear in `ps` output for the life of the container. Docker
+# takes each value literally - no quoting is applied or honoured - which
+# suits the connection string's ';' and '=' characters.
+#
+# One file per consumer, so no container is handed a credential it has no
+# use for. All are 0600 and removed by the EXIT trap.
+new_env_file() {
+    local f
+    f=$(mktemp /tmp/octopus-e2e-env.XXXXXX)
+    chmod 600 "$f"
+    printf '%s\n' "$@" > "$f"
+    printf '%s' "$f"
+}
+
+E2E_ENV_SQL=$(new_env_file \
+    "MSSQL_SA_PASSWORD=${SA_PASSWORD}")
+
+E2E_ENV_SERVER=$(new_env_file \
+    "OCTOPUS_SERVER_BASE64_LICENSE=${OCTOPUS_LICENSE}" \
+    "ADMIN_PASSWORD=${OCTOPUS_PASSWORD}" \
+    "DB_CONNECTION_STRING=Server=${E2E_SQL},1433;Initial Catalog=Octopus;Persist Security Info=False;User ID=sa;Password=${SA_PASSWORD};MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=True")
+
+E2E_ENV_AGENT=$(new_env_file \
+    "ServerUsername=${OCTOPUS_USER}" \
+    "ServerPassword=${OCTOPUS_PASSWORD}")
+
+E2E_ENV_API=$(new_env_file \
+    "OCTO_USER=${OCTOPUS_USER}" \
+    "OCTO_PASS=${OCTOPUS_PASSWORD}")
+
+octopus_call() {
+    docker run --rm --platform "$PLATFORM" --network "$E2E_NET" \
+        --env-file "$E2E_ENV_API" \
+        -v "${E2E_HELPER}:/octopus-api.sh:ro" \
+        --entrypoint sh curlimages/curl:latest \
+        /octopus-api.sh "http://${E2E_SERVER}:8080" "$@"
+}
+
+# wait_for_log <container> <timeout-seconds> <pattern> - poll a container's log
+# until the pattern shows up. Fails fast if the container has already exited
+# without ever printing it, rather than burning the whole timeout.
+#
+# Note: the log is captured into a variable rather than piped into `grep -q`.
+# `grep -q` exits on the first match, and under `set -o pipefail` the SIGPIPE
+# that gives the producer makes the whole pipeline report failure even though
+# the pattern matched.
+wait_for_log() {
+    local container="$1" timeout="$2" pattern="$3"
+    local waited=0 logs
+    while (( waited < timeout )); do
+        logs=$(docker logs "$container" 2>&1 || true)
+        [[ "$logs" == *"$pattern"* ]] && return 0
+        if [[ "$(docker inspect -f '{{.State.Status}}' "$container" 2>/dev/null)" == "exited" ]]; then
+            logs=$(docker logs "$container" 2>&1 || true)
+            [[ "$logs" == *"$pattern"* ]] && return 0
+            return 1
+        fi
+        sleep 5
+        waited=$((waited + 5))
+    done
+    return 1
+}
+
+# octopus_api <path> - GET an Octopus API path as the admin user.
+octopus_api() { octopus_call GET "$1"; }
+
+# octopus_post <path> <json-body> - POST to the Octopus API as the admin user.
+octopus_post() { octopus_call POST "$1" "$2"; }
+
+# sql_ready - can we log in and run a query yet? The password is read from
+# the container's own environment, so it is not on the `docker exec` argv
+# either.
+sql_ready() {
+    docker exec "$E2E_SQL" bash -c \
+        '/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C -Q "select 1"' \
+        >/dev/null 2>&1
+}
+
+# machines_json - /api/machines/all with all whitespace stripped, so the
+# assertions below do not depend on how the server chooses to format its JSON.
+# None of the values we match on contain spaces.
+machines_json() {
+    octopus_api /api/machines/all | tr -d ' \n\r\t'
+}
+
+both_registered() {
+    local json
+    json=$(machines_json) || return 1
+    [[ "$json" == *"\"Name\":\"${E2E_LISTENING}\""* && "$json" == *"\"Name\":\"${E2E_POLLING}\""* ]]
+}
+
+both_healthy() {
+    local json count
+    json=$(machines_json) || return 1
+    count=$(printf '%s' "$json" | grep -o '"HealthStatus":"\(Healthy\|HasWarnings\)"' | wc -l)
+    (( count >= 2 ))
+}
+
+if [[ $SKIP_E2E -eq 0 ]]; then
+    step "Stage 4/4: end-to-end registration against a real Octopus Server"
+    info "Spinning up SQL Server + Octopus Server, then registering a listening"
+    info "and a polling Tentacle from the image just built."
+
+    trap 'e2e_teardown; e2e_rm_temp' EXIT
+    e2e_teardown   # clear out anything left over from a previous run
+
+    # Guard against the helper going missing: Docker would silently mount an
+    # empty directory over it and every API call would fail for no clear reason.
+    [[ -s "$E2E_HELPER" ]] || die "internal error: Octopus API helper script missing at $E2E_HELPER"
+
+    docker network create "$E2E_NET" >/dev/null
+
+    # --- SQL Server -------------------------------------------------------
+    info "Starting SQL Server..."
+    docker run -d --name "$E2E_SQL" --platform "$PLATFORM" --network "$E2E_NET" \
+        --env-file "$E2E_ENV_SQL" \
+        -e ACCEPT_EULA=Y \
+        -e MSSQL_PID=Express \
+        mcr.microsoft.com/mssql/server:2022-latest >/dev/null
+
+    if wait_for "SQL Server" 420 sql_ready; then
+        pass "SQL Server started"
+    else
+        fail "SQL Server started"
+        dump_logs "$E2E_SQL"
+        die "cannot run the e2e test without a database"
+    fi
+
+    # --- Octopus Server ---------------------------------------------------
+    info "Starting Octopus Server (this takes several minutes on first run)..."
+
+    docker run -d --name "$E2E_SERVER" --platform "$PLATFORM" --network "$E2E_NET" \
+        --env-file "$E2E_ENV_SERVER" \
+        -e ACCEPT_EULA=Y \
+        -e "ADMIN_USERNAME=${OCTOPUS_USER}" \
+        -e "MASTER_KEY=" \
+        docker.packages.octopushq.com/octopusdeploy/octopusdeploy:latest >/dev/null
+
+    if wait_for "Octopus Server" 900 \
+        "docker run --rm --platform $PLATFORM --network $E2E_NET curlimages/curl:latest -sf http://${E2E_SERVER}:8080/api"; then
+        pass "Octopus Server started"
+    else
+        fail "Octopus Server started"
+        dump_logs "$E2E_SERVER"
+        die "cannot run the e2e test without an Octopus Server"
+    fi
+
+    # --- target environment ----------------------------------------------
+    # A fresh Octopus Server has no environments, and `tentacle register-with`
+    # will not create one: it fails with "Could not find the environment ...".
+    # Roles, by contrast, are free-form and are created on registration.
+    info "Creating the Development environment..."
+    octopus_post /api/environments '{"Name":"Development"}' >/dev/null 2>&1 || true
+    ENVIRONMENTS=$(octopus_api /api/environments/all | tr -d ' \n\r\t')
+    if [[ "$ENVIRONMENTS" == *'"Name":"Development"'* ]]; then
+        pass "Development environment exists"
+    else
+        fail "Development environment exists" "the Tentacles will not be able to register"
+    fi
+
+    # --- Tentacles --------------------------------------------------------
+    # DISABLE_DIND=Y because docker-in-docker needs --privileged, which is not
+    # reliable under cross-architecture emulation. The dind payload itself is
+    # covered by the smoke tests above.
+    # --hostname matters for the listening Tentacle: it registers itself under
+    # PublicHostNameConfiguration=ComputerName, i.e. whatever `hostname` returns,
+    # and the server has to be able to resolve that name to call back to it.
+    info "Starting the listening Tentacle..."
+    docker run -d --name "$E2E_LISTENING" --hostname "$E2E_LISTENING" --platform "$PLATFORM" --network "$E2E_NET" \
+        --env-file "$E2E_ENV_AGENT" \
+        -e ACCEPT_EULA=Y \
+        -e DISABLE_DIND=Y \
+        -e "ServerUrl=http://${E2E_SERVER}:8080" \
+        -e "TargetEnvironment=Development" \
+        -e "TargetRole=app-server" \
+        -e "TargetName=${E2E_LISTENING}" \
+        "$IMAGE" >/dev/null
+
+    info "Starting the polling Tentacle..."
+    docker run -d --name "$E2E_POLLING" --hostname "$E2E_POLLING" --platform "$PLATFORM" --network "$E2E_NET" \
+        --env-file "$E2E_ENV_AGENT" \
+        -e ACCEPT_EULA=Y \
+        -e DISABLE_DIND=Y \
+        -e "ServerUrl=http://${E2E_SERVER}:8080" \
+        -e "ServerPort=10943" \
+        -e "TargetEnvironment=Development" \
+        -e "TargetRole=web-server" \
+        -e "TargetName=${E2E_POLLING}" \
+        "$IMAGE" >/dev/null
+
+if [[ -z "$OCTOPUS_LICENSE" ]]; then
+    # An unlicensed Octopus Server reports a Targets limit of 0, so
+    # `tentacle register-with` is refused before a machine is ever created.
+    # Everything up to that point still exercises the image for real, so
+    # assert on that instead of pretending the stage passed.
+    warn "No licence available, so no Tentacle can register (0-target limit)."
+    warn "Verifying configuration and server connectivity instead. Sign in to"
+    warn "1Password ('op signin') or set OCTOPUS_SERVER_BASE64_LICENSE to run"
+    warn "the full registration test."
+
+    # Self-configuration: create-instance, set paths, comms mode, certificate.
+    if wait_for_log "$E2E_LISTENING" 300 "A new certificate has been generated"; then
+        pass "listening Tentacle configured itself and generated a certificate"
+    else
+        fail "listening Tentacle configured itself and generated a certificate"
+        dump_logs "$E2E_LISTENING"
+    fi
+
+    # Reaching this line means the Tentacle resolved the server, opened an HTTP
+    # connection and authenticated with the username/password it was given.
+    if wait_for_log "$E2E_LISTENING" 300 "Registering the tentacle with the server at"; then
+        pass "listening Tentacle reached and authenticated against the server"
+    else
+        fail "listening Tentacle reached and authenticated against the server"
+        dump_logs "$E2E_LISTENING"
+    fi
+
+    # A licence refusal (rather than an auth or connection error) proves the
+    # whole request round-tripped and the only thing left is the licence.
+    if wait_for_log "$E2E_LISTENING" 300 "exceed the limits of your current license"; then
+        pass "listening Tentacle blocked only by the licence target limit"
+    else
+        fail "listening Tentacle blocked only by the licence target limit"
+        dump_logs "$E2E_LISTENING"
+    fi
+
+    # The polling Tentacle additionally opens a raw Halibut connection to the
+    # server communications port, which the listening one never does.
+    if wait_for_log "$E2E_POLLING" 300 "Connected successfully"; then
+        pass "polling Tentacle connected to the server comms port (10943)"
+    else
+        fail "polling Tentacle connected to the server comms port (10943)"
+        dump_logs "$E2E_POLLING"
+    fi
+
+else
+    # Registration is the first thing the entrypoint does, so both machines
+    # should appear in the API well before the health check runs.
+    if wait_for "Tentacle registration" 420 both_registered; then
+        pass "both Tentacles registered with the Octopus Server"
+    else
+        fail "both Tentacles registered with the Octopus Server"
+        dump_logs "$E2E_LISTENING"
+        dump_logs "$E2E_POLLING"
+    fi
+
+    MACHINES=$(machines_json)
+
+    # Assert on each machine individually so a half-working image is obvious.
+    for name in "$E2E_LISTENING" "$E2E_POLLING"; do
+        if [[ "$MACHINES" == *"\"Name\":\"$name\""* ]]; then
+            pass "registered: $name"
+        else
+            fail "registered: $name"
+            dump_logs "$name"
+        fi
+    done
+
+    assert_contains "listening Tentacle registered as TentaclePassive" "$MACHINES" "TentaclePassive"
+    assert_contains "polling Tentacle registered as TentacleActive"    "$MACHINES" "TentacleActive"
+
+    # --- health -----------------------------------------------------------
+    # A machine only reports Healthy once the server has completed a health
+    # check against it, which exercises the Halibut connection in both
+    # directions - the real proof the image works.
+    info "Waiting for the Octopus Server to health-check both Tentacles..."
+    if wait_for "Tentacle health checks" 600 both_healthy; then
+        pass "both Tentacles reported Healthy"
+    else
+        fail "both Tentacles reported Healthy" \
+             "statuses: $(machines_json | grep -o '"HealthStatus":"[A-Za-z]*"' | tr '\n' ' ')"
+        dump_logs "$E2E_LISTENING"
+        dump_logs "$E2E_POLLING"
+    fi
+
+    # The version the server sees comes off the wire from the Tentacle itself,
+    # so this confirms the .deb inside the image is the one we just built.
+    MACHINES=$(machines_json)
+    SHORT_VERSION="${BUILD_NUMBER%%-*}"
+    assert_contains "server reports the built Tentacle version ($SHORT_VERSION)" "$MACHINES" "$SHORT_VERSION"
+fi
+fi
+
+###############################################################################
+# Summary
+###############################################################################
+
+step "Summary"
+info "Image:        $IMAGE"
+info "Package:      $DEB_PATH"
+info "Tests run:    $TESTS_RUN"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    info "Tests failed: ${C_RED}${TESTS_FAILED}${C_RESET}"
+    for n in "${FAILED_NAMES[@]}"; do echo "      - $n"; done
+    echo
+    echo "${C_RED}${C_BOLD}FAILED${C_RESET}"
+    exit 1
+fi
+
+echo
+echo "${C_GREEN}${C_BOLD}ALL $TESTS_RUN TESTS PASSED${C_RESET}"

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && \
         ca-certificates \
         libicu70 \
         libssl3 && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 ARG BUILD_NUMBER

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -2,22 +2,6 @@ FROM ubuntu:22.04
 ENV ASPNETCORE_URLS=http://+:80 DOTNET_RUNNING_IN_CONTAINER=true
 
 # .NET 8 runtime dependencies.
-#
-# libc6, libgcc-s1, libgssapi-krb5-2, libstdc++6 and zlib1g were dropped from
-# this list: ubuntu:22.04 already ships them at the newest version jammy
-# offers, so naming them installed nothing.
-#
-# The three below are NOT redundant, and the distinction matters:
-#   ca-certificates  not in the base image at all
-#   libicu70         not in the base image at all
-#   libssl3          in the base, but at 3.0.2-0ubuntu1.26 while jammy-security
-#                    has 3.0.2-0ubuntu1.29. Naming it is what pulls that
-#                    security update in, so it has to stay.
-#
-# Beware when trimming this further: a package that is a no-op today stops
-# being one the moment the base image lags behind jammy-security. The smoke
-# tests in testing/docker-linux/build-and-test-linux-docker-image.sh assert all
-# eight are present in the built image regardless of what installed them.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,15 +1,28 @@
 FROM ubuntu:22.04
 ENV ASPNETCORE_URLS=http://+:80 DOTNET_RUNNING_IN_CONTAINER=true
+
+# .NET 8 runtime dependencies.
+#
+# libc6, libgcc-s1, libgssapi-krb5-2, libstdc++6 and zlib1g were dropped from
+# this list: ubuntu:22.04 already ships them at the newest version jammy
+# offers, so naming them installed nothing.
+#
+# The three below are NOT redundant, and the distinction matters:
+#   ca-certificates  not in the base image at all
+#   libicu70         not in the base image at all
+#   libssl3          in the base, but at 3.0.2-0ubuntu1.26 while jammy-security
+#                    has 3.0.2-0ubuntu1.29. Naming it is what pulls that
+#                    security update in, so it has to stay.
+#
+# Beware when trimming this further: a package that is a no-op today stops
+# being one the moment the base image lags behind jammy-security. The smoke
+# tests in testing/docker-linux/build-and-test-linux-docker-image.sh assert all
+# eight are present in the built image regardless of what installed them.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        libc6 \
-        libgcc-s1 \
-        libgssapi-krb5-2 \
         libicu70 \
-        libssl3 \
-        libstdc++6 \
-        zlib1g && \
+        libssl3 && \
     rm -rf /var/lib/apt/lists/*
 
 ARG BUILD_NUMBER
@@ -43,7 +56,7 @@ RUN /install-scripts/install-docker.sh
 # Install Tentacle
 COPY _artifacts/deb/tentacle_${BUILD_NUMBER}_amd64.deb /tmp/
 RUN apt-get update && \
-    apt install ./tentacle_${BUILD_NUMBER}_amd64.deb && \
+    apt-get install -y --no-install-recommends ./tentacle_${BUILD_NUMBER}_amd64.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /opt/octopus/tentacle/Tentacle /usr/bin/tentacle

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -1,13 +1,13 @@
-FROM debian:11-slim
+FROM ubuntu:22.04
 ENV ASPNETCORE_URLS=http://+:80 DOTNET_RUNNING_IN_CONTAINER=true
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         libc6 \
-        libgcc1 \
+        libgcc-s1 \
         libgssapi-krb5-2 \
-        libicu67 \
-        libssl1.1 \
+        libicu70 \
+        libssl3 \
         libstdc++6 \
         zlib1g && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/linux/install-scripts/install-docker.sh
+++ b/docker/linux/install-scripts/install-docker.sh
@@ -7,21 +7,49 @@ set -eux
 # Add the apt sources for Docker (they're not part of the stock Ubuntu distro).
 apt-get update
 
+# Only ca-certificates and curl are needed to add the repository. Three
+# packages that used to be installed here are not:
+#   apt-transport-https - a transitional stub on jammy ("transitional package
+#                         for https support"); apt 2.4 ships
+#                         /usr/lib/apt/methods/https itself.
+#   gnupg               - was only needed for `gpg --dearmor`. apt reads the
+#                         ASCII-armoured key directly via Signed-By and verifies
+#                         it with gpgv, which apt itself depends on.
+#   lsb-release         - replaced by /etc/os-release, which is always present.
 apt-get install -y --no-install-recommends \
-    apt-transport-https \
     ca-certificates \
-    curl \
-    gnupg \
-    lsb-release
+    curl
 
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+# This follows Docker's documented setup for Ubuntu: the ASCII-armoured key
+# under /etc/apt/keyrings, referenced from a deb822 .sources file rather than a
+# one-line .list. deb822 is supported by apt 2.4 on jammy.
+# https://docs.docker.com/engine/install/ubuntu/
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
 
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+# UBUNTU_CODENAME first so this still resolves on Ubuntu derivatives, which set
+# VERSION_CODENAME to their own release name. Deliberately unguarded: with
+# `set -u` an unset codename fails the build rather than writing empty Suites.
+cat > /etc/apt/sources.list.d/docker.sources <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
 
 
 # Install Docker and its runtime dependencies.
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+#
+# iproute2 is here for `ip`, which dockerd-entrypoint.sh uses in _tls_san to
+# collect the container's addresses. dockerd itself does not need it, but
+# without it a dind TLS certificate is issued with DNS SANs only - verified as
+# DNS:docker,DNS:<hostname>,DNS:localhost and no IP: entries - so a client
+# connecting to the daemon by IP address fails hostname verification. Upstream
+# docker:dind ships iproute2 for the same reason.
 
 apt-get update
 apt-get install -y \
@@ -31,6 +59,7 @@ apt-get install -y \
     docker-ce-cli \
     dos2unix \
     e2fsprogs \
+    iproute2 \
     iptables \
     jq \
     openssl \

--- a/docker/linux/install-scripts/install-docker.sh
+++ b/docker/linux/install-scripts/install-docker.sh
@@ -4,7 +4,7 @@ set -eux
 # This script is adapted from https://github.com/docker-library/docker/blob/master/19.03/dind/Dockerfile
 
 
-# Add the apt sources for Docker (they're not part of the stock Debian distro).
+# Add the apt sources for Docker (they're not part of the stock Ubuntu distro).
 apt-get update
 
 apt-get install -y --no-install-recommends \
@@ -14,9 +14,9 @@ apt-get install -y --no-install-recommends \
     gnupg \
     lsb-release
 
-curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 
@@ -56,6 +56,22 @@ dos2unix /usr/local/bin/dind
 chmod +x /usr/local/bin/dockerd-entrypoint.sh
 dos2unix /usr/local/bin/dockerd-entrypoint.sh
 
+# KNOWN BUG: this condition never succeeds, so the legacy branch below is dead
+# code and nft is always selected.
+#
+# The intent is "if `iptables -nL` works, use legacy, else use nft". But `[ ]`
+# is the `test` builtin, not a subshell, so `iptables` is never executed - test
+# just compares the two literal strings `iptables` and `-nL`, and with two
+# arguments it expects the first to be a unary operator. `iptables` is not one,
+# so test errors and returns non-zero. The `> /dev/null 2>&1` is inside the
+# brackets too, so it redirects nothing useful.
+#
+# The fix is to drop the brackets: `if iptables -nL > /dev/null 2>&1; then`.
+# Deliberately not done here: it would flip docker-in-docker's firewall
+# backend from nft to legacy on most hosts, which is a real behavioural change
+# and needs its own testing. Behaviour has been this way since the image was
+# based on Debian, so it is not a regression. Verified on Ubuntu 22.04 that
+# `readlink /etc/alternatives/iptables` is `/usr/sbin/iptables-nft`.
 if [ iptables -nL > /dev/null 2>&1 ]; then
   # https://forums.docker.com/t/failing-to-start-dockerd-failed-to-create-nat-chain-docker/78269
   update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/docker/linux/install-scripts/install-docker.sh
+++ b/docker/linux/install-scripts/install-docker.sh
@@ -3,34 +3,18 @@ set -eux
 
 # This script is adapted from https://github.com/docker-library/docker/blob/master/19.03/dind/Dockerfile
 
-
 # Add the apt sources for Docker (they're not part of the stock Ubuntu distro).
 apt-get update
 
-# Only ca-certificates and curl are needed to add the repository. Three
-# packages that used to be installed here are not:
-#   apt-transport-https - a transitional stub on jammy ("transitional package
-#                         for https support"); apt 2.4 ships
-#                         /usr/lib/apt/methods/https itself.
-#   gnupg               - was only needed for `gpg --dearmor`. apt reads the
-#                         ASCII-armoured key directly via Signed-By and verifies
-#                         it with gpgv, which apt itself depends on.
-#   lsb-release         - replaced by /etc/os-release, which is always present.
 apt-get install -y --no-install-recommends \
     ca-certificates \
     curl
 
-# This follows Docker's documented setup for Ubuntu: the ASCII-armoured key
-# under /etc/apt/keyrings, referenced from a deb822 .sources file rather than a
-# one-line .list. deb822 is supported by apt 2.4 on jammy.
 # https://docs.docker.com/engine/install/ubuntu/
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
 chmod a+r /etc/apt/keyrings/docker.asc
 
-# UBUNTU_CODENAME first so this still resolves on Ubuntu derivatives, which set
-# VERSION_CODENAME to their own release name. Deliberately unguarded: with
-# `set -u` an unset codename fails the build rather than writing empty Suites.
 cat > /etc/apt/sources.list.d/docker.sources <<EOF
 Types: deb
 URIs: https://download.docker.com/linux/ubuntu
@@ -40,17 +24,8 @@ Architectures: $(dpkg --print-architecture)
 Signed-By: /etc/apt/keyrings/docker.asc
 EOF
 
-
 # Install Docker and its runtime dependencies.
 # https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
-#
-# iproute2 is here for `ip`, which dockerd-entrypoint.sh uses in _tls_san to
-# collect the container's addresses. dockerd itself does not need it, but
-# without it a dind TLS certificate is issued with DNS SANs only - verified as
-# DNS:docker,DNS:<hostname>,DNS:localhost and no IP: entries - so a client
-# connecting to the daemon by IP address fails hostname verification. Upstream
-# docker:dind ships iproute2 for the same reason.
-
 apt-get update
 apt-get install -y \
     btrfs-progs \
@@ -85,21 +60,6 @@ dos2unix /usr/local/bin/dind
 chmod +x /usr/local/bin/dockerd-entrypoint.sh
 dos2unix /usr/local/bin/dockerd-entrypoint.sh
 
-# Newer operating systems (RHEL in particular) have moved from iptables to
-# nftables, and dockerd fails to create its NAT chain against the wrong
-# backend. See
-# https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1677028476905509 and
-# https://forums.docker.com/t/failing-to-start-dockerd-failed-to-create-nat-chain-docker/78269
-#
-# This selection used to be wrapped in `if [ iptables -nL > /dev/null 2>&1 ]`,
-# intended as "use legacy if iptables works, else nft". That condition was
-# never true: `[` is the `test` builtin rather than a subshell, so `iptables`
-# never ran and test failed with "unary operator expected" (exit 2). nft has
-# therefore always been selected, and the legacy branch was dead code, so
-# removing the conditional and keeping nft is a no-op at runtime.
-#
-# Selecting legacy instead would be a genuine behavioural change for
-# docker-in-docker and needs its own testing - deliberately not done here.
 update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
 update-alternatives --set iptables /usr/sbin/iptables-nft
 

--- a/docker/linux/install-scripts/install-docker.sh
+++ b/docker/linux/install-scripts/install-docker.sh
@@ -56,32 +56,23 @@ dos2unix /usr/local/bin/dind
 chmod +x /usr/local/bin/dockerd-entrypoint.sh
 dos2unix /usr/local/bin/dockerd-entrypoint.sh
 
-# KNOWN BUG: this condition never succeeds, so the legacy branch below is dead
-# code and nft is always selected.
+# Newer operating systems (RHEL in particular) have moved from iptables to
+# nftables, and dockerd fails to create its NAT chain against the wrong
+# backend. See
+# https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1677028476905509 and
+# https://forums.docker.com/t/failing-to-start-dockerd-failed-to-create-nat-chain-docker/78269
 #
-# The intent is "if `iptables -nL` works, use legacy, else use nft". But `[ ]`
-# is the `test` builtin, not a subshell, so `iptables` is never executed - test
-# just compares the two literal strings `iptables` and `-nL`, and with two
-# arguments it expects the first to be a unary operator. `iptables` is not one,
-# so test errors and returns non-zero. The `> /dev/null 2>&1` is inside the
-# brackets too, so it redirects nothing useful.
+# This selection used to be wrapped in `if [ iptables -nL > /dev/null 2>&1 ]`,
+# intended as "use legacy if iptables works, else nft". That condition was
+# never true: `[` is the `test` builtin rather than a subshell, so `iptables`
+# never ran and test failed with "unary operator expected" (exit 2). nft has
+# therefore always been selected, and the legacy branch was dead code, so
+# removing the conditional and keeping nft is a no-op at runtime.
 #
-# The fix is to drop the brackets: `if iptables -nL > /dev/null 2>&1; then`.
-# Deliberately not done here: it would flip docker-in-docker's firewall
-# backend from nft to legacy on most hosts, which is a real behavioural change
-# and needs its own testing. Behaviour has been this way since the image was
-# based on Debian, so it is not a regression. Verified on Ubuntu 22.04 that
-# `readlink /etc/alternatives/iptables` is `/usr/sbin/iptables-nft`.
-if [ iptables -nL > /dev/null 2>&1 ]; then
-  # https://forums.docker.com/t/failing-to-start-dockerd-failed-to-create-nat-chain-docker/78269
-  update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-  update-alternatives --set iptables /usr/sbin/iptables-legacy
-else
-  # There can be issues with some (newer) operating systems are moving away from iptables to nftables, like RHEL.
-  # See https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1677028476905509 for more details
-  update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
-  update-alternatives --set iptables /usr/sbin/iptables-nft
-fi
+# Selecting legacy instead would be a genuine behavioural change for
+# docker-in-docker and needs its own testing - deliberately not done here.
+update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
+update-alternatives --set iptables /usr/sbin/iptables-nft
 
 # Remove the apt cache
 apt-get clean

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -77,3 +77,4 @@ Please contact [Octopus Support](https://octopus.com/support) for support.
 ## Additional Information ##
 
 * These images are based off the [OctopusTentacle](https://github.com/OctopusDeploy/OctopusTentacle) repo on GitHub.
+* Contributors changing the Linux image can build and verify it locally with [`testing/docker-linux/build-and-test-linux-docker-image.sh`](https://github.com/OctopusDeploy/OctopusTentacle/blob/main/testing/docker-linux/build-and-test-linux-docker-image.sh), which reproduces the TeamCity build chain and then smoke- and end-to-end-tests the resulting image.

--- a/testing/README.md
+++ b/testing/README.md
@@ -15,3 +15,29 @@ Use the [Docker Compose](./compatibility/docker/README.md) scripts to setup dock
 ### Azure
 
 Use the [Azure](./compatibility/azure/README.md) scripts to setup Azure Virtual Machines with a selection of Tentacle versions, both Polling and Listening Deployment Targets and Workers are supported.
+
+## Linux Docker Image
+
+Use [`docker-linux/build-and-test-linux-docker-image.sh`](./docker-linux/build-and-test-linux-docker-image.sh) to build and verify the Linux Tentacle container image (`docker/linux/Dockerfile`) end to end, the way TeamCity does. This is the only local way to check a change to that Dockerfile, since the image is built in TeamCity rather than by NUKE.
+
+The script runs in four stages, each of which can be skipped:
+
+| Stage | What it does |
+|---|---|
+| `deb` | Builds the linux-x64 `.deb` via NUKE (`--target PackDebianPackage`) |
+| `image` | Builds the image with the same `docker-compose.build.yml` command TeamCity runs |
+| `smoke` | Asserts the image's contents and behaviour - base image, .NET runtime dependencies, docker-in-docker, entrypoint guards, labels |
+| `e2e` | Stands up SQL Server and an Octopus Server, then registers a listening and a polling Tentacle built from the fresh image |
+
+```
+# everything
+./docker-linux/build-and-test-linux-docker-image.sh
+
+# reuse the last .deb and image, just re-run the assertions
+./docker-linux/build-and-test-linux-docker-image.sh --skip-deb --skip-image
+
+# full options
+./docker-linux/build-and-test-linux-docker-image.sh --help
+```
+
+The `e2e` stage needs an Octopus Server licence, because an unlicensed server enforces a limit of 0 targets and no Tentacle can register. Set `OCTOPUS_SERVER_BASE64_LICENSE`, or let the script read a development licence from 1Password when run interactively. Without one, the stage still verifies configuration and server connectivity up to the licence refusal. Pass `--no-1password` anywhere `op` must not run.

--- a/testing/docker-linux/build-and-test-linux-docker-image.sh
+++ b/testing/docker-linux/build-and-test-linux-docker-image.sh
@@ -273,13 +273,25 @@ if [[ $SKIP_SMOKE -eq 0 ]]; then
     assert_contains "OpenSSL is 3.x" "$OPENSSL_VER" "OpenSSL 3."
 
     # --- Docker-in-Docker ------------------------------------------------
-    # install-docker.sh adds Docker's apt repo. That repo is distro-specific,
-    # so it has to point at .../linux/ubuntu now, not .../linux/debian.
-    DOCKER_LIST=$(run_in_image 'cat /etc/apt/sources.list.d/docker.list')
-    assert_contains "Docker apt source targets the Ubuntu repo" "$DOCKER_LIST" "download.docker.com/linux/ubuntu"
-    assert_contains "Docker apt source targets jammy"           "$DOCKER_LIST" "jammy"
+    # install-docker.sh adds Docker's apt repo. That repo is distro-specific, so
+    # it has to point at .../linux/ubuntu now, not .../linux/debian. The source
+    # is a deb822 .sources file, not a one-line .list, and the key is the
+    # ASCII-armoured one under /etc/apt/keyrings.
+    DOCKER_SOURCES=$(run_in_image 'cat /etc/apt/sources.list.d/docker.sources')
+    assert_contains "Docker apt source targets the Ubuntu repo" "$DOCKER_SOURCES" "download.docker.com/linux/ubuntu"
+    assert_contains "Docker apt source targets jammy"           "$DOCKER_SOURCES" "jammy"
+    assert_contains "Docker apt source is signed by the keyring" "$DOCKER_SOURCES" "Signed-By: /etc/apt/keyrings/docker.asc"
 
-    for bin in docker dockerd containerd; do
+    if run_in_image 'test -r /etc/apt/keyrings/docker.asc && grep -q "BEGIN PGP PUBLIC KEY" /etc/apt/keyrings/docker.asc' >/dev/null 2>&1; then
+        pass "Docker apt keyring is present, readable and armoured"
+    else
+        fail "Docker apt keyring is present, readable and armoured"
+    fi
+
+    # `ip` (iproute2) is part of the dind payload rather than a Docker binary:
+    # dockerd-entrypoint.sh needs it in _tls_san, or a dind TLS certificate is
+    # issued with no IP SANs. See the note in install-docker.sh.
+    for bin in docker dockerd containerd ip; do
         if run_in_image "command -v $bin >/dev/null" >/dev/null 2>&1; then
             pass "docker-in-docker binary present: $bin"
         else
@@ -405,21 +417,38 @@ OCTOPUS_LICENSE=""
 OCTOPUS_LICENSE_OP_REF="op://software licencing/octopus deploy ultimate license key base64/value"
 
 resolve_license() {
+    local from="OCTOPUS_SERVER_BASE64_LICENSE"
     OCTOPUS_LICENSE="${OCTOPUS_SERVER_BASE64_LICENSE:-}"
-    [[ -n "$OCTOPUS_LICENSE" ]] && return 0
-    [[ $NO_1PASSWORD -eq 0 ]] || return 0
-    [[ -t 0 ]] || return 0
-    command -v op >/dev/null 2>&1 || return 0
 
-    info "Looking up a development licence in 1Password (you may be prompted)..."
-    if OCTOPUS_LICENSE=$(op read "$OCTOPUS_LICENSE_OP_REF" 2>/dev/null) && [[ -n "$OCTOPUS_LICENSE" ]]; then
-        info "Licence retrieved from 1Password (${#OCTOPUS_LICENSE} chars)."
-    else
-        OCTOPUS_LICENSE=""
-        warn "Could not read a licence from 1Password. Sign in with 'op signin'"
-        warn "and check you have access to the 'software licencing' vault, or set"
-        warn "OCTOPUS_SERVER_BASE64_LICENSE yourself."
+    if [[ -z "$OCTOPUS_LICENSE" ]] \
+            && [[ $NO_1PASSWORD -eq 0 ]] \
+            && [[ -t 0 ]] \
+            && command -v op >/dev/null 2>&1; then
+        info "Looking up a development licence in 1Password (you may be prompted)..."
+        if OCTOPUS_LICENSE=$(op read "$OCTOPUS_LICENSE_OP_REF" 2>/dev/null) && [[ -n "$OCTOPUS_LICENSE" ]]; then
+            from="1Password"
+        else
+            OCTOPUS_LICENSE=""
+            warn "Could not read a licence from 1Password. Sign in with 'op signin'"
+            warn "and check you have access to the 'software licencing' vault, or set"
+            warn "OCTOPUS_SERVER_BASE64_LICENSE yourself."
+        fi
     fi
+
+    # A licence is single-line base64, so strip any newlines. An embedded one
+    # would split the --env-file entry in two, handing the server a truncated
+    # licence plus a garbage second variable, and would also break the sed in
+    # dump_logs that scrubs the licence out of container logs. Both are painful
+    # to diagnose from the output, so normalise once here rather than defending
+    # against it in two places.
+    OCTOPUS_LICENSE=$(printf '%s' "$OCTOPUS_LICENSE" | tr -d '\n\r')
+
+    [[ -n "$OCTOPUS_LICENSE" ]] \
+        && info "Licence loaded from ${from} (${#OCTOPUS_LICENSE} chars)."
+
+    # Explicit, because the test above is the last command and a missing licence
+    # is not a failure - stage 4 falls back to its unlicensed assertions.
+    return 0
 }
 
 # Note: this also runs *before* the stack is started, to clear out anything a

--- a/testing/docker-linux/build-and-test-linux-docker-image.sh
+++ b/testing/docker-linux/build-and-test-linux-docker-image.sh
@@ -36,7 +36,8 @@
 # .nuke/build.schema.json. Both are tracked, so `git checkout --` them
 # afterwards if you do not want that noise in your working tree.
 #
-# Usage: ./build-and-test-linux-docker-image.sh [options]
+# Usage: ./testing/docker-linux/build-and-test-linux-docker-image.sh [options]
+#        (runs from anywhere; it resolves the repo root itself)
 #   --skip-deb     Reuse the newest existing _artifacts/deb/tentacle_*_amd64.deb
 #   --skip-image   Reuse the already-built image for the resolved BUILD_NUMBER
 #   --skip-smoke   Skip the image smoke tests
@@ -48,8 +49,13 @@
 #
 set -euo pipefail
 
-REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# This script lives in testing/docker-linux/, but every path below (./build.sh,
+# _artifacts/deb, docker-compose.build.yml, docker/linux/Dockerfile) is relative
+# to the repo root, so resolve that and work from there.
+REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 cd "$REPO_DIR"
+[[ -f "$REPO_DIR/docker-compose.build.yml" ]] \
+    || { echo "ERROR: could not locate the repo root (got '$REPO_DIR')" >&2; exit 1; }
 
 SKIP_DEB=0
 SKIP_IMAGE=0
@@ -179,6 +185,13 @@ BUILD_NUMBER="${DEB_FILE#tentacle_}"
 BUILD_NUMBER="${BUILD_NUMBER%_amd64.deb}"
 [[ -n "$BUILD_NUMBER" ]] || die "could not derive BUILD_NUMBER from $DEB_FILE"
 
+# A local NUKE build appends '-<yyyyMMddHHmmss>' to FullSemVer for the package
+# filename (Build.cs), but the binary itself only carries the plain FullSemVer,
+# followed by '+Branch...Sha...'. Strip the timestamp so both the smoke test and
+# the e2e stage can compare against the version Tentacle actually reports. On
+# TeamCity there is no timestamp suffix and this is a straight comparison.
+EXPECTED_VERSION=$(echo "$BUILD_NUMBER" | sed -E 's/-[0-9]{14}$//')
+
 info "Package:      $DEB_PATH"
 info "BUILD_NUMBER: $BUILD_NUMBER"
 
@@ -248,11 +261,6 @@ if [[ $SKIP_SMOKE -eq 0 ]]; then
     done
 
     # --- Tentacle --------------------------------------------------------
-    # A local NUKE build appends '-<yyyyMMddHHmmss>' to FullSemVer for the package
-    # filename (Build.cs), but the binary itself only carries the plain FullSemVer,
-    # followed by '+Branch...Sha...'. Normalise both ends before comparing. On
-    # TeamCity there is no timestamp suffix and this is a straight comparison.
-    EXPECTED_VERSION=$(echo "$BUILD_NUMBER" | sed -E 's/-[0-9]{14}$//')
     TENTACLE_VERSION=$(run_in_image 'tentacle version')
     assert_equals "'tentacle version' reports the built version" \
         "${TENTACLE_VERSION%%+*}" "$EXPECTED_VERSION"
@@ -298,7 +306,9 @@ if [[ $SKIP_SMOKE -eq 0 ]]; then
         fail "iptables alternative selected" "got '$IPTABLES_ALT'"
     fi
 
-    if run_in_image 'getent passwd dockremap >/dev/null && grep -q "^dockremap:" /etc/subuid /etc/subgid' >/dev/null 2>&1; then
+    # Both files are checked separately: `grep -q a b` exits 0 on the first
+    # match in *either* file, so passing both at once would pass with only one.
+    if run_in_image 'getent passwd dockremap >/dev/null && grep -q "^dockremap:" /etc/subuid && grep -q "^dockremap:" /etc/subgid' >/dev/null 2>&1; then
         pass "dockremap user and subuid/subgid ranges configured"
     else
         fail "dockremap user and subuid/subgid ranges configured"
@@ -371,20 +381,16 @@ random_password() {
     done
 }
 
-# Fresh for every run, and never written anywhere but the containers they are
-# created for, which are torn down at the end.
-SA_PASSWORD=$(random_password)
+# Populated by e2e_prepare, which only runs when stage 4 is actually going to
+# run - there is no reason to mint credentials or touch 1Password under
+# --skip-e2e. Declared here so `set -u` and dump_logs are safe either way.
 OCTOPUS_USER="admin"
-OCTOPUS_PASSWORD=$(random_password)
+SA_PASSWORD=""
+OCTOPUS_PASSWORD=""
+OCTOPUS_LICENSE=""
 
-# An Octopus Server with no licence enforces a limit of 0 targets, so no
-# Tentacle can register against it. Supply a base64-encoded licence in
-# OCTOPUS_SERVER_BASE64_LICENSE to run the full registration and health-check
-# assertions; without one the stage falls back to verifying configuration and
-# connectivity up to the licence check.
-OCTOPUS_LICENSE="${OCTOPUS_SERVER_BASE64_LICENSE:-}"
-
-# Failing that, try 1Password, which is where the Octopus Server repo's own
+# resolve_license prefers OCTOPUS_SERVER_BASE64_LICENSE. Failing that it tries
+# 1Password, which is where the Octopus Server repo's own
 # `./environment.sh setup` gets a local development licence from (see
 # setup-octopus/OctopusInstanceManager.cs). Note the vault is "software
 # licencing", not the "Octopus Server Secrets for Tests" vault the secrets
@@ -398,8 +404,13 @@ OCTOPUS_LICENSE="${OCTOPUS_SERVER_BASE64_LICENSE:-}"
 # background shells and agents without anyone having to remember a flag.
 OCTOPUS_LICENSE_OP_REF="op://software licencing/octopus deploy ultimate license key base64/value"
 
-if [[ -z "$OCTOPUS_LICENSE" && $SKIP_E2E -eq 0 && $NO_1PASSWORD -eq 0 ]] \
-        && [[ -t 0 ]] && command -v op >/dev/null 2>&1; then
+resolve_license() {
+    OCTOPUS_LICENSE="${OCTOPUS_SERVER_BASE64_LICENSE:-}"
+    [[ -n "$OCTOPUS_LICENSE" ]] && return 0
+    [[ $NO_1PASSWORD -eq 0 ]] || return 0
+    [[ -t 0 ]] || return 0
+    command -v op >/dev/null 2>&1 || return 0
+
     info "Looking up a development licence in 1Password (you may be prompted)..."
     if OCTOPUS_LICENSE=$(op read "$OCTOPUS_LICENSE_OP_REF" 2>/dev/null) && [[ -n "$OCTOPUS_LICENSE" ]]; then
         info "Licence retrieved from 1Password (${#OCTOPUS_LICENSE} chars)."
@@ -409,7 +420,7 @@ if [[ -z "$OCTOPUS_LICENSE" && $SKIP_E2E -eq 0 && $NO_1PASSWORD -eq 0 ]] \
         warn "and check you have access to the 'software licencing' vault, or set"
         warn "OCTOPUS_SERVER_BASE64_LICENSE yourself."
     fi
-fi
+}
 
 # Note: this also runs *before* the stack is started, to clear out anything a
 # previous run left behind, so it must not touch $E2E_HELPER - that is cleaned
@@ -459,6 +470,17 @@ wait_for() {
     return 1
 }
 
+# e2e_rm_temp - remove the helper script and every env file holding a secret.
+# Runs from the EXIT trap, possibly before e2e_prepare has created any of them,
+# so it must tolerate every one being unset.
+e2e_rm_temp() {
+    rm -f "${E2E_HELPER:-}" \
+          "${E2E_ENV_SQL:-}" "${E2E_ENV_SERVER:-}" \
+          "${E2E_ENV_AGENT:-}" "${E2E_ENV_API:-}" 2>/dev/null || true
+}
+
+# write_api_helper - write the Octopus API helper this stage shells out to.
+#
 # Octopus authenticates API calls with either an API key or a session cookie.
 # Minting an API key itself needs an authenticated POST, so signing in and
 # reusing the session is simpler. This runs inside a curl container on the e2e
@@ -466,19 +488,13 @@ wait_for() {
 # so the quoting stays readable.
 #
 # /tmp is one of Docker Desktop's default shared paths, so the mount works on
-# macOS as well as Linux.
-# e2e_rm_temp - remove the helper script and every env file holding a secret.
-# Referenced by both EXIT traps, so it must tolerate any of them being unset.
-e2e_rm_temp() {
-    rm -f "${E2E_HELPER:-}" \
-          "${E2E_ENV_SQL:-}" "${E2E_ENV_SERVER:-}" \
-          "${E2E_ENV_AGENT:-}" "${E2E_ENV_API:-}" 2>/dev/null || true
-}
+# macOS as well as Linux. BSD (macOS) mktemp only substitutes Xs at the very
+# end of the template.
+E2E_HELPER=""
 
-# BSD (macOS) mktemp only substitutes Xs at the very end of the template.
-E2E_HELPER=$(mktemp /tmp/octopus-api.XXXXXX)
-trap 'e2e_rm_temp' EXIT
-cat > "$E2E_HELPER" <<'HELPER_SH'
+write_api_helper() {
+    E2E_HELPER=$(mktemp /tmp/octopus-api.XXXXXX)
+    cat > "$E2E_HELPER" <<'HELPER_SH'
 #!/bin/sh
 # usage: octopus-api.sh <server-url> <GET|POST> <path> [body]
 # Credentials come from OCTO_USER / OCTO_PASS in the environment, supplied by
@@ -513,6 +529,7 @@ else
         -d "$BODY" "${SERVER}${API_PATH}"
 fi
 HELPER_SH
+}
 
 # Every secret reaches a container through --env-file rather than `-e`, so
 # none of them appear in `ps` output for the life of the container. Docker
@@ -529,21 +546,43 @@ new_env_file() {
     printf '%s' "$f"
 }
 
-E2E_ENV_SQL=$(new_env_file \
-    "MSSQL_SA_PASSWORD=${SA_PASSWORD}")
+E2E_ENV_SQL=""
+E2E_ENV_SERVER=""
+E2E_ENV_AGENT=""
+E2E_ENV_API=""
 
-E2E_ENV_SERVER=$(new_env_file \
-    "OCTOPUS_SERVER_BASE64_LICENSE=${OCTOPUS_LICENSE}" \
-    "ADMIN_PASSWORD=${OCTOPUS_PASSWORD}" \
-    "DB_CONNECTION_STRING=Server=${E2E_SQL},1433;Initial Catalog=Octopus;Persist Security Info=False;User ID=sa;Password=${SA_PASSWORD};MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=True")
+# e2e_prepare - mint this run's credentials and write every temp file stage 4
+# needs. Called from stage 4 only, so --skip-e2e neither generates passwords
+# nor prompts 1Password.
+e2e_prepare() {
+    # Fresh for every run, and never written anywhere but the containers they
+    # are created for, which are torn down at the end.
+    SA_PASSWORD=$(random_password)
+    OCTOPUS_PASSWORD=$(random_password)
 
-E2E_ENV_AGENT=$(new_env_file \
-    "ServerUsername=${OCTOPUS_USER}" \
-    "ServerPassword=${OCTOPUS_PASSWORD}")
+    resolve_license
+    write_api_helper
 
-E2E_ENV_API=$(new_env_file \
-    "OCTO_USER=${OCTOPUS_USER}" \
-    "OCTO_PASS=${OCTOPUS_PASSWORD}")
+    E2E_ENV_SQL=$(new_env_file \
+        "MSSQL_SA_PASSWORD=${SA_PASSWORD}")
+
+    # The licence line is omitted entirely when we have no licence, rather than
+    # written as an empty value, so the server image sees it as unset.
+    local server_env=(
+        "ADMIN_PASSWORD=${OCTOPUS_PASSWORD}"
+        "DB_CONNECTION_STRING=Server=${E2E_SQL},1433;Initial Catalog=Octopus;Persist Security Info=False;User ID=sa;Password=${SA_PASSWORD};MultipleActiveResultSets=False;Connection Timeout=30;TrustServerCertificate=True"
+    )
+    [[ -n "$OCTOPUS_LICENSE" ]] && server_env+=("OCTOPUS_SERVER_BASE64_LICENSE=${OCTOPUS_LICENSE}")
+    E2E_ENV_SERVER=$(new_env_file "${server_env[@]}")
+
+    E2E_ENV_AGENT=$(new_env_file \
+        "ServerUsername=${OCTOPUS_USER}" \
+        "ServerPassword=${OCTOPUS_PASSWORD}")
+
+    E2E_ENV_API=$(new_env_file \
+        "OCTO_USER=${OCTOPUS_USER}" \
+        "OCTO_PASS=${OCTOPUS_PASSWORD}")
+}
 
 octopus_call() {
     docker run --rm --platform "$PLATFORM" --network "$E2E_NET" \
@@ -618,7 +657,10 @@ if [[ $SKIP_E2E -eq 0 ]]; then
     info "Spinning up SQL Server + Octopus Server, then registering a listening"
     info "and a polling Tentacle from the image just built."
 
+    # Trap first, so anything e2e_prepare manages to create is still cleaned up
+    # if it fails partway.
     trap 'e2e_teardown; e2e_rm_temp' EXIT
+    e2e_prepare
     e2e_teardown   # clear out anything left over from a previous run
 
     # Guard against the helper going missing: Docker would silently mount an
@@ -650,7 +692,6 @@ if [[ $SKIP_E2E -eq 0 ]]; then
         --env-file "$E2E_ENV_SERVER" \
         -e ACCEPT_EULA=Y \
         -e "ADMIN_USERNAME=${OCTOPUS_USER}" \
-        -e "MASTER_KEY=" \
         docker.packages.octopushq.com/octopusdeploy/octopusdeploy:latest >/dev/null
 
     if wait_for "Octopus Server" 900 \
@@ -705,97 +746,100 @@ if [[ $SKIP_E2E -eq 0 ]]; then
         -e "TargetName=${E2E_POLLING}" \
         "$IMAGE" >/dev/null
 
-if [[ -z "$OCTOPUS_LICENSE" ]]; then
-    # An unlicensed Octopus Server reports a Targets limit of 0, so
-    # `tentacle register-with` is refused before a machine is ever created.
-    # Everything up to that point still exercises the image for real, so
-    # assert on that instead of pretending the stage passed.
-    warn "No licence available, so no Tentacle can register (0-target limit)."
-    warn "Verifying configuration and server connectivity instead. Sign in to"
-    warn "1Password ('op signin') or set OCTOPUS_SERVER_BASE64_LICENSE to run"
-    warn "the full registration test."
+    if [[ -z "$OCTOPUS_LICENSE" ]]; then
+        # An unlicensed Octopus Server reports a Targets limit of 0, so
+        # `tentacle register-with` is refused before a machine is ever created.
+        # Everything up to that point still exercises the image for real, so
+        # assert on that instead of pretending the stage passed.
+        warn "No licence available, so no Tentacle can register (0-target limit)."
+        warn "Verifying configuration and server connectivity instead. Sign in to"
+        warn "1Password ('op signin') or set OCTOPUS_SERVER_BASE64_LICENSE to run"
+        warn "the full registration test."
 
-    # Self-configuration: create-instance, set paths, comms mode, certificate.
-    if wait_for_log "$E2E_LISTENING" 300 "A new certificate has been generated"; then
-        pass "listening Tentacle configured itself and generated a certificate"
-    else
-        fail "listening Tentacle configured itself and generated a certificate"
-        dump_logs "$E2E_LISTENING"
-    fi
-
-    # Reaching this line means the Tentacle resolved the server, opened an HTTP
-    # connection and authenticated with the username/password it was given.
-    if wait_for_log "$E2E_LISTENING" 300 "Registering the tentacle with the server at"; then
-        pass "listening Tentacle reached and authenticated against the server"
-    else
-        fail "listening Tentacle reached and authenticated against the server"
-        dump_logs "$E2E_LISTENING"
-    fi
-
-    # A licence refusal (rather than an auth or connection error) proves the
-    # whole request round-tripped and the only thing left is the licence.
-    if wait_for_log "$E2E_LISTENING" 300 "exceed the limits of your current license"; then
-        pass "listening Tentacle blocked only by the licence target limit"
-    else
-        fail "listening Tentacle blocked only by the licence target limit"
-        dump_logs "$E2E_LISTENING"
-    fi
-
-    # The polling Tentacle additionally opens a raw Halibut connection to the
-    # server communications port, which the listening one never does.
-    if wait_for_log "$E2E_POLLING" 300 "Connected successfully"; then
-        pass "polling Tentacle connected to the server comms port (10943)"
-    else
-        fail "polling Tentacle connected to the server comms port (10943)"
-        dump_logs "$E2E_POLLING"
-    fi
-
-else
-    # Registration is the first thing the entrypoint does, so both machines
-    # should appear in the API well before the health check runs.
-    if wait_for "Tentacle registration" 420 both_registered; then
-        pass "both Tentacles registered with the Octopus Server"
-    else
-        fail "both Tentacles registered with the Octopus Server"
-        dump_logs "$E2E_LISTENING"
-        dump_logs "$E2E_POLLING"
-    fi
-
-    MACHINES=$(machines_json)
-
-    # Assert on each machine individually so a half-working image is obvious.
-    for name in "$E2E_LISTENING" "$E2E_POLLING"; do
-        if [[ "$MACHINES" == *"\"Name\":\"$name\""* ]]; then
-            pass "registered: $name"
+        # Self-configuration: create-instance, set paths, comms mode, certificate.
+        if wait_for_log "$E2E_LISTENING" 300 "A new certificate has been generated"; then
+            pass "listening Tentacle configured itself and generated a certificate"
         else
-            fail "registered: $name"
-            dump_logs "$name"
+            fail "listening Tentacle configured itself and generated a certificate"
+            dump_logs "$E2E_LISTENING"
         fi
-    done
 
-    assert_contains "listening Tentacle registered as TentaclePassive" "$MACHINES" "TentaclePassive"
-    assert_contains "polling Tentacle registered as TentacleActive"    "$MACHINES" "TentacleActive"
+        # Reaching this line means the Tentacle resolved the server, opened an HTTP
+        # connection and authenticated with the username/password it was given.
+        if wait_for_log "$E2E_LISTENING" 300 "Registering the tentacle with the server at"; then
+            pass "listening Tentacle reached and authenticated against the server"
+        else
+            fail "listening Tentacle reached and authenticated against the server"
+            dump_logs "$E2E_LISTENING"
+        fi
 
-    # --- health -----------------------------------------------------------
-    # A machine only reports Healthy once the server has completed a health
-    # check against it, which exercises the Halibut connection in both
-    # directions - the real proof the image works.
-    info "Waiting for the Octopus Server to health-check both Tentacles..."
-    if wait_for "Tentacle health checks" 600 both_healthy; then
-        pass "both Tentacles reported Healthy"
+        # A licence refusal (rather than an auth or connection error) proves the
+        # whole request round-tripped and the only thing left is the licence.
+        if wait_for_log "$E2E_LISTENING" 300 "exceed the limits of your current license"; then
+            pass "listening Tentacle blocked only by the licence target limit"
+        else
+            fail "listening Tentacle blocked only by the licence target limit"
+            dump_logs "$E2E_LISTENING"
+        fi
+
+        # The polling Tentacle additionally opens a raw Halibut connection to the
+        # server communications port, which the listening one never does.
+        if wait_for_log "$E2E_POLLING" 300 "Connected successfully"; then
+            pass "polling Tentacle connected to the server comms port (10943)"
+        else
+            fail "polling Tentacle connected to the server comms port (10943)"
+            dump_logs "$E2E_POLLING"
+        fi
+
     else
-        fail "both Tentacles reported Healthy" \
-             "statuses: $(machines_json | grep -o '"HealthStatus":"[A-Za-z]*"' | tr '\n' ' ')"
-        dump_logs "$E2E_LISTENING"
-        dump_logs "$E2E_POLLING"
-    fi
+        # Registration is the first thing the entrypoint does, so both machines
+        # should appear in the API well before the health check runs.
+        if wait_for "Tentacle registration" 420 both_registered; then
+            pass "both Tentacles registered with the Octopus Server"
+        else
+            fail "both Tentacles registered with the Octopus Server"
+            dump_logs "$E2E_LISTENING"
+            dump_logs "$E2E_POLLING"
+        fi
 
-    # The version the server sees comes off the wire from the Tentacle itself,
-    # so this confirms the .deb inside the image is the one we just built.
-    MACHINES=$(machines_json)
-    SHORT_VERSION="${BUILD_NUMBER%%-*}"
-    assert_contains "server reports the built Tentacle version ($SHORT_VERSION)" "$MACHINES" "$SHORT_VERSION"
-fi
+        MACHINES=$(machines_json)
+
+        # Assert on each machine individually so a half-working image is obvious.
+        for name in "$E2E_LISTENING" "$E2E_POLLING"; do
+            if [[ "$MACHINES" == *"\"Name\":\"$name\""* ]]; then
+                pass "registered: $name"
+            else
+                fail "registered: $name"
+                dump_logs "$name"
+            fi
+        done
+
+        assert_contains "listening Tentacle registered as TentaclePassive" "$MACHINES" "TentaclePassive"
+        assert_contains "polling Tentacle registered as TentacleActive"    "$MACHINES" "TentacleActive"
+
+        # --- health -----------------------------------------------------------
+        # A machine only reports Healthy once the server has completed a health
+        # check against it, which exercises the Halibut connection in both
+        # directions - the real proof the image works.
+        info "Waiting for the Octopus Server to health-check both Tentacles..."
+        if wait_for "Tentacle health checks" 600 both_healthy; then
+            pass "both Tentacles reported Healthy"
+        else
+            fail "both Tentacles reported Healthy" \
+                 "statuses: $(machines_json | grep -o '"HealthStatus":"[A-Za-z]*"' | tr '\n' ' ')"
+            dump_logs "$E2E_LISTENING"
+            dump_logs "$E2E_POLLING"
+        fi
+
+        # The version the server sees comes off the wire from the Tentacle itself,
+        # so this confirms the .deb inside the image is the one we just built.
+        MACHINES=$(machines_json)
+        # EXPECTED_VERSION is the full FullSemVer (timestamp suffix stripped),
+        # not just the numeric prefix, so this cannot pass on a coincidental
+        # substring match elsewhere in the JSON.
+        assert_contains "server reports the built Tentacle version ($EXPECTED_VERSION)" \
+            "$MACHINES" "$EXPECTED_VERSION"
+    fi
 fi
 
 ###############################################################################

--- a/testing/docker-linux/build-and-test-linux-docker-image.sh
+++ b/testing/docker-linux/build-and-test-linux-docker-image.sh
@@ -154,7 +154,12 @@ docker info >/dev/null 2>&1 || die "the Docker daemon is not running"
 
 find_deb() {
     # Newest tentacle_*_amd64.deb, or empty if there are none.
-    ls -t _artifacts/deb/tentacle_*_amd64.deb 2>/dev/null | head -1
+    #
+    # The trailing `|| true` is what makes "or empty" true: with no match the
+    # glob is passed through literally, `ls` fails, and under `set -o pipefail`
+    # the caller's `DEB_PATH=$(find_deb)` would abort the script before it could
+    # reach the `die` that explains what is missing.
+    ls -t _artifacts/deb/tentacle_*_amd64.deb 2>/dev/null | head -1 || true
 }
 
 if [[ $SKIP_DEB -eq 1 ]]; then
@@ -232,8 +237,13 @@ if [[ $SKIP_SMOKE -eq 0 ]]; then
     step "Stage 3/4: smoke-testing the image"
 
     # --- base image -------------------------------------------------------
-    OS_ID=$(run_in_image '. /etc/os-release && echo "$ID"')
-    OS_VER=$(run_in_image '. /etc/os-release && echo "$VERSION_ID"')
+    # Every capture below is guarded. A failed `docker run` should be recorded
+    # as a failed assertion and still reach the Summary, not abort the script at
+    # the point of capture and lose the tally - the harness relies on fail()
+    # returning 0 so a run always reports. (A dead Docker daemon is caught by the
+    # `docker info` check near the top, so this cannot mass-fail for that.)
+    OS_ID=$(run_in_image '. /etc/os-release && echo "$ID"') || OS_ID=""
+    OS_VER=$(run_in_image '. /etc/os-release && echo "$VERSION_ID"') || OS_VER=""
     assert_equals "base image is Ubuntu"        "$OS_ID"  "ubuntu"
     assert_equals "base image is 22.04 (jammy)" "$OS_VER" "22.04"
 
@@ -243,7 +253,7 @@ if [[ $SKIP_SMOKE -eq 0 ]]; then
     # but a silently-missing one would fail Tentacle at runtime instead.
     for pkg in ca-certificates libc6 libgcc-s1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g; do
         # Captured rather than piped into grep -q: see the note on wait_for_log.
-        PKG_STATUS=$(run_in_image "dpkg-query -W -f='\${Status}' $pkg")
+        PKG_STATUS=$(run_in_image "dpkg-query -W -f='\${Status}' $pkg") || PKG_STATUS=""
         if [[ "$PKG_STATUS" == *"install ok installed"* ]]; then
             pass "runtime dependency installed: $pkg"
         else
@@ -261,15 +271,15 @@ if [[ $SKIP_SMOKE -eq 0 ]]; then
     done
 
     # --- Tentacle --------------------------------------------------------
-    TENTACLE_VERSION=$(run_in_image 'tentacle version')
+    TENTACLE_VERSION=$(run_in_image 'tentacle version') || TENTACLE_VERSION=""
     assert_equals "'tentacle version' reports the built version" \
         "${TENTACLE_VERSION%%+*}" "$EXPECTED_VERSION"
 
-    SYMLINK=$(run_in_image 'readlink -f /usr/bin/tentacle')
+    SYMLINK=$(run_in_image 'readlink -f /usr/bin/tentacle') || SYMLINK=""
     assert_equals "/usr/bin/tentacle symlinks to the install" "$SYMLINK" "/opt/octopus/tentacle/Tentacle"
 
     # OpenSSL 3 is what libssl3 provides; Tentacle's .deb accepts 1.0/1.1/3.
-    OPENSSL_VER=$(run_in_image 'openssl version')
+    OPENSSL_VER=$(run_in_image 'openssl version') || OPENSSL_VER=""
     assert_contains "OpenSSL is 3.x" "$OPENSSL_VER" "OpenSSL 3."
 
     # --- Docker-in-Docker ------------------------------------------------
@@ -277,7 +287,7 @@ if [[ $SKIP_SMOKE -eq 0 ]]; then
     # it has to point at .../linux/ubuntu now, not .../linux/debian. The source
     # is a deb822 .sources file, not a one-line .list, and the key is the
     # ASCII-armoured one under /etc/apt/keyrings.
-    DOCKER_SOURCES=$(run_in_image 'cat /etc/apt/sources.list.d/docker.sources')
+    DOCKER_SOURCES=$(run_in_image 'cat /etc/apt/sources.list.d/docker.sources') || DOCKER_SOURCES=""
     assert_contains "Docker apt source targets the Ubuntu repo" "$DOCKER_SOURCES" "download.docker.com/linux/ubuntu"
     assert_contains "Docker apt source targets jammy"           "$DOCKER_SOURCES" "jammy"
     assert_contains "Docker apt source is signed by the keyring" "$DOCKER_SOURCES" "Signed-By: /etc/apt/keyrings/docker.asc"
@@ -311,7 +321,7 @@ if [[ $SKIP_SMOKE -eq 0 ]]; then
     # skipped, dockerd would fail to create its NAT chain at runtime.
     # Read the link one level only: -f would resolve on through to the shared
     # xtables-*-multi binary, which does not say which mode was selected.
-    IPTABLES_ALT=$(run_in_image 'readlink /etc/alternatives/iptables')
+    IPTABLES_ALT=$(run_in_image 'readlink /etc/alternatives/iptables') || IPTABLES_ALT=""
     if [[ "$IPTABLES_ALT" == *"iptables-legacy" || "$IPTABLES_ALT" == *"iptables-nft" ]]; then
         pass "iptables alternative selected ($(basename "$IPTABLES_ALT"))"
     else
@@ -336,7 +346,7 @@ if [[ $SKIP_SMOKE -eq 0 ]]; then
     done
 
     # --- image metadata ---------------------------------------------------
-    INSPECT=$(docker image inspect "$IMAGE")
+    INSPECT=$(docker image inspect "$IMAGE") || INSPECT=""
     assert_contains "ENTRYPOINT is configure-and-run.sh" "$INSPECT" "/scripts/configure-and-run.sh"
     assert_contains "port 10933 is exposed"              "$INSPECT" "10933/tcp"
     assert_contains "/var/lib/docker is a volume"        "$INSPECT" "/var/lib/docker"
@@ -356,11 +366,20 @@ fi
 # 4. End-to-end registration test
 ###############################################################################
 
-E2E_NET="tentacle-e2e-net"
-E2E_SQL="tentacle-e2e-sql"
-E2E_SERVER="tentacle-e2e-octopus"
-E2E_LISTENING="tentacle-e2e-listening"
-E2E_POLLING="tentacle-e2e-polling"
+# Every Docker name this stage creates carries a per-run suffix, so two runs on
+# the same host cannot collide. Without it, the pre-run cleanup below would
+# force-remove a concurrent run's live containers, and `docker network create`
+# would race - which matters as soon as this runs on a shared build agent where
+# a PR build and a nightly can overlap.
+#
+# $$ is the script's PID: unique among live processes, short, and readable in
+# `docker ps`, which a random hex string would not be.
+E2E_RUN_ID="$$"
+E2E_NET="tentacle-e2e-net-${E2E_RUN_ID}"
+E2E_SQL="tentacle-e2e-sql-${E2E_RUN_ID}"
+E2E_SERVER="tentacle-e2e-octopus-${E2E_RUN_ID}"
+E2E_LISTENING="tentacle-e2e-listening-${E2E_RUN_ID}"
+E2E_POLLING="tentacle-e2e-polling-${E2E_RUN_ID}"
 E2E_CONTAINERS=("$E2E_LISTENING" "$E2E_POLLING" "$E2E_SERVER" "$E2E_SQL")
 
 # random_password - 20 characters of upper case, lower case and digits.
@@ -451,17 +470,44 @@ resolve_license() {
     return 0
 }
 
-# Note: this also runs *before* the stack is started, to clear out anything a
-# previous run left behind, so it must not touch $E2E_HELPER - that is cleaned
-# up by the EXIT trap instead.
+# e2e_remove_stack - force-remove the e2e containers and network, if present.
+#
+# Neither of the two callers below may touch $E2E_HELPER or the env files;
+# those belong to the EXIT trap via e2e_rm_temp.
+e2e_remove_stack() {
+    docker rm -f "${E2E_CONTAINERS[@]}" >/dev/null 2>&1 || true
+    docker network rm "$E2E_NET" >/dev/null 2>&1 || true
+}
+
+# e2e_cleanup_stale - clear out anything already holding this run's names.
+#
+# Deliberately NOT gated on --keep. It used to share a function with the EXIT
+# trap below, which meant that after a --keep run, the next --keep run returned
+# early here and then died on a `docker run --name` conflict. What --keep means
+# is "leave MY containers up when I finish", not "never clean up anyone else's".
+#
+# Now that the names carry a per-run suffix this should never find anything -
+# it would take PID reuse - but it stays as a cheap guard, and it only ever
+# matches this run's own names, so it cannot disturb a concurrent run. Stacks
+# left behind by --keep are no longer in the way, and the message printed then
+# gives the exact command to remove them.
+e2e_cleanup_stale() {
+    local stale
+    stale=$(docker ps -a --filter "name=^/tentacle-e2e-.*-${E2E_RUN_ID}$" --format '{{.Names}}' 2>/dev/null | tr '\n' ' ')
+    if [[ -n "${stale// /}" ]]; then
+        warn "Removing containers already holding this run's names: ${stale% }"
+    fi
+    e2e_remove_stack
+}
+
+# e2e_teardown - EXIT trap cleanup, honouring --keep.
 e2e_teardown() {
     if [[ $KEEP -eq 1 ]]; then
         warn "--keep was given; leaving the e2e containers running."
         warn "Tear down with: docker rm -f ${E2E_CONTAINERS[*]}; docker network rm $E2E_NET"
         return
     fi
-    docker rm -f "${E2E_CONTAINERS[@]}" >/dev/null 2>&1 || true
-    docker network rm "$E2E_NET" >/dev/null 2>&1 || true
+    e2e_remove_stack
 }
 
 # dump_logs <container> - print the tail of a container's logs, for diagnosis.
@@ -480,16 +526,31 @@ dump_logs() {
     echo "    --- end ---"
 }
 
-# wait_for <description> <timeout-seconds> <shell test> - poll until the test
-# passes, or give up. Returns non-zero on timeout.
+# wait_for <description> <timeout-seconds> <shell test> [container...] - poll
+# until the test passes, or give up. Returns non-zero on timeout.
+#
+# Any containers named after the test are watched for having exited, the same
+# way wait_for_log does it. The timeouts here run to 900s, so a container that
+# dies on startup - an SA password the policy rejects, a port clash, an OOM -
+# would otherwise sit out the entire wait and then report a timeout that hides
+# the real cause.
 wait_for() {
     local what="$1" timeout="$2" test_cmd="$3"
-    local waited=0
+    shift 3
+    local waited=0 container
     while (( waited < timeout )); do
         if eval "$test_cmd" >/dev/null 2>&1; then
             info "$what ready after ${waited}s"
             return 0
         fi
+        # Checked after the condition, so a container that satisfies the test
+        # and then exits still counts as ready.
+        for container in "$@"; do
+            if [[ "$(docker inspect -f '{{.State.Status}}' "$container" 2>/dev/null)" == "exited" ]]; then
+                warn "$container has exited; not waiting out the remaining $((timeout - waited))s"
+                return 1
+            fi
+        done
         sleep 5
         waited=$((waited + 5))
         if (( waited % 60 == 0 )); then
@@ -713,7 +774,7 @@ if [[ $SKIP_E2E -eq 0 ]]; then
     # if it fails partway.
     trap 'e2e_teardown; e2e_rm_temp' EXIT
     e2e_prepare
-    e2e_teardown   # clear out anything left over from a previous run
+    e2e_cleanup_stale
 
     # Guard against the helper going missing: Docker would silently mount an
     # empty directory over it and every API call would fail for no clear reason.
@@ -729,7 +790,7 @@ if [[ $SKIP_E2E -eq 0 ]]; then
         -e MSSQL_PID=Express \
         mcr.microsoft.com/mssql/server:2022-latest >/dev/null
 
-    if wait_for "SQL Server" 420 sql_ready; then
+    if wait_for "SQL Server" 420 sql_ready "$E2E_SQL"; then
         pass "SQL Server started"
     else
         fail "SQL Server started"
@@ -747,7 +808,8 @@ if [[ $SKIP_E2E -eq 0 ]]; then
         docker.packages.octopushq.com/octopusdeploy/octopusdeploy:latest >/dev/null
 
     if wait_for "Octopus Server" 900 \
-        "docker run --rm --platform $PLATFORM --network $E2E_NET curlimages/curl:latest -sf http://${E2E_SERVER}:8080/api"; then
+        "docker run --rm --platform $PLATFORM --network $E2E_NET curlimages/curl:latest -sf http://${E2E_SERVER}:8080/api" \
+        "$E2E_SERVER"; then
         pass "Octopus Server started"
     else
         fail "Octopus Server started"
@@ -761,7 +823,9 @@ if [[ $SKIP_E2E -eq 0 ]]; then
     # Roles, by contrast, are free-form and are created on registration.
     info "Creating the Development environment..."
     octopus_post /api/environments '{"Name":"Development"}' >/dev/null 2>&1 || true
-    ENVIRONMENTS=$(octopus_api /api/environments/all | tr -d ' \n\r\t')
+    # Guarded like the smoke captures: a transient API failure here should fail
+    # this assertion, not kill the stage before it can report or dump logs.
+    ENVIRONMENTS=$(octopus_api /api/environments/all | tr -d ' \n\r\t') || ENVIRONMENTS=""
     if [[ "$ENVIRONMENTS" == *'"Name":"Development"'* ]]; then
         pass "Development environment exists"
     else
@@ -846,7 +910,7 @@ if [[ $SKIP_E2E -eq 0 ]]; then
     else
         # Registration is the first thing the entrypoint does, so both machines
         # should appear in the API well before the health check runs.
-        if wait_for "Tentacle registration" 420 both_registered; then
+        if wait_for "Tentacle registration" 420 both_registered "$E2E_LISTENING" "$E2E_POLLING"; then
             pass "both Tentacles registered with the Octopus Server"
         else
             fail "both Tentacles registered with the Octopus Server"
@@ -854,7 +918,7 @@ if [[ $SKIP_E2E -eq 0 ]]; then
             dump_logs "$E2E_POLLING"
         fi
 
-        MACHINES=$(machines_json)
+        MACHINES=$(machines_json) || MACHINES=""
 
         # Assert on each machine individually so a half-working image is obvious.
         for name in "$E2E_LISTENING" "$E2E_POLLING"; do
@@ -874,7 +938,7 @@ if [[ $SKIP_E2E -eq 0 ]]; then
         # check against it, which exercises the Halibut connection in both
         # directions - the real proof the image works.
         info "Waiting for the Octopus Server to health-check both Tentacles..."
-        if wait_for "Tentacle health checks" 600 both_healthy; then
+        if wait_for "Tentacle health checks" 600 both_healthy "$E2E_LISTENING" "$E2E_POLLING"; then
             pass "both Tentacles reported Healthy"
         else
             fail "both Tentacles reported Healthy" \
@@ -885,7 +949,7 @@ if [[ $SKIP_E2E -eq 0 ]]; then
 
         # The version the server sees comes off the wire from the Tentacle itself,
         # so this confirms the .deb inside the image is the one we just built.
-        MACHINES=$(machines_json)
+        MACHINES=$(machines_json) || MACHINES=""
         # EXPECTED_VERSION is the full FullSemVer (timestamp suffix stripped),
         # not just the numeric prefix, so this cannot pass on a coincidental
         # substring match elsewhere in the JSON.

--- a/testing/docker-linux/build-and-test-linux-docker-image.sh
+++ b/testing/docker-linux/build-and-test-linux-docker-image.sh
@@ -645,11 +645,34 @@ both_registered() {
     [[ "$json" == *"\"Name\":\"${E2E_LISTENING}\""* && "$json" == *"\"Name\":\"${E2E_POLLING}\""* ]]
 }
 
+# machine_health <machines-json> <name> - the HealthStatus of the machine
+# registered under <name>, or empty if there is no such machine.
+#
+# The payload is split into one line per machine before matching, so the status
+# read back belongs to that machine. Counting '"HealthStatus"' across the whole
+# payload instead - as this used to - would accept one healthy Tentacle plus any
+# second healthy record while the other Tentacle was still unhealthy.
+#
+# Name and HealthStatus both appear near the top of a machine resource, ahead of
+# the nested Endpoint and Links objects, so splitting on '},{' keeps the two
+# together. awk does the split rather than sed, whose replacement-side '\n' is
+# not portable to the BSD sed on macOS.
+machine_health() {
+    printf '%s' "$1" \
+        | awk '{ gsub(/\},\{/, "}\n{"); print }' \
+        | grep -F "\"Name\":\"$2\"" \
+        | sed -n 's/.*"HealthStatus":"\([A-Za-z]*\)".*/\1/p'
+}
+
 both_healthy() {
-    local json count
+    local json status name
     json=$(machines_json) || return 1
-    count=$(printf '%s' "$json" | grep -o '"HealthStatus":"\(Healthy\|HasWarnings\)"' | wc -l)
-    (( count >= 2 ))
+    for name in "$E2E_LISTENING" "$E2E_POLLING"; do
+        # grep exits non-zero when the machine is not there yet; under pipefail
+        # that fails the substitution, so normalise it to an empty status.
+        status=$(machine_health "$json" "$name") || status=""
+        [[ "$status" == "Healthy" || "$status" == "HasWarnings" ]] || return 1
+    done
 }
 
 if [[ $SKIP_E2E -eq 0 ]]; then


### PR DESCRIPTION
# Summary (Tod-written)

Moves `docker/linux/Dockerfile` from `debian:11-slim` to `ubuntu:22.04`.

This fixes the broken `Build: Linux Docker image` and anything else that depends on that Dockerfile.

This (IMHO) is a breaking change (i.e. who knows who is depending on Tentacle having something Debian 11 specific that isn't included in Ubuntu 22.04 e.g. `libssl1.1` so we need to rev the major version, which I will do as part of the merge commit).

Tests still broken in this PR are fixed in the next (stacked) PR: https://github.com/OctopusDeploy/OctopusTentacle/pull/1293.

Fixes: https://github.com/OctopusDeploy/OctopusTentacle/issues/1294.

## Why Ubuntu 22.04 specifically

22.04 is deliberate, for two reasons:

1. **It is the smallest possible move off Debian 11.** Jammy is the closest still-supported distro to bullseye, and the whole change came to three ABI-versioned package names (`libgcc1` -> `libgcc-s1`, `libicu67` -> `libicu70`, `libssl1.1` -> `libssl3`) plus repointing Docker's apt repo at `/linux/ubuntu`. Nothing in the `.deb`, the entrypoint scripts or the image's behaviour had to change with it.
2. **Staying on Debian isn't an option.** The Developer Experience team will not be providing Debian 12 or Debian 13 build agents, so a Debian 12 base - which is where the earlier EFT-3311 spike went, and what `docker/kubernetes-agent-tentacle/Dockerfile` already uses via `runtime-deps:8.0-bookworm-slim` - would leave the Linux image on a distro we can't build on.

Ubuntu 24.04 is the eventual destination (it costs `libicu70` -> `libicu74`), but there's no 24.04 build agent yet either, so that's a follow-up rather than part of this.

## Why the runtime dependency list shrank

`libc6`, `libgcc-s1`, `libgssapi-krb5-2`, `libstdc++6` and `zlib1g` were dropped from the first `apt-get install`. `ubuntu:22.04` already ships all five at the newest version jammy offers, so naming them installed nothing.

`ca-certificates`, `libicu70` and `libssl3` stay, and the reason differs for each: the first two are genuinely absent from the base image, while `libssl3` **is** in the base but at `3.0.2-0ubuntu1.26` when jammy-security has `3.0.2-0ubuntu1.29`. Naming `libssl3` is precisely what pulls that security update in, so dropping it as "already present" would have shipped an unpatched OpenSSL. That distinction, and the warning that a no-op today stops being one as soon as the base image lags behind jammy-security, is now written into the Dockerfile so the list doesn't get "tidied" again by mistake.

The smoke tests still assert all eight packages are present in the built image regardless of what installed them, so a future base that stops shipping one of them fails there rather than at runtime.

# Details (Claude-authored)

Moves `docker/linux/Dockerfile` to `ubuntu:22.04`. The base image swap alone doesn't build — two Debian-specific things had to change with it.

## Not a one-line change

1. **Package names were bullseye-specific.** `libicu67` and `libssl1.1` don't exist on jammy at all — the build failed with `E: Couldn't find any package by regex 'libssl1.1'`. Now `libicu70` and `libssl3`, plus `libgcc1` → `libgcc-s1` (`libgcc1` survives on jammy only as a transitional dummy). The `.deb`'s own dependency line already accepts `libssl3`, so no packaging change was needed.
2. **`install-docker.sh` pointed at the Debian apt repo.** `lsb_release -cs` now returns `jammy`, and there's no such suite under `download.docker.com/linux/debian` — confirmed `404 Not Found` → `E: The repository ... does not have a Release file`. Since that script runs `set -eux`, docker-in-docker would have failed to install. Repointed at `/linux/ubuntu`.

Both failures would have gone red in `Build: Linux Docker image`, so CI would have caught them — but only at build time, which is the gap the script below closes.

## Verification

The Linux image is built in TeamCity, not by NUKE here, so there was no local way to check a Dockerfile change short of pushing. `testing/docker-linux/build-and-test-linux-docker-image.sh` (added here) reproduces that chain and tests the result — **50/50 passing**:

| Stage | What |
|---|---|
| deb | `PackDebianPackage`, linux-x64 only |
| image | the same `docker-compose.build.yml` command TeamCity runs |
| smoke | 40 assertions: base image, runtime deps, dind, apt source and keyring, entrypoint guards, labels |
| e2e | SQL Server + Octopus Server + a listening and a polling Tentacle from the fresh image |

The e2e stage registers both Tentacles, asserts `TentaclePassive`/`TentacleActive`, waits for health checks, and confirms the server reads the built version off the wire. Registration in 15s, health in 5s.

Confirmed in the image: Ubuntu 22.04.5 LTS, OpenSSL 3.0.2, `tentacle` and `dockerd` both working.

Worth knowing: there is a `Test: Windows Docker Image` config in TeamCity but **no Linux equivalent** — `Build: Linux Docker image` feeds straight into `Build: Docker manifest` with nothing starting a container. So build-time regressions are covered today; runtime ones are not. Wiring this script in is a sensible follow-up.

## Secret handling in the test script

- An unlicensed Octopus Server allows **0 targets**, so the e2e stage needs a licence. It reads `OCTOPUS_SERVER_BASE64_LICENSE`, else the same 1Password item `./environment.sh setup` uses — and only when stdin is a TTY, since `op` can't prompt in CI or under an agent. `--no-1password` is a hard override. Without a licence the stage falls back to asserting configuration and connectivity up to the licence refusal.
- The SQL SA and Octopus admin passwords are **generated per run** (20 chars, `[A-Za-z0-9]`), not hardcoded. Alphanumeric because the value lands in a SQL connection string, a `sqlcmd -P` argument and a JSON body; one upper, one lower and one digit are guaranteed rather than left to chance, since SQL Server's SA policy needs three of its four categories.
- **Every secret reaches its container via a `0600 --env-file`, never `-e`**, so none appear in `ps`. One file per consumer. The licence is additionally scrubbed from dumped container logs, because the server image logs its own `--licenseBase64` invocation.

## Notes for review

- Running stage 1 dirties `Product.wxs` and `.nuke/build.schema.json` — NUKE side-effects, noted in the script header.
- **Docker repository setup brought in line with [Docker's Ubuntu docs](https://docs.docker.com/engine/install/ubuntu/), and three packages dropped.** The armoured key now lives at `/etc/apt/keyrings/docker.asc` and is referenced from a deb822 `.sources` file rather than a one-line `.list`. That let `apt-transport-https` go (a transitional stub on jammy; apt 2.4 ships the `https` method itself), `gnupg` go (only ever needed for `gpg --dearmor` — apt reads the armoured key directly and verifies it with `gpgv`, which apt depends on), and `lsb-release` go (replaced by `/etc/os-release`). Verified against a bare `ubuntu:22.04` with only `ca-certificates` and `curl` added: InRelease fetched and verified, `docker-ce` resolvable, zero apt warnings. Image 1.17 GB → 1.16 GB, 213 packages. Note Python 3.10 stays regardless — it arrives via `networkd-dispatcher` in `docker-ce`'s apparmor chain, not via `lsb-release`.
- **`iproute2` added.** `dockerd` does not need it — confirmed by running the image `--privileged`, where the daemon starts, reports no missing binaries and runs a nested container without it. But `dockerd-entrypoint.sh` uses `ip` in `_tls_san`, and without it a dind TLS certificate is issued with DNS SANs only (measured: `DNS:docker,DNS:<hostname>,DNS:localhost`, against `…,IP:127.0.0.1,IP:172.17.0.2,IP:::1` with it), so a client connecting to the daemon by IP fails hostname verification. Upstream `docker:dind` ships it for the same reason.
- The buildx and compose plugins still arrive via `docker-ce-cli` Recommends (verified present: buildx v0.37.0, compose v5.5.1).
- **Dead code removed:** `install-docker.sh` had `if [ iptables -nL > /dev/null 2>&1 ]`, which is `test` comparing two literal strings rather than running the command — it fails with "unary operator expected" (exit 2), so the `iptables-legacy` branch was unreachable and nft has always been selected. The conditional and its dead branch are now deleted and nft is set unconditionally, which is a **no-op at runtime** and gets shellcheck to parse the file again (it was erroring with SC1073/SC1072 and bailing out mid-file). Actually selecting legacy would flip dind's firewall backend and still needs its own testing, so that is untouched.
- `apt install ./tentacle_*.deb` is now `apt-get install -y --no-install-recommends ./tentacle_*.deb`. Without `-y`, apt aborts (`Do you want to continue? [Y/n] Abort.`, exit 1) the moment the `.deb` needs a dependency the earlier layers didn't already install — the exact invariant this base-image change moves. It also drops apt's "does not have a stable CLI interface" warning from the build log.

## Follow-ups raised

- **LEV-1833** — add a TeamCity `Test: Linux Docker Image` configuration that runs this script, so runtime regressions in the image are caught rather than shipped. Probing the image for this PR also disproved the script's own assumption that privileged dind cannot run under emulation: `dockerd` came up (29.8.0, overlayfs) and ran a nested container, so asserting "the daemon starts and can run a container" is both feasible and the highest-value assertion missing today. The `iproute2` gap above went unnoticed precisely because nothing exercises dind.
- **LEV-1834** — stop hand-maintaining ABI-pinned runtime dependency names, by moving to `mcr.microsoft.com/dotnet/runtime-deps` as `docker/kubernetes-agent-tentacle/Dockerfile` already does. Deliberately not done here: it needs the whole dind payload re-verified on a new base, and it depends on LEV-1833 for anything better than hand-verification.

## CI status

The three red integration-test checks are **not from this change** — `Build: Linux Docker image` passes:

- `Integration Test: Linux (not sudo)` — 38 tests failing with Tentacle child processes aborting (SIGABRT). Also failing on `refs/heads/main` (main-nightly `24129127`) and on unrelated PRs #1187 and #1285. Last green main was 6 Sep; this branch's first build already carried all 38.
- `Integration Test: Windows` — all 861 tests pass, the Nuke step exits 1. The three prior builds of this branch were green. Flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


