### PR TITLE
Checking certificate

### DIFF
--- a/source/Octopus.Tentacle.Tests/Commands/RegisterKubernetesDeploymentTargetCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterKubernetesDeploymentTargetCommandFixture.cs
@@ -67,7 +67,8 @@ namespace Octopus.Tentacle.Tests.Commands
                                                  new ProxyConfigParser(),
                                                  octopusClientInitializer,
                                                  new SpaceRepositoryFactory(),
-                                                 Substitute.For<ILogFileOnlyLogger>());
+                                                 Substitute.For<ILogFileOnlyLogger>(),
+                                                 Substitute.For<IServerCertificateTrustConfirmation>());
 
             configuration.ServicesPortNumber.Returns(90210);
             certificate = new CertificateGenerator(new NullLog()).GenerateNew("CN=Hello");

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterKubernetesWorkerCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterKubernetesWorkerCommandFixture.cs
@@ -69,7 +69,8 @@ namespace Octopus.Tentacle.Tests.Commands
                 new ProxyConfigParser(),
                 octopusClientInitializer,
                 new SpaceRepositoryFactory(),
-                Substitute.For<ILogFileOnlyLogger>());
+                Substitute.For<ILogFileOnlyLogger>(),
+                Substitute.For<IServerCertificateTrustConfirmation>());
 
             configuration.ServicesPortNumber.Returns(90210);
             certificate = new CertificateGenerator(new NullLog()).GenerateNew("CN=Hello");

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterMachineCommandFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,12 +21,16 @@ using Octopus.Tentacle.Configuration.Instances;
 using Octopus.Tentacle.Core.Diagnostics;
 using Octopus.Tentacle.Diagnostics;
 using Octopus.Tentacle.Startup;
+using Octopus.Tentacle.Tests.Support.TestAttributes;
 
 namespace Octopus.Tentacle.Tests.Commands
 {
     [TestFixture]
     public class RegisterMachineCommandFixture : CommandFixture<RegisterMachineCommand>
     {
+        const string WebSocketAddress = "wss://polling.localhost/OctopusComms";
+        const string WebSocketSslThumbprint = "76B1C4A6F1E2B3C4D5E6F708192A3B4C5D6E7F80";
+        
         IWritableTentacleConfiguration configuration;
         ISystemLog log;
         X509Certificate2 certificate;
@@ -33,6 +38,7 @@ namespace Octopus.Tentacle.Tests.Commands
         IOctopusServerChecker serverChecker;
         IOctopusAsyncRepository repository;
         string serverThumbprint;
+        IPrompt trustPrompt;
 
         [SetUp]
         public void BeforeEachTest()
@@ -42,6 +48,11 @@ namespace Octopus.Tentacle.Tests.Commands
             operation = Substitute.For<IRegisterMachineOperation>();
             serverChecker = Substitute.For<IOctopusServerChecker>();
             log = Substitute.For<ISystemLog>();
+
+            // Assume an operator is present and says yes, unless an individual test decides otherwise.
+            trustPrompt = Substitute.For<IPrompt>();
+            trustPrompt.CanPrompt.Returns(true);
+            trustPrompt.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
             var octopusClientInitializer = Substitute.For<IOctopusClientInitializer>();
             var octopusAsyncClient = Substitute.For<IOctopusAsyncClient>();
 
@@ -68,7 +79,8 @@ namespace Octopus.Tentacle.Tests.Commands
                                                  new ProxyConfigParser(),
                                                  octopusClientInitializer,
                                                  new SpaceRepositoryFactory(),
-                                                 Substitute.For<ILogFileOnlyLogger>());
+                                                 Substitute.For<ILogFileOnlyLogger>(),
+                                                 new ServerCertificateTrustConfirmation(log, trustPrompt));
 
             configuration.ServicesPortNumber.Returns(90210);
             certificate = new CertificateGenerator(new NullLog()).GenerateNew("CN=Hello");
@@ -222,6 +234,80 @@ namespace Octopus.Tentacle.Tests.Commands
         }
 
         [Test]
+        [WindowsTest]
+        public void ShouldTrustAWebSocketServerWhoseCertificateValidates()
+        {
+            StartWebSocketRegistration(SslPolicyErrors.None);
+
+            trustPrompt.DidNotReceiveWithAnyArgs().Confirm(default!, default!);
+
+            configuration.Received().AddOrUpdateTrustedOctopusServer(
+                Arg.Is<OctopusServerConfiguration>(x => x.Thumbprint == WebSocketSslThumbprint &&
+                    x.CommunicationStyle == CommunicationStyle.TentacleActive));
+        }
+
+        [Test]
+        [WindowsTest]
+        public void ShouldNotTrustAWebSocketServerWhoseCertificateFailsValidationWhenTheOperatorDeclines()
+        {
+            trustPrompt.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+
+            Assert.Throws<ControlledFailureException>(() => StartWebSocketRegistration(SslPolicyErrors.RemoteCertificateChainErrors));
+
+            configuration.DidNotReceiveWithAnyArgs().AddOrUpdateTrustedOctopusServer(default!);
+            operation.DidNotReceive().ExecuteAsync(repository);
+        }
+
+        [Test]
+        [WindowsTest]
+        public void ShouldNotTrustAWebSocketServerWhoseCertificateFailsValidationWhenNobodyCanBeAsked()
+        {
+            trustPrompt.CanPrompt.Returns(false);
+
+            Assert.Throws<ControlledFailureException>(() => StartWebSocketRegistration(SslPolicyErrors.RemoteCertificateChainErrors));
+
+            configuration.DidNotReceiveWithAnyArgs().AddOrUpdateTrustedOctopusServer(default!);
+        }
+
+        [Test]
+        [WindowsTest]
+        public void ShouldTrustAWebSocketServerWhoseCertificateFailsValidationWhenItsThumbprintWasSuppliedUpFront()
+        {
+            StartWebSocketRegistration(SslPolicyErrors.RemoteCertificateChainErrors,
+                $"--server-web-socket-thumbprint={WebSocketSslThumbprint}");
+
+            trustPrompt.DidNotReceiveWithAnyArgs().Confirm(default!, default!);
+
+            configuration.Received().AddOrUpdateTrustedOctopusServer(
+                Arg.Is<OctopusServerConfiguration>(x => x.Thumbprint == WebSocketSslThumbprint));
+        }
+
+        [Test]
+        [WindowsTest]
+        public void ShouldNotTrustAWebSocketServerWhoseCertificateDoesNotMatchTheSuppliedThumbprint()
+        {
+            Assert.Throws<ControlledFailureException>(() => StartWebSocketRegistration(SslPolicyErrors.None,
+                "--server-web-socket-thumbprint=0123456789ABCDEF0123456789ABCDEF01234567"));
+
+            configuration.DidNotReceiveWithAnyArgs().AddOrUpdateTrustedOctopusServer(default!);
+        }
+
+        [Test]
+        public void ShouldRejectAServerWebSocketThumbprintWithoutAServerWebSocketAddress()
+        {
+            var ex = Assert.Throws<ControlledFailureException>(() => Start("--env=Development",
+                "--server=http://localhost",
+                "--name=MyMachine",
+                "--apiKey=ABC123",
+                "--force",
+                "--role=app-server",
+                "--comms-style=TentacleActive",
+                $"--server-web-socket-thumbprint={WebSocketSslThumbprint}"));
+
+            ex!.Message.Should().Be("Option --server-web-socket-thumbprint can only be used with --server-web-socket.");
+        }
+
+        [Test]
         public void ShouldReuseSubscriptionIdForPollingTentacleIfReRegistering()
         {
             var subscriptionId = "poll://xz6h25sh28shx52/";
@@ -330,6 +416,26 @@ namespace Octopus.Tentacle.Tests.Commands
                 "--server-subscription-id=https://xz6h25sh28shx52/"
             ));
             ex.Message.Should().Be("The ServerSubscriptionId must start with poll://");
+        }
+        
+        void StartWebSocketRegistration(SslPolicyErrors certificateErrors, params string[] additionalArgs)
+        {
+            serverChecker.CheckServerCommunicationsIsOpen(Arg.Any<Uri>(), Arg.Any<IWebProxy>())
+                .Returns(new OctopusServerCommunicationsCheckResult(WebSocketSslThumbprint, certificateErrors));
+
+            var args = new[]
+            {
+                "--env=Development",
+                "--server=http://localhost",
+                "--name=MyMachine",
+                "--apiKey=ABC123",
+                "--force",
+                "--role=app-server",
+                "--comms-style=TentacleActive",
+                $"--server-web-socket={WebSocketAddress}"
+            };
+
+            Start(args.Concat(additionalArgs).ToArray());
         }
     }
 }

--- a/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Commands/RegisterWorkerCommandFixture.cs
@@ -70,7 +70,8 @@ namespace Octopus.Tentacle.Tests.Commands
                 new ProxyConfigParser(),
                 octopusClientInitializer,
                 new SpaceRepositoryFactory(),
-                Substitute.For<ILogFileOnlyLogger>());
+                Substitute.For<ILogFileOnlyLogger>(),
+                Substitute.For<IServerCertificateTrustConfirmation>());
 
             configuration.ServicesPortNumber.Returns(90210);
             certificate = new CertificateGenerator(new NullLog()).GenerateNew("CN=Hello");

--- a/source/Octopus.Tentacle.Tests/Communications/ServerCertificateTrustConfirmationFixture.cs
+++ b/source/Octopus.Tentacle.Tests/Communications/ServerCertificateTrustConfirmationFixture.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Net.Security;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Octopus.Tentacle.Communications;
+using Octopus.Tentacle.Core.Diagnostics;
+
+namespace Octopus.Tentacle.Tests.Communications
+{
+    [TestFixture]
+    public class ServerCertificateTrustConfirmationFixture
+    {
+        const string Thumbprint = "76B1C4A6F1E2B3C4D5E6F708192A3B4C5D6E7F80";
+
+        static readonly Uri ServerAddress = new("wss://octopus.example.com/OctopusComms");
+
+        ISystemLog log;
+        IPrompt prompt;
+        ServerCertificateTrustConfirmation confirmation;
+
+        [SetUp]
+        public void BeforeEachTest()
+        {
+            log = Substitute.For<ISystemLog>();
+            prompt = Substitute.For<IPrompt>();
+            confirmation = new ServerCertificateTrustConfirmation(log, prompt);
+        }
+
+        static OctopusServerCommunicationsCheckResult Validated() => new(Thumbprint, SslPolicyErrors.None);
+
+        static OctopusServerCommunicationsCheckResult NotValidated(SslPolicyErrors errors = SslPolicyErrors.RemoteCertificateChainErrors) => new(Thumbprint, errors);
+
+        [Test]
+        public void ACertificateThatPassedValidationIsTrustedWithoutAskingTheOperator()
+        {
+            confirmation.Invoking(c => c.EnsureCertificateIsTrusted(ServerAddress, Validated(), null))
+                .Should()
+                .NotThrow();
+
+            prompt.DidNotReceiveWithAnyArgs().Confirm(default!, default!);
+            _ = prompt.DidNotReceive().CanPrompt;
+        }
+
+        [Test]
+        public void ACertificateThatFailedValidationIsTrustedWithoutPromptingWhenItsThumbprintWasSuppliedUpFront()
+        {
+            confirmation.Invoking(c => c.EnsureCertificateIsTrusted(ServerAddress, NotValidated(), Thumbprint))
+                .Should()
+                .NotThrow();
+
+            prompt.DidNotReceiveWithAnyArgs().Confirm(default!, default!);
+            _ = prompt.DidNotReceive().CanPrompt;
+        }
+
+        [TestCase("76b1c4a6f1e2b3c4d5e6f708192a3b4c5d6e7f80", TestName = "DifferentCasing")]
+        [TestCase("  76B1C4A6F1E2B3C4D5E6F708192A3B4C5D6E7F80  ", TestName = "SurroundingWhitespace")]
+        public void ASuppliedThumbprintIsMatchedLeniently(string suppliedThumbprint)
+        {
+            confirmation.Invoking(c => c.EnsureCertificateIsTrusted(ServerAddress, NotValidated(), suppliedThumbprint))
+                .Should()
+                .NotThrow();
+
+            prompt.DidNotReceiveWithAnyArgs().Confirm(default!, default!);
+        }
+
+        [Test]
+        public void ACertificateIsRejectedWhenItsThumbprintDoesNotMatchTheOneSupplied()
+        {
+            prompt.CanPrompt.Returns(true);
+            prompt.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+
+            const string someOtherThumbprint = "0123456789ABCDEF0123456789ABCDEF01234567";
+
+            confirmation.Invoking(c => c.EnsureCertificateIsTrusted(ServerAddress, NotValidated(), someOtherThumbprint))
+                .Should()
+                .Throw<ControlledFailureException>()
+                .Where(e => e.Message.Contains(Thumbprint), "the operator needs to see what was actually presented")
+                .Where(e => e.Message.Contains(someOtherThumbprint), "and what they asked for");
+
+            prompt.DidNotReceiveWithAnyArgs().Confirm(default!, default!);
+        }
+
+        [Test]
+        public void AValidCertificateIsStillRejectedWhenItsThumbprintDoesNotMatchTheOneSupplied()
+        {
+            confirmation.Invoking(c => c.EnsureCertificateIsTrusted(ServerAddress, Validated(), "0123456789ABCDEF0123456789ABCDEF01234567"))
+                .Should()
+                .Throw<ControlledFailureException>();
+        }
+
+        [Test]
+        public void ACertificateThatFailedValidationIsRejectedWhenThereIsNobodyToAsk()
+        {
+            prompt.CanPrompt.Returns(false);
+
+            confirmation.Invoking(c => c.EnsureCertificateIsTrusted(ServerAddress, NotValidated(), null))
+                .Should()
+                .Throw<ControlledFailureException>()
+                .Where(e => e.Message.Contains(Thumbprint), "the operator needs to know which thumbprint to verify")
+                .Where(e => e.Message.Contains("--server-web-socket-thumbprint"), "the message has to say how to proceed deliberately")
+                .Where(e => e.Message.Contains("not the Octopus Server's Tentacle Communications certificate"),
+                    "the websocket endpoint's certificate is configured in IIS/HTTP.SYS/a reverse proxy, so sending the operator to the thumbprint in the Octopus Server UI would send them to a value that can never match");
+
+            prompt.DidNotReceiveWithAnyArgs().Confirm(default!, default!);
+        }
+
+        [Test]
+        public void ACertificateThatFailedValidationIsTrustedWhenTheOperatorConfirmsIt()
+        {
+            prompt.CanPrompt.Returns(true);
+            prompt.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+
+            confirmation.Invoking(c => c.EnsureCertificateIsTrusted(ServerAddress, NotValidated(), null))
+                .Should()
+                .NotThrow();
+
+            prompt.Received().Confirm(
+                Arg.Is<string>(m => m.Contains(Thumbprint) && m.Contains("websockets certificate")),
+                Arg.Any<string>());
+        }
+
+        [Test]
+        public void ACertificateThatFailedValidationIsRejectedWhenTheOperatorDeclinesIt()
+        {
+            prompt.CanPrompt.Returns(true);
+            prompt.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+
+            confirmation.Invoking(c => c.EnsureCertificateIsTrusted(ServerAddress, NotValidated(), null))
+                .Should()
+                .Throw<ControlledFailureException>();
+        }
+
+        [TestCase(SslPolicyErrors.RemoteCertificateChainErrors)]
+        [TestCase(SslPolicyErrors.RemoteCertificateNameMismatch)]
+        [TestCase(SslPolicyErrors.RemoteCertificateNotAvailable)]
+        [TestCase(SslPolicyErrors.RemoteCertificateChainErrors | SslPolicyErrors.RemoteCertificateNameMismatch)]
+        public void EveryKindOfValidationFailureRequiresConfirmation(SslPolicyErrors errors)
+        {
+            prompt.CanPrompt.Returns(true);
+            prompt.Confirm(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+
+            confirmation.Invoking(c => c.EnsureCertificateIsTrusted(ServerAddress, NotValidated(errors), null))
+                .Should()
+                .Throw<ControlledFailureException>();
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Commands/PollCommand.cs
+++ b/source/Octopus.Tentacle/Commands/PollCommand.cs
@@ -24,11 +24,13 @@ namespace Octopus.Tentacle.Commands
         readonly IOctopusClientInitializer octopusClientInitializer;
         readonly ISystemLog log;
         readonly IApplicationInstanceSelector selector;
+        readonly IServerCertificateTrustConfirmation serverCertificateTrustConfirmation;
         readonly ApiEndpointOptions api;
         int? serverCommsPort = null;
         string serverWebSocketAddress = null!;
         string serverCommsAddress = null!;
         bool reuseThumbprint;
+        string? serverWebSocketThumbprint;
 
         public PollCommand(Lazy<IWritableTentacleConfiguration> configuration,
                            ISystemLog log,
@@ -36,7 +38,8 @@ namespace Octopus.Tentacle.Commands
                            Lazy<IOctopusServerChecker> octopusServerChecker,
                            IProxyConfigParser proxyConfig,
                            IOctopusClientInitializer octopusClientInitializer,
-                           ILogFileOnlyLogger logFileOnlyLogger)
+                           ILogFileOnlyLogger logFileOnlyLogger,
+                           IServerCertificateTrustConfirmation serverCertificateTrustConfirmation)
             : base(selector, log, logFileOnlyLogger)
         {
             this.configuration = configuration;
@@ -45,6 +48,7 @@ namespace Octopus.Tentacle.Commands
             this.octopusClientInitializer = octopusClientInitializer;
             this.log = log;
             this.selector = selector;
+            this.serverCertificateTrustConfirmation = serverCertificateTrustConfirmation;
 
             // purposefully not adding this with AddOptionSet because
             // we only want to validate it if reuseThumbprint is false.
@@ -54,6 +58,7 @@ namespace Octopus.Tentacle.Commands
             Options.Add("server-comms-port=", "The comms port on the Octopus Server; the default is " + DefaultServerCommsPort + ". If specified, this will take precedence over any port number in server-comms-address.", s => serverCommsPort = int.Parse(s));
             Options.Add("server-web-socket=", "When using active communication over websockets, the address of the Octopus Server, eg 'wss://example.com/OctopusComms'. Refer to http://g.octopushq.com/WebSocketComms", s => serverWebSocketAddress = s);
             Options.Add("reuse-server-thumbprint", "Reuse the Server Thumbprint from the first trusted server instance currently configured", _ => reuseThumbprint = true);
+            Options.Add("server-web-socket-thumbprint=", "When using active communication over websockets, the thumbprint of your server's websockets certificate, eg 'AB1C2D...'. This is the SSL certificate configured wherever TLS is terminated for the websockets endpoint, not the Octopus Server's Tentacle Communications certificate. When supplied the certificate is trusted only if its thumbprint matches, which allows registering against an endpoint whose certificate cannot otherwise be validated (for example a self-signed certificate) without prompting.", s => serverWebSocketThumbprint = s);
         }
 
         protected override void Start()
@@ -68,9 +73,16 @@ namespace Octopus.Tentacle.Commands
             {
                 api.Validate();
             }
+            else if (!string.IsNullOrWhiteSpace(serverWebSocketThumbprint))
+            {
+                throw new ControlledFailureException("Option --server-web-socket-thumbprint cannot be used with --reuse-server-thumbprint, which takes the thumbprint from an already trusted server instead of checking the one the server presents.");
+            }
 
             if (!string.IsNullOrEmpty(serverWebSocketAddress) && !string.IsNullOrEmpty(serverCommsAddress))
                 throw new ControlledFailureException("Please specify a --server-web-socket, or a --server-comms-address - not both.");
+
+            if (!string.IsNullOrWhiteSpace(serverWebSocketThumbprint) && string.IsNullOrWhiteSpace(serverWebSocketAddress))
+                throw new ControlledFailureException("Option --server-web-socket-thumbprint can only be used with --server-web-socket.");
 
             var serverAddress = GetAddress();
 
@@ -100,7 +112,7 @@ namespace Octopus.Tentacle.Commands
             //if we are on a polling tentacle with a polling proxy set up, use the api through that proxy
             var proxyOverride = proxyConfig.ParseToWebProxy(configuration.Value.PollingProxyConfiguration);
 
-            var sslThumbprint = octopusServerChecker.Value.CheckServerCommunicationsIsOpen(serverAddress, proxyOverride);
+            var serverCheckResult = octopusServerChecker.Value.CheckServerCommunicationsIsOpen(serverAddress, proxyOverride);
 
             log.Info($"Configuring Tentacle to poll the server at {api.ServerUri}");
 
@@ -108,7 +120,7 @@ namespace Octopus.Tentacle.Commands
 
             var repository = new OctopusAsyncRepository(client);
 
-            var serverThumbprint = await GetServerThumbprint(repository, serverAddress, sslThumbprint);
+            var serverThumbprint = await GetServerThumbprint(repository, serverAddress, serverCheckResult);
 
             var alreadyConfiguredServerInCluster = GetAlreadyConfiguredServerInCluster(serverThumbprint);
 
@@ -148,14 +160,17 @@ namespace Octopus.Tentacle.Commands
             return pollingServerConfiguration;
         }
 
-        async Task<string> GetServerThumbprint(IOctopusAsyncRepository repository, Uri serverAddress, string sslThumbprint)
+        async Task<string> GetServerThumbprint(IOctopusAsyncRepository repository, Uri serverAddress, OctopusServerCommunicationsCheckResult serverCheckResult)
         {
             if (serverAddress != null && ServiceEndPoint.IsWebSocketAddress(serverAddress))
             {
-                if (sslThumbprint == null)
-                    throw new ControlledFailureException($"Could not determine thumbprint of the SSL Certificate at {serverAddress}");
-                return sslThumbprint;
+                serverCertificateTrustConfirmation.EnsureCertificateIsTrusted(serverAddress, serverCheckResult, serverWebSocketThumbprint);
+
+                return serverCheckResult.Thumbprint;
             }
+
+            // Every other address takes its thumbprint from the authenticated Octopus API rather than from the probe,
+            // so there is nothing here for the operator to vouch for.
             return (await repository.CertificateConfiguration.GetOctopusCertificate()).Thumbprint;
         }
 

--- a/source/Octopus.Tentacle/Commands/RegisterKubernetesClusterCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterKubernetesClusterCommand.cs
@@ -16,7 +16,7 @@ namespace Octopus.Tentacle.Commands
         readonly ISystemLog log;
         string? defaultNamespace;
 
-        public RegisterKubernetesClusterCommand(Lazy<IRegisterKubernetesClusterOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger)
+        public RegisterKubernetesClusterCommand(Lazy<IRegisterKubernetesClusterOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger, IServerCertificateTrustConfirmation serverCertificateTrustConfirmation) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger, serverCertificateTrustConfirmation)
         {
             this.configuration = configuration;
             this.log = log;

--- a/source/Octopus.Tentacle/Commands/RegisterKubernetesDeploymentTargetCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterKubernetesDeploymentTargetCommand.cs
@@ -15,7 +15,7 @@ namespace Octopus.Tentacle.Commands
         readonly ISystemLog log;
         string? defaultNamespace;
 
-        public RegisterKubernetesDeploymentTargetCommand(Lazy<IRegisterKubernetesDeploymentTargetOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger)
+        public RegisterKubernetesDeploymentTargetCommand(Lazy<IRegisterKubernetesDeploymentTargetOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger, IServerCertificateTrustConfirmation serverCertificateTrustConfirmation) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger, serverCertificateTrustConfirmation)
         {
             this.configuration = configuration;
             this.log = log;

--- a/source/Octopus.Tentacle/Commands/RegisterKubernetesWorkerCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterKubernetesWorkerCommand.cs
@@ -14,7 +14,7 @@ namespace Octopus.Tentacle.Commands
         readonly Lazy<IWritableTentacleConfiguration> configuration;
         readonly ISystemLog log;
 
-        public RegisterKubernetesWorkerCommand(Lazy<IRegisterKubernetesWorkerOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger)
+        public RegisterKubernetesWorkerCommand(Lazy<IRegisterKubernetesWorkerOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger, IServerCertificateTrustConfirmation serverCertificateTrustConfirmation) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger, serverCertificateTrustConfirmation)
         {
             this.configuration = configuration;
             this.log = log;

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommand.cs
@@ -16,7 +16,7 @@ namespace Octopus.Tentacle.Commands
 {
     public class RegisterMachineCommand : RegisterMachineCommand<IRegisterMachineOperation>
     {
-        public RegisterMachineCommand(Lazy<IRegisterMachineOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger)
+        public RegisterMachineCommand(Lazy<IRegisterMachineOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger, IServerCertificateTrustConfirmation serverCertificateTrustConfirmation) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger, serverCertificateTrustConfirmation)
         {
         }
     }
@@ -37,8 +37,9 @@ namespace Octopus.Tentacle.Commands
                                       IProxyConfigParser proxyConfig,
                                       IOctopusClientInitializer octopusClientInitializer,
                                       ISpaceRepositoryFactory spaceRepositoryFactory,
-                                      ILogFileOnlyLogger logFileOnlyLogger)
-            : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger)
+                                      ILogFileOnlyLogger logFileOnlyLogger,
+                                      IServerCertificateTrustConfirmation serverCertificateTrustConfirmation)
+            : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger, serverCertificateTrustConfirmation)
         {
             Options.Add("env|environment=", "The environment name, slug or Id to add the machine to - e.g., 'Production'; specify this argument multiple times to add multiple environments", s => environments.Add(s));
             Options.Add("r|role=", "The machine role that the machine will assume - e.g., 'web-server'; specify this argument multiple times to add multiple roles", s => roles.Add(s));

--- a/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterMachineCommandBase.cs
@@ -29,6 +29,7 @@ namespace Octopus.Tentacle.Commands
         readonly IProxyConfigParser proxyConfig;
         readonly IOctopusClientInitializer octopusClientInitializer;
         readonly ISpaceRepositoryFactory spaceRepositoryFactory;
+        readonly IServerCertificateTrustConfirmation serverCertificateTrustConfirmation;
 
         readonly ISystemLog log;
         readonly ApiEndpointOptions api;
@@ -44,6 +45,7 @@ namespace Octopus.Tentacle.Commands
         string serverWebSocketAddress = null!;
         int? tentacleCommsPort = null;
         string? serverSubscriptionId = null!;
+        string? serverWebSocketThumbprint;
 
         public RegisterMachineCommandBase(Lazy<TRegistrationOperationType> lazyRegisterMachineOperation,
             Lazy<IWritableTentacleConfiguration> configuration,
@@ -53,7 +55,8 @@ namespace Octopus.Tentacle.Commands
             IProxyConfigParser proxyConfig,
             IOctopusClientInitializer octopusClientInitializer,
             ISpaceRepositoryFactory spaceRepositoryFactory,
-            ILogFileOnlyLogger logFileOnlyLogger)
+            ILogFileOnlyLogger logFileOnlyLogger,
+            IServerCertificateTrustConfirmation serverCertificateTrustConfirmation)
             : base(selector, log, logFileOnlyLogger)
         {
             this.lazyRegisterMachineOperation = lazyRegisterMachineOperation;
@@ -63,6 +66,7 @@ namespace Octopus.Tentacle.Commands
             this.proxyConfig = proxyConfig;
             this.octopusClientInitializer = octopusClientInitializer;
             this.spaceRepositoryFactory = spaceRepositoryFactory;
+            this.serverCertificateTrustConfirmation = serverCertificateTrustConfirmation;
 
             api = AddOptionSet(new ApiEndpointOptions(Options));
 
@@ -78,6 +82,7 @@ namespace Octopus.Tentacle.Commands
             Options.Add("server-web-socket=", "When using active communication over websockets, the address of the Octopus Server, eg 'wss://example.com/OctopusComms'. Refer to http://g.octopushq.com/WebSocketComms", s => serverWebSocketAddress = s);
             Options.Add("server-subscription-id=", "When using active communication, the subscription id is what Octopus Server uses to identify this Tentacle this must be a valid URI e.g. poll://foobar/. If not specified, a new subscription id will be generated.", s => serverSubscriptionId = s);
             Options.Add("tentacle-comms-port=", "When using passive communication, the comms port that the Octopus Server is instructed to call back on to reach this machine; defaults to the configured listening port", s => tentacleCommsPort = int.Parse(s));
+            Options.Add("server-web-socket-thumbprint=", "When using active communication over websockets, the thumbprint of your server's websockets certificate, eg 'AB1C2D...'. This is the SSL certificate configured wherever TLS is terminated for the websockets endpoint, not the Octopus Server's Tentacle Communications certificate. When supplied the certificate is trusted only if its thumbprint matches, which allows registering against an endpoint whose certificate cannot otherwise be validated (for example a self-signed certificate) without prompting.", s => serverWebSocketThumbprint = s);
         }
 
         protected override void Start()
@@ -103,6 +108,9 @@ namespace Octopus.Tentacle.Commands
             if (!string.IsNullOrEmpty(serverWebSocketAddress) && !string.IsNullOrEmpty(serverCommsAddress))
                 throw new ControlledFailureException("Please specify a --server-web-socket, or a --server-comms-address - not both.");
 
+            if (!string.IsNullOrWhiteSpace(serverWebSocketThumbprint) && string.IsNullOrWhiteSpace(serverWebSocketAddress))
+                throw new ControlledFailureException("Option --server-web-socket-thumbprint can only be used with --server-web-socket.");
+
             Uri? serverAddress = null;
 
             var useDefaultProxy = communicationStyle == CommunicationStyle.TentacleActive
@@ -111,12 +119,12 @@ namespace Octopus.Tentacle.Commands
 
             //if we are on a polling tentacle with a polling proxy set up, use the api through that proxy
             IWebProxy? proxyOverride = null;
-            string? sslThumbprint = null;
+            OctopusServerCommunicationsCheckResult? serverCheckResult = null;
             if (communicationStyle == CommunicationStyle.TentacleActive)
             {
                 serverAddress = GetActiveTentacleAddress();
                 proxyOverride = proxyConfig.ParseToWebProxy(configuration.Value.PollingProxyConfiguration);
-                sslThumbprint = octopusServerChecker.Value.CheckServerCommunicationsIsOpen(serverAddress, proxyOverride);
+                serverCheckResult = octopusServerChecker.Value.CheckServerCommunicationsIsOpen(serverAddress, proxyOverride);
             }
 
             log.Info($"Registering the tentacle with the server at {api.ServerUri}");
@@ -126,14 +134,14 @@ namespace Octopus.Tentacle.Commands
                 : await octopusClientInitializer.CreateClient(api, proxyOverride);
 
             var spaceRepository = await spaceRepositoryFactory.CreateSpaceRepository(client, spaceName);
-            await RegisterMachine(client.ForSystem(), spaceRepository, serverAddress, sslThumbprint, communicationStyle);
+            await RegisterMachine(client.ForSystem(), spaceRepository, serverAddress, serverCheckResult, communicationStyle);
         }
 
-        async Task RegisterMachine(IOctopusSystemAsyncRepository systemRepository, IOctopusSpaceAsyncRepository repository, Uri? serverAddress, string? sslThumbprint, CommunicationStyle communicationStyle)
+        async Task RegisterMachine(IOctopusSystemAsyncRepository systemRepository, IOctopusSpaceAsyncRepository repository, Uri? serverAddress, OctopusServerCommunicationsCheckResult? serverCheckResult, CommunicationStyle communicationStyle)
         {
             await ConfirmTentacleCanRegisterWithServerBasedOnItsVersion(systemRepository);
 
-            var server = new OctopusServerConfiguration(await GetServerThumbprint(systemRepository, serverAddress, sslThumbprint))
+            var server = new OctopusServerConfiguration(await GetServerThumbprint(systemRepository, serverAddress, serverCheckResult))
             {
                 Address = serverAddress!,
                 CommunicationStyle = communicationStyle
@@ -201,15 +209,22 @@ namespace Octopus.Tentacle.Commands
 
         protected abstract void EnhanceOperation(TRegistrationOperationType registerOperation);
 
-        async Task<string> GetServerThumbprint(IOctopusSystemAsyncRepository repository, Uri? serverAddress, string? sslThumbprint)
+        async Task<string> GetServerThumbprint(IOctopusSystemAsyncRepository repository, Uri? serverAddress, OctopusServerCommunicationsCheckResult? serverCheckResult)
         {
             if (serverAddress != null && ServiceEndPoint.IsWebSocketAddress(serverAddress))
             {
-                if (sslThumbprint == null)
+                if (serverCheckResult == null)
+                {
                     throw new Exception($"Could not determine thumbprint of the SSL Certificate at {serverAddress}");
-                return sslThumbprint;
+                }
+
+                serverCertificateTrustConfirmation.EnsureCertificateIsTrusted(serverAddress, serverCheckResult, serverWebSocketThumbprint);
+
+                return serverCheckResult.Thumbprint;
             }
 
+            // Every other address takes its thumbprint from the authenticated Octopus API rather than from the probe,
+            // so there is nothing here for the operator to vouch for.
             var certificate = await repository.CertificateConfiguration.GetOctopusCertificate();
             return certificate.Thumbprint;
         }

--- a/source/Octopus.Tentacle/Commands/RegisterWorkerCommand.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterWorkerCommand.cs
@@ -11,7 +11,7 @@ namespace Octopus.Tentacle.Commands
 {
     public class RegisterWorkerCommand : RegisterWorkerCommandBase<IRegisterWorkerOperation>
     {
-        public RegisterWorkerCommand(Lazy<IRegisterWorkerOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger)
+        public RegisterWorkerCommand(Lazy<IRegisterWorkerOperation> lazyRegisterMachineOperation, Lazy<IWritableTentacleConfiguration> configuration, ISystemLog log, IApplicationInstanceSelector selector, Lazy<IOctopusServerChecker> octopusServerChecker, IProxyConfigParser proxyConfig, IOctopusClientInitializer octopusClientInitializer, ISpaceRepositoryFactory spaceRepositoryFactory, ILogFileOnlyLogger logFileOnlyLogger, IServerCertificateTrustConfirmation serverCertificateTrustConfirmation) : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger, serverCertificateTrustConfirmation)
         {
         }
     }

--- a/source/Octopus.Tentacle/Commands/RegisterWorkerCommandBase.cs
+++ b/source/Octopus.Tentacle/Commands/RegisterWorkerCommandBase.cs
@@ -23,8 +23,9 @@ namespace Octopus.Tentacle.Commands
             IProxyConfigParser proxyConfig,
             IOctopusClientInitializer octopusClientInitializer,
             ISpaceRepositoryFactory spaceRepositoryFactory,
-            ILogFileOnlyLogger logFileOnlyLogger)
-            : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger)
+            ILogFileOnlyLogger logFileOnlyLogger,
+            IServerCertificateTrustConfirmation serverCertificateTrustConfirmation)
+            : base(lazyRegisterMachineOperation, configuration, log, selector, octopusServerChecker, proxyConfig, octopusClientInitializer, spaceRepositoryFactory, logFileOnlyLogger, serverCertificateTrustConfirmation)
         {
             Options.Add("workerpool=", "The worker pool name, slug or Id to add the machine to - e.g., 'Windows Pool'; specify this argument multiple times to add to multiple pools", s => workerpools.Add(s));
         }

--- a/source/Octopus.Tentacle/Communications/ConsolePrompt.cs
+++ b/source/Octopus.Tentacle/Communications/ConsolePrompt.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Octopus.Tentacle.Communications
+{
+    public class ConsolePrompt : IPrompt
+    {
+        // When input has been redirected there is nobody at a keyboard to answer us, and reading from it would either
+        // block forever or consume input intended for something else.
+        public bool CanPrompt => !Console.IsInputRedirected;
+
+        public bool Confirm(string context, string question)
+        {
+            Console.WriteLine();
+            Console.WriteLine(context);
+            Console.Write($"{question} [y/N]: ");
+
+            var response = (Console.ReadLine() ?? string.Empty).Trim();
+
+            return response.Equals("y", StringComparison.OrdinalIgnoreCase) ||
+                response.Equals("yes", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Communications/IOctopusServerChecker.cs
+++ b/source/Octopus.Tentacle/Communications/IOctopusServerChecker.cs
@@ -5,6 +5,6 @@ namespace Octopus.Tentacle.Communications
 {
     public interface IOctopusServerChecker
     {
-        string CheckServerCommunicationsIsOpen(Uri serverAddress, IWebProxy? proxyOverride);
+        OctopusServerCommunicationsCheckResult CheckServerCommunicationsIsOpen(Uri serverAddress, IWebProxy? proxyOverride);
     }
 }

--- a/source/Octopus.Tentacle/Communications/IPrompt.cs
+++ b/source/Octopus.Tentacle/Communications/IPrompt.cs
@@ -1,0 +1,9 @@
+namespace Octopus.Tentacle.Communications
+{
+    public interface IPrompt
+    {
+        bool CanPrompt { get; }
+
+        bool Confirm(string context, string question);
+    }
+}

--- a/source/Octopus.Tentacle/Communications/IServerCertificateTrustConfirmation.cs
+++ b/source/Octopus.Tentacle/Communications/IServerCertificateTrustConfirmation.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Octopus.Tentacle.Communications
+{
+    public interface IServerCertificateTrustConfirmation
+    {
+        void EnsureCertificateIsTrusted(Uri serverAddress, OctopusServerCommunicationsCheckResult checkResult, string? expectedThumbprint);
+    }
+}

--- a/source/Octopus.Tentacle/Communications/OctopusServerChecker.cs
+++ b/source/Octopus.Tentacle/Communications/OctopusServerChecker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using Halibut;
 using Octopus.Tentacle.Core.Diagnostics;
@@ -16,7 +17,7 @@ namespace Octopus.Tentacle.Communications
             this.log = log;
         }
 
-        public string CheckServerCommunicationsIsOpen(Uri serverAddress, IWebProxy? proxyOverride)
+        public OctopusServerCommunicationsCheckResult CheckServerCommunicationsIsOpen(Uri serverAddress, IWebProxy? proxyOverride)
         {
             Uri handshake;
             if (ServiceEndPoint.IsWebSocketAddress(serverAddress))
@@ -30,57 +31,71 @@ namespace Octopus.Tentacle.Communications
                 log.Info($"Checking connectivity on the server communications port {serverAddress.Port}...");
             }
             string? thumbprint = null;
+            var policyErrors = SslPolicyErrors.None;
+
+            var previousValidationCallbackToRestore = ServicePointManager.ServerCertificateValidationCallback;
             ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) =>
             {
                 thumbprint = (certificate as X509Certificate2)?.Thumbprint;
+                policyErrors = errors;
+
+                // We have to accept the certificate to complete the handshake, otherwise we never get to read its thumbprint. 
                 return true;
             };
 
-            Retry("Checking that server communications are open", () =>
+            try
             {
+                Retry("Checking that server communications are open", () =>
+                {
 #pragma warning disable DE0003,SYSLIB0014
-                var req = WebRequest.Create(handshake);
-                req.Proxy = proxyOverride;
-                req.Method = "POST";
-                req.ContentLength = 0;
+                    var req = WebRequest.Create(handshake);
+                    req.Proxy = proxyOverride;
+                    req.Method = "POST";
+                    req.ContentLength = 0;
 #pragma warning restore DE0003,SYSLIB0014
-                try
-                {
-                    using var resp = req.GetResponse();
-                    using var rs = resp.GetResponseStream();
-                    using var reader = new StreamReader(rs);
-                    var wr = (HttpWebResponse)resp;
-                    var content = reader.ReadToEnd();
-                    if (wr.StatusCode != HttpStatusCode.OK)
-                        throw new Exception("The service listening on " + serverAddress + " does not appear to be an Octopus Server. The response code was: " + wr.StatusCode + ". The response was: " + content);
-
-                    log.Verbose("Connectivity with the server communications port successfully verified.");
-                }
-                catch (WebException wex)
-                {
-                    if (wex.Response is null)
+                    try
                     {
-                        throw;
-                    }
-                    
-                    var wr = (HttpWebResponse)wex.Response;
+                        using var resp = req.GetResponse();
+                        using var rs = resp.GetResponseStream();
+                        using var reader = new StreamReader(rs);
+                        var wr = (HttpWebResponse)resp;
+                        var content = reader.ReadToEnd();
+                        if (wr.StatusCode != HttpStatusCode.OK)
+                            throw new Exception("The service listening on " + serverAddress + " does not appear to be an Octopus Server. The response code was: " + wr.StatusCode + ". The response was: " + content);
 
-                    // "The remote server returned an error: (400) Bad Request."
-                    // Server requires we send a cert, which we didn't. Port must be open.
-                    if (wr.StatusCode != HttpStatusCode.BadRequest)
+                        log.Verbose("Connectivity with the server communications port successfully verified.");
+                    }
+                    catch (WebException wex)
                     {
-                        throw;
-                    }
+                        if (wex.Response is null)
+                        {
+                            throw;
+                        }
 
-                    log.Verbose("Connectivity with the server communications port successfully verified.");
-                }
-            }, 5, TimeSpan.FromSeconds(0.5));
+                        var wr = (HttpWebResponse)wex.Response;
+
+                        // "The remote server returned an error: (400) Bad Request."
+                        // Server requires we send a cert, which we didn't. Port must be open.
+                        if (wr.StatusCode != HttpStatusCode.BadRequest)
+                        {
+                            throw;
+                        }
+
+                        log.Verbose("Connectivity with the server communications port successfully verified.");
+                    }
+                }, 5, TimeSpan.FromSeconds(0.5));
+            }
+            finally
+            {
+                ServicePointManager.ServerCertificateValidationCallback = previousValidationCallbackToRestore;
+            }
 
             log.Info("Connected successfully");
 
             if (thumbprint == null)
-                throw new Exception("Unable to determine the thumbprint of the Octopus Server");
-            return thumbprint;
+                throw new Exception($"Unable to determine the thumbprint of the certificate presented by {serverAddress}");
+
+            return new OctopusServerCommunicationsCheckResult(thumbprint, policyErrors);
         }
 
          void Retry(string actionDescription, Action action, int retryCount, TimeSpan initialDelay, double backOffFactor = 1.5)

--- a/source/Octopus.Tentacle/Communications/OctopusServerCommunicationsCheckResult.cs
+++ b/source/Octopus.Tentacle/Communications/OctopusServerCommunicationsCheckResult.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Net.Security;
+
+namespace Octopus.Tentacle.Communications
+{
+    public sealed class OctopusServerCommunicationsCheckResult
+    {
+        public OctopusServerCommunicationsCheckResult(string thumbprint, SslPolicyErrors certificatePolicyErrors)
+        {
+            Thumbprint = thumbprint;
+            CertificatePolicyErrors = certificatePolicyErrors;
+        }
+
+        public string Thumbprint { get; }
+
+        public SslPolicyErrors CertificatePolicyErrors { get; }
+
+        public bool CertificateWasValidated => CertificatePolicyErrors == SslPolicyErrors.None;
+    }
+}

--- a/source/Octopus.Tentacle/Communications/ServerCertificateTrustConfirmation.cs
+++ b/source/Octopus.Tentacle/Communications/ServerCertificateTrustConfirmation.cs
@@ -1,0 +1,67 @@
+using System;
+using Octopus.Tentacle.Core.Diagnostics;
+
+namespace Octopus.Tentacle.Communications
+{
+    public class ServerCertificateTrustConfirmation : IServerCertificateTrustConfirmation
+    {
+        readonly ISystemLog log;
+        readonly IPrompt prompt;
+
+        public ServerCertificateTrustConfirmation(ISystemLog log, IPrompt prompt)
+        {
+            this.log = log;
+            this.prompt = prompt;
+        }
+
+        public void EnsureCertificateIsTrusted(Uri serverAddress, OctopusServerCommunicationsCheckResult checkResult, string? expectedThumbprint)
+        {
+            // An expected thumbprint is checked even when the certificate validated, because the operator has told us
+            // exactly which certificate they mean and anything else is worth failing over.
+            if (!string.IsNullOrWhiteSpace(expectedThumbprint))
+            {
+                var expected = expectedThumbprint!.Trim();
+
+                if (!string.Equals(expected, checkResult.Thumbprint, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new ControlledFailureException(
+                        $"The certificate presented by {serverAddress} has thumbprint {checkResult.Thumbprint}, which does not match the thumbprint {expected} given by --server-web-socket-thumbprint. " +
+                        "Either that thumbprint is wrong, or something other than the expected endpoint answered at that address.");
+                }
+
+                log.Verbose($"The certificate presented by {serverAddress} matches the thumbprint given by --server-web-socket-thumbprint. Trusting {serverAddress} using thumbprint {checkResult.Thumbprint}.");
+                return;
+            }
+
+            if (checkResult.CertificateWasValidated)
+            {
+                log.Verbose($"The certificate presented by {serverAddress} was validated successfully. Trusting {serverAddress} using thumbprint {checkResult.Thumbprint}.");
+                return;
+            }
+
+            var problem = $"The certificate presented by {serverAddress} could not be validated ({checkResult.CertificatePolicyErrors}). Its thumbprint is {checkResult.Thumbprint}.";
+
+            log.Warn(problem);
+
+            if (!prompt.CanPrompt)
+            {
+                throw new ControlledFailureException(
+                    $"{problem} Because this certificate could not be validated, it is not possible to confirm that it belongs to your Octopus Server rather than to an attacker positioned between this machine and the server. " +
+                    "Check that this thumbprint matches your server's websockets certificate - the one configured wherever TLS is terminated for the websockets endpoint, such as IIS, HTTP.SYS or a reverse proxy, and not the Octopus Server's Tentacle Communications certificate. " +
+                    "Once you have confirmed it, re-run this command with --server-web-socket-thumbprint=<thumbprint> to trust it.");
+            }
+
+            var context = $"{problem}{Environment.NewLine}" +
+                $"Because this certificate could not be validated, it is not possible to confirm that it belongs to your Octopus Server rather than to an attacker positioned between this machine and the server.{Environment.NewLine}" +
+                $"The certificate presented is the one configured wherever TLS is terminated for the websockets endpoint, not the Octopus Server's Tentacle Communications certificate.{Environment.NewLine}" +
+                "Check that this thumbprint matches your server's websockets certificate before continuing.";
+
+            if (!prompt.Confirm(context, "Trust this certificate?"))
+            {
+                throw new ControlledFailureException($"The certificate presented by {serverAddress} was not trusted, so the Octopus Server has not been configured.");
+            }
+
+            log.Warn($"The operator confirmed that the certificate with thumbprint {checkResult.Thumbprint} should be trusted, despite it failing validation.");
+        }
+    }
+}

--- a/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
+++ b/source/Octopus.Tentacle/Communications/TentacleCommunicationsModule.cs
@@ -41,6 +41,8 @@ namespace Octopus.Tentacle.Communications
                 return halibutRuntime;
             }).As<HalibutRuntime>().SingleInstance();
             builder.RegisterType<OctopusServerChecker>().As<IOctopusServerChecker>();
+            builder.RegisterType<ConsolePrompt>().As<IPrompt>();
+            builder.RegisterType<ServerCertificateTrustConfirmation>().As<IServerCertificateTrustConfirmation>();
         }
 
         static readonly string FriendlyHtmlPageContent = @"

--- a/source/Octopus.Tentacle/GlobalSuppressions.cs
+++ b/source/Octopus.Tentacle/GlobalSuppressions.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Usage", "DE0003:API is deprecated",
     Justification = "<Pending>",
     Scope = "member",
-    Target = "~M:Octopus.Tentacle.Communications.OctopusServerChecker.CheckServerCommunicationsIsOpen(System.Uri,System.Net.IWebProxy)~System.String")]
+    Target = "~M:Octopus.Tentacle.Communications.OctopusServerChecker.CheckServerCommunicationsIsOpen(System.Uri,System.Net.IWebProxy)~Octopus.Tentacle.Communications.OctopusServerCheckResult")]
 [assembly: SuppressMessage("Usage",
     "DE0003:API is deprecated",
     Justification = "<Pending>",


### PR DESCRIPTION
# Background

When registering or configuring a polling Tentacle against a WebSocket address, `OctopusServerChecker` probes the Octopus Server over TLS to learn the thumbprint to trust. The probe accepts any certificate — it has to, since the thumbprint can't be read from a handshake we refuse to complete — but the harvested thumbprint was then pinned with no further checks and nothing shown to the operator.

Establishing trust this way is intentional and documented, and exploiting it needs an attacker already positioned between the Tentacle and the Server, so this isn't treated as a vulnerability. 

# Results

Fixes LEV-1806

Fixes https://github.com/OctopusDeploy/OctopusTentacle/issues/1296

The probe now records the `SslPolicyErrors` alongside the thumbprint, and registration acts on it:

- Certificate validates → trusted as before, no prompt.
- Doesn't validate → operator is shown the thumbprint and the failure reason, and must confirm.
- No operator to ask (`Console.IsInputRedirected`) → fails with a message naming the thumbprint and
  how to proceed.
- New `--dangerously-skip-certificate-validation` → trusts without prompting, for unattended runs.

Only the WebSocket path changes. Comms-port registration takes its thumbprint from the authenticated
Octopus API, so it never relied on the probe.

**Breaking change:** unattended WebSocket registration against a server whose certificate doesn't
chain to a local trust anchor now fails instead of silently trusting it. Intended for the next set
of breaking changes.

Also fixes a real defect: `ServicePointManager.ServerCertificateValidationCallback` is process-wide
and was left installed after the probe. It's now restored in a `finally`.

## Testing
We wrote tests for this functionality. This did mean having to pass down classes through the layers so we could mock these objects.

We manually ran the "register-with" command with a couple of these scenarios to ensure registration behaved as expected.

# Pre-requisites

- [x] I have read How we use GitHub Issues for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the ownership map.
- [x] I have considered appropriate testing for my change.